### PR TITLE
Compact glance pill and click-to-jump to the session's terminal

### DIFF
--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -302,13 +302,16 @@ final class DashboardStore: ObservableObject {
     }
 
     /// Honest feedback for a jump — success lands on the Mac, so the phone has to
-    /// say so; `nil` means the Mac wasn't reachable.
+    /// say so; `nil` means the Mac wasn't reachable. `activatedApp` is the case
+    /// worth naming: the right app is now in front, but the session's own window
+    /// wasn't reachable, so the user still has to find the tab themselves.
     static func jumpMessage(_ outcome: JumpOutcome?) -> String {
         switch outcome {
-        case .focused:     return String(localized: "Focused the terminal on your Mac")
-        case .unsupported: return String(localized: "Can't focus this terminal type yet")
-        case .noTerminal:  return String(localized: "No terminal for this session")
-        case nil:          return String(localized: "Couldn't reach your Mac")
+        case .focused:      return String(localized: "Focused the terminal on your Mac")
+        case .activatedApp: return String(localized: "Opened the app on your Mac — find the tab there")
+        case .unsupported:  return String(localized: "Can't focus this terminal type yet")
+        case .noTerminal:   return String(localized: "No terminal for this session")
+        case nil:           return String(localized: "Couldn't reach your Mac")
         }
     }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/JumpOutcome.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/JumpOutcome.swift
@@ -4,16 +4,24 @@ import Foundation
 /// route and read by the phone so it can give honest feedback instead of failing
 /// silently. (A transport failure is represented client-side as the absence of an
 /// outcome, i.e. `nil`.)
+///
+/// The middle case matters: most hosts let us raise the *app* but not the exact
+/// window — VS Code and Cursor expose no API for their integrated terminals, and
+/// kitty without a remote-control socket cannot be addressed at all. Reporting
+/// that as `focused` would promise a precision we didn't deliver.
 public enum JumpOutcome: String, Codable, Sendable {
-    case focused        // a terminal ref existed and a focus command was run
-    case unsupported    // a ref existed but no runnable focus command (unknown terminal type)
+    case focused        // the session's own pane/tab/window was raised
+    case activatedApp   // only its host application could be brought forward
+    case unsupported    // a ref existed but nothing about it was actionable
     case noTerminal     // the session has no terminal ref to focus
 
-    /// Decide the outcome from whether a terminal ref exists and whether a
-    /// runnable focus command was produced for it. Pure so it can be unit-tested
-    /// away from the route and the `Process`-running jumper.
-    public static func decide(hasRef: Bool, hasRunnableCommand: Bool) -> JumpOutcome {
+    /// Decide the outcome from what the jump actually achieved. Pure so it can be
+    /// unit-tested away from the route and the `Process`-running jumper.
+    public static func decide(hasRef: Bool,
+                              focusedExactTarget: Bool,
+                              activatedApp: Bool) -> JumpOutcome {
         guard hasRef else { return .noTerminal }
-        return hasRunnableCommand ? .focused : .unsupported
+        if focusedExactTarget { return .focused }
+        return activatedApp ? .activatedApp : .unsupported
     }
 }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -91,13 +91,173 @@ public struct PendingQuestion: Codable, Sendable, Equatable, Identifiable {
 }
 
 /// Identifies the terminal a session runs in, so the Mac can jump to it.
+///
+/// Three levels of precision, captured together by `hooks/capture-terminal.sh`
+/// and consumed in that order by the jumper:
+///
+/// 1. **Pane** — `tmuxPane` (+ `tmux` socket) selects the pane inside a
+///    multiplexer.
+/// 2. **Surface** — `tty`, `itermSessionId`, `ghosttyTerminalId`,
+///    `weztermPane`, `kittyWindowId` each identify one window/tab/split of a
+///    specific terminal emulator, so the exact one can be raised.
+/// 3. **App** — `termProgram`, or `hostBundleId` when the host sets no
+///    `TERM_PROGRAM` at all (VS Code/Cursor tell each other apart only this
+///    way, and the Claude desktop app sets none). Bringing the app forward is
+///    the honest floor: it lands the user in the right application even when
+///    the surface is unknowable.
+///
+/// Wire format is snake_case throughout, so the `/terminal` hook payload and
+/// the phone's `AgentSession` JSON are the same shape. Empty strings decode as
+/// `nil` — shell hooks find it easier to send `""` than to omit a key.
 public struct TerminalRef: Codable, Sendable, Equatable {
-    public let termProgram: String
+    /// `$TERM_PROGRAM`: `ghostty`, `iTerm.app`, `apple_terminal`, `WezTerm`,
+    /// `WarpTerminal`, `vscode`, or `kitty` (synthesized — kitty sets none).
+    /// `nil` when the host exports nothing; `hostBundleId` covers that case.
+    public let termProgram: String?
+    /// Controlling tty without the `/dev/` prefix (`ttys003`). Terminal.app and
+    /// iTerm2 both expose it per tab, which makes it an exact target there.
     public let tty: String?
+    /// `$TMUX` — `socket,pid,session`; only the socket path is used.
     public let tmux: String?
+    /// `$TMUX_PANE` — `%3`.
     public let tmuxPane: String?
-    public init(termProgram: String, tty: String? = nil, tmux: String? = nil, tmuxPane: String? = nil) {
-        self.termProgram = termProgram; self.tty = tty; self.tmux = tmux; self.tmuxPane = tmuxPane
+    /// The UUID half of `$ITERM_SESSION_ID` (`w0t0p0:UUID`), which equals an
+    /// iTerm2 session's `unique ID`.
+    public let itermSessionId: String?
+    /// `$WEZTERM_PANE` — an integer pane id for `wezterm cli activate-pane`.
+    public let weztermPane: String?
+    /// `$KITTY_WINDOW_ID` — an integer for `kitten @ focus-window --match id:N`.
+    public let kittyWindowId: String?
+    /// `$KITTY_LISTEN_ON` — the remote-control socket. Without it kitty's
+    /// window cannot be addressed from outside, so the jump stops at the app.
+    public let kittyListenOn: String?
+    /// Ghostty's AppleScript `terminal` id, probed once at SessionStart while
+    /// the surface is still focused (Ghostty exports no env var for it).
+    public let ghosttyTerminalId: String?
+    /// Bundle identifier of the nearest GUI ancestor process. The universal
+    /// fallback: it names whatever app is hosting the session even when that
+    /// app is not a terminal emulator we know.
+    public let hostBundleId: String?
+    /// Pid of that GUI ancestor. Diagnostic only — kept so a stale ref can be
+    /// told from a live one.
+    public let hostPid: Int?
+    /// The session's working directory. Ghostty can be matched on it when the
+    /// terminal id is missing or stale.
+    public let cwd: String?
+
+    public init(termProgram: String? = nil,
+                tty: String? = nil,
+                tmux: String? = nil,
+                tmuxPane: String? = nil,
+                itermSessionId: String? = nil,
+                weztermPane: String? = nil,
+                kittyWindowId: String? = nil,
+                kittyListenOn: String? = nil,
+                ghosttyTerminalId: String? = nil,
+                hostBundleId: String? = nil,
+                hostPid: Int? = nil,
+                cwd: String? = nil) {
+        self.termProgram = termProgram
+        self.tty = tty
+        self.tmux = tmux
+        self.tmuxPane = tmuxPane
+        self.itermSessionId = itermSessionId
+        self.weztermPane = weztermPane
+        self.kittyWindowId = kittyWindowId
+        self.kittyListenOn = kittyListenOn
+        self.ghosttyTerminalId = ghosttyTerminalId
+        self.hostBundleId = hostBundleId
+        self.hostPid = hostPid
+        self.cwd = cwd
+    }
+
+    /// Bundle identifiers of the two emulators that expose a per-tab `tty`, and
+    /// so are the only ones a bare tty can address below app level.
+    private static let ttyAddressableBundleIDs: Set<String> = ["com.apple.Terminal", "com.googlecode.iterm2"]
+    private static let ttyAddressableTermPrograms: Set<String> = ["apple_terminal", "iterm.app"]
+
+    /// Whether this ref names a specific pane/tab/window rather than only an
+    /// app. Drives the difference between `JumpOutcome.focused` and
+    /// `.activatedApp`, and lets the UI promise only what it can deliver.
+    ///
+    /// A `tty` counts only under Terminal.app and iTerm2: they are the two
+    /// emulators whose AppleScript dictionary exposes it per tab. Everywhere
+    /// else the tty is real but unaddressable, and a jump can reach the app at
+    /// best — so promising an exact target would be a lie.
+    public var hasExactTarget: Bool {
+        if tmuxPane != nil || itermSessionId != nil || weztermPane != nil
+            || kittyWindowId != nil || ghosttyTerminalId != nil { return true }
+        guard tty != nil else { return false }
+        if let tp = termProgram?.lowercased(), Self.ttyAddressableTermPrograms.contains(tp) { return true }
+        return hostBundleId.map(Self.ttyAddressableBundleIDs.contains) ?? false
+    }
+
+    /// Whether storing this ref would buy the jumper anything. A ref with no
+    /// exact target, no `TERM_PROGRAM` and no host bundle id names nothing the
+    /// jumper could act on — keeping it would only turn an honest "no terminal
+    /// recorded" into a mystifying "couldn't locate this session's window".
+    public var isActionable: Bool {
+        hasExactTarget || termProgram != nil || hostBundleId != nil
+    }
+
+    /// This ref updated by a later capture: every field the new one carries
+    /// wins, everything it is silent about is kept.
+    ///
+    /// Re-capture is not idempotent, which is why this exists. The
+    /// `UserPromptSubmit` capture deliberately skips the Ghostty AppleScript
+    /// probe (it is only correct while the surface is focused, i.e. at
+    /// `SessionStart`), so a wholesale replace would erase
+    /// `ghosttyTerminalId` on the session's next prompt.
+    public func merging(_ newer: TerminalRef) -> TerminalRef {
+        TerminalRef(
+            termProgram: newer.termProgram ?? termProgram,
+            tty: newer.tty ?? tty,
+            tmux: newer.tmux ?? tmux,
+            tmuxPane: newer.tmuxPane ?? tmuxPane,
+            itermSessionId: newer.itermSessionId ?? itermSessionId,
+            weztermPane: newer.weztermPane ?? weztermPane,
+            kittyWindowId: newer.kittyWindowId ?? kittyWindowId,
+            kittyListenOn: newer.kittyListenOn ?? kittyListenOn,
+            ghosttyTerminalId: newer.ghosttyTerminalId ?? ghosttyTerminalId,
+            hostBundleId: newer.hostBundleId ?? hostBundleId,
+            hostPid: newer.hostPid ?? hostPid,
+            cwd: newer.cwd ?? cwd
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case termProgram = "term_program"
+        case tty
+        case tmux
+        case tmuxPane = "tmux_pane"
+        case itermSessionId = "iterm_session_id"
+        case weztermPane = "wezterm_pane"
+        case kittyWindowId = "kitty_window_id"
+        case kittyListenOn = "kitty_listen_on"
+        case ghosttyTerminalId = "ghostty_terminal_id"
+        case hostBundleId = "host_bundle_id"
+        case hostPid = "host_pid"
+        case cwd
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        func str(_ k: CodingKeys) -> String? {
+            guard let v = try? c.decodeIfPresent(String.self, forKey: k), !v.isEmpty else { return nil }
+            return v
+        }
+        termProgram = str(.termProgram)
+        tty = str(.tty)
+        tmux = str(.tmux)
+        tmuxPane = str(.tmuxPane)
+        itermSessionId = str(.itermSessionId)
+        weztermPane = str(.weztermPane)
+        kittyWindowId = str(.kittyWindowId)
+        kittyListenOn = str(.kittyListenOn)
+        ghosttyTerminalId = str(.ghosttyTerminalId)
+        hostBundleId = str(.hostBundleId)
+        hostPid = (try? c.decodeIfPresent(Int.self, forKey: .hostPid)) ?? nil
+        cwd = str(.cwd)
     }
 }
 

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/JumpOutcomeTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/JumpOutcomeTests.swift
@@ -5,25 +5,33 @@ import Foundation
 @Suite("JumpOutcome — what a jump-to-terminal request resolved to")
 struct JumpOutcomeTests {
 
-    @Test("no terminal ref → noTerminal")
+    @Test("no terminal ref → noTerminal, whatever else is claimed")
     func noRef() {
-        #expect(JumpOutcome.decide(hasRef: false, hasRunnableCommand: false) == .noTerminal)
-        #expect(JumpOutcome.decide(hasRef: false, hasRunnableCommand: true) == .noTerminal)
+        #expect(JumpOutcome.decide(hasRef: false, focusedExactTarget: false, activatedApp: false) == .noTerminal)
+        #expect(JumpOutcome.decide(hasRef: false, focusedExactTarget: true, activatedApp: true) == .noTerminal)
     }
 
-    @Test("a ref with a runnable focus command → focused")
+    @Test("the session's own pane/tab came forward → focused")
     func focused() {
-        #expect(JumpOutcome.decide(hasRef: true, hasRunnableCommand: true) == .focused)
+        #expect(JumpOutcome.decide(hasRef: true, focusedExactTarget: true, activatedApp: true) == .focused)
+        // Focus without activation still counts: a tmux pane can be selected in a
+        // terminal whose app we could not raise.
+        #expect(JumpOutcome.decide(hasRef: true, focusedExactTarget: true, activatedApp: false) == .focused)
     }
 
-    @Test("a ref but no runnable command (unknown terminal) → unsupported")
+    @Test("only the host app could be raised → activatedApp, not focused")
+    func activatedApp() {
+        #expect(JumpOutcome.decide(hasRef: true, focusedExactTarget: false, activatedApp: true) == .activatedApp)
+    }
+
+    @Test("a ref that achieved nothing → unsupported")
     func unsupported() {
-        #expect(JumpOutcome.decide(hasRef: true, hasRunnableCommand: false) == .unsupported)
+        #expect(JumpOutcome.decide(hasRef: true, focusedExactTarget: false, activatedApp: false) == .unsupported)
     }
 
     @Test("round-trips over the wire as its raw string")
     func codable() throws {
-        for outcome in [JumpOutcome.focused, .unsupported, .noTerminal] {
+        for outcome in [JumpOutcome.focused, .activatedApp, .unsupported, .noTerminal] {
             let data = try JSONEncoder().encode(["outcome": outcome.rawValue])
             let back = try JSONDecoder().decode([String: String].self, from: data)
             #expect(back["outcome"].flatMap(JumpOutcome.init(rawValue:)) == outcome)

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/TerminalRefTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/TerminalRefTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import Foundation
+@testable import VibeBuddyKit
+
+/// `TerminalRef` is the wire shape of the `/terminal` hook payload as well as a
+/// field of `AgentSession`, so its snake_case keys are load-bearing in both
+/// directions.
+@Suite("TerminalRef — the capture hook's payload")
+struct TerminalRefTests {
+
+    private func decode(_ json: String) throws -> TerminalRef {
+        try JSONDecoder().decode(TerminalRef.self, from: Data(json.utf8))
+    }
+
+    @Test("every captured field decodes from the hook's snake_case payload")
+    func decodesFullPayload() throws {
+        let ref = try decode("""
+        {"session_id":"s","term_program":"iTerm.app","tty":"ttys003",
+         "tmux":"/tmp/tmux-501/default,1,0","tmux_pane":"%3",
+         "iterm_session_id":"9C1E2E1E-0F3A-4B6D-9A11-2B7C4D5E6F70","wezterm_pane":"4",
+         "kitty_window_id":"9","kitty_listen_on":"unix:/tmp/k","ghostty_terminal_id":"7",
+         "host_bundle_id":"com.googlecode.iterm2","host_pid":4242,"cwd":"/Users/x/p"}
+        """)
+        #expect(ref.termProgram == "iTerm.app")
+        #expect(ref.tty == "ttys003")
+        #expect(ref.tmux == "/tmp/tmux-501/default,1,0")
+        #expect(ref.tmuxPane == "%3")
+        #expect(ref.itermSessionId == "9C1E2E1E-0F3A-4B6D-9A11-2B7C4D5E6F70")
+        #expect(ref.weztermPane == "4")
+        #expect(ref.kittyWindowId == "9")
+        #expect(ref.kittyListenOn == "unix:/tmp/k")
+        #expect(ref.ghosttyTerminalId == "7")
+        #expect(ref.hostBundleId == "com.googlecode.iterm2")
+        #expect(ref.hostPid == 4242)
+        #expect(ref.cwd == "/Users/x/p")
+    }
+
+    @Test("an empty string is absence — shells find it easier to send \"\" than to omit a key")
+    func emptyStringsAreNil() throws {
+        let ref = try decode(#"{"term_program":"","tty":"","tmux":"","host_bundle_id":""}"#)
+        #expect(ref.termProgram == nil)
+        #expect(ref.tty == nil)
+        #expect(ref.tmux == nil)
+        #expect(ref.hostBundleId == nil)
+        #expect(!ref.hasExactTarget)
+    }
+
+    @Test("a payload with nothing but a host bundle id is still a valid ref")
+    func hostOnly() throws {
+        let ref = try decode(#"{"host_bundle_id":"com.anthropic.claude-code","host_pid":99}"#)
+        #expect(ref.termProgram == nil)
+        #expect(ref.hostBundleId == "com.anthropic.claude-code")
+        #expect(ref.hostPid == 99)
+        #expect(!ref.hasExactTarget)
+    }
+
+    @Test("hasExactTarget is true for any pane/surface handle, one at a time",
+          arguments: [
+            #"{"tmux_pane":"%3"}"#,
+            #"{"iterm_session_id":"UUID"}"#,
+            #"{"wezterm_pane":"4"}"#,
+            #"{"kitty_window_id":"9"}"#,
+            #"{"ghostty_terminal_id":"7"}"#,
+          ])
+    func exactTargets(_ json: String) throws {
+        #expect(try decode(json).hasExactTarget)
+    }
+
+    /// Terminal.app and iTerm2 are the only emulators whose dictionary exposes a
+    /// tab's `tty`, so they are the only ones where a bare tty locates a
+    /// surface. Everywhere else the tty is real but unaddressable, and claiming
+    /// an exact target would promise a precision the jump can't deliver.
+    @Test("a bare tty is an exact target only under Terminal.app and iTerm2",
+          arguments: [
+            (#"{"tty":"ttys003","term_program":"apple_terminal"}"#, true),
+            (#"{"tty":"ttys003","term_program":"Apple_Terminal"}"#, true),
+            (#"{"tty":"ttys003","term_program":"iTerm.app"}"#, true),
+            (#"{"tty":"ttys003","host_bundle_id":"com.apple.Terminal"}"#, true),
+            (#"{"tty":"ttys003","host_bundle_id":"com.googlecode.iterm2"}"#, true),
+            (#"{"tty":"ttys003","term_program":"ghostty"}"#, false),
+            (#"{"tty":"ttys003","term_program":"vscode"}"#, false),
+            (#"{"tty":"ttys003","term_program":"WezTerm"}"#, false),
+            (#"{"tty":"ttys003"}"#, false),
+          ])
+    func bareTTY(_ json: String, _ expected: Bool) throws {
+        #expect(try decode(json).hasExactTarget == expected)
+    }
+
+    @Test("cwd alone is not an exact target — it's a hint, and several sessions can share it")
+    func cwdIsNotATarget() throws {
+        #expect(try !decode(#"{"cwd":"/Users/x/p","term_program":"ghostty"}"#).hasExactTarget)
+    }
+
+    /// What the `/terminal` route uses to decide whether a ref is worth storing.
+    @Test("isActionable needs an exact target, a TERM_PROGRAM, or a host bundle id",
+          arguments: [
+            (#"{"cwd":"/Users/x/p"}"#, false),
+            (#"{"tty":"ttys003"}"#, false),          // unaddressable without an emulator
+            (#"{}"#, false),
+            (#"{"term_program":"ghostty"}"#, true),
+            (#"{"host_bundle_id":"com.anthropic.claude-code"}"#, true),
+            (#"{"tmux_pane":"%3"}"#, true),
+          ])
+    func actionable(_ json: String, _ expected: Bool) throws {
+        #expect(try decode(json).isActionable == expected)
+    }
+
+    /// Re-capture is not idempotent: `UserPromptSubmit` skips the Ghostty
+    /// AppleScript probe, so merging is what keeps the terminal id alive.
+    @Test("merging keeps what the newer capture couldn't see and takes what it could")
+    func merges() {
+        let first = TerminalRef(termProgram: "ghostty", tty: "ttys003",
+                                ghosttyTerminalId: "42", hostBundleId: "com.mitchellh.ghostty",
+                                hostPid: 100, cwd: "/x/p")
+        let second = TerminalRef(termProgram: "ghostty", tty: "ttys009", cwd: "/x/q")
+        let merged = first.merging(second)
+        #expect(merged.ghosttyTerminalId == "42")
+        #expect(merged.hostBundleId == "com.mitchellh.ghostty")
+        #expect(merged.hostPid == 100)
+        #expect(merged.tty == "ttys009")
+        #expect(merged.cwd == "/x/q")
+        // Merging an empty ref changes nothing at all.
+        #expect(first.merging(TerminalRef()) == first)
+    }
+
+    @Test("round-trips through its own encoder, omitting what wasn't captured")
+    func roundTrips() throws {
+        let ref = TerminalRef(termProgram: "ghostty", ghosttyTerminalId: "7", cwd: "/Users/x/p")
+        let data = try JSONEncoder().encode(ref)
+        #expect(try decode(String(decoding: data, as: UTF8.self)) == ref)
+        let keys = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any]).keys
+        #expect(Set(keys) == ["term_program", "ghostty_terminal_id", "cwd"])
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ForegroundTerminal.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ForegroundTerminal.swift
@@ -12,8 +12,9 @@ import VibeBuddyKit
 /// — it silences a finishing session's cue when its terminal is on screen, and
 /// at worst over-silences sibling tabs in the same app, never the reverse.
 public enum ForegroundTerminal {
-    /// Bundle identifiers a given `TERM_PROGRAM` is known to run under. The
-    /// reverse of `TerminalJumper.appName(forTermProgram:)`; keep the two in sync.
+    /// Bundle identifiers a given `TERM_PROGRAM` is known to run under. The one
+    /// table for the mapping — `TerminalJumper` reads it too, to decide which app
+    /// a jump should bring forward.
     static func bundleIDs(forTermProgram tp: String) -> [String] {
         switch tp.lowercased() {
         case "ghostty":               return ["com.mitchellh.ghostty"]
@@ -27,6 +28,17 @@ public enum ForegroundTerminal {
         }
     }
 
+    /// Every bundle id a ref could be running under: the captured host bundle id
+    /// (exact, from process ancestry) plus whatever its `TERM_PROGRAM` implies.
+    /// Both are needed — a session inside an embedded terminal has only the
+    /// former, and a session under tmux, whose server has no GUI ancestor, has
+    /// only the latter.
+    static func bundleIDs(for ref: TerminalRef) -> [String] {
+        let fromTermProgram = ref.termProgram.map { bundleIDs(forTermProgram: $0) } ?? []
+        guard let host = ref.hostBundleId else { return fromTermProgram }
+        return [host] + fromTermProgram
+    }
+
     /// The sessions whose terminal app is `frontmostBundleID`. Empty when nothing
     /// matches — a non-terminal app is frontmost, the terminal is unknown, or no
     /// session reported a terminal.
@@ -35,7 +47,7 @@ public enum ForegroundTerminal {
         guard let front = frontmostBundleID else { return [] }
         return Set(
             sessions
-                .filter { ($0.terminalRef.map { bundleIDs(forTermProgram: $0.termProgram) } ?? []).contains(front) }
+                .filter { ($0.terminalRef.map { bundleIDs(for: $0) } ?? []).contains(front) }
                 .map(\.id)
         )
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -206,9 +206,15 @@ public struct SessionReducer: Sendable {
     }
 
     /// Attach the terminal a session runs in (does not change status).
+    ///
+    /// Merged, never replaced: the `UserPromptSubmit` re-capture skips the
+    /// Ghostty AppleScript probe (only valid while the surface is focused), so
+    /// a wholesale assignment would drop `ghosttyTerminalId` on the session's
+    /// second prompt. Whatever the new capture saw wins; whatever it is silent
+    /// about survives.
     public mutating func setTerminalRef(sessionID: String, _ ref: TerminalRef) {
         guard var s = sessions[sessionID] else { return }
-        s.terminalRef = ref
+        s.terminalRef = s.terminalRef?.merging(ref) ?? ref
         sessions[sessionID] = s
     }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -167,7 +167,10 @@ public actor SessionStore {
     }
 
     public func setTerminalRef(sessionID: String, _ ref: TerminalRef) {
-        pendingTerminalRefs[sessionID] = ref          // remembered even if the session isn't here yet
+        // Remembered even if the session isn't here yet — and merged for the
+        // same reason the reducer merges: a re-capture that skipped the Ghostty
+        // probe must not erase the id the first one found.
+        pendingTerminalRefs[sessionID] = pendingTerminalRefs[sessionID]?.merging(ref) ?? ref
         if reducer.sessions[sessionID] != nil {
             reducer.setTerminalRef(sessionID: sessionID, ref)
             broadcast()

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/TerminalCommand.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/TerminalCommand.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Absolute paths to the CLI tools the jumper and injector shell out to. Hooks
+/// run under the user's shell, but the daemon does not inherit a useful `PATH`,
+/// so every command is resolved to a real file before it is planned.
 enum TerminalCommand {
     static let tmuxCandidates = [
         "/opt/homebrew/bin/tmux",
@@ -7,7 +10,39 @@ enum TerminalCommand {
         "/usr/bin/tmux",
     ]
 
+    /// WezTerm's CLI. The app bundle ships its own copy, so a user who never
+    /// installed the Homebrew formula is still reachable.
+    static let weztermCandidates = [
+        "/opt/homebrew/bin/wezterm",
+        "/usr/local/bin/wezterm",
+        "/Applications/WezTerm.app/Contents/MacOS/wezterm",
+    ]
+
+    /// kitty's remote-control client.
+    static let kittenCandidates = [
+        "/opt/homebrew/bin/kitten",
+        "/usr/local/bin/kitten",
+        "/Applications/kitty.app/Contents/MacOS/kitten",
+    ]
+
+    static let osascriptPath = "/usr/bin/osascript"
+
     static func tmuxPath(fileManager: FileManager = .default) -> String {
-        tmuxCandidates.first { fileManager.isExecutableFile(atPath: $0) } ?? "/usr/bin/tmux"
+        first(of: tmuxCandidates, fileManager: fileManager) ?? "/usr/bin/tmux"
+    }
+
+    /// `nil` when WezTerm isn't installed — the jumper then skips its step
+    /// instead of planning a command that cannot run.
+    static func weztermPath(fileManager: FileManager = .default) -> String? {
+        first(of: weztermCandidates, fileManager: fileManager)
+    }
+
+    /// `nil` when kitty isn't installed.
+    static func kittenPath(fileManager: FileManager = .default) -> String? {
+        first(of: kittenCandidates, fileManager: fileManager)
+    }
+
+    private static func first(of candidates: [String], fileManager: FileManager) -> String? {
+        candidates.first { fileManager.isExecutableFile(atPath: $0) }
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/TerminalJumper.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/TerminalJumper.swift
@@ -1,44 +1,393 @@
+import AppKit
 import Foundation
 import VibeBuddyKit
 
-/// Builds and runs the commands to focus a session's terminal. `commands(for:)`
-/// is pure (testable); `jump(_:)` executes them best-effort via `Process`.
+/// One try at raising the session's exact surface. Its commands run in order and
+/// the attempt counts as a hit only if every one of them exits 0 — WezTerm needs
+/// both `activate-pane` and `activate-tab`, and a half-done focus is not a focus.
+struct JumpAttempt: Equatable, Sendable {
+    var commands: [[String]]
+    init(_ commands: [[String]]) { self.commands = commands }
+    init(_ argv: [String]) { self.commands = [argv] }
+}
+
+/// One multiplexer command, plus whether its success means the pane actually
+/// came into view. `switch-client` and `select-window` move the viewport;
+/// `select-pane` and the unzoom only rearrange what is already on screen, so
+/// their success alone is not a focus.
+struct TmuxStep: Equatable, Sendable {
+    var argv: [String]
+    var focuses: Bool
+}
+
+/// Everything a jump will do, decided without running anything. Split by the
+/// three levels of precision a `TerminalRef` can carry.
+struct JumpPlan: Equatable, Sendable {
+    /// Multiplexer pane selection. Every command runs; they are independent.
+    var tmux: [TmuxStep] = []
+    /// Surface targeting, most specific first. Execution stops at the first hit.
+    var surface: [JumpAttempt] = []
+    /// Bundle ids of the emulator the `surface` attempts address. At least one
+    /// of them must already be running before any attempt may be made:
+    /// `tell application id "…"` *launches* the app when it isn't, and a jump
+    /// that opens a brand-new terminal is not the action the user asked for.
+    /// Empty means "nothing below app level was planned".
+    var requiredRunningBundleIDs: [String] = []
+    /// The app to bring forward afterwards. `nil` when the host is unknown.
+    var activateBundleID: String?
+
+    var isEmpty: Bool { tmux.isEmpty && surface.isEmpty && activateBundleID == nil }
+}
+
+/// Plans and runs the jump from a session's `TerminalRef` to the terminal the
+/// user left it in.
+///
+/// `plan(for:)` is pure — it decides which commands *would* run, which is where
+/// every safety rule lives (ids are validated against a strict allowlist before
+/// they can reach AppleScript, and an app is only scripted when the ref says the
+/// session actually lives in it, so a jump can never launch a terminal the user
+/// isn't using). `jump(_:)` executes that plan off the main actor with a per-step
+/// timeout and reports what it actually achieved.
 public enum TerminalJumper {
-    public static func commands(for ref: TerminalRef) -> [[String]] {
-        var cmds: [[String]] = []
-        if let tmux = ref.tmux, let pane = ref.tmuxPane,
-           !tmux.isEmpty, !pane.isEmpty,
-           let socket = tmux.split(separator: ",").first.map(String.init), !socket.isEmpty {
-            let tmuxPath = TerminalCommand.tmuxPath()
-            cmds.append([tmuxPath, "-S", socket, "switch-client", "-t", pane])
-            cmds.append([tmuxPath, "-S", socket, "select-window", "-t", pane])
-            cmds.append([tmuxPath, "-S", socket, "select-pane", "-t", pane])
+
+    // MARK: - Planning
+
+    /// Terminal emulators we can address below app level. Derived from
+    /// `TERM_PROGRAM`, or from the host bundle id when the host exports none.
+    /// Scripting is gated on this twice over: the ref has to say the session
+    /// lives in this family, *and* the family has to be running when the plan
+    /// executes — `tell application id "com.apple.Terminal"` launches
+    /// Terminal.app otherwise.
+    enum Family: Equatable {
+        case appleTerminal, iterm, ghostty, wezterm, kitty, other
+
+        /// The `TERM_PROGRAM` this family is named by, which is also the key
+        /// into `ForegroundTerminal`'s one bundle-id table — the same table
+        /// that decides which sessions count as foregrounded.
+        var termProgram: String? {
+            switch self {
+            case .appleTerminal: return "apple_terminal"
+            case .iterm: return "iTerm.app"
+            case .ghostty: return "ghostty"
+            case .wezterm: return "wezterm"
+            case .kitty: return "kitty"
+            case .other: return nil
+            }
         }
-        if let app = appName(forTermProgram: ref.termProgram) {
-            cmds.append(["/usr/bin/open", "-a", app])
+
+        /// Every bundle id this family can run under.
+        var bundleIDs: [String] {
+            termProgram.map { ForegroundTerminal.bundleIDs(forTermProgram: $0) } ?? []
         }
-        return cmds
     }
 
-    static func appName(forTermProgram tp: String) -> String? {
-        switch tp.lowercased() {
-        case "ghostty": return "Ghostty"
-        case "iterm.app": return "iTerm"
-        case "apple_terminal": return "Terminal"
-        case "wezterm": return "WezTerm"
-        case "warpterminal", "warp": return "Warp"   // Warp sets TERM_PROGRAM=WarpTerminal
-        case "kitty": return "kitty"                  // kitty has no TERM_PROGRAM; capture-terminal.sh synthesizes it
-        case "vscode": return "Visual Studio Code"
-        default: return nil
+    static func family(for ref: TerminalRef) -> Family {
+        switch ref.termProgram?.lowercased() {
+        case "apple_terminal": return .appleTerminal
+        case "iterm.app": return .iterm
+        case "ghostty": return .ghostty
+        case "wezterm": return .wezterm
+        case "kitty": return .kitty
+        case .some: return .other
+        case nil: break
+        }
+        switch ref.hostBundleId {
+        case "com.apple.Terminal": return .appleTerminal
+        case "com.googlecode.iterm2": return .iterm
+        case "com.mitchellh.ghostty": return .ghostty
+        case "com.github.wez.wezterm": return .wezterm
+        case "net.kovidgoyal.kitty": return .kitty
+        default: return .other
         }
     }
 
-    public static func jump(_ ref: TerminalRef) {
-        for argv in commands(for: ref) where !argv.isEmpty {
-            let p = Process()
-            p.executableURL = URL(fileURLWithPath: argv[0])
-            p.arguments = Array(argv.dropFirst())
-            try? p.run(); p.waitUntilExit()
+    static func plan(for ref: TerminalRef,
+                            tmuxPath: String = TerminalCommand.tmuxPath(),
+                            weztermPath: String? = TerminalCommand.weztermPath(),
+                            kittenPath: String? = TerminalCommand.kittenPath()) -> JumpPlan {
+        var plan = JumpPlan()
+
+        if let socket = tmuxSocket(ref.tmux), let pane = paneID(ref.tmuxPane) {
+            plan.tmux = [
+                TmuxStep(argv: [tmuxPath, "-S", socket, "switch-client", "-t", pane], focuses: true),
+                TmuxStep(argv: [tmuxPath, "-S", socket, "select-window", "-t", pane], focuses: true),
+                // A zoomed window hides every other pane; unzoom only when it is
+                // zoomed, evaluated by tmux itself so the plan stays pure.
+                TmuxStep(argv: [tmuxPath, "-S", socket, "if-shell", "-F", "-t", pane,
+                                "#{window_zoomed_flag}", "resize-pane -Z -t \(pane)"], focuses: false),
+                // Picks the pane inside a window that is already on screen —
+                // it succeeds just as happily when that window is buried, so
+                // on its own it is not evidence of a jump.
+                TmuxStep(argv: [tmuxPath, "-S", socket, "select-pane", "-t", pane], focuses: false),
+            ]
         }
+
+        let family = family(for: ref)
+        switch family {
+        case .appleTerminal:
+            if let tty = ttyDevice(ref.tty) {
+                plan.surface.append(JumpAttempt(osascript(appleTerminalScript(tty: tty))))
+            }
+        case .iterm:
+            if let id = opaqueID(ref.itermSessionId) {
+                plan.surface.append(JumpAttempt(osascript(itermScript(match: "unique ID", value: id))))
+            }
+            if let tty = ttyDevice(ref.tty) {
+                plan.surface.append(JumpAttempt(osascript(itermScript(match: "tty", value: tty))))
+            }
+        case .ghostty:
+            if let id = opaqueID(ref.ghosttyTerminalId) {
+                plan.surface.append(JumpAttempt(osascript(ghosttyScript(match: "id", value: id))))
+            }
+            if let cwd = scriptSafePath(ref.cwd) {
+                plan.surface.append(JumpAttempt(osascript(ghosttyScript(match: "working directory", value: cwd))))
+            }
+        case .wezterm:
+            if let pane = digits(ref.weztermPane), let wezterm = weztermPath {
+                plan.surface.append(JumpAttempt([
+                    [wezterm, "cli", "activate-pane", "--pane-id", pane],
+                    [wezterm, "cli", "activate-tab", "--pane-id", pane],
+                ]))
+            }
+        case .kitty:
+            if let window = digits(ref.kittyWindowId), let socket = kittySocket(ref.kittyListenOn),
+               let kitten = kittenPath {
+                plan.surface.append(JumpAttempt(
+                    [kitten, "@", "--to", socket, "focus-window", "--match", "id:\(window)"]))
+            }
+        case .other:
+            break
+        }
+
+        // Nothing below app level may be attempted against an app that isn't
+        // already running (see `JumpPlan.requiredRunningBundleIDs`).
+        if !plan.surface.isEmpty { plan.requiredRunningBundleIDs = family.bundleIDs }
+
+        // The host bundle id comes from real process ancestry, so it wins over the
+        // `TERM_PROGRAM` table — that table cannot tell Cursor from VS Code (both
+        // report `vscode`), and the ancestry can.
+        plan.activateBundleID = ref.hostBundleId
+            ?? ref.termProgram.flatMap { ForegroundTerminal.bundleIDs(forTermProgram: $0).first }
+        return plan
+    }
+
+    // MARK: - AppleScript
+
+    private static func osascript(_ source: String) -> [String] {
+        [TerminalCommand.osascriptPath, "-e", source]
+    }
+
+    /// Terminal.app tabs expose a read-only `tty`, which is the only per-tab
+    /// handle it offers. Raising the window needs both `selected tab` and
+    /// `index` — the first picks the tab, the second brings the window forward.
+    ///
+    /// Addressed by bundle id, not by name, throughout: `tell application "X"`
+    /// resolves the name at compile time and pops the "Where is X?" chooser
+    /// when it can't, while `tell application id "…"` is unambiguous.
+    private static func appleTerminalScript(tty: String) -> String {
+        """
+        tell application id "com.apple.Terminal"
+        \trepeat with w in windows
+        \t\trepeat with t in tabs of w
+        \t\t\tif tty of t is "\(tty)" then
+        \t\t\t\tset selected tab of w to t
+        \t\t\t\tset index of w to 1
+        \t\t\t\tactivate
+        \t\t\t\treturn "ok"
+        \t\t\tend if
+        \t\tend repeat
+        \tend repeat
+        end tell
+        error "vibebuddy: no matching Terminal tab"
+        """
+    }
+
+    /// iTerm2 nests window → tab → session and every level has its own `select`.
+    private static func itermScript(match property: String, value: String) -> String {
+        """
+        tell application id "com.googlecode.iterm2"
+        \trepeat with w in windows
+        \t\trepeat with t in tabs of w
+        \t\t\trepeat with s in sessions of t
+        \t\t\t\tif \(property) of s is "\(value)" then
+        \t\t\t\t\tselect w
+        \t\t\t\t\tselect t
+        \t\t\t\t\tselect s
+        \t\t\t\t\tactivate
+        \t\t\t\t\treturn "ok"
+        \t\t\t\tend if
+        \t\t\tend repeat
+        \t\tend repeat
+        \tend repeat
+        end tell
+        error "vibebuddy: no matching iTerm session"
+        """
+    }
+
+    /// Ghostty exposes `focus` on a terminal and a `whose` filter over them.
+    /// `activate` comes second so a miss (which raises an AppleScript error)
+    /// doesn't pull Ghostty forward on its way to failing.
+    private static func ghosttyScript(match property: String, value: String) -> String {
+        """
+        tell application id "com.mitchellh.ghostty"
+        \tfocus (first terminal whose \(property) is "\(value)")
+        \tactivate
+        end tell
+        """
+    }
+
+    // MARK: - Validation
+    //
+    // Every value below is interpolated into an AppleScript source string or an
+    // argv, and all of it originates in a hook running on the user's machine.
+    // Nothing reaches a script until it matches a closed allowlist, so a quote or
+    // newline smuggled into e.g. `$ITERM_SESSION_ID` cannot end the string
+    // literal and append statements.
+
+    private static let idCharacters = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789:_.-")
+    private static let socketCharacters = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789:/._-")
+
+    /// `%3` — a tmux pane id.
+    static func paneID(_ value: String?) -> String? {
+        guard let value, value.hasPrefix("%"), value.count > 1,
+              value.dropFirst().allSatisfy(\.isNumber) else { return nil }
+        return value
+    }
+
+    /// The socket path out of `$TMUX` (`socket,pid,session`). argv-only, so a
+    /// path is enough; it never reaches a shell — but it must be an absolute
+    /// path, which is the only shape tmux ever writes there, so a relative or
+    /// option-looking value (`-S`, `--x`) can't be smuggled into the argv.
+    static func tmuxSocket(_ tmux: String?) -> String? {
+        guard let socket = tmux?.split(separator: ",").first.map(String.init),
+              socket.hasPrefix("/") else { return nil }
+        return socket
+    }
+
+    static func digits(_ value: String?) -> String? {
+        guard let value, !value.isEmpty, value.allSatisfy(\.isNumber) else { return nil }
+        return value
+    }
+
+    /// An emulator-assigned identifier: iTerm2's `unique ID`, Ghostty's terminal id.
+    static func opaqueID(_ value: String?) -> String? {
+        guard let value, !value.isEmpty, value.allSatisfy(idCharacters.contains) else { return nil }
+        return value
+    }
+
+    /// `ttys003` (however it was captured) → `/dev/ttys003`, the form both
+    /// Terminal.app and iTerm2 report.
+    static func ttyDevice(_ value: String?) -> String? {
+        guard var name = value, !name.isEmpty else { return nil }
+        if name.hasPrefix("/dev/") { name = String(name.dropFirst(5)) }
+        guard name.hasPrefix("ttys"), name.count > 4,
+              name.dropFirst(4).allSatisfy(\.isNumber) else { return nil }
+        return "/dev/" + name
+    }
+
+    static func kittySocket(_ value: String?) -> String? {
+        guard let value, !value.isEmpty, value.allSatisfy(socketCharacters.contains) else { return nil }
+        return value
+    }
+
+    /// A path is the one value we can't allowlist by character — directory names
+    /// are arbitrary — so it is escaped instead, and rejected outright if it
+    /// carries a control character that could break out of the string literal.
+    static func scriptSafePath(_ value: String?) -> String? {
+        guard let value, !value.isEmpty, value.hasPrefix("/"),
+              !value.unicodeScalars.contains(where: { $0.value < 0x20 }) else { return nil }
+        return value.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    // MARK: - Execution
+
+    /// How long any single command gets. AppleScript to a live app answers in
+    /// milliseconds; the budget exists for the first-run Automation prompt, which
+    /// blocks `osascript` until the user answers it.
+    static let stepTimeout: TimeInterval = 3
+
+    /// The plan runs on a plain dispatch queue, never on the cooperative pool:
+    /// every step blocks on a `Process` for up to `stepTimeout`, and blocking a
+    /// pool thread starves every other task on it. `withCheckedContinuation`
+    /// bridges the two worlds, so the caller still just awaits.
+    public static func jump(_ ref: TerminalRef) async -> JumpOutcome {
+        let plan = plan(for: ref)
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: execute(plan))
+            }
+        }
+    }
+
+    /// Whether an app with this bundle id is running right now. Injected so the
+    /// gate can be tested without launching anything.
+    static func isRunning(_ bundleID: String) -> Bool {
+        !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty
+    }
+
+    static func execute(_ plan: JumpPlan,
+                        isRunning: (String) -> Bool = TerminalJumper.isRunning,
+                        activate: (String) -> Bool = TerminalJumper.activate) -> JumpOutcome {
+        var focused = false
+        // tmux commands are independent: a detached client makes `switch-client`
+        // fail while `select-window` still lands, so any success counts — but
+        // only from a step that actually moves the viewport.
+        for step in plan.tmux {
+            if run(step.argv), step.focuses { focused = true }
+        }
+        // Scripting a terminal launches it if it isn't running, so the whole
+        // surface tier is skipped unless the emulator is already up. Losing the
+        // exact target degrades the jump to `.activatedApp`, which is the right
+        // answer: there is no window of ours to raise.
+        if plan.requiredRunningBundleIDs.contains(where: isRunning) {
+            // Surface attempts are alternatives, ordered most specific first.
+            for attempt in plan.surface {
+                if attempt.commands.allSatisfy(run) {
+                    focused = true
+                    break
+                }
+            }
+        }
+        let activated = plan.activateBundleID.map(activate) ?? false
+        return JumpOutcome.decide(hasRef: true, focusedExactTarget: focused, activatedApp: activated)
+    }
+
+    /// Runs one command and reports whether it exited 0. Never throws, never
+    /// blocks longer than `stepTimeout`, and produces no output of its own.
+    ///
+    /// A timed-out step is killed, not merely asked to stop: `osascript` waiting
+    /// on the Automation consent dialog ignores `SIGTERM`, and an orphan of it
+    /// would hold that dialog open for the rest of the session.
+    private static func run(_ argv: [String]) -> Bool {
+        guard let executable = argv.first,
+              FileManager.default.isExecutableFile(atPath: executable) else { return false }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = Array(argv.dropFirst())
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+        do { try process.run() } catch { return false }
+        if finished.wait(timeout: .now() + stepTimeout) == .timedOut {
+            let pid = process.processIdentifier
+            process.terminate()
+            if finished.wait(timeout: .now() + 0.5) == .timedOut, pid > 0 {
+                kill(pid, SIGKILL)
+                _ = finished.wait(timeout: .now() + 0.5)
+            }
+            return false
+        }
+        return process.terminationStatus == 0
+    }
+
+    /// Brings an already-running app forward. Deliberately does *not* launch it:
+    /// a jump is a return to work in progress, and starting a fresh terminal
+    /// would be a different, unasked-for action. Injected into `execute` so a
+    /// test's verdict doesn't depend on which apps happen to be open.
+    static func activate(_ bundleID: String) -> Bool {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            .first?.activate(options: [.activateAllWindows]) ?? false
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -29,7 +29,7 @@ public struct VibeBuddyServer: Sendable {
     public let approvalContext: ApprovalContextStore
     public let approvalTimeout: Duration
     public let approvalID: @Sendable () -> String
-    public let onJump: @Sendable (TerminalRef) -> Void
+    public let onJump: @Sendable (TerminalRef) async -> JumpOutcome
     public let onAnswer: @Sendable (TerminalRef, String) -> Void
     public let onDevicePaired: @Sendable (DeviceRegistrationPayload) -> Void
 
@@ -45,7 +45,7 @@ public struct VibeBuddyServer: Sendable {
                 approvalContext: ApprovalContextStore = ApprovalContextStore(),
                 approvalTimeout: Duration = .seconds(25),
                 approvalID: @escaping @Sendable () -> String = { UUID().uuidString },
-                onJump: @escaping @Sendable (TerminalRef) -> Void = { TerminalJumper.jump($0) },
+                onJump: @escaping @Sendable (TerminalRef) async -> JumpOutcome = { await TerminalJumper.jump($0) },
                 onAnswer: @escaping @Sendable (TerminalRef, String) -> Void = { ref, answer in TerminalInjector.inject(answer, into: ref) },
                 onDevicePaired: @escaping @Sendable (DeviceRegistrationPayload) -> Void = { _ in }) {
         self.store = store
@@ -362,11 +362,22 @@ public struct VibeBuddyServer: Sendable {
         router.post("terminal") { request, _ -> HTTPResponse.Status in
             guard Self.hookAuthorized(request, token: token) else { throw HTTPError(.unauthorized) }
             let buffer = try await request.body.collect(upTo: 64 * 1024)
-            guard let o = try? JSONSerialization.jsonObject(with: Data(buffer: buffer)) as? [String: Any],
-                  let sid = o["session_id"] as? String, let tp = o["term_program"] as? String
+            let body = Data(buffer: buffer)
+            // `TerminalRef` is the wire shape, so the payload decodes straight
+            // into it; only the session id is envelope.
+            struct Envelope: Decodable {
+                let sessionID: String
+                enum CodingKeys: String, CodingKey { case sessionID = "session_id" }
+            }
+            guard let sid = (try? JSONDecoder().decode(Envelope.self, from: body))?.sessionID,
+                  !sid.isEmpty,
+                  let ref = try? JSONDecoder().decode(TerminalRef.self, from: body)
             else { return .ok }
-            func nz(_ k: String) -> String? { (o[k] as? String).flatMap { $0.isEmpty ? nil : $0 } }
-            let ref = TerminalRef(termProgram: tp, tty: nz("tty"), tmux: nz("tmux"), tmuxPane: nz("tmux_pane"))
+            // A ref with no exact target, no TERM_PROGRAM and no host bundle id
+            // names nothing the jumper could act on. Accept the POST (the hook
+            // must never see an error) but don't store it, so `/jump` answers
+            // the truthful `.noTerminal` rather than `.unsupported`.
+            guard ref.isActionable else { return .ok }
             await store.setTerminalRef(sessionID: sid, ref)
             return .ok
         }
@@ -378,12 +389,15 @@ public struct VibeBuddyServer: Sendable {
             // Jumping is an explicit return to the task, even if this terminal
             // type cannot ultimately be focused.
             await store.acknowledgeCompletion(sessionID: sid)
-            // Report what actually happened so the phone can give honest feedback:
-            // focused (ran), unsupported (known terminal type → no command), or none.
-            let ref = await store.terminalRef(for: sid)
-            let hasRunnable = ref.map { !TerminalJumper.commands(for: $0).isEmpty } ?? false
-            let outcome = JumpOutcome.decide(hasRef: ref != nil, hasRunnableCommand: hasRunnable)
-            if outcome == .focused, let ref { onJump(ref) }
+            // Report what actually happened so the phone can give honest feedback.
+            // The jumper answers after it has run, so `focused` means the exact
+            // pane/tab really came forward — not merely that a command existed.
+            let outcome: JumpOutcome
+            if let ref = await store.terminalRef(for: sid) {
+                outcome = await onJump(ref)
+            } else {
+                outcome = .noTerminal
+            }
             let data = try JSONEncoder().encode(["outcome": outcome.rawValue])
             return Response(status: .ok, headers: [.contentType: "application/json"],
                             body: .init(byteBuffer: ByteBuffer(bytes: data)))

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ForegroundTerminalTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ForegroundTerminalTests.swift
@@ -41,6 +41,18 @@ struct ForegroundTerminalTests {
                 frontmostBundleID: "com.mitchellh.ghostty") == ["a", "b"])
     }
 
+    @Test("a session in an embedded terminal is matched by its captured host bundle id")
+    func hostBundleID() {
+        let embedded = AgentSession(id: "a", agent: .claudeCode, project: "a", status: .done,
+                                    terminalRef: TerminalRef(hostBundleId: "com.anthropic.claude-code"),
+                                    statusSince: .init(timeIntervalSince1970: 0),
+                                    updatedAt: .init(timeIntervalSince1970: 0))
+        #expect(ForegroundTerminal.focusedSessionIDs(among: [embedded],
+                frontmostBundleID: "com.anthropic.claude-code") == ["a"])
+        #expect(ForegroundTerminal.focusedSessionIDs(among: [embedded],
+                frontmostBundleID: "com.mitchellh.ghostty").isEmpty)
+    }
+
     @Test("no frontmost / no terminalRef → empty")
     func nilCases() {
         #expect(ForegroundTerminal.focusedSessionIDs(among: [session("a", term: nil)],

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/JumpRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/JumpRoutesTests.swift
@@ -14,7 +14,7 @@ struct JumpRoutesTests {
         let box = Box()
         let store = SessionStore()
         let server = VibeBuddyServer(store: store, token: "t0k",
-                                     onJump: { box.jumped.append($0.tmuxPane ?? "") })
+                                     onJump: { box.jumped.append($0.tmuxPane ?? ""); return .focused })
         try await server.buildApplication().test(.router) { client in
             _ = try await client.execute(uri: "/hook", method: .post,
                 headers: [.authorization: "Bearer t0k"],
@@ -41,6 +41,108 @@ struct JumpRoutesTests {
         }
     }
 
+    @Test("/terminal decodes the full ref, empty strings included, as nil")
+    func storesRichRef() async throws {
+        let store = SessionStore()
+        let server = VibeBuddyServer(store: store, token: "t0k", onJump: { _ in .focused })
+        try await server.buildApplication().test(.router) { client in
+            _ = try await client.execute(uri: "/hook", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"hook_event_name":"SessionStart","session_id":"s","cwd":"/x/p"}"#)) { _ in }
+            _ = try await client.execute(uri: "/terminal", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: """
+                {"session_id":"s","term_program":"ghostty","tty":"ttys003","tmux":"",\
+                "iterm_session_id":"","wezterm_pane":"4","kitty_window_id":"9",\
+                "kitty_listen_on":"unix:/tmp/k","ghostty_terminal_id":"7",\
+                "host_bundle_id":"com.mitchellh.ghostty","host_pid":4242,"cwd":"/x/p"}
+                """)) { _ in }
+            let ref = try #require(await store.terminalRef(for: "s"))
+            #expect(ref.termProgram == "ghostty")
+            #expect(ref.tty == "ttys003")
+            #expect(ref.tmux == nil)
+            #expect(ref.itermSessionId == nil)
+            #expect(ref.weztermPane == "4")
+            #expect(ref.kittyWindowId == "9")
+            #expect(ref.kittyListenOn == "unix:/tmp/k")
+            #expect(ref.ghosttyTerminalId == "7")
+            #expect(ref.hostBundleId == "com.mitchellh.ghostty")
+            #expect(ref.hostPid == 4242)
+            #expect(ref.cwd == "/x/p")
+            #expect(ref.hasExactTarget)
+        }
+    }
+
+    @Test("/terminal accepts a session that reported no TERM_PROGRAM at all")
+    func storesHostOnlyRef() async throws {
+        let store = SessionStore()
+        try await VibeBuddyServer(store: store, token: "t0k", onJump: { _ in .activatedApp })
+            .buildApplication().test(.router) { client in
+            _ = try await client.execute(uri: "/hook", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"hook_event_name":"SessionStart","session_id":"s","cwd":"/x/p"}"#)) { _ in }
+            _ = try await client.execute(uri: "/terminal", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"session_id":"s","host_bundle_id":"com.anthropic.claude-code"}"#)) { _ in }
+            let ref = try #require(await store.terminalRef(for: "s"))
+            #expect(ref.termProgram == nil)
+            #expect(ref.hostBundleId == "com.anthropic.claude-code")
+            #expect(!ref.hasExactTarget)
+        }
+    }
+
+    /// A ref carrying only a `cwd` names nothing: several sessions share a
+    /// directory, and no emulator can be addressed by it alone. Storing it would
+    /// turn the honest "no terminal recorded" into "couldn't locate this
+    /// session's window", which reads like a bug in the jump.
+    @Test("/terminal accepts but ignores a ref with nothing actionable in it")
+    func ignoresUselessRef() async throws {
+        final class Box: @unchecked Sendable { var jumped = 0 }
+        let box = Box()
+        let store = SessionStore()
+        try await VibeBuddyServer(store: store, token: "t0k",
+                                  onJump: { _ in box.jumped += 1; return .unsupported })
+            .buildApplication().test(.router) { client in
+            _ = try await client.execute(uri: "/hook", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"hook_event_name":"SessionStart","session_id":"s","cwd":"/x/p"}"#)) { _ in }
+            try await client.execute(uri: "/terminal", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"session_id":"s","cwd":"/x/p","term_program":"","host_bundle_id":""}"#)) { res in
+                #expect(res.status == .ok)   // never an error: a hook must not fail its session
+            }
+            #expect(await store.terminalRef(for: "s") == nil)
+            try await client.execute(uri: "/jump", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"sessionId":"s"}"#)) { res in
+                #expect(self.outcome(res.body) == "noTerminal")
+            }
+        }
+        #expect(box.jumped == 0)
+    }
+
+    /// The re-capture on `UserPromptSubmit` skips the Ghostty probe, so the
+    /// route has to merge rather than replace — end to end, through the store.
+    @Test("a second /terminal POST merges into the first instead of replacing it")
+    func mergesSuccessiveRefs() async throws {
+        let store = SessionStore()
+        try await VibeBuddyServer(store: store, token: "t0k", onJump: { _ in .focused })
+            .buildApplication().test(.router) { client in
+            _ = try await client.execute(uri: "/hook", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"hook_event_name":"SessionStart","session_id":"s","cwd":"/x/p"}"#)) { _ in }
+            _ = try await client.execute(uri: "/terminal", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"session_id":"s","term_program":"ghostty","tty":"ttys003","ghostty_terminal_id":"7","cwd":"/x/p"}"#)) { _ in }
+            _ = try await client.execute(uri: "/terminal", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"session_id":"s","term_program":"ghostty","tty":"ttys011","ghostty_terminal_id":"","cwd":"/x/p"}"#)) { _ in }
+            let ref = try #require(await store.terminalRef(for: "s"))
+            #expect(ref.ghosttyTerminalId == "7")
+            #expect(ref.tty == "ttys011")
+        }
+    }
+
     @Test("/jump without a token is 401")
     func jumpUnauthorized() async throws {
         try await VibeBuddyServer(store: SessionStore(), token: "t0k").buildApplication().test(.router) { client in
@@ -53,10 +155,13 @@ struct JumpRoutesTests {
         (try? JSONDecoder().decode([String: String].self, from: Data(buffer: body)))?["outcome"]
     }
 
-    @Test("a supported terminal reports outcome=focused")
-    func reportsFocused() async throws {
+    /// The route reports whatever the jumper achieved — it no longer guesses from
+    /// the ref, so every outcome the jumper can return has to survive the wire.
+    @Test("the jumper's own verdict is what the phone reads back",
+          arguments: [JumpOutcome.focused, .activatedApp, .unsupported])
+    func reportsJumperOutcome(_ expected: JumpOutcome) async throws {
         let store = SessionStore()
-        let server = VibeBuddyServer(store: store, token: "t0k", onJump: { _ in })
+        let server = VibeBuddyServer(store: store, token: "t0k", onJump: { _ in expected })
         try await server.buildApplication().test(.router) { client in
             _ = try await client.execute(uri: "/hook", method: .post,
                 headers: [.authorization: "Bearer t0k"],
@@ -68,41 +173,24 @@ struct JumpRoutesTests {
                 headers: [.authorization: "Bearer t0k"],
                 body: ByteBuffer(string: #"{"sessionId":"s"}"#)) { res in
                 #expect(res.status == .ok)
-                #expect(self.outcome(res.body) == "focused")
+                #expect(self.outcome(res.body) == expected.rawValue)
             }
         }
     }
 
-    @Test("an unknown terminal reports outcome=unsupported and does not jump")
-    func reportsUnsupported() async throws {
+    @Test("a session with no terminal ref reports noTerminal and never runs the jumper")
+    func reportsNoTerminal() async throws {
         final class Box: @unchecked Sendable { var jumped = 0 }
         let box = Box()
-        let store = SessionStore()
-        let server = VibeBuddyServer(store: store, token: "t0k", onJump: { _ in box.jumped += 1 })
-        try await server.buildApplication().test(.router) { client in
-            _ = try await client.execute(uri: "/hook", method: .post,
-                headers: [.authorization: "Bearer t0k"],
-                body: ByteBuffer(string: #"{"hook_event_name":"SessionStart","session_id":"s","cwd":"/x/p"}"#)) { _ in }
-            _ = try await client.execute(uri: "/terminal", method: .post,
-                headers: [.authorization: "Bearer t0k"],
-                body: ByteBuffer(string: #"{"session_id":"s","term_program":"mystery"}"#)) { _ in }
-            try await client.execute(uri: "/jump", method: .post,
-                headers: [.authorization: "Bearer t0k"],
-                body: ByteBuffer(string: #"{"sessionId":"s"}"#)) { res in
-                #expect(self.outcome(res.body) == "unsupported")
-            }
-            #expect(box.jumped == 0)
-        }
-    }
-
-    @Test("a session with no terminal ref reports outcome=noTerminal")
-    func reportsNoTerminal() async throws {
-        try await VibeBuddyServer(store: SessionStore(), token: "t0k", onJump: { _ in }).buildApplication().test(.router) { client in
+        try await VibeBuddyServer(store: SessionStore(), token: "t0k",
+                                  onJump: { _ in box.jumped += 1; return .focused })
+            .buildApplication().test(.router) { client in
             try await client.execute(uri: "/jump", method: .post,
                 headers: [.authorization: "Bearer t0k"],
                 body: ByteBuffer(string: #"{"sessionId":"ghost"}"#)) { res in
                 #expect(self.outcome(res.body) == "noTerminal")
             }
         }
+        #expect(box.jumped == 0)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -416,6 +416,35 @@ struct SessionReducerTests {
         #expect(r.sessions["s1"]?.status == .done)
     }
 
+    /// The UserPromptSubmit re-capture deliberately skips the Ghostty
+    /// AppleScript probe, so it reports strictly less than the SessionStart one.
+    /// Replacing the ref wholesale would silently downgrade a jump from the
+    /// exact surface to the whole app on the session's second prompt.
+    @Test("a later capture that couldn't probe Ghostty doesn't erase the terminal id")
+    func terminalRefMergesRatherThanReplaces() {
+        var r = SessionReducer()
+        r.apply(ev(.sessionStart))
+        r.setTerminalRef(sessionID: "s1", TerminalRef(termProgram: "ghostty", tty: "ttys003",
+                                                      ghosttyTerminalId: "42", cwd: "/x/p"))
+        r.setTerminalRef(sessionID: "s1", TerminalRef(termProgram: "ghostty", tty: "ttys009", cwd: "/x/p"))
+        let ref = r.sessions["s1"]?.terminalRef
+        #expect(ref?.ghosttyTerminalId == "42")   // kept — the re-capture never looked
+        #expect(ref?.tty == "ttys009")            // updated — the re-capture did look
+        #expect(ref?.termProgram == "ghostty")
+    }
+
+    @Test("a re-capture can also add a field the first one missed")
+    func terminalRefAddsNewFields() {
+        var r = SessionReducer()
+        r.apply(ev(.sessionStart))
+        r.setTerminalRef(sessionID: "s1", TerminalRef(termProgram: "ghostty", tty: "ttys003"))
+        r.setTerminalRef(sessionID: "s1", TerminalRef(tmux: "/tmp/x,1,0", tmuxPane: "%7"))
+        let ref = r.sessions["s1"]?.terminalRef
+        #expect(ref?.tmuxPane == "%7")
+        #expect(ref?.termProgram == "ghostty")
+        #expect(ref?.tty == "ttys003")
+    }
+
     // MARK: - Context usage enrichment
 
     @Test("enrich carries contextTokens and a model-derived contextWindow")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TerminalJumperTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TerminalJumperTests.swift
@@ -2,35 +2,289 @@ import Testing
 import VibeBuddyKit
 @testable import VibeBuddyMacCore
 
-@Suite("TerminalJumper.commands")
+/// The planner is the whole of the jump's decision-making, and it is pure — these
+/// tests cover which commands *would* run without launching anything.
+@Suite("TerminalJumper.plan")
 struct TerminalJumperTests {
-    @Test("tmux ref → switch/select tmux argv (socket parsed) + open the app")
-    func tmux() {
-        let ref = TerminalRef(termProgram: "ghostty", tty: "ttys003", tmux: "/tmp/tmux-501/default,1234,0", tmuxPane: "%3")
-        let c = TerminalJumper.commands(for: ref)
-        let tmux = TerminalCommand.tmuxPath()
-        #expect(c.contains([tmux, "-S", "/tmp/tmux-501/default", "select-pane", "-t", "%3"]))
-        #expect(c.contains([tmux, "-S", "/tmp/tmux-501/default", "switch-client", "-t", "%3"]))
-        #expect(c.last == ["/usr/bin/open", "-a", "Ghostty"])
+
+    // Fixed tool paths so a plan doesn't depend on what happens to be installed.
+    private static let tmux = "/opt/homebrew/bin/tmux"
+    private static let wezterm = "/opt/homebrew/bin/wezterm"
+    private static let kitten = "/opt/homebrew/bin/kitten"
+
+    private func plan(_ ref: TerminalRef,
+                      wezterm: String? = TerminalJumperTests.wezterm,
+                      kitten: String? = TerminalJumperTests.kitten) -> JumpPlan {
+        TerminalJumper.plan(for: ref, tmuxPath: Self.tmux, weztermPath: wezterm, kittenPath: kitten)
     }
-    @Test("no tmux → just activate the app")
-    func noTmux() {
-        #expect(TerminalJumper.commands(for: TerminalRef(termProgram: "iTerm.app")) == [["/usr/bin/open", "-a", "iTerm"]])
+
+    /// The AppleScript source of the nth surface attempt.
+    private func script(_ plan: JumpPlan, _ index: Int) -> String {
+        let argv = plan.surface[index].commands[0]
+        #expect(argv[0] == "/usr/bin/osascript")
+        #expect(argv[1] == "-e")
+        return argv[2]
     }
-    @Test("unknown term program → no commands")
-    func unknown() {
-        #expect(TerminalJumper.commands(for: TerminalRef(termProgram: "mystery")).isEmpty)
+
+    // MARK: tmux
+
+    @Test("a tmux pane is selected, unzoomed only when zoomed, and its terminal raised")
+    func tmuxPane() {
+        let p = plan(TerminalRef(termProgram: "ghostty", tmux: "/tmp/tmux-501/default,1234,0", tmuxPane: "%3"))
+        #expect(p.tmux == [
+            TmuxStep(argv: [Self.tmux, "-S", "/tmp/tmux-501/default", "switch-client", "-t", "%3"], focuses: true),
+            TmuxStep(argv: [Self.tmux, "-S", "/tmp/tmux-501/default", "select-window", "-t", "%3"], focuses: true),
+            TmuxStep(argv: [Self.tmux, "-S", "/tmp/tmux-501/default", "if-shell", "-F", "-t", "%3",
+                            "#{window_zoomed_flag}", "resize-pane -Z -t %3"], focuses: false),
+            TmuxStep(argv: [Self.tmux, "-S", "/tmp/tmux-501/default", "select-pane", "-t", "%3"], focuses: false),
+        ])
+        // The outer terminal is still brought forward: selecting a pane in a
+        // background window is not a jump.
+        #expect(p.activateBundleID == "com.mitchellh.ghostty")
     }
-    @Test("Warp (TERM_PROGRAM=WarpTerminal) → activate Warp")
-    func warp() {
-        #expect(TerminalJumper.commands(for: TerminalRef(termProgram: "WarpTerminal")) == [["/usr/bin/open", "-a", "Warp"]])
+
+    @Test("a pane id that isn't %N is refused")
+    func tmuxPaneRejected() {
+        #expect(plan(TerminalRef(tmux: "/tmp/x,1,0", tmuxPane: "3")).tmux.isEmpty)
+        #expect(plan(TerminalRef(tmux: "/tmp/x,1,0", tmuxPane: "%3; rm -rf /")).tmux.isEmpty)
+        #expect(plan(TerminalRef(tmux: "", tmuxPane: "%3")).tmux.isEmpty)
     }
-    @Test("WezTerm → activate WezTerm")
+
+    @Test("a $TMUX socket that isn't an absolute path is refused")
+    func tmuxSocketRejected() {
+        for bad in ["default,1,0", "-S,1,0", "--socket,1,0", ",1,0"] {
+            #expect(plan(TerminalRef(tmux: bad, tmuxPane: "%3")).tmux.isEmpty, "accepted \(bad)")
+        }
+        #expect(TerminalJumper.tmuxSocket("/tmp/tmux-501/default,1,0") == "/tmp/tmux-501/default")
+    }
+
+    /// `select-pane` succeeds just as happily against a buried window, so it is
+    /// not on its own evidence that the user was taken anywhere.
+    @Test("only the steps that move the viewport are marked as focusing")
+    func tmuxFocusingSteps() {
+        let p = plan(TerminalRef(tmux: "/tmp/x,1,0", tmuxPane: "%3"))
+        #expect(p.tmux.filter(\.focuses).map { $0.argv[3] } == ["switch-client", "select-window"])
+        #expect(p.tmux.filter { !$0.focuses }.map { $0.argv[3] } == ["if-shell", "select-pane"])
+    }
+
+    // MARK: Terminal.app
+
+    @Test("Apple Terminal is targeted by the tab's tty")
+    func appleTerminal() {
+        let p = plan(TerminalRef(termProgram: "Apple_Terminal", tty: "ttys003"))
+        #expect(p.surface.count == 1)
+        let s = script(p, 0)
+        #expect(s.contains(#"tell application id "com.apple.Terminal""#))
+        #expect(s.contains(#"if tty of t is "/dev/ttys003""#))
+        #expect(p.activateBundleID == "com.apple.Terminal")
+    }
+
+    @Test("a tty already carrying /dev/ is accepted once, not twice")
+    func ttyNormalized() {
+        #expect(script(plan(TerminalRef(termProgram: "Apple_Terminal", tty: "/dev/ttys012")), 0)
+            .contains(#""/dev/ttys012""#))
+    }
+
+    @Test("a tty that isn't ttysN never reaches AppleScript")
+    func ttyRejected() {
+        for bad in ["??", "console", "ttys003\" then activate", "ttys", "ttysX"] {
+            #expect(plan(TerminalRef(termProgram: "Apple_Terminal", tty: bad)).surface.isEmpty,
+                    "accepted \(bad)")
+        }
+    }
+
+    // MARK: iTerm2
+
+    @Test("iTerm2 tries the session's unique ID first, then its tty")
+    func iterm() {
+        let p = plan(TerminalRef(termProgram: "iTerm.app", tty: "ttys009",
+                                 itermSessionId: "9C1E2E1E-0F3A-4B6D-9A11-2B7C4D5E6F70"))
+        #expect(p.surface.count == 2)
+        #expect(script(p, 0).contains(#"if unique ID of s is "9C1E2E1E-0F3A-4B6D-9A11-2B7C4D5E6F70""#))
+        #expect(script(p, 1).contains(#"if tty of s is "/dev/ttys009""#))
+        #expect(p.activateBundleID == "com.googlecode.iterm2")
+    }
+
+    @Test("an id carrying a quote or a newline is dropped, never escaped into the script")
+    func idSanitized() {
+        for bad in [#"abc" then do shell script "id"#, "abc\ndo shell script \"id\"", "abc def", "abc'x"] {
+            let p = plan(TerminalRef(termProgram: "iTerm.app", itermSessionId: bad))
+            #expect(p.surface.isEmpty, "accepted \(bad)")
+        }
+    }
+
+    // MARK: Ghostty
+
+    @Test("Ghostty tries its terminal id first and falls back to the working directory")
+    func ghostty() {
+        let p = plan(TerminalRef(termProgram: "ghostty", ghosttyTerminalId: "42", cwd: "/Users/x/p"))
+        #expect(p.surface.count == 2)
+        #expect(script(p, 0).contains(#"first terminal whose id is "42""#))
+        #expect(script(p, 1).contains(#"first terminal whose working directory is "/Users/x/p""#))
+    }
+
+    @Test("without a terminal id the working directory is the only Ghostty target")
+    func ghosttyCWDOnly() {
+        let p = plan(TerminalRef(termProgram: "ghostty", cwd: "/Users/x/p"))
+        #expect(p.surface.count == 1)
+        #expect(script(p, 0).contains(#"working directory is "/Users/x/p""#))
+    }
+
+    @Test("a backslash in a path is doubled, so it can't escape the AppleScript literal")
+    func ghosttyBackslashDoubled() {
+        #expect(script(plan(TerminalRef(termProgram: "ghostty", cwd: #"/Users/x/a\b"#)), 0)
+            .contains(#"working directory is "/Users/x/a\\b""#))
+        // A trailing backslash is the dangerous one: undoubled it would escape
+        // the closing quote and let the rest of the path become AppleScript.
+        #expect(script(plan(TerminalRef(termProgram: "ghostty", cwd: #"/Users/x/a\"#)), 0)
+            .contains(#"working directory is "/Users/x/a\\""#))
+    }
+
+    @Test("a quote in a path is escaped; a control character rejects it outright")
+    func ghosttyPathSafety() {
+        #expect(script(plan(TerminalRef(termProgram: "ghostty", cwd: #"/Users/x/a"b"#)), 0)
+            .contains(#"working directory is "/Users/x/a\"b""#))
+        #expect(plan(TerminalRef(termProgram: "ghostty", cwd: "/Users/x\nactivate")).surface.isEmpty)
+        #expect(plan(TerminalRef(termProgram: "ghostty", cwd: "relative/path")).surface.isEmpty)
+    }
+
+    // MARK: WezTerm / kitty
+
+    @Test("WezTerm activates the pane and its tab as one attempt")
     func wezterm() {
-        #expect(TerminalJumper.commands(for: TerminalRef(termProgram: "WezTerm")) == [["/usr/bin/open", "-a", "WezTerm"]])
+        let p = plan(TerminalRef(termProgram: "WezTerm", weztermPane: "7"))
+        #expect(p.surface == [JumpAttempt([
+            [Self.wezterm, "cli", "activate-pane", "--pane-id", "7"],
+            [Self.wezterm, "cli", "activate-tab", "--pane-id", "7"],
+        ])])
+        #expect(p.activateBundleID == "com.github.wez.wezterm")
     }
-    @Test("kitty (synthesized term program) → activate kitty")
+
+    @Test("no wezterm binary installed → nothing below app level is planned")
+    func weztermMissing() {
+        let p = plan(TerminalRef(termProgram: "WezTerm", weztermPane: "7"), wezterm: nil)
+        #expect(p.surface.isEmpty)
+        #expect(p.activateBundleID == "com.github.wez.wezterm")
+    }
+
+    @Test("kitty is focused over its remote-control socket")
     func kitty() {
-        #expect(TerminalJumper.commands(for: TerminalRef(termProgram: "kitty")) == [["/usr/bin/open", "-a", "kitty"]])
+        let p = plan(TerminalRef(termProgram: "kitty", kittyWindowId: "3",
+                                 kittyListenOn: "unix:/tmp/kitty-501"))
+        #expect(p.surface == [JumpAttempt(
+            [Self.kitten, "@", "--to", "unix:/tmp/kitty-501", "focus-window", "--match", "id:3"])])
+        #expect(p.activateBundleID == "net.kovidgoyal.kitty")
+    }
+
+    @Test("kitty without a listen socket cannot be addressed, so it stops at the app")
+    func kittyNoSocket() {
+        let p = plan(TerminalRef(termProgram: "kitty", kittyWindowId: "3"))
+        #expect(p.surface.isEmpty)
+        #expect(p.activateBundleID == "net.kovidgoyal.kitty")
+    }
+
+    // MARK: app-level fallback
+
+    @Test("an unknown TERM_PROGRAM still jumps to the host app that was captured")
+    func unknownTermProgramWithHost() {
+        let p = plan(TerminalRef(termProgram: "mystery", hostBundleId: "com.anthropic.claude-code"))
+        #expect(p.surface.isEmpty)
+        #expect(p.activateBundleID == "com.anthropic.claude-code")
+    }
+
+    @Test("no TERM_PROGRAM at all — an embedded terminal — is carried by the host bundle id")
+    func embeddedTerminal() {
+        let p = plan(TerminalRef(hostBundleId: "com.anthropic.claudefordesktop", hostPid: 4242))
+        #expect(p.activateBundleID == "com.anthropic.claudefordesktop")
+    }
+
+    @Test("the captured host wins over the TERM_PROGRAM table, which can't tell Cursor from VS Code")
+    func cursorVersusVSCode() {
+        #expect(plan(TerminalRef(termProgram: "vscode",
+                                 hostBundleId: "com.todesktop.230313mzl4w4u92")).activateBundleID
+                == "com.todesktop.230313mzl4w4u92")
+        #expect(plan(TerminalRef(termProgram: "vscode")).activateBundleID == "com.microsoft.VSCode")
+    }
+
+    @Test("the host bundle id also names the terminal family when TERM_PROGRAM is missing")
+    func familyFromHostBundle() {
+        let p = plan(TerminalRef(tty: "ttys004", hostBundleId: "com.apple.Terminal"))
+        #expect(p.surface.count == 1)
+        #expect(script(p, 0).contains(#""/dev/ttys004""#))
+    }
+
+    @Test("a session we know nothing about plans nothing at all")
+    func empty() {
+        #expect(plan(TerminalRef()).isEmpty)
+        #expect(plan(TerminalRef(termProgram: "mystery")).isEmpty)
+    }
+
+    // MARK: the no-launch gate
+
+    /// `tell application id "…"` launches the app when it isn't running, so
+    /// every plan that scripts one has to say which app must already be up.
+    @Test("every family that plans a surface attempt names the app that must be running",
+          arguments: [
+            (TerminalRef(termProgram: "Apple_Terminal", tty: "ttys003"), ["com.apple.Terminal"]),
+            (TerminalRef(termProgram: "iTerm.app", tty: "ttys003"), ["com.googlecode.iterm2"]),
+            (TerminalRef(termProgram: "ghostty", ghosttyTerminalId: "42"), ["com.mitchellh.ghostty"]),
+            (TerminalRef(termProgram: "WezTerm", weztermPane: "7"), ["com.github.wez.wezterm"]),
+            (TerminalRef(termProgram: "kitty", kittyWindowId: "3", kittyListenOn: "unix:/tmp/k"),
+             ["net.kovidgoyal.kitty"]),
+          ])
+    func requiredRunningBundleIDs(_ ref: TerminalRef, _ expected: [String]) {
+        let p = plan(ref)
+        #expect(!p.surface.isEmpty)
+        #expect(p.requiredRunningBundleIDs == expected)
+    }
+
+    @Test("a plan with nothing below app level requires nothing to be running")
+    func noSurfaceNoRequirement() {
+        #expect(plan(TerminalRef(termProgram: "vscode")).requiredRunningBundleIDs.isEmpty)
+        #expect(plan(TerminalRef(tmux: "/tmp/x,1,0", tmuxPane: "%3")).requiredRunningBundleIDs.isEmpty)
+    }
+
+    /// `/usr/bin/true` stands in for a surface attempt that would certainly
+    /// succeed, so a `.unsupported` verdict can only mean it was never run.
+    @Test("the surface tier is skipped entirely when the emulator isn't running")
+    func surfaceGatedOnRunningApp() {
+        var p = JumpPlan()
+        p.surface = [JumpAttempt(["/usr/bin/true"])]
+        p.requiredRunningBundleIDs = ["com.example.terminal"]
+        #expect(TerminalJumper.execute(p, isRunning: { _ in false }, activate: { _ in false })
+                == .unsupported)
+        #expect(TerminalJumper.execute(p, isRunning: { _ in true }, activate: { _ in false })
+                == .focused)
+    }
+
+    /// A jump that can't reach the surface is still allowed to raise the app —
+    /// it just has to say so, which is what `.activatedApp` means.
+    @Test("a gated surface degrades the jump to the app, it doesn't abort it")
+    func gatedSurfaceStillActivates() {
+        var p = JumpPlan()
+        p.surface = [JumpAttempt(["/usr/bin/true"])]
+        p.requiredRunningBundleIDs = ["com.example.terminal"]
+        p.activateBundleID = "com.example.terminal"
+        #expect(TerminalJumper.execute(p, isRunning: { _ in false }, activate: { _ in true })
+                == .activatedApp)
+    }
+
+    // MARK: outcome wiring
+
+    @Test("a tmux step that only rearranges an off-screen window is not a focus")
+    func tmuxNonFocusingStepIsNotAJump() {
+        var p = JumpPlan()
+        p.tmux = [TmuxStep(argv: ["/usr/bin/true"], focuses: false)]
+        #expect(TerminalJumper.execute(p, isRunning: { _ in true }, activate: { _ in false })
+                == .unsupported)
+        p.tmux.append(TmuxStep(argv: ["/usr/bin/true"], focuses: true))
+        #expect(TerminalJumper.execute(p, isRunning: { _ in true }, activate: { _ in false })
+                == .focused)
+    }
+
+    @Test("an empty plan can only report unsupported")
+    func emptyPlanOutcome() {
+        #expect(TerminalJumper.execute(JumpPlan(), isRunning: { _ in true }, activate: { _ in false })
+                == .unsupported)
     }
 }

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -78,10 +78,11 @@ struct DashboardView: View {
                 Button("") { statusFilter = nil }.keyboardShortcut("0", modifiers: .command)
                 // ⌘F focuses the sessions search field.
                 Button("") { searchFocused = true }.keyboardShortcut("f", modifiers: .command)
-                // ⏎ jumps to the selected session's terminal (no-op without a
-                // terminalRef; ignored while typing in search so it doesn't shadow
-                // the field's own Return).
-                Button("") { if !searchFocused, let s = selectedSession, s.terminalRef != nil { model.jump(s) } }
+                // ⏎ jumps to the selected session's terminal. Sessions without a
+                // terminalRef are not excluded — they answer with "No terminal
+                // recorded" in the detail pane. Ignored while typing in search so
+                // it doesn't shadow the field's own Return.
+                Button("") { if !searchFocused, let s = selectedSession { model.jump(s) } }
                     .keyboardShortcut(.return, modifiers: [])
             }
             .opacity(0)
@@ -374,7 +375,6 @@ private struct DetailView: View {
                         Button("Deny") { model.decide(approval.id, .deny) }
                             .keyboardShortcut("d", modifiers: []).tint(.red)
                         Button("Jump to terminal") { model.jump(session) }
-                            .disabled(session.terminalRef == nil)
                     }
                     .buttonStyle(.borderedProminent)
                     HStack(spacing: 10) {
@@ -386,7 +386,15 @@ private struct DetailView: View {
                 } else {
                     if let s = session.summary { Text(s).foregroundStyle(.secondary) }
                     Button("Jump to terminal") { model.jump(session) }
-                        .disabled(session.terminalRef == nil)
+                }
+                // What the last jump actually achieved — focused the pane, only
+                // raised the app, or found nothing to raise. Same wording as the
+                // glance rows.
+                if let outcome = model.jumpFeedback[session.id] {
+                    Label(outcome.macMessage(for: session.terminalRef), systemImage: "arrow.uturn.forward")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .contentTransition(.opacity)
                 }
                 // Peek at what the agent has been doing without leaving the app.
                 Button { showTranscript = true } label: {
@@ -398,6 +406,7 @@ private struct DetailView: View {
             }
             .padding(20)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .animation(.smooth(duration: 0.18), value: model.jumpFeedback)
         }
         .sheet(isPresented: $showTranscript) {
             TranscriptSheet(session: session, model: model)

--- a/VibeBuddyMacApp/Sources/GlanceView.swift
+++ b/VibeBuddyMacApp/Sources/GlanceView.swift
@@ -11,13 +11,14 @@ struct GlanceView: View {
     private var expanded: Bool { model.glanceExpanded }
     private var groups: SessionGroups { SessionGroups(model.sessions) }
     private var pending: AgentSession? { model.sessions.first { $0.pendingApproval != nil } }
-    private var width: CGFloat { (expanded ? 440 : 300) * s }
+
+    /// The collapsed pill lives next to the menu bar, so the cat is drawn at a
+    /// menu-bar-ish height (60 * 0.4 = 24pt). Expanded it grows, but stays a
+    /// header mark rather than the full 60pt card sprite.
+    private var petScale: CGFloat { s * (expanded ? 0.65 : 0.4) }
 
     var body: some View {
-        content
-            .frame(maxWidth: .infinity, alignment: expanded ? .leading : .center)
-            .padding(.horizontal, 20 * s).padding(.vertical, (expanded ? 16 : 9) * s)
-            .frame(width: width, alignment: expanded ? .leading : .center)
+        shell
             .background(background)
             .clipShape(clipShape)
             .overlay {
@@ -35,11 +36,30 @@ struct GlanceView: View {
             }
     }
 
+    /// Expanded is a fixed-width card (the session rows need a stable column);
+    /// collapsed **hugs its content** — a hard-coded width is what used to
+    /// squeeze a two-digit count into a two-line "1 / 0".
+    @ViewBuilder private var shell: some View {
+        if expanded {
+            content
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20 * s)
+                .padding(.vertical, 16 * s)
+                .frame(width: 440 * s, alignment: .leading)
+        } else {
+            content
+                .padding(.horizontal, 13 * s)
+                .padding(.vertical, 5 * s)
+                .fixedSize()
+        }
+    }
+
     @ViewBuilder private var content: some View {
         if expanded {
             VStack(alignment: .leading, spacing: 8 * s) {
                 HStack(spacing: 8 * s) {
                     counts
+                    Spacer(minLength: 8 * s)
                     Button {
                         model.setShowGlance(false)   // get out of the way; the shortcut or menu brings it back
                     } label: {
@@ -65,57 +85,35 @@ struct GlanceView: View {
                         Button("Always") { model.decide(a.id, .alwaysAllow) }
                             .tint(.white).buttonStyle(.bordered).controlSize(.regular)
                             .help("Always allow this exact command in future")
-                        if p.terminalRef != nil {
-                            Button { model.jump(p) } label: {
-                                Label("Jump", systemImage: "terminal")
-                            }
-                            .tint(.white).buttonStyle(.bordered).controlSize(.regular)
-                            .help("Jump to terminal")
+                        Button { model.jump(p) } label: {
+                            Label("Jump", systemImage: "terminal")
                         }
+                        .tint(.white).buttonStyle(.bordered).controlSize(.regular)
+                        .help("Jump to terminal")
+                    }
+                    if let outcome = model.jumpFeedback[p.id] {
+                        Text(outcome.macMessage(for: p.terminalRef))
+                            .font(.system(size: 10 * s, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.68))
                     }
                 } else {
                     ForEach(model.sessions.prefix(6)) { sess in
-                        let canJump = sess.terminalRef != nil
-                        Button { model.jump(sess) } label: {
-                            HStack(spacing: 8 * s) {
-                                TaskStatusIndicator(sess.presentationState, size: 8 * s)
-                                VStack(alignment: .leading, spacing: 1 * s) {
-                                    HStack(spacing: 5 * s) {
-                                        Text(sess.project).font(.system(size: 13 * s, weight: .semibold))
-                                        Text(sess.agent.displayName)
-                                            .font(.system(size: 9 * s, weight: .semibold))
-                                            .padding(.horizontal, 5 * s).padding(.vertical, 1 * s)
-                                            .background(.white.opacity(0.14), in: Capsule())
-                                    }
-                                    Text(ToolActivity.label(for: sess))
-                                        .font(.system(size: 10 * s, weight: .medium))
-                                        .foregroundStyle(.white.opacity(0.62))
-                                }
-                                .foregroundStyle(.white).lineLimit(1)
-                                if canJump {
-                                    Spacer(minLength: 0)
-                                    Image(systemName: "terminal")      // click the row to focus its terminal
-                                        .font(.system(size: 11 * s))
-                                        .foregroundStyle(.white.opacity(0.5))
-                                }
-                            }
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(!canJump)
-                        .help(canJump ? "Jump to terminal" : "")
+                        GlanceSessionRow(session: sess,
+                                         feedback: model.jumpFeedback[sess.id],
+                                         scale: s) { model.jump(sess) }
                     }
                 }
             }
+            .animation(.smooth(duration: 0.18), value: model.jumpFeedback)
         } else {
             counts
         }
     }
 
     private var counts: some View {
-        HStack(spacing: 16 * s) {
+        HStack(spacing: (expanded ? 14 : 10) * s) {
             PetFace(state: BuddyState.from(groups, now: Date()),
-                    speaking: voice.isSpeaking, listening: voice.isListening, bare: true, scale: s)
+                    speaking: voice.isSpeaking, listening: voice.isListening, bare: true, scale: petScale)
                 .onTapGesture { voice.toggle() }   // tap the buddy to talk
             if voice.isActive { voiceBadge } else {
                 ForEach([TaskPresentationState.error, .requiresInput, .thinking, .completeUnread, .idle], id: \.self) { state in
@@ -125,36 +123,45 @@ struct GlanceView: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, alignment: .center)
+        .fixedSize()
     }
 
     /// When the realtime voice is live, the counts give way to a clear status
     /// badge so it's obvious from the notch that the buddy is listening/talking.
     private var voiceBadge: some View {
         let speaking = voice.isSpeaking
-        return HStack(spacing: 8 * s) {
+        return HStack(spacing: 6 * s) {
             Image(systemName: speaking ? "waveform" : "mic.fill")
-                .font(.system(size: 15 * s, weight: .semibold))
+                .font(.system(size: 13 * s, weight: .semibold))
                 .foregroundStyle(speaking ? Color.green : Color.red)
                 .symbolEffect(.variableColor.iterative, options: .repeating, isActive: true)
             Text(speaking ? "Speaking" as LocalizedStringKey : "Listening")
-                .font(.system(size: 15 * s, weight: .semibold))
+                .font(.system(size: 13 * s, weight: .semibold))
                 .foregroundStyle(.white)
+                .lineLimit(1)
             if let p = voice.activeProvider {
                 Text(p.rawValue)
-                    .font(.system(size: 11 * s, weight: .medium))
+                    .font(.system(size: 10 * s, weight: .medium))
                     .foregroundStyle(.white.opacity(0.6))
+                    .lineLimit(1)
             }
         }
+        .fixedSize()
     }
 
+    /// One glyph + one number per status. The tinted SF Symbol *is* the
+    /// non-color differentiator (what `TaskStatusIndicator` only showed under
+    /// Differentiate Without Color), so the separate dot was pure width.
     private func countPill(_ n: Int, _ state: TaskPresentationState) -> some View {
-        HStack(spacing: 4 * s) {
-            TaskStatusIndicator(state, size: 9 * s)
+        HStack(spacing: 3 * s) {
             Image(systemName: state.symbolName)
-                .font(.system(size: 8 * s, weight: .bold))
+                .font(.system(size: 9 * s, weight: .bold))
                 .foregroundStyle(Color(taskStatus: state.colorToken))
-            Text("\(n)").font(.system(size: 17 * s, weight: .semibold).monospacedDigit()).foregroundStyle(.white)
+            Text("\(n)")
+                .font(.system(size: 13 * s, weight: .semibold).monospacedDigit())
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)   // never wrap "10" into "1"/"0"
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(n) \(state.label)")
@@ -174,5 +181,97 @@ struct GlanceView: View {
 
     private var clipShape: AnyShape {
         panelShape
+    }
+}
+
+/// One session in the expanded glance. Always clickable: the row *is* the jump
+/// control, and every session has an honest answer to a click — the ones with no
+/// recorded terminal say so instead of ignoring the press.
+private struct GlanceSessionRow: View {
+    let session: AgentSession
+    let feedback: JumpOutcome?
+    let scale: CGFloat
+    let jump: () -> Void
+
+    @State private var hovering = false
+
+    private var s: CGFloat { scale }
+
+    /// How precisely this row's click can land, told at a glance:
+    /// `terminal` = its own pane/tab, `macwindow` = only the app around it,
+    /// nothing = no terminal was ever recorded. Quiet on purpose — the status
+    /// dot owns the row's colour.
+    private var targetSymbol: String? {
+        guard let ref = session.terminalRef else { return nil }
+        if ref.hasExactTarget { return "terminal" }
+        return (ref.hostBundleId ?? ref.termProgram) != nil ? "macwindow" : nil
+    }
+
+    private var subtitle: String {
+        feedback?.macMessage(for: session.terminalRef) ?? ToolActivity.label(for: session)
+    }
+
+    private var helpText: String {
+        switch targetSymbol {
+        case "terminal": return "Jump to this session's terminal"
+        case "macwindow": return "Bring this session's app to the front"
+        default: return "No terminal recorded for this session"
+        }
+    }
+
+    var body: some View {
+        Button(action: jump) {
+            HStack(spacing: 8 * s) {
+                TaskStatusIndicator(session.presentationState, size: 8 * s)
+                VStack(alignment: .leading, spacing: 1 * s) {
+                    HStack(spacing: 5 * s) {
+                        Text(session.project).font(.system(size: 13 * s, weight: .semibold))
+                        Text(session.agent.displayName)
+                            .font(.system(size: 9 * s, weight: .semibold))
+                            .padding(.horizontal, 5 * s).padding(.vertical, 1 * s)
+                            .background(.white.opacity(0.14), in: Capsule())
+                    }
+                    Text(subtitle)
+                        .font(.system(size: 10 * s, weight: .medium))
+                        .foregroundStyle(.white.opacity(feedback == nil ? 0.62 : 0.85))
+                        .contentTransition(.opacity)
+                }
+                .foregroundStyle(.white).lineLimit(1)
+                Spacer(minLength: 4 * s)
+                if let symbol = targetSymbol {
+                    Image(systemName: symbol)
+                        .font(.system(size: 11 * s))
+                        .foregroundStyle(.white.opacity(hovering ? 0.75 : 0.45))
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(GlanceRowButtonStyle(scale: s, hovering: hovering))
+        .onHover { hovering = $0 }
+        .help(helpText)
+    }
+}
+
+/// Tactile, not decorative: the row lifts slightly under the pointer and dips
+/// under the press, so it reads as a control while adding no colour of its own.
+/// Negative outer padding keeps the text aligned with the card's other rows
+/// while the highlight bleeds past them.
+private struct GlanceRowButtonStyle: ButtonStyle {
+    let scale: CGFloat
+    let hovering: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 7 * scale)
+            .padding(.vertical, 4 * scale)
+            .background(
+                RoundedRectangle(cornerRadius: 8 * scale, style: .continuous)
+                    .fill(.white.opacity(configuration.isPressed ? 0.18 : (hovering ? 0.09 : 0)))
+            )
+            .opacity(configuration.isPressed ? 0.9 : 1)
+            .padding(.horizontal, -7 * scale)
+            .padding(.vertical, -2 * scale)
+            .animation(.smooth(duration: 0.12), value: configuration.isPressed)
+            .animation(.smooth(duration: 0.12), value: hovering)
     }
 }

--- a/VibeBuddyMacApp/Sources/GlanceWindow.swift
+++ b/VibeBuddyMacApp/Sources/GlanceWindow.swift
@@ -125,12 +125,16 @@ final class GlanceWindow {
 
     private func measuredContentSize(on screen: NSScreen) -> NSSize {
         let maxWidth = min(screen.frame.width - 80, 560)
-        let measured = measuringController.sizeThatFits(in: NSSize(width: maxWidth, height: 280))
+        // Propose the usable height rather than a guessed cap: expanded the glance
+        // is a header plus up to six session rows, which no longer fits in 280pt.
+        // SwiftUI still reports the *ideal* height, so the collapsed pill stays short.
+        let maxHeight = max(160, screen.visibleFrame.height - 40)
+        let measured = measuringController.sizeThatFits(in: NSSize(width: maxWidth, height: maxHeight))
         guard measured.width.isFinite, measured.height.isFinite,
               measured.width > 0, measured.height > 0 else {
             return NSSize(width: 140, height: mode == .notch ? 38 : 28)
         }
-        return measured
+        return NSSize(width: min(measured.width, maxWidth), height: min(measured.height, maxHeight))
     }
 
     private func scheduleReposition() {

--- a/VibeBuddyMacApp/Sources/JumpOutcomeCopy.swift
+++ b/VibeBuddyMacApp/Sources/JumpOutcomeCopy.swift
@@ -1,0 +1,36 @@
+import AppKit
+import VibeBuddyKit
+
+/// The one place the Mac turns a `JumpOutcome` into words. The glance rows, the
+/// glance approval card and the dashboard detail pane all read it, so a jump
+/// never reports differently depending on where it was started from.
+///
+/// The wording promises only what happened: `.focused` means the session's own
+/// pane came forward, `.activatedApp` means we could only raise the app around
+/// it, and the two failure cases say which kind of failure it was.
+extension JumpOutcome {
+    @MainActor
+    func macMessage(for ref: TerminalRef?) -> String {
+        switch self {
+        case .focused:
+            return "Focused terminal"
+        case .activatedApp:
+            // The app's own name when macOS can tell us (it is running — that is
+            // what `.activatedApp` means), otherwise the honest generic.
+            if let name = ref?.hostBundleId.flatMap(Self.runningAppName) {
+                return "Brought \(name) to front"
+            }
+            return "Brought app to front"
+        case .unsupported:
+            return "Couldn't locate this session's window"
+        case .noTerminal:
+            return "No terminal recorded for this session"
+        }
+    }
+
+    @MainActor
+    private static func runningAppName(_ bundleID: String) -> String? {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            .first?.localizedName
+    }
+}

--- a/VibeBuddyMacApp/Sources/MacDemoData.swift
+++ b/VibeBuddyMacApp/Sources/MacDemoData.swift
@@ -41,6 +41,11 @@ enum MacDemoData {
                     filePath: "src/reminders.ts",
                     oldText: "todos.sort((a, b) => a.id - b.id)",
                     newText: "todos.sort((a, b) => a.dueDate - b.dueDate)"),
+                // iTerm2 with a captured session id — the most precise jump there is.
+                terminalRef: TerminalRef(termProgram: "iTerm.app", tty: "ttys004",
+                                         itermSessionId: "9F2C41A0-5B7E-4E1D-8C3A-1D0E77B26F44",
+                                         hostBundleId: "com.googlecode.iterm2", hostPid: 2841,
+                                         cwd: "/Users/xw/Projects/todo-app"),
                 summary: "Sort reminders by due date",
                 tokens: 4200, contextTokens: 128_000, contextWindow: 200_000,
                 observations: [ObservationEvidence(
@@ -56,6 +61,11 @@ enum MacDemoData {
                         QuestionOption(id: "tight", label: "Tighten", value: "Tighten the draft without changing the argument."),
                         QuestionOption(id: "plain", label: "Plain language", value: "Make it plainer and keep the citations intact."),
                     ]),
+                // Ghostty: no env var for the surface, so the id was probed at
+                // SessionStart and the cwd is the fallback match.
+                terminalRef: TerminalRef(termProgram: "ghostty", ghosttyTerminalId: "17",
+                                         hostBundleId: "com.mitchellh.ghostty", hostPid: 3102,
+                                         cwd: "/Users/xw/Projects/docs-review"),
                 summary: "Which revision style should I use?",
                 tokens: 2100, contextTokens: 92_000, contextWindow: 200_000,
                 statusSince: now.addingTimeInterval(-28), updatedAt: now.addingTimeInterval(-28)),
@@ -63,7 +73,13 @@ enum MacDemoData {
             // ── Working ─────────────────────────────────────────────────────
             AgentSession(
                 id: "demo-work-1", agent: .codex, project: "api-gateway", branch: "main",
-                model: "gpt-5-codex", status: .working, summary: "Running the test suite…",
+                model: "gpt-5-codex", status: .working,
+                // tmux inside iTerm2: the pane is selected first, then the tab raised.
+                terminalRef: TerminalRef(termProgram: "iTerm.app", tty: "ttys011",
+                                         tmux: "/private/tmp/tmux-501/default,914,0", tmuxPane: "%3",
+                                         hostBundleId: "com.googlecode.iterm2", hostPid: 2841,
+                                         cwd: "/Users/xw/Projects/api-gateway"),
+                summary: "Running the test suite…",
                 tokens: 1500, contextTokens: 64_000, contextWindow: 200_000,
                 activeTool: "Bash",
                 observations: [ObservationEvidence(
@@ -71,7 +87,12 @@ enum MacDemoData {
                 statusSince: now.addingTimeInterval(-9), updatedAt: now.addingTimeInterval(-9)),
             AgentSession(
                 id: "demo-work-2", agent: .claudeCode, project: "web-dashboard", branch: "feat/auth",
-                model: "claude-opus-4-8", status: .working, summary: "Refactoring the auth middleware…",
+                model: "claude-opus-4-8", status: .working,
+                // Claude desktop: no TERM_PROGRAM at all, so only the host app is
+                // known and a jump can honestly promise no more than that.
+                terminalRef: TerminalRef(hostBundleId: "com.anthropic.claude-code", hostPid: 4507,
+                                         cwd: "/Users/xw/Projects/web-dashboard"),
+                summary: "Refactoring the auth middleware…",
                 tokens: 6300, contextTokens: 151_000, contextWindow: 200_000,
                 activeTool: "Edit",
                 childAgents: [
@@ -88,18 +109,32 @@ enum MacDemoData {
             // ── Done ────────────────────────────────────────────────────────
             AgentSession(
                 id: "demo-done-1", agent: .codex, project: "payments-api", branch: "main",
-                model: "gpt-5-codex", status: .done, summary: "All tests green — 142 passed.",
+                model: "gpt-5-codex", status: .done,
+                // Terminal.app exposes a per-tab tty, which is an exact target.
+                terminalRef: TerminalRef(termProgram: "apple_terminal", tty: "ttys002",
+                                         hostBundleId: "com.apple.Terminal", hostPid: 1990,
+                                         cwd: "/Users/xw/Projects/payments-api"),
+                summary: "All tests green — 142 passed.",
                 tokens: 5400, contextTokens: 78_000, contextWindow: 200_000,
                 hasUnreadCompletion: true,
                 statusSince: now.addingTimeInterval(-180), updatedAt: now.addingTimeInterval(-180)),
             AgentSession(
                 id: "demo-done-2", agent: .claudeCode, project: "docs-site", branch: "main",
-                model: "claude-haiku-4-5", status: .done, summary: "Idle — no unread updates.",
+                model: "claude-haiku-4-5", status: .done,
+                // Deliberately left without a ref: the "no terminal recorded"
+                // state has to be visible in the demo too.
+                summary: "Idle — no unread updates.",
                 tokens: 900, contextTokens: 20_000, contextWindow: 200_000,
                 statusSince: now.addingTimeInterval(-320), updatedAt: now.addingTimeInterval(-320)),
             AgentSession(
                 id: "demo-error", agent: .codex, project: "release-check", branch: "main",
-                model: "gpt-5-codex", status: .done, summary: "Build failed with two signing errors.",
+                model: "gpt-5-codex", status: .done,
+                // VS Code's integrated terminal exposes no addressable surface —
+                // app level is the ceiling.
+                terminalRef: TerminalRef(termProgram: "vscode",
+                                         hostBundleId: "com.microsoft.VSCode", hostPid: 5210,
+                                         cwd: "/Users/xw/Projects/release-check"),
+                summary: "Build failed with two signing errors.",
                 tokens: 3100, contextTokens: 48_000, contextWindow: 200_000,
                 failed: true,
                 statusSince: now.addingTimeInterval(-120), updatedAt: now.addingTimeInterval(-120)),

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -29,6 +29,10 @@ final class MenuBarModel: ObservableObject {
     @Published private(set) var lifecycleJournalClearFailed = false
     @Published private(set) var notificationDeliveryHealth = NotificationDeliveryHealth()
     @Published private(set) var recentNotificationDeliveries: [NotificationDeliveryRecord] = []
+    /// The outcome of the most recent jump per session id, shown transiently in
+    /// the row that was clicked and cleared by `showJumpFeedback`.
+    @Published private(set) var jumpFeedback: [String: JumpOutcome] = [:]
+    private var jumpFeedbackClears: [String: Task<Void, Never>] = [:]
     /// Sessions the user has pointed the buddy at (in-memory, never persisted).
     /// Empty = the buddy sees all sessions; pruned to live IDs on every snapshot.
     @Published private(set) var buddySessionIDs: Set<String> = []
@@ -496,10 +500,36 @@ final class MenuBarModel: ObservableObject {
     /// Back-compat for voice + existing callers.
     func decide(_ approvalId: String, approve: Bool) { decide(approvalId, approve ? .allow : .deny) }
 
+    /// Jump to a session's terminal without blocking the UI: the click is
+    /// acknowledged immediately and the AppleScript/`tmux` work happens off the
+    /// main actor, publishing what it actually achieved when it lands.
+    ///
+    /// Never refuses. A session with no ref is a real answer ("no terminal
+    /// recorded"), not a dead control — that silence was the bug.
     func jump(_ session: AgentSession) {
         acknowledge(session.id)
-        guard let ref = session.terminalRef else { return }
-        TerminalJumper.jump(ref)
+        guard let ref = session.terminalRef else {
+            showJumpFeedback(.noTerminal, for: session.id)
+            return
+        }
+        Task { [weak self] in
+            let outcome = await TerminalJumper.jump(ref)
+            self?.showJumpFeedback(outcome, for: session.id)
+        }
+    }
+
+    /// Publish a jump result against its session and retract it a beat later, so
+    /// the row goes back to showing live activity. A second jump replaces the
+    /// first one's countdown instead of inheriting its deadline.
+    private func showJumpFeedback(_ outcome: JumpOutcome, for sessionID: String) {
+        jumpFeedback[sessionID] = outcome
+        jumpFeedbackClears[sessionID]?.cancel()
+        jumpFeedbackClears[sessionID] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            guard !Task.isCancelled else { return }
+            self?.jumpFeedback[sessionID] = nil
+            self?.jumpFeedbackClears[sessionID] = nil
+        }
     }
 
     /// Explicitly viewing/selecting a completion clears its authoritative unread

--- a/VibeBuddyMacApp/Sources/PetFace.swift
+++ b/VibeBuddyMacApp/Sources/PetFace.swift
@@ -15,6 +15,8 @@ struct PetFace: View {
     var bare: Bool = false
     var scale: CGFloat = 1
 
+    @Environment(\.displayScale) private var displayScale
+
     private var accent: Color { Color(taskStatus: state.presentationState.colorToken) }
     private var ink: Color { bare ? .white : .primary }
 
@@ -41,11 +43,18 @@ struct PetFace: View {
                 let grid = rows(blink: blink, mouthOpen: mouthOpen)
                 let cw = size.width / 13
                 let ch = size.height / CGFloat(grid.count)
+                // Snap every cell edge to the display grid instead of padding each
+                // rect by 0.6pt: shared edges land on the same device pixel, so the
+                // sprite stays crisp (and seam-free) even at the small collapsed
+                // glance size, where a cell is only ~1.5pt wide.
+                let dp = max(displayScale, 1)
+                func snap(_ v: CGFloat) -> CGFloat { (v * dp).rounded() / dp }
                 for (r, line) in grid.enumerated() {
+                    let y0 = snap(CGFloat(r) * ch), y1 = snap(CGFloat(r + 1) * ch)
                     for (c, char) in line.enumerated() {
                         guard let color = fill(char) else { continue }
-                        let rect = CGRect(x: CGFloat(c) * cw, y: CGFloat(r) * ch,
-                                          width: cw + 0.6, height: ch + 0.6)
+                        let x0 = snap(CGFloat(c) * cw), x1 = snap(CGFloat(c + 1) * cw)
+                        let rect = CGRect(x: x0, y: y0, width: x1 - x0, height: y1 - y0)
                         ctx.fill(Path(rect), with: .color(color))
                     }
                 }

--- a/VibeBuddyMacApp/project.yml
+++ b/VibeBuddyMacApp/project.yml
@@ -41,6 +41,10 @@ targets:
         LSMinimumSystemVersion: "14.0"
         NSMicrophoneUsageDescription: "Talk to your buddy to ask about your agents and approve actions by voice."
         NSSpeechRecognitionUsageDescription: "Recognize your speech on-device so your buddy understands what you say."
+        # Jump-to-terminal scripts Terminal.app / iTerm2 / Ghostty to raise the
+        # session's own tab. macOS asks for Automation permission per target app on
+        # the first attempt and refuses without this string.
+        NSAppleEventsUsageDescription: "Bring the terminal window running your agent session back to the front when you jump to it."
         # Sparkle auto-update (issue 07, direct-distribution only). Inert until a real
         # signed appcast + EdDSA public key are filled in (see .scratch/.../07 + handoff).
         SUFeedURL: "https://vibebuddy.invalid/appcast.xml"   # TODO: host a signed appcast

--- a/docs/multi-cli-hook-setup.md
+++ b/docs/multi-cli-hook-setup.md
@@ -30,12 +30,12 @@ The CLI pipes its event JSON on stdin. VibeBuddy reads `hook_event_name`,
 | CLI | source | config | hook style | status |
 |-----|--------|--------|-----------|--------|
 | Claude Code | `claude` | `~/.claude/settings.json` | JSON `hooks` array | ✅ tested |
-| Codex | `codex` | `~/.codex/config.toml` | TOML `[hooks]` / notify | ✅ tested |
+| Codex | `codex` | `~/.codex/hooks.json` (`notify` untouched) | JSON `hooks` array | ✅ tested |
 | OpenCode | `opencode` | `~/.config/opencode/` plugin | Claude-compatible hooks | ⚠️ template |
 | Qwen Code | `qwen` | `~/.qwen/` | Claude-compatible hooks | ⚠️ template |
 | Kimi | `kimi` | `~/.kimi/config.toml` | TOML hooks | ⚠️ template |
 | Antigravity (Gemini) | `antigravity` | `~/.gemini/antigravity-cli/hooks.json` | JSON `command` hooks | blocked: `agy` 1.0.5 loads but skips execution |
-| Grok | `grok` | per-CLI hooks | Claude-compatible hooks | ⚠️ template |
+| Grok | `grok` | `~/.grok/hooks/vibebuddy.json` | JSON `command` hooks | ✅ tested |
 | GitHub Copilot | `copilot` | — | observe mode (no hooks) | ⚠️ partial |
 
 ✅ = wired and exercised. ⚠️ template = the source routing + display are done in
@@ -69,13 +69,33 @@ yet — it appears once a future watcher observes it.
 ### Terminal capture (for jump-to-terminal)
 
 Jump-to-terminal needs to know which terminal each session runs in. A second hook,
-`hooks/capture-terminal.sh`, POSTs `{session_id, term_program, tty, tmux, tmux_pane}`
-to `/terminal`. `install-claude-hooks.py` wires it to **both `SessionStart` and
+`hooks/capture-terminal.sh`, POSTs to `/terminal` at three levels of precision:
+`{tmux, tmux_pane}` for the multiplexer pane, `{tty, iterm_session_id,
+wezterm_pane, kitty_window_id, kitty_listen_on, ghostty_terminal_id}` for the
+window/tab/split of one emulator, and `{term_program, host_bundle_id, host_pid,
+cwd}` for the app. `host_bundle_id` is the bundle identifier of the nearest GUI
+ancestor process, so a session inside an embedded terminal — the Claude desktop
+app, Cursor, Zed, a JetBrains IDE — is still reachable even though it exports no
+`TERM_PROGRAM` at all. Background-only ancestors (`LSBackgroundOnly` or
+`LSUIElement` in their `Info.plist`) are stepped over, because such a bundle id
+can never be activated: the Claude Code CLI is itself one of these wrapper
+`.app`s, nested under the Claude desktop app that actually owns the window. Empty values are omitted, and the Mac reads an empty
+string as absence. Run the script with `--print` to see what it would send. `install-claude-hooks.py`, `install-codex-hooks.py`, and
+`install-grok-hooks.py` all wire it to **both `SessionStart` and
 `UserPromptSubmit`**: SessionStart catches new sessions, and UserPromptSubmit
 re-captures so a session that missed SessionStart — e.g. the hook was added while
-the session was already open — **self-heals on its next prompt** (writing the same
-ref is idempotent). A session with no captured terminal can't be jumped to (the iOS
-button hides; the Mac button disables; a phone jump reports "no terminal").
+the session was already open — **self-heals on its next prompt**. That re-capture
+is not idempotent (it skips the Ghostty AppleScript probe, which only answers
+while the surface is focused), so the Mac **merges** each ref into the stored one
+field by field — a later capture updates what it saw and never erases what it
+didn't see. Grok's event payload uses camelCase `sessionId`; the script
+reads both key spellings. A session with no captured terminal can't be jumped to
+(the iOS button hides; the Mac button disables; a phone jump reports "no
+terminal"), and a session captured only at app level reports `activatedApp` —
+the right app comes forward but the user still finds the tab. Codex requires re-trusting hooks via `/hooks` after this change picks
+up the new capture group, same as any other `hooks.json` edit; Grok requires
+reloading hooks (Ctrl+L → Hooks tab → 'l', or restart the session) before the new
+capture group takes effect.
 
 ### Reversibility
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -49,7 +49,10 @@ Codex sends lifecycle event JSON on stdin to commands registered in
 for all 12 events supported by the current Codex hook schema: SessionStart,
 UserPromptSubmit, PreToolUse, PostToolUse, PermissionRequest, PreCompact,
 PostCompact, SubagentStart, SubagentStop, Stop, Interrupt, and SessionEnd.
-Existing hook groups are retained.
+Existing hook groups are retained. It also appends the terminal-capture hook
+(`capture-terminal.sh`, see below) as its own group on `SessionStart` and
+`UserPromptSubmit`, synchronous like the rest, so Codex sessions get a
+jump-to-terminal ref.
 
 Released Codex builds currently skip command hooks carrying `async: true`, even
 though the rolling documentation describes asynchronous handlers. VibeBuddy
@@ -93,9 +96,53 @@ your Mac actually prompts (prompting mode); auto-mode users gain nothing.
 
 ## Terminal capture (jump-back)
 
-`capture-terminal.sh` is installed automatically as a second SessionStart hook by
-`--install` (and removed by `--uninstall`). On each new Claude Code session it
-POSTs the session's `TERM_PROGRAM`, `TTY`, `TMUX`, and `TMUX_PANE` to
-`http://127.0.0.1:${VIBEBUDDY_PORT:-9876}/terminal`. The Mac app stores this as
-`AgentSession.terminalRef` and uses it to focus the right terminal window when you
-press **Jump to terminal** in the Dashboard.
+`capture-terminal.sh` is installed automatically as a second hook group on
+`SessionStart` and `UserPromptSubmit` by the Claude, Codex, and Grok installers'
+`--install` (and removed by their `--uninstall`). SessionStart catches new
+sessions; UserPromptSubmit re-captures so a session that missed SessionStart
+self-heals on its next prompt. The re-capture reports less than the first one —
+it skips the Ghostty AppleScript probe, which is only valid while the surface is
+focused — so the Mac *merges* each ref into the stored one field by field: a
+later capture updates what it saw and never erases what it didn't. On each
+event it POSTs the session's `session_id` (or Grok's camelCase `sessionId`) plus
+everything it can learn about where the session lives, to
+`http://127.0.0.1:${VIBEBUDDY_PORT:-9876}/terminal`:
+
+| level | fields | what it buys |
+| --- | --- | --- |
+| pane | `tmux`, `tmux_pane` | selects the pane, unzooming the window if it was zoomed |
+| surface | `tty`, `iterm_session_id`, `wezterm_pane`, `kitty_window_id`, `kitty_listen_on`, `ghostty_terminal_id` | raises the session's own window/tab/split |
+| app | `term_program`, `host_bundle_id`, `host_pid`, `cwd` | brings the host application forward |
+
+Hooks run with a stripped environment and no controlling tty, so all of it comes
+from one `ps` snapshot walked up the process tree (~100 ms). `host_bundle_id` is
+the bundle identifier of the nearest GUI ancestor, which is the only handle an
+embedded terminal (the Claude desktop app, Cursor, Zed, a JetBrains IDE) ever
+gives us — and the only way to tell Cursor from VS Code, since both report
+`TERM_PROGRAM=vscode`. Ancestors whose bundle is background-only
+(`LSBackgroundOnly` or `LSUIElement`) are skipped and the walk keeps climbing:
+the Claude Code CLI itself ships as such a wrapper `.app`, and its bundle id
+never appears in `NSRunningApplication`, so recording it would make every jump a
+no-op instead of raising the Claude desktop app that hosts it.
+
+Ghostty exports no identifier for its surface, so it is asked for one over
+AppleScript, at `SessionStart` only and capped at 2 s. The first such call raises
+the system's Automation consent dialog; decline it, or set
+`VIBEBUDDY_GHOSTTY_PROBE=0`, and Ghostty jumps fall back to matching on `cwd`.
+
+The Mac app stores all of this as `AgentSession.terminalRef` and uses it to focus
+the right terminal window when you press **Jump to terminal** in the Dashboard.
+`bash capture-terminal.sh --print` (or `VIBEBUDDY_CAPTURE_DRY_RUN=1`) prints the
+JSON instead of POSTing it — the quickest way to see what your terminal reveals.
+
+The script's parsers are unit-tested against fixed strings (no process table, no
+network, no AppleScript):
+
+```
+bash hooks/tests/capture-terminal-parsing.sh
+```
+
+Because the capture hook rides inside each CLI's own hook config, it needs the
+same reload/trust step as any other change there: Codex requires re-running
+`/hooks` in a fresh session to trust the new group; Grok requires reloading
+hooks (Ctrl+L → Hooks tab → 'l', or restart the session).

--- a/hooks/capture-terminal.sh
+++ b/hooks/capture-terminal.sh
@@ -1,50 +1,292 @@
 #!/usr/bin/env bash
-# SessionStart hook: report which terminal this session runs in, keyed by session_id.
-# Claude Code may run hooks with a stripped env / no controlling tty, so we fall
-# back to reading TMUX/TMUX_PANE/TERM_PROGRAM from an ancestor process (the shell
-# or `claude` running in the pane) via `ps eww`.
-INPUT=$(cat)
-SID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
-[ -z "$SID" ] && exit 0
+# SessionStart hook: report *where* this agent session lives, keyed by session_id,
+# so the Mac app can jump back to it.
+#
+# Three levels of precision are captured, because that is how much the host is
+# willing to tell us:
+#   pane    — $TMUX_PANE inside a multiplexer
+#   surface — the tty, $ITERM_SESSION_ID, $WEZTERM_PANE, $KITTY_WINDOW_ID, or
+#             Ghostty's terminal id: one window/tab/split of one emulator
+#   app     — $TERM_PROGRAM, and the bundle id of the nearest *foreground* GUI
+#             ancestor process, which is the only handle an embedded terminal
+#             (the Claude desktop app, Cursor, Zed, a JetBrains IDE) ever gives
+#             us. Background-only wrapper bundles in between are skipped.
+#
+# Agents run hooks with a stripped env and no controlling tty, so almost nothing
+# is readable from this process: the environment, the tty and the host app all
+# come from walking up the process tree. That walk is done once, from a single
+# `ps` snapshot, plus one short `ps` per ancestor for its environment and
+# executable path — a couple of dozen in the worst case, well under 100 ms.
+#
+# Dry run: `VIBEBUDDY_CAPTURE_DRY_RUN=1 bash capture-terminal.sh` (or `--print`)
+# prints the JSON instead of POSTing it.
+#
+# Deliberately not `set -e`/`set -u`: a hook must never fail the session it is
+# reporting on, and `"${AUTH[@]}"` on an empty array is an error under `set -u`
+# in the bash 3.2 that ships with macOS.
 
-# Read $1 from this process's env, else walk up ancestors and read theirs.
-read_var() {
-  local var="$1" pid depth=0 val
-  eval "val=\${$var:-}"
-  [ -n "$val" ] && { printf '%s' "$val"; return; }
-  pid=$(ps -o ppid= -p "$$" 2>/dev/null | tr -d ' ')
-  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$depth" -lt 8 ]; do
-    val=$(ps eww -p "$pid" -o command= 2>/dev/null | tr ' ' '\n' | sed -n "s/^${var}=//p" | head -1)
-    [ -n "$val" ] && { printf '%s' "$val"; return; }
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    depth=$((depth + 1))
+# --------------------------------------------------------------------- helpers
+# Everything above the library guard below reads no globals and touches nothing
+# but the Info.plist files it is handed. `hooks/tests/capture-terminal-parsing.sh`
+# sources this file with VIBEBUDDY_CAPTURE_LIB_ONLY=1 to exercise these directly.
+
+# The .app bundle an executable lives in, or nothing when it isn't in one.
+# Cuts at the *first* ".app/", which is what makes an Electron helper
+# (/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Plugin).app/...)
+# resolve to the app the user actually sees rather than to the helper bundle.
+bundle_path() {  # bundle_path <executable path>
+  case "$1" in
+    /*.app/Contents/MacOS/*) printf '%s' "${1%%.app/*}.app" ;;
+  esac
+}
+
+# True when a value read out of an Info.plist means yes. `defaults read` prints
+# 1 for a real boolean; some bundles still ship the string forms.
+plist_true() {  # plist_true <value>
+  case "$1" in
+    1 | true | TRUE | True | YES | Yes | yes) return 0 ;;
+  esac
+  return 1
+}
+
+# The bundle id of the .app an executable lives in, but only when that app can
+# actually be brought to the front. A background-only bundle (LSBackgroundOnly
+# or LSUIElement) never appears in NSRunningApplication's activatable set, so
+# recording it makes the jump a no-op: the Claude Code CLI ships as exactly such
+# a wrapper .app (com.anthropic.claude-code) nested inside the Claude desktop
+# app, and the ancestor walk has to step over it to reach the real GUI host
+# (com.anthropic.claudefordesktop). Prints nothing when the executable is not in
+# a bundle, the bundle has no identifier, or the bundle is background-only.
+gui_bundle_id() {  # gui_bundle_id <executable path>
+  local bundle plist id
+  bundle=$(bundle_path "$1")
+  [ -n "$bundle" ] || return 0
+  plist="$bundle/Contents/Info"
+  [ -f "$plist.plist" ] || return 0
+  plist_true "$(defaults read "$plist" LSBackgroundOnly 2>/dev/null)" && return 0
+  plist_true "$(defaults read "$plist" LSUIElement 2>/dev/null)" && return 0
+  id=$(defaults read "$plist" CFBundleIdentifier 2>/dev/null)
+  [ -n "$id" ] || return 0
+  printf '%s' "$id"
+}
+
+# Pull wanted variables out of `ps eww` output on stdin, printing `NAME=value`
+# for the first occurrence of each. macOS `ps` appends the environment to the
+# command line with no delimiter and offers no machine-readable alternative
+# (`-E`/`e` is this same concatenated form), so a value is everything up to the
+# next ` NAME=` token: splitting on whitespace would truncate
+# `TMUX=/Volumes/My Disk/tmux-501/default,1,0` and would happily mistake an
+# argv token such as `--foo=bar` for a variable.
+env_extract() {  # env_extract <NAME>...
+  awk -v wanted="$*" '
+    BEGIN { n = split(wanted, names, " "); for (i = 1; i <= n; i++) want[names[i]] = 1 }
+    {
+      line = " " $0
+      while (match(line, / [A-Z_][A-Z0-9_]*=/)) {
+        k = substr(line, RSTART + 1, RLENGTH - 2)
+        line = substr(line, RSTART + RLENGTH)
+        if (match(line, / [A-Z_][A-Z0-9_]*=/)) v = substr(line, 1, RSTART - 1)
+        else v = line
+        if (want[k] && !(k in seen)) { seen[k] = 1; print k "=" v }
+      }
+    }'
+}
+
+JSON=""
+add() {  # add <key> <string value> — omitted entirely when empty
+  [ -n "${2:-}" ] || return 0
+  local escaped
+  # Control characters are stripped, not escaped: a raw newline or tab inside a
+  # JSON string is invalid, and the server drops the whole payload without a
+  # word. None of the values we send (paths, ids, $TERM_PROGRAM) can legitimately
+  # contain one. Backslash first, so the quote escape isn't re-escaped.
+  escaped=$(printf '%s' "$2" | tr -d '[:cntrl:]' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+  [ -n "$escaped" ] || return 0
+  JSON="$JSON,\"$1\":\"$escaped\""
+}
+add_num() {  # add_num <key> <integer value> — non-digits are dropped
+  case "${2:-}" in
+    "" | *[!0-9]*) return 0 ;;
+  esac
+  JSON="$JSON,\"$1\":$2"
+}
+
+# Sourced by hooks/tests/ to reach the helpers above; everything below has side
+# effects (reads stdin, walks the process table, POSTs).
+if [ "${VIBEBUDDY_CAPTURE_LIB_ONLY:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+DRY_RUN=0
+[ "${VIBEBUDDY_CAPTURE_DRY_RUN:-0}" = "1" ] && DRY_RUN=1
+[ "${1:-}" = "--print" ] && DRY_RUN=1
+
+# The hook payload arrives on stdin. Don't block on an interactive terminal, so
+# the dry run can be invoked by hand.
+INPUT=""
+[ -t 0 ] || INPUT=$(cat)
+
+json_str() {  # json_str <key>  — first string value of "key" in $INPUT
+  printf '%s' "$INPUT" \
+    | sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1
+}
+
+# Claude/Codex/Qwen/Kimi/OpenCode send `session_id`; the Grok CLI sends `sessionId`.
+SID=$(json_str session_id)
+[ -z "$SID" ] && SID=$(json_str sessionId)
+EVENT=$(json_str hook_event_name)
+CWD=$(json_str cwd)
+[ -z "$CWD" ] && CWD="$PWD"
+if [ -z "$SID" ] && [ "$DRY_RUN" = "0" ]; then exit 0; fi
+
+# ---------------------------------------------------------------- ancestor walk
+# One snapshot of the process table, then climb it in awk: pid, tty and full
+# command for this process and each ancestor, nearest first.
+CHAIN=$(ps -Awwo pid=,ppid=,tty=,command= 2>/dev/null | awk -v start="$$" '
+  {
+    parent[$1] = $2; term[$1] = $3
+    c = ""
+    for (i = 4; i <= NF; i++) c = c (i > 4 ? " " : "") $i
+    cmd[$1] = c
+  }
+  END {
+    p = start; n = 0
+    while (p != "" && p != "0" && p != "1" && n < 12) {
+      if (!(p in parent)) break
+      printf "%s\t%s\t%s\n", p, term[p], cmd[p]
+      p = parent[p]; n++
+    }
+  }')
+
+PIDS=""
+TTY=""
+HOST_BUNDLE=""
+HOST_PID=""
+while IFS=$'\t' read -r pid ptty _pcmd; do
+  [ -n "$pid" ] || continue
+  PIDS="$PIDS $pid"
+  # First ancestor that still owns a terminal. Hook processes never do.
+  if [ -z "$TTY" ] && [ -n "$ptty" ] && [ "$ptty" != "??" ] && [ "$ptty" != "?" ]; then
+    TTY="$ptty"
+  fi
+  # First ancestor that is a GUI app the user can actually be sent to. Matched
+  # against `comm` — the executable path alone — rather than the full command
+  # line, so an argument that merely mentions an .app path can't be mistaken for
+  # the host, and background-only bundles are walked past (see gui_bundle_id).
+  if [ -z "$HOST_BUNDLE" ]; then
+    id=$(gui_bundle_id "$(ps -o comm= -p "$pid" 2>/dev/null)")
+    if [ -n "$id" ]; then HOST_BUNDLE="$id"; HOST_PID="$pid"; fi
+  fi
+done <<EOF
+$CHAIN
+EOF
+
+# ------------------------------------------------------------------ environment
+# `ps eww` prints a process's environment after its command line. Collect this
+# process's env and every ancestor's in one pass and keep the nearest value of
+# each variable we care about.
+env_dump() {
+  for pid in $PIDS; do
+    ps eww -p "$pid" -o command= 2>/dev/null
   done
 }
 
-TP=$(read_var TERM_PROGRAM)
-TMUXV=$(read_var TMUX)
-PANE=$(read_var TMUX_PANE)
-TTY=$(ps -o tty= -p $$ 2>/dev/null | tr -d ' ')
-{ [ -z "$TTY" ] || [ "$TTY" = "??" ]; } && TTY=$(ps -o tty= -p "$(ps -o ppid= -p $$ | tr -d ' ')" 2>/dev/null | tr -d ' ')
+TERM_PROGRAM_V=""; TMUX_V=""; TMUX_PANE_V=""; ITERM_V=""
+WEZTERM_V=""; KITTY_WINDOW_V=""; KITTY_LISTEN_V=""; TERM_V=""
+WANTED="TERM_PROGRAM TMUX TMUX_PANE ITERM_SESSION_ID WEZTERM_PANE KITTY_WINDOW_ID KITTY_LISTEN_ON TERM"
+# `read -r key value` splits on the first `=` only, so a value containing one
+# (`$TMUX` never does, `$KITTY_LISTEN_ON` can) survives intact.
+while IFS='=' read -r key value; do
+  case "$key" in
+    TERM_PROGRAM)     TERM_PROGRAM_V="$value" ;;
+    TMUX)             TMUX_V="$value" ;;
+    TMUX_PANE)        TMUX_PANE_V="$value" ;;
+    ITERM_SESSION_ID) ITERM_V="$value" ;;
+    WEZTERM_PANE)     WEZTERM_V="$value" ;;
+    KITTY_WINDOW_ID)  KITTY_WINDOW_V="$value" ;;
+    KITTY_LISTEN_ON)  KITTY_LISTEN_V="$value" ;;
+    TERM)             TERM_V="$value" ;;
+  esac
+done <<EOF
+$(env_dump | env_extract $WANTED)
+EOF
 
-# Inside tmux, TERM_PROGRAM is "tmux"; the real terminal is the one that launched
+# Inside tmux, TERM_PROGRAM is "tmux"; the real terminal is the one that started
 # the tmux server (its pid is the middle field of $TMUX). Resolve it so the Mac
-# can foreground the actual app (e.g. Ghostty), not "tmux".
-if [ "$TP" = "tmux" ] && [ -n "$TMUXV" ]; then
-  server_pid=$(printf '%s' "$TMUXV" | cut -d, -f2)
+# foregrounds the actual app rather than the multiplexer.
+if [ "$TERM_PROGRAM_V" = "tmux" ] && [ -n "$TMUX_V" ]; then
+  server_pid=$(printf '%s' "$TMUX_V" | cut -d, -f2)
   if [ -n "$server_pid" ]; then
-    real=$(ps eww -p "$server_pid" -o command= 2>/dev/null | tr ' ' '\n' | sed -n 's/^TERM_PROGRAM=//p' | head -1)
-    [ -n "$real" ] && TP="$real"
+    real=$(ps eww -p "$server_pid" -o command= 2>/dev/null \
+      | env_extract TERM_PROGRAM | sed -n 's/^TERM_PROGRAM=//p' | head -1)
+    [ -n "$real" ] && TERM_PROGRAM_V="$real"
   fi
 fi
 
-# kitty doesn't set TERM_PROGRAM; synthesize it from kitty's own markers so the
-# Mac can foreground it (open -a kitty). Other terminals (Warp=WarpTerminal,
-# WezTerm=WezTerm) already export TERM_PROGRAM, so no fallback needed for them.
-if [ -z "$TP" ]; then
-  if [ -n "$(read_var KITTY_WINDOW_ID)" ] || [ "$(read_var TERM)" = "xterm-kitty" ]; then
-    TP="kitty"
+# kitty sets no TERM_PROGRAM; synthesize it from kitty's own markers. Warp
+# (WarpTerminal) and WezTerm both export one, so they need no fallback.
+if [ -z "$TERM_PROGRAM_V" ]; then
+  if [ -n "$KITTY_WINDOW_V" ] || [ "$TERM_V" = "xterm-kitty" ]; then
+    TERM_PROGRAM_V="kitty"
   fi
+fi
+
+# $ITERM_SESSION_ID is "w0t0p0:UUID"; only the UUID half matches an iTerm2
+# session's `unique ID`.
+ITERM_SESSION_ID="${ITERM_V##*:}"
+
+# ------------------------------------------------------------- Ghostty terminal
+# Ghostty exports no identifier for the surface, so ask it — while this session
+# is still the focused one, which is only true at SessionStart. AppleScript to
+# another app needs Automation permission, and the very first attempt blocks on
+# the system's consent dialog, so the call is hard-capped at 2 s. Once granted it
+# costs ~50-150 ms; it is skipped on every later event, and with
+# VIBEBUDDY_GHOSTTY_PROBE=0.
+run_with_timeout() {  # run_with_timeout <seconds> <command...>
+  local secs="$1"; shift
+  local out; out=$(mktemp -t vbcapture) || return 1
+  "$@" >"$out" 2>/dev/null &
+  local child=$!
+  ( sleep "$secs"; kill -9 "$child" 2>/dev/null ) >/dev/null 2>&1 &
+  local watchdog=$!
+  wait "$child" 2>/dev/null
+  kill "$watchdog" 2>/dev/null
+  wait "$watchdog" 2>/dev/null
+  head -1 "$out"
+  rm -f "$out"
+}
+
+GHOSTTY_TERMINAL_ID=""
+if [ "$TERM_PROGRAM_V" = "ghostty" ] && [ "${VIBEBUDDY_GHOSTTY_PROBE:-1}" != "0" ] \
+   && { [ "$EVENT" = "SessionStart" ] || [ "$DRY_RUN" = "1" ]; }; then
+  # Dictionary shape (verified against `sdef /Applications/Ghostty.app`):
+  # application → `front window` (window) → `selected tab` (tab) →
+  # `focused terminal` (terminal) → `id` (text). Addressed by bundle id so the
+  # "Where is Ghostty?" chooser can never appear, and matching the jumper's
+  # `tell application id "com.mitchellh.ghostty"`.
+  GHOSTTY_TERMINAL_ID=$(run_with_timeout 2 /usr/bin/osascript -e \
+    'tell application id "com.mitchellh.ghostty" to return id of focused terminal of selected tab of front window')
+fi
+
+# ------------------------------------------------------------------------- POST
+add session_id "$SID"
+add term_program "$TERM_PROGRAM_V"
+add tty "$TTY"
+add tmux "$TMUX_V"
+add tmux_pane "$TMUX_PANE_V"
+add iterm_session_id "$ITERM_SESSION_ID"
+add wezterm_pane "$WEZTERM_V"
+add kitty_window_id "$KITTY_WINDOW_V"
+add kitty_listen_on "$KITTY_LISTEN_V"
+add ghostty_terminal_id "$GHOSTTY_TERMINAL_ID"
+add host_bundle_id "$HOST_BUNDLE"
+add_num host_pid "$HOST_PID"
+add cwd "$CWD"
+BODY="{${JSON#,}}"
+
+if [ "$DRY_RUN" = "1" ]; then
+  printf '%s\n' "$BODY"
+  exit 0
 fi
 
 PORT="${VIBEBUDDY_PORT:-9876}"
@@ -52,7 +294,7 @@ PORT="${VIBEBUDDY_PORT:-9876}"
 TOKEN_FILE="${VIBEBUDDY_TOKEN_FILE:-$HOME/Library/Application Support/vibebuddy/token}"
 TOKEN="${VIBEBUDDY_TOKEN:-$(cat "$TOKEN_FILE" 2>/dev/null)}"
 AUTH=(); [ -n "$TOKEN" ] && AUTH=(-H "Authorization: Bearer $TOKEN")
-printf '{"session_id":"%s","term_program":"%s","tty":"%s","tmux":"%s","tmux_pane":"%s"}' \
-  "$SID" "$TP" "$TTY" "$TMUXV" "$PANE" \
-  | curl -sS --max-time 3 "${AUTH[@]}" -X POST --data-binary @- "http://127.0.0.1:${PORT}/terminal" 2>/dev/null || true
+printf '%s' "$BODY" \
+  | curl -sS --max-time 3 "${AUTH[@]}" -X POST --data-binary @- \
+      "http://127.0.0.1:${PORT}/terminal" >/dev/null 2>&1 || true
 exit 0

--- a/hooks/install-claude-hooks.py
+++ b/hooks/install-claude-hooks.py
@@ -42,7 +42,9 @@ EVENTS = [
 ]
 # Terminal capture runs on SessionStart (catch new sessions) AND UserPromptSubmit
 # (re-capture so a session that missed SessionStart — e.g. the hook was added
-# mid-session — self-heals on its next prompt; writing the same ref is idempotent).
+# mid-session — self-heals on its next prompt). The re-capture skips the Ghostty
+# AppleScript probe, so it is not idempotent; the Mac merges each ref into the
+# stored one field by field, keeping what a later capture couldn't see.
 CAPTURE_EVENTS = ["SessionStart", "UserPromptSubmit"]
 
 

--- a/hooks/install-codex-hooks.py
+++ b/hooks/install-codex-hooks.py
@@ -30,6 +30,17 @@ EVENTS = [
     "Interrupt",
     "SessionEnd",
 ]
+# Terminal capture (jump-to-terminal) runs as a second, independent hook group on
+# SessionStart (catch new sessions) and UserPromptSubmit (self-heal a session that
+# missed SessionStart) — see capture-terminal.sh and install-claude-hooks.py's
+# CAPTURE_EVENTS for the matching Claude wiring. The re-capture is *not*
+# idempotent: it skips the Ghostty AppleScript probe, which is only correct while
+# the surface is focused. The Mac therefore merges each ref into the stored one
+# field by field, so a later capture can add and update but never erase.
+CAPTURE_HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "capture-terminal.sh")
+CAPTURE_MARKER = "capture-terminal.sh"
+CAPTURE_COMMAND = f'"{CAPTURE_HOOK}"'
+CAPTURE_EVENTS = ["SessionStart", "UserPromptSubmit"]
 
 
 def load():
@@ -53,7 +64,7 @@ def load():
     return value
 
 
-def is_vibebuddy(hook):
+def is_forwarder(hook):
     if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
         return False
     try:
@@ -62,6 +73,20 @@ def is_vibebuddy(hook):
         return False
     return (len(argv) == 2 and os.path.basename(argv[0]) == "vibebuddy-forward.sh"
             and argv[1] == "codex")
+
+
+def is_capture(hook):
+    if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
+        return False
+    try:
+        argv = shlex.split(hook["command"])
+    except ValueError:
+        return False
+    return len(argv) == 1 and os.path.basename(argv[0]) == CAPTURE_MARKER
+
+
+def is_vibebuddy(hook):
+    return is_forwarder(hook) or is_capture(hook)
 
 
 def without_vibebuddy(groups):
@@ -92,6 +117,14 @@ def install(root):
         # handlers synchronous and bounded, while the forwarder caps its local
         # HTTP request at one second.
         hooks.setdefault(event, []).append({"hooks": [command]})
+    for event in CAPTURE_EVENTS:
+        capture = {
+            "type": "command",
+            "command": CAPTURE_COMMAND,
+            "timeout": 5,
+        }
+        # Same released-Codex constraint as above: no `async: true`.
+        hooks.setdefault(event, []).append({"hooks": [capture]})
     root["hooks"] = hooks
     return root
 

--- a/hooks/install-grok-hooks.py
+++ b/hooks/install-grok-hooks.py
@@ -31,6 +31,16 @@ FORWARDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vibebuddy-
 COMMAND = f'"{FORWARDER}" grok'
 MARKER = "vibebuddy-forward.sh"
 
+# Terminal capture (jump-to-terminal) rides along as a second hook group on
+# SessionStart and UserPromptSubmit — see capture-terminal.sh. Grok's payload
+# uses camelCase `sessionId`; the script already handles that key. The
+# UserPromptSubmit re-capture reports less than the first one (no Ghostty probe),
+# so the Mac merges refs field by field rather than replacing them.
+CAPTURE_HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "capture-terminal.sh")
+CAPTURE_COMMAND = f'"{CAPTURE_HOOK}"'
+CAPTURE_MARKER = "capture-terminal.sh"
+CAPTURE_EVENTS = ["SessionStart", "UserPromptSubmit"]
+
 # Passive events report status; tool events (omitted matcher → match every tool)
 # carry the working / stuck cues. PostToolUseFailure → the grok decoder flags it.
 # NB: no `Notification` — grok's notification event is hook-execution telemetry
@@ -44,8 +54,14 @@ def group():
     return {"hooks": [{"type": "command", "command": COMMAND, "timeout": 5}]}
 
 
+def capture_group():
+    return {"hooks": [{"type": "command", "command": CAPTURE_COMMAND, "timeout": 5}]}
+
+
 def build():
     hooks = {ev: [group()] for ev in PASSIVE_EVENTS + TOOL_EVENTS}
+    for ev in CAPTURE_EVENTS:
+        hooks[ev].append(capture_group())
     return {"hooks": hooks}
 
 

--- a/hooks/opencode/vibebuddy.js
+++ b/hooks/opencode/vibebuddy.js
@@ -46,14 +46,29 @@ function sendHook(name, fields) {
   return post(HOOK_URL, { hook_event_name: name, ...fields });
 }
 
+// OpenCode plugins run inside the OpenCode process itself, which *is* the child
+// of the terminal, so the environment here is the real one — no ancestor walk is
+// needed (unlike `hooks/capture-terminal.sh`, which runs in a stripped hook
+// process). What this cannot see is the host app's bundle id or Ghostty's
+// terminal id; those need a process-tree walk and an AppleScript round trip,
+// which the shell hook does for the CLIs that have one.
 function sendTerminal(sessionId, env) {
   const e = env || {};
+  const tty = (e.TTY || e.SSH_TTY || "").replace(/^\/dev\//, "");
+  // $ITERM_SESSION_ID is "w0t0p0:UUID"; only the UUID half is an iTerm2 session's
+  // `unique ID`.
+  const iterm = (e.ITERM_SESSION_ID || "").split(":").pop();
   return post(TERM_URL, {
     session_id: sessionId || "",
-    term_program: e.TERM_PROGRAM || "",
-    tty: e.TTY || e.SSH_TTY || "",
+    term_program: e.TERM_PROGRAM || (e.KITTY_WINDOW_ID || e.TERM === "xterm-kitty" ? "kitty" : ""),
+    tty,
     tmux: e.TMUX || "",
     tmux_pane: e.TMUX_PANE || "",
+    iterm_session_id: iterm,
+    wezterm_pane: e.WEZTERM_PANE || "",
+    kitty_window_id: e.KITTY_WINDOW_ID || "",
+    kitty_listen_on: e.KITTY_LISTEN_ON || "",
+    cwd: e.PWD || "",
   });
 }
 

--- a/hooks/tests/capture-terminal-parsing.sh
+++ b/hooks/tests/capture-terminal-parsing.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Unit test for the pure helpers in hooks/capture-terminal.sh, plus one
+# end-to-end `--print` run. No network, no AppleScript, no process-table
+# assumptions: the parsers are fed fixed strings.
+#
+#   bash hooks/tests/capture-terminal-parsing.sh
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SCRIPT="$HERE/../capture-terminal.sh"
+
+FAILED=0
+check() {  # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    printf 'ok   %s\n' "$1"
+  else
+    printf 'FAIL %s\n       expected: [%s]\n       actual:   [%s]\n' "$1" "$2" "$3"
+    FAILED=1
+  fi
+}
+
+# Source the helpers without running the capture.
+VIBEBUDDY_CAPTURE_LIB_ONLY=1 . "$SCRIPT"
+
+# ------------------------------------------------------------- bundle_path
+check "Electron helper resolves to the app the user sees" \
+  "/Applications/Cursor.app" \
+  "$(bundle_path '/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Plugin).app/Contents/MacOS/Cursor Helper (Plugin)')"
+
+check "a plain GUI executable resolves to its own bundle" \
+  "/Applications/Ghostty.app" \
+  "$(bundle_path /Applications/Ghostty.app/Contents/MacOS/ghostty)"
+
+check "a bundle path with a space survives" \
+  "/Applications/Visual Studio Code.app" \
+  "$(bundle_path '/Applications/Visual Studio Code.app/Contents/MacOS/Electron')"
+
+check "a non-GUI executable is not a bundle" "" "$(bundle_path /bin/zsh)"
+check "a relative path is not a bundle" "" "$(bundle_path 'Foo.app/Contents/MacOS/Foo')"
+check "an .app mentioned outside Contents/MacOS is not a bundle" "" \
+  "$(bundle_path /Users/x/notes-about-Cursor.app/readme.txt)"
+
+# ----------------------------------------------------------- gui_bundle_id
+# A fake ancestry: an agent CLI shipped as a background-only wrapper .app that
+# lives *beside* (not inside) the real GUI app hosting it — the shape of a
+# Claude Code desktop session, where the wrapper's bundle id is not activatable
+# and the walk has to keep climbing to reach the app the user actually sees.
+FIXTURE=$(mktemp -d -t vbcapture-bundles) || exit 1
+trap 'rm -rf "$FIXTURE"' EXIT
+
+make_bundle() {  # make_bundle <name> <bundle id> [<extra plist keys XML>]
+  mkdir -p "$FIXTURE/$1.app/Contents/MacOS"
+  cat >"$FIXTURE/$1.app/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleIdentifier</key><string>$2</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  ${3:-}
+</dict></plist>
+PLIST
+  printf '%s' "$FIXTURE/$1.app/Contents/MacOS/$1"
+}
+
+WRAPPER=$(make_bundle wrapper com.example.wrapper '<key>LSBackgroundOnly</key><true/>')
+AGENT=$(make_bundle agent com.example.agent '<key>LSUIElement</key><string>YES</string>')
+HOST=$(make_bundle host com.example.host)
+
+check "a background-only bundle is not a jumpable host" "" "$(gui_bundle_id "$WRAPPER")"
+check "an LSUIElement bundle is not a jumpable host either" "" "$(gui_bundle_id "$AGENT")"
+check "a plain foreground bundle is" "com.example.host" "$(gui_bundle_id "$HOST")"
+check "an executable outside any bundle is not" "" "$(gui_bundle_id /bin/zsh)"
+
+# The ancestor walk itself: nearest first, first non-empty id wins.
+WALK=""
+for exe in "$WRAPPER" "/usr/bin/some-helper" "$HOST"; do
+  [ -n "$WALK" ] && continue
+  WALK=$(gui_bundle_id "$exe")
+done
+check "the walk skips the background-only wrapper and picks the GUI host" \
+  "com.example.host" "$WALK"
+
+check "plist_true accepts 1" "true" "$(plist_true 1 && echo true)"
+check "plist_true accepts YES and true" "true" "$(plist_true YES && plist_true true && echo true)"
+check "plist_true rejects 0 and an absent value" "" "$(plist_true 0 || plist_true '' || true)"
+
+# ------------------------------------------------------------- env_extract
+PS_LINE='/bin/zsh -l TERM_PROGRAM=ghostty TMUX=/Volumes/My Disk/tmux-501/default,1234,0 TMUX_PANE=%3 TERM=xterm-ghostty'
+check "a value containing spaces is not truncated" \
+  "TMUX=/Volumes/My Disk/tmux-501/default,1234,0" \
+  "$(printf '%s\n' "$PS_LINE" | env_extract TMUX)"
+
+check "each wanted variable is extracted, argv left alone" \
+  "TERM_PROGRAM=ghostty
+TMUX_PANE=%3" \
+  "$(printf '%s\n' "$PS_LINE" | env_extract TERM_PROGRAM TMUX_PANE)"
+
+check "an argv token that looks like an assignment is not a variable" "" \
+  "$(printf '%s\n' '/usr/bin/foo --term_program=bar --x=1' | env_extract TERM_PROGRAM)"
+
+check "the nearest ancestor's value wins" \
+  "TERM_PROGRAM=ghostty" \
+  "$(printf '%s\n%s\n' 'a TERM_PROGRAM=ghostty' 'b TERM_PROGRAM=iTerm.app' | env_extract TERM_PROGRAM)"
+
+check "a value containing = survives (KITTY_LISTEN_ON)" \
+  "KITTY_LISTEN_ON=unix:/tmp/k=1" \
+  "$(printf '%s\n' 'kitty KITTY_LISTEN_ON=unix:/tmp/k=1 TERM=xterm-kitty' | env_extract KITTY_LISTEN_ON)"
+
+check "nothing is printed for a variable that isn't set" "" \
+  "$(printf '%s\n' '/bin/zsh TERM=xterm' | env_extract WEZTERM_PANE)"
+
+# --------------------------------------------------------------------- add
+JSON=""; add cwd '/Users/x/a"b\c'
+check "a quote and a backslash are escaped, not dropped" \
+  ',"cwd":"/Users/x/a\"b\\c"' "$JSON"
+
+JSON=""; add tty "$(printf 'ttys003\nrogue')"
+check "a newline is stripped so the JSON stays valid" ',"tty":"ttys003rogue"' "$JSON"
+
+JSON=""; add term_program "$(printf 'ghos\ttty')"
+check "a tab is stripped too" ',"term_program":"ghostty"' "$JSON"
+
+JSON=""; add cwd "$(printf '\001\002')"
+check "a value that was nothing but control characters is omitted" "" "$JSON"
+
+JSON=""; add tty ""
+check "an empty value is omitted" "" "$JSON"
+
+JSON=""; add_num host_pid 4242; add_num host_pid_bad "12a"; add_num host_pid_empty ""
+check "add_num takes digits and refuses anything else" ',"host_pid":4242' "$JSON"
+
+# --------------------------------------------------------- end-to-end shape
+BODY=$(echo '{"session_id":"probe-test","cwd":"/tmp"}' | VIBEBUDDY_GHOSTTY_PROBE=0 bash "$SCRIPT" --print)
+case "$BODY" in
+  '{"session_id":"probe-test"'*'"cwd":"/tmp"}') printf 'ok   %s\n' "--print emits one JSON object for the given session" ;;
+  *) printf 'FAIL %s\n       actual: [%s]\n' "--print emits one JSON object for the given session" "$BODY"; FAILED=1 ;;
+esac
+LINES=$(printf '%s\n' "$BODY" | wc -l | tr -d ' ')
+check "--print output is a single line" "1" "$LINES"
+if command -v python3 >/dev/null 2>&1; then
+  if printf '%s' "$BODY" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+    printf 'ok   %s\n' "--print output parses as JSON"
+  else
+    printf 'FAIL %s\n       actual: [%s]\n' "--print output parses as JSON" "$BODY"; FAILED=1
+  fi
+else
+  printf 'skip %s (no python3)\n' "--print output parses as JSON"
+fi
+
+if [ "$FAILED" = "0" ]; then
+  echo "PASS: capture-terminal.sh parsing"
+else
+  echo "FAIL: capture-terminal.sh parsing"
+fi
+exit "$FAILED"


### PR DESCRIPTION
Two user-visible fixes, plus the hook plumbing the second one needs.

## What was wrong

**The collapsed glance pill was oversized and wrapped its counters.** It was
pinned to a fixed 300pt width with unconstrained `Text`, so a two-digit counter
such as "10" broke onto a second line, and the 60pt sprite pushed the pill to
78pt tall. The pill now sizes to its content, the counters cannot wrap, and the
sprite is scaled to fit a compact bar.

**Clicking a session did not take you to it.** Rows were disabled whenever no
terminal ref was recorded, and the only jump mechanism was `open -a`, which
raises whatever window the app happens to have in front rather than the one
running the session. Now a click locates and focuses the originating terminal
window/tab, or the host app, or tells you plainly that it could not.

## Architecture

The locator is captured at hook time, not guessed at jump time. `capture-terminal.sh`
runs on SessionStart and UserPromptSubmit and records tty, iTerm/Ghostty/WezTerm/
kitty window and tab identifiers, the tmux pane, and the host application's bundle
id. Each capture is merged into the stored ref field by field, so a later capture
that cannot see a value does not erase the one an earlier capture found.

The jumper then degrades along an explicit chain rather than failing silently:

1. **Exact** — focus the specific window/tab/pane via the terminal's own scripting
   dictionary.
2. **App-level** — activate the host application when the exact target is gone or
   the terminal exposes no addressable window.
3. **Honest outcome** — a typed `JumpOutcome` the UI renders as human copy
   (`JumpOutcomeCopy.swift`), so "we could not find that terminal" is a real
   answer instead of a dead click.

Codex and Grok installers now wire the same capture into their SessionStart and
UserPromptSubmit hooks. Antigravity is deliberately untouched: its upstream hook
surface does not execute commands, so there is nothing to hang the capture off.

## Verification

- 152 VibeBuddyKit tests and 324 VibeBuddyMacCore tests pass.
- 29 shell assertions in `hooks/tests/capture-terminal-parsing.sh` cover the
  capture parsing across the supported terminals and tmux.
- Live jump exercised end to end, producing both an `activatedApp` outcome and a
  `noTerminal` outcome from the running app.
- Collapsed pill verified against a live screenshot of the deployed build.

## Caveats

- **Installed hooks must be reinstalled.** Existing Claude/Codex/Grok configs
  point at the old hook wiring and will not capture terminal refs until the
  installers are re-run from the main checkout.
- **The AppleScripts were validated against each terminal's scripting dictionary,
  not executed live** for every terminal. iTerm, Ghostty, WezTerm and kitty paths
  are dictionary-checked; only the terminals present on the dev machine were
  driven for real.
