### PR TITLE
fix(tools): prefer Developer ID over Apple Development in redeploy-mac

### DIFF
--- a/docs/planning/prompts-2026-09.md
+++ b/docs/planning/prompts-2026-09.md
@@ -31,19 +31,28 @@ P0 收口仓库 ── 唯一前置，串行，主工作区（当前会话直接
 
 ## 启动方式（最少复制粘贴）
 
-主工作区任务（P1、P2、MERGE）直接在 `~/Projects/iOS-vibebuddy` 起会话：
+**Claude Code 桌面版（默认）：** 在项目文件夹 `~/Projects/iOS-vibebuddy` 上开一个新会话，粘一行，其它什么都不用做：
 
-```bash
-claude "按 docs/planning/prompts-2026-09.md 只执行 P1"
+```
+按 docs/planning/prompts-2026-09.md 只执行 P1
 ```
 
-分支任务（W*、R*、FIX）先建 worktree 再起会话，一行搞定（把 `claude` 换成 `codex` 一样用）：
-
-```bash
-cd "$(tools/agent-worktree.sh watch-01)" && claude "按 docs/planning/prompts-2026-09.md 只执行 W1"
+```
+按 docs/planning/prompts-2026-09.md 只执行 W1
 ```
 
-Grok：
+```
+按 docs/planning/prompts-2026-09.md 只执行 R1
+```
+
+分支任务（W*、R*、FIX）由 agent 自己建 worktree 并切进去（见通用约束第 2 条）；主工作区任务（P1、P2、MERGE）留在项目文件夹。
+几个会话可以同时开，错开几秒即可。
+
+**终端 / Codex / Grok（可选）：** 先建 worktree 再起会话：
+
+```bash
+cd "$(tools/agent-worktree.sh watch-01)" && codex "按 docs/planning/prompts-2026-09.md 只执行 W1"
+```
 
 ```bash
 ~/.grok/bin/grok --cwd "$(tools/agent-worktree.sh watch-01)" "按 docs/planning/prompts-2026-09.md 只执行 W1"
@@ -51,12 +60,13 @@ Grok：
 
 worktree 名字对照：`watch-01` … `watch-08`、`release-mac`、`release-ios`、`fix-<slug>`。
 `tools/agent-worktree.sh` 会把 `.scratch/`（ticket）和 `.claude/skills` 软链到主工作区，所以 ticket 状态改动直接落地，不用合并。
-它在 P0 完成前会拒绝运行。
 
 ## 通用约束（每个任务都先读）
 
 1. 只做被点名的那个任务 ID；不碰其它任务的文件；只改自己 ticket 的 Status。
-2. 在指定分支 / worktree 工作。`.scratch/` 和 `.claude/skills` 是软链，直接改即可。
+2. **分支任务先把自己放进 worktree：** 运行 `tools/agent-worktree.sh <name>`（name 见任务标题），它会在 `.claude/worktrees/<name>` 建分支 `feat/<name>` 并打印路径；
+   Claude Code 随后用 EnterWorktree（`path` = 打印出的路径）切换进去，Codex / Grok 则 `cd` 进去。之后所有读写、构建、测试、提交都在那里。
+   主工作区任务（P1、P2、MERGE、R3）不建 worktree。`.scratch/` 和 `.claude/skills` 是软链，直接改即可。
 3. 不 push、不 merge main、不建 Release、不改远端。集成由主工作区的 MERGE 任务做。
 4. 不中断已安装的 `/Applications/VibeBuddyMacApp.app` 和 `:9876`。端到端验证用隔离端口 +
    临时 `HOME` + 临时日志路径（例：`VIBEBUDDY_PORT=18765 VIBEBUDDY_TOKEN=e2e ./.build/debug/vibebuddyd`）。

--- a/tools/redeploy-mac.sh
+++ b/tools/redeploy-mac.sh
@@ -38,9 +38,18 @@ echo "▸ regenerating + building Release…"
 
 # Prefer a Developer ID, else any Apple Development cert; fall back to ad-hoc.
 pick_identity() {
-  security find-identity -p codesigning -v 2>/dev/null \
-    | grep -Eo '[0-9A-F]{40} "(Developer ID Application|Apple Development)[^"]*"' \
-    | sort -r | head -1 | awk '{print $1}'
+  local identities type hash
+  identities="$(security find-identity -p codesigning -v 2>/dev/null || true)"
+  for type in "Developer ID Application" "Apple Development"; do
+    hash="$(printf '%s\n' "$identities" \
+      | grep -Eo "[0-9A-F]{40} \"${type}[^\"]*\"" \
+      | head -1 | awk '{print $1}')" || hash=""
+    if [[ -n "$hash" ]]; then
+      printf '%s\n' "$hash"
+      return 0
+    fi
+  done
+  return 0
 }
 IDENTITY="$(pick_identity || true)"
 


### PR DESCRIPTION
## Problem

`pick_identity()` in `tools/redeploy-mac.sh` promised, in its comment, to
"Prefer a Developer ID, else any Apple Development cert". The implementation
collected both certificate types with a single `grep` and then picked a winner
with `sort -r` — which orders by the leading 40-char SHA-1 hash, not by
certificate type. Which identity won was therefore arbitrary.

On this Mac the keychain holds:

```
DA21EDAF291DFA031973B5C5A62BB4913B90DF92 "Apple Development: … (B6NUMVUKU7)"
1E5C7A0291DB48F6B7E268F04275B18198008BFB "Developer ID Application: … (LQAVR62TK2)"
```

`DA21…` sorts above `1E5C…`, so the script picked Apple Development — the
opposite of what the comment promises.

## Fix

Iterate over the certificate types in preference order and take the first
match, instead of sorting hashes. `grep`'s no-match exit is neutralized so the
fallback isn't swallowed under `set -euo pipefail` regardless of call site. The
ad-hoc fallback when neither cert exists is unchanged.

## Verification

The function was extracted and exercised against a stubbed `security`:

| keychain contents | picked |
| --- | --- |
| real (this Mac, Apple Dev listed first) | `1E5C…` Developer ID ✓ |
| same two, listing order reversed | `1E5C…` Developer ID ✓ |
| Apple Development only | `DA21…` ✓ |
| unrelated cert only (`Mac Developer:`) | empty → ad-hoc ✓ |
| no identities | empty → ad-hoc ✓ |

Unstubbed against the real keychain it also picks `1E5C7A02…`. `bash -n` passes
and `shellcheck` is clean on the new function — its two remaining warnings are
pre-existing, in the unrelated `pids` handling at lines 68–70, and were left
alone.

## Impact

Benign for redeploy's stated purpose: any stable identity keeps Keychain ACLs
from re-prompting across rebuilds. This makes the code match its comment.

`tools/release-mac.sh` resolves its own identity independently and correctly;
it is untouched (and does not exist on this branch).

## Note on scope

This branch also carries `01a62b4` (`docs(prompts): Claude Code desktop launch
flow…`), which was already the branch HEAD before this fix and is not on `main`.
It rides along in this PR.
