### PR TITLE
feat(grok): bring Grok Build to parity with Claude Code and Codex

### DIFF
--- a/VibeBuddyApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "Question" = "问题";
 "Answer" = "回答";
 "… (truncated)" = "…（已截断）";
+"Grok will still ask in the terminal after Allow (permission mode: %@). Set permission_mode = \"always-approve\" to approve from here." = "批准后，Grok 仍会在终端里再确认一次（权限模式：%@）。设置 permission_mode = \"always-approve\" 才能直接在这里批准。";
 
 /* MARK: Settings */
 "Sound" = "声音";

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -235,6 +235,12 @@ final class DashboardStore: ObservableObject {
                 ],
                 statusSince: now.addingTimeInterval(-15), updatedAt: now.addingTimeInterval(-15)),
             AgentSession(
+                id: "demo-grok", agent: .grok, project: "glaux-book", branch: "main",
+                model: "grok-4.6", status: .working, summary: "Running the build script…",
+                tokens: 2800, contextTokens: 96_000, contextWindow: 500_000,
+                activeTool: "run_terminal_command",
+                statusSince: now.addingTimeInterval(-6), updatedAt: now.addingTimeInterval(-6)),
+            AgentSession(
                 id: "demo-question", agent: .claudeCode, project: "docs-review",
                 model: "claude-sonnet-4-5", status: .needsResponse, waitKind: .question,
                 pendingQuestion: PendingQuestion(

--- a/VibeBuddyApp/Sources/DashboardView.swift
+++ b/VibeBuddyApp/Sources/DashboardView.swift
@@ -276,6 +276,16 @@ private struct SessionRow: View {
                     }
                     .buttonStyle(.bordered).controlSize(.small).font(.caption)
                     .padding(.top, 1)
+                    if session.agent == .grok, let mode = approval.permissionMode, mode != "bypassPermissions" {
+                        Label {
+                            Text("Grok will still ask in the terminal after Allow (permission mode: \(mode)). Set permission_mode = \"always-approve\" to approve from here.")
+                        } icon: {
+                            Image(systemName: "terminal")
+                        }
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 3)
+                    }
                 }
 
                 if let question = session.pendingQuestion {

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -48,10 +48,18 @@ public struct PendingApproval: Codable, Sendable, Equatable {
     public let filePath: String?     // Edit/Write/Read target
     public let oldText: String?      // Edit: pre-image (for a diff)
     public let newText: String?      // Edit/Write: post-image / new content
+    /// The agent's permission mode when it asked, when it reports one — Grok
+    /// Build sends `default | auto | plan | bypassPermissions`. Only
+    /// `bypassPermissions` makes a remote *allow* final: in the other modes Grok
+    /// raises its own local prompt after the hook passes, and that prompt has no
+    /// remote answer channel. A remote *deny* is authoritative in every mode.
+    /// Nil for agents that don't report a mode (Claude Code and friends).
+    public let permissionMode: String?
 
     public init(id: String, tool: String, commandPreview: String,
                 command: String? = nil, filePath: String? = nil,
-                oldText: String? = nil, newText: String? = nil) {
+                oldText: String? = nil, newText: String? = nil,
+                permissionMode: String? = nil) {
         self.id = id
         self.tool = tool
         self.commandPreview = commandPreview
@@ -59,6 +67,7 @@ public struct PendingApproval: Codable, Sendable, Equatable {
         self.filePath = filePath
         self.oldText = oldText
         self.newText = newText
+        self.permissionMode = permissionMode
     }
 }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
@@ -9,11 +9,13 @@ public enum AccountUsageWindowKind: String, Codable, Sendable {
 public enum AccountUsageProvider: String, Codable, CaseIterable, Sendable {
     case codex
     case claude
+    case grok
 
     public var displayName: String {
         switch self {
         case .codex: "Codex"
         case .claude: "Claude"
+        case .grok: "Grok"
         }
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VibeBuddyKit
 
 /// Pulls the rich approval-card fields out of a PreToolUse `tool_input`. Pure
 /// and synchronous so the `/approval` route can build a `PendingApproval` before
@@ -25,10 +26,49 @@ public struct ApprovalDetails: Equatable, Sendable {
         let filePath = first("file_path")
         let oldText  = capped(first("old_string", "old_text"))
         let newText  = capped(first("new_string", "new_text", "content", "file_text"))
-        // Preview mirrors the old behaviour: Bash → command, file tools → path.
-        let previewSource = command ?? filePath ?? newText ?? ""
+        // Preview mirrors the old behaviour: Bash → command, file tools → path;
+        // `url` closes the WebFetch/web_fetch case, which has neither.
+        let previewSource = command ?? filePath ?? newText ?? first("url") ?? ""
         let preview = String(previewSource.prefix(120))
         return ApprovalDetails(commandPreview: preview, command: command,
                                filePath: filePath, oldText: oldText, newText: newText)
+    }
+}
+
+/// The fields the `/approval` route needs out of a blocking PreToolUse payload,
+/// decoded per agent. Claude Code (and every Claude-shape CLI) sends snake_case
+/// `tool_name` / `tool_input` / `session_id`; Grok Build sends camelCase
+/// `toolName` / `toolInput` / `sessionId` and adds a `permissionMode`.
+///
+/// Grok's tool vocabulary is normalized here, at the boundary, so the matcher,
+/// the allow-store and `ApprovalDetails` all stay agent-agnostic.
+public enum ApprovalPayload {
+    public struct Call {
+        public let tool: String
+        public let input: [String: Any]
+        public let sessionID: String
+        /// Grok only: `default | auto | plan | bypassPermissions` at the time of
+        /// the call. Outside `bypassPermissions` an `allow` from the phone only
+        /// means "the hook didn't block it" — Grok still raises its own local
+        /// prompt, which no remote client can answer. A `deny` is authoritative
+        /// in every mode, so the phone approval still runs; the mode rides along
+        /// on the approval so the UI can say so.
+        public let permissionMode: String?
+    }
+
+    public static func decode(_ obj: [String: Any], agent: AgentKind) -> Call {
+        guard agent == .grok else {
+            return Call(tool: obj["tool_name"] as? String ?? "",
+                        input: obj["tool_input"] as? [String: Any] ?? [:],
+                        sessionID: obj["session_id"] as? String ?? "",
+                        permissionMode: nil)
+        }
+        let normalized = GrokToolVocabulary.normalize(
+            tool: obj["toolName"] as? String ?? "",
+            input: obj["toolInput"] as? [String: Any] ?? [:])
+        let mode = (obj["permissionMode"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        return Call(tool: normalized.tool, input: normalized.input,
+                    sessionID: obj["sessionId"] as? String ?? "",
+                    permissionMode: mode)
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokACPClient.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokACPClient.swift
@@ -1,0 +1,175 @@
+import Darwin
+import Foundation
+
+/// One newline-delimited JSON-RPC exchange with `grok agent --no-leader stdio`.
+///
+/// The Grok CLI speaks the Agent Client Protocol, whose extension methods carry
+/// a leading underscore on the wire (`_x.ai/billing`); the unprefixed name is
+/// answered with "Method not found". Requests are pipelined, so `initialize`
+/// and the extension call cost one round trip, and the child is torn down as
+/// soon as the awaited response arrives.
+final class GrokACPClient: @unchecked Sendable {
+    /// `params` is raw JSON so the request line can be written verbatim. A
+    /// serializer would escape the `/` in `_x.ai/billing`, and the agent looks
+    /// methods up literally, so the escaped form is an unknown method.
+    struct Request: Sendable {
+        var id: Int
+        var method: String
+        var params: String = "{}"
+
+        var line: Data {
+            Data(#"{"jsonrpc":"2.0","id":\#(id),"method":"\#(method)","params":\#(params)}"#.utf8) + [0x0A]
+        }
+    }
+
+    static let initializeRequest = Request(
+        id: 1,
+        method: "initialize",
+        params: #"""
+        {"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":false,"writeTextFile":false},"terminal":false}}
+        """#
+    )
+
+    static let billingRequest = Request(id: 2, method: "_x.ai/billing")
+
+    private let lock = NSLock()
+    private var process: Process?
+    private var isCancelled = false
+
+    /// Requests termination from any thread. The blocking worker stays the sole
+    /// owner of the pipes and of the final reap.
+    func cancel() {
+        lock.lock()
+        isCancelled = true
+        let process = process
+        lock.unlock()
+        if let process, process.isRunning { process.terminate() }
+    }
+
+    var cancellationRequested: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isCancelled
+    }
+
+    /// Blocking: spawns the child, writes every request, and returns the raw
+    /// response line whose `id` matches `responseID`.
+    func exchange(
+        executableURL: URL,
+        arguments: [String],
+        requests: [Request],
+        responseID: Int,
+        timeout: TimeInterval
+    ) throws -> Data {
+        guard timeout > 0 else { throw AccountUsageError.timedOut }
+        let deadline = Date().addingTimeInterval(timeout)
+
+        let process = Process()
+        let input = Pipe()
+        let output = Pipe()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            throw AccountUsageError.providerUnavailable
+        }
+
+        lock.lock()
+        self.process = process
+        let cancelledBeforeInstall = isCancelled
+        lock.unlock()
+        defer { teardown(process: process, input: input, output: output) }
+        if cancelledBeforeInstall { throw CancellationError() }
+
+        let inputDescriptor = input.fileHandleForWriting.fileDescriptor
+        _ = Darwin.fcntl(inputDescriptor, F_SETNOSIGPIPE, 1)
+        for request in requests {
+            try write(request, to: inputDescriptor)
+        }
+
+        return try readResponse(
+            id: responseID,
+            from: output.fileHandleForReading.fileDescriptor,
+            deadline: deadline
+        )
+    }
+
+    private func write(_ request: Request, to descriptor: Int32) throws {
+        try request.line.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            var written = 0
+            while written < bytes.count {
+                let count = Darwin.write(descriptor, baseAddress.advanced(by: written), bytes.count - written)
+                if count > 0 {
+                    written += count
+                    continue
+                }
+                if count < 0, errno == EINTR { continue }
+                throw AccountUsageError.providerUnavailable
+            }
+        }
+    }
+
+    private func readResponse(id: Int, from descriptor: Int32, deadline: Date) throws -> Data {
+        var buffer = Data()
+        var bytes = [UInt8](repeating: 0, count: 16_384)
+        while true {
+            while let newline = buffer.firstIndex(of: 0x0A) {
+                let line = Data(buffer[..<newline])
+                buffer.removeSubrange(...newline)
+                guard !line.isEmpty,
+                      let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+                      let responseID = (object["id"] as? NSNumber)?.intValue,
+                      responseID == id else { continue }
+                return line
+            }
+
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { throw AccountUsageError.timedOut }
+            var descriptors = [pollfd(fd: descriptor, events: Int16(POLLIN | POLLHUP), revents: 0)]
+            let milliseconds = Int32(min(remaining * 1_000, Double(Int32.max)))
+            let pollResult = descriptors.withUnsafeMutableBufferPointer {
+                Darwin.poll($0.baseAddress, nfds_t($0.count), max(1, milliseconds))
+            }
+            if pollResult == 0 { throw AccountUsageError.timedOut }
+            if pollResult < 0 {
+                if errno == EINTR { continue }
+                throw AccountUsageError.unknown
+            }
+            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            if count < 0, errno == EINTR { continue }
+            guard count > 0 else {
+                if cancellationRequested { throw CancellationError() }
+                throw AccountUsageError.providerUnavailable
+            }
+            buffer.append(bytes, count: count)
+        }
+    }
+
+    /// Closing stdin is the agent's normal shutdown signal; TERM and then KILL
+    /// bound how long a stuck child can outlive the request.
+    private func teardown(process: Process, input: Pipe, output: Pipe) {
+        try? input.fileHandleForWriting.close()
+        try? output.fileHandleForReading.close()
+        let graceDeadline = ContinuousClock.now + .milliseconds(200)
+        while process.isRunning, ContinuousClock.now < graceDeadline {
+            Darwin.usleep(5_000)
+        }
+        if process.isRunning { process.terminate() }
+        let terminationDeadline = ContinuousClock.now + .milliseconds(200)
+        while process.isRunning, ContinuousClock.now < terminationDeadline {
+            Darwin.usleep(5_000)
+        }
+        if process.isRunning {
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        }
+        process.waitUntilExit()
+        lock.lock()
+        self.process = nil
+        lock.unlock()
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokHome.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokHome.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Where Grok Build keeps its data. Grok resolves it from `$GROK_HOME` and only
+/// falls back to `~/.grok`, so every read of grok's files goes through here —
+/// otherwise an isolated profile (a test rig, a second install) would be
+/// observed at the wrong path while its hooks were installed at the right one
+/// (`hooks/install-grok-hooks.py` honours the same variable).
+public enum GrokHome {
+    public static var url: URL {
+        if let value = ProcessInfo.processInfo.environment["GROK_HOME"], !value.isEmpty {
+            return URL(fileURLWithPath: (value as NSString).expandingTildeInPath)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".grok", isDirectory: true)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokParser.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokParser.swift
@@ -4,30 +4,60 @@ import VibeBuddyKit
 /// Parses Grok Build's hook envelope into a normalized `HookEvent`. Grok's stdin
 /// is **camelCase keys with snake_case event values** —
 /// `{"hookEventName":"pre_tool_use","sessionId":…,"cwd"/"workspaceRoot":…,
-/// "toolName":…,"toolResult":{"isError":…}}` — distinct from the Claude shape, so
-/// it gets its own decoder behind the source-aware `HookDecoder`. Unknown events
-/// and malformed input return `nil` so the daemon ignores them (fail-open).
+/// "promptId":…,"toolName":…,"toolResult":{"isError":…}}` — distinct from the
+/// Claude shape, so it gets its own decoder behind the source-aware
+/// `HookDecoder`. Field names follow grok 1.0.13's `HookEventEnvelope`
+/// (`xai-grok-hooks/src/event.rs`).
+///
+/// A payload whose envelope decodes is always *understood*: the events that
+/// carry no status change (teardown `stop`, subagent-session events, passive
+/// audit records) answer `.ignored`, and only a payload that is not a grok hook
+/// envelope at all answers `.undecodable`. Grok fires ignorable events on every
+/// session, so conflating the two would report the hook source as an unknown
+/// CLI version after each teardown.
+///
+/// Stateless by design: turn ordering (a `stop_cancelled` that lands after the
+/// next prompt) is resolved by the reducer from `HookEvent.turnID`.
 public enum GrokParser {
-    public static func parse(_ data: Data, receivedAt: Date) -> HookEvent? {
+    public static func parse(_ data: Data, receivedAt: Date) -> HookDecoder.Result {
         guard let raw = try? JSONDecoder().decode(RawGrok.self, from: data),
               let event = raw.hookEventName,
-              let sessionID = raw.sessionId,
-              let kind = mapKind(event)
-        else { return nil }
+              let sessionID = raw.sessionId
+        else { return .undecodable }
+
+        // Subagent lifecycle is topology, never parent progress. `subagent_start`
+        // fires in the parent; `subagent_stop` fires in the child's own session
+        // and carries the same `subagentId`, so the reducer re-attaches it to the
+        // parent that already owns that child.
+        if event == "subagent_start" || event == "subagent_stop" {
+            return .event(childLifecycle(event, raw: raw, sessionID: sessionID,
+                                         receivedAt: receivedAt))
+        }
+
+        // Every other event that can fire inside a subagent's own session carries
+        // `subagentType` there and omits it in the main session (grok's documented
+        // "exit 0 when subagentType is present" rule). A child session is not a
+        // session we track, and it must never move the parent's status.
+        if nonEmpty(raw.subagentType) != nil { return .ignored }
+
+        guard let kind = mapKind(event, raw: raw) else { return .ignored }
 
         // Grok signals a failed tool either by a dedicated `post_tool_use_failure`
         // event or by `toolResult.isError` inside a `post_tool_use`.
         let isFailureEvent = event == "post_tool_use_failure"
-        return HookEvent(
+        return .event(HookEvent(
             kind: kind,
             sessionID: sessionID,
             agent: .grok,
             cwd: raw.cwd ?? raw.workspaceRoot,
             toolName: raw.toolName,
-            message: raw.message,
+            message: message(for: event, raw: raw),
+            transcriptPath: nonEmpty(raw.transcriptPath),
+            model: nonEmpty(raw.modelId),
             toolError: kind == .postToolUse && (isFailureEvent || detectToolError(data)),
-            timestamp: receivedAt
-        )
+            timestamp: receivedAt,
+            turnID: nonEmpty(raw.promptId)
+        ))
     }
 
     /// Read `toolResult.isError` defensively with `JSONSerialization` (not the
@@ -51,21 +81,104 @@ public enum GrokParser {
         }
     }
 
-    private static func mapKind(_ name: String) -> HookEvent.Kind? {
+    private static func mapKind(_ name: String, raw: RawGrok) -> HookEvent.Kind? {
         switch name {
         case "session_start":         return .sessionStart
         case "user_prompt_submit":    return .userPromptSubmit
         case "pre_tool_use":          return .preToolUse
         case "post_tool_use",
              "post_tool_use_failure": return .postToolUse
-        case "stop":                  return .stop
+        case "stop":
+            // `end_turn` is the genuine turn end. Grok fires `stop` a second time
+            // at teardown (`channel_closed`/`shutdown`); `session_end` already
+            // reports that, and settling on it would resurrect a closed session.
+            switch raw.reason {
+            case nil, "end_turn": return .stop
+            default:              return nil
+            }
+        // A failed or cancelled turn is still a turn that ended. `stop_failure`
+        // additionally reads as failed through its message (see `message(for:)`).
+        case "stop_failure", "stop_cancelled": return .stop
+        case "notification":
+            switch raw.notificationType {
+            // The only grok event that means "a permission UI is actually waiting".
+            case "permission_prompt": return .notification
+            // Documented idle backstop: fires ~1 min after ANY turn end (including
+            // the ends that report no stop at all), and is cancelled by the next
+            // prompt. Settling on it is what keeps a missed `stop` from sticking.
+            case "idle_prompt":       return .stop
+            // `task_complete` reports a BACKGROUND task finishing; it can land
+            // mid-turn, so treating it as a turn end would flip a working session
+            // to done. The turn end is reported by stop*/idle_prompt.
+            default:                  return nil
+            }
         case "session_end":           return .sessionEnd
-        // Grok's `notification` is hook-execution telemetry (it echoes which hooks
-        // ran), NOT a user-attention request like Claude's — so ignore it; mapping
-        // it to needsResponse wrongly overrides `stop`→done. Grok approvals come
-        // through the blocking `pre_tool_use` path instead.
-        default:                      return nil   // notification, pre_compact, subagent_*, unknown
+        // `permission_denied` is a passive audit record — the tool call is already
+        // over, so it carries no progress. Compaction never changes the three-state.
+        default:                      return nil   // permission_denied, pre/post_compact, unknown
         }
+    }
+
+    private static func message(for event: String, raw: RawGrok) -> String? {
+        switch event {
+        case "notification":
+            guard raw.notificationType == "permission_prompt" else { return nil }
+            // `SessionReducer.waitKind(from:)` reads the wait kind out of this
+            // prose, and grok's display text is release-dependent ("Tool
+            // permission requested", "Plan approval requested"), so name the
+            // permission explicitly when the CLI's own wording doesn't.
+            let text = nonEmpty(raw.message) ?? nonEmpty(raw.title)
+            guard let text else { return "Permission required" }
+            return text.lowercased().contains("permission") ? text : "Permission required: \(text)"
+        case "stop_failure":
+            // Mirrors Claude's `StopFailure` prose so `FailureHeuristic` marks the
+            // session stuck through the same path.
+            let kind = nonEmpty(raw.error) ?? "unknown"
+            guard let detail = nonEmpty(raw.errorDetails) ?? nonEmpty(raw.lastAssistantMessage) else {
+                return "Turn failed: \(kind)"
+            }
+            return "Turn failed (\(kind)): \(detail)"
+        case "stop_cancelled":
+            // A cancel is not a failure, so carry only the agent's own words —
+            // synthesized prose here would trip the failure heuristic.
+            return nonEmpty(raw.lastAssistantMessage)
+        case "stop":
+            return nonEmpty(raw.lastAssistantMessage)
+        default:
+            return nonEmpty(raw.message)
+        }
+    }
+
+    /// `subagentId` is the child's session id on both events, so start (fired in
+    /// the parent) and stop (fired in the child) share one stable identity.
+    private static func childLifecycle(
+        _ event: String,
+        raw: RawGrok,
+        sessionID: String,
+        receivedAt: Date
+    ) -> HookEvent {
+        let started = event == "subagent_start"
+        let type = nonEmpty(raw.subagentType)
+        return HookEvent(
+            kind: .childLifecycle,
+            sessionID: sessionID,
+            agent: .grok,
+            cwd: raw.cwd ?? raw.workspaceRoot,
+            message: nonEmpty(raw.description) ?? nonEmpty(raw.lastAssistantMessage),
+            transcriptPath: nonEmpty(raw.transcriptPath),
+            timestamp: receivedAt,
+            childID: nonEmpty(raw.subagentId).map { "subagent:\($0)" },
+            childKind: .subagent,
+            childName: type,
+            childType: type,
+            childAction: started ? .started : .stopped,
+            turnID: nonEmpty(raw.promptId)
+        )
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
     }
 
     private struct RawGrok: Decodable {
@@ -73,7 +186,19 @@ public enum GrokParser {
         let sessionId: String?
         let cwd: String?
         let workspaceRoot: String?
+        let transcriptPath: String?
+        let promptId: String?
         let toolName: String?
         let message: String?
+        let title: String?
+        let notificationType: String?
+        let reason: String?
+        let error: String?
+        let errorDetails: String?
+        let lastAssistantMessage: String?
+        let modelId: String?
+        let subagentId: String?
+        let subagentType: String?
+        let description: String?
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokPermissionConfig.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokPermissionConfig.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// The `[permission]` allow / deny lists Grok Build reads from its own
+/// `~/.grok/config.toml`, in the same Claude-style rule grammar
+/// (`Bash(npm *)`, `Read(/x/**)`).
+///
+/// Grok honours these *alongside* `~/.claude/settings.json`, so vibebuddy's
+/// approval gate has to see both — otherwise it would hold the phone on calls
+/// Grok itself would have run silently, or (worse) auto-allow one the user
+/// denied natively.
+///
+/// Deliberately a small scanner rather than a new dependency: we need exactly
+/// one table and two arrays of strings out of the file, and the package has no
+/// TOML library.
+///
+/// Unsupported grammar, all of it deliberately: multi-line basic (`"""`) and
+/// literal (`'''`) strings, `[permission.…]` sub-tables, the structured
+/// `[[permission.rules]]` form, and dotted/quoted keys. Every one of them yields
+/// *fewer* rules than the file states, so the failure direction is over-asking
+/// (the phone is asked about a call Grok would have run silently) and never
+/// auto-allowing something the user did not allow.
+public enum GrokPermissionConfig {
+
+    /// `<grok home>/config.toml`.
+    public static func defaultConfigURL() -> URL {
+        GrokHome.url.appendingPathComponent("config.toml")
+    }
+
+    public static func load(configURL: URL = defaultConfigURL()) -> PermissionRules {
+        guard let text = try? String(contentsOf: configURL, encoding: .utf8) else {
+            return PermissionRules(allow: [], deny: [])
+        }
+        return parse(text)
+    }
+
+    static func parse(_ text: String) -> PermissionRules {
+        var section = ""
+        var collecting: (key: String, body: String, depth: Int)?
+        var lists: [String: [String]] = [:]
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = stripComment(String(rawLine))
+
+            if var open = collecting {
+                open.body += "\n" + line
+                open.depth += bracketDelta(line)
+                if open.depth <= 0 {
+                    lists[open.key] = stringLiterals(open.body)
+                    collecting = nil
+                } else {
+                    collecting = open
+                }
+                continue
+            }
+
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("[") {
+                section = sectionName(trimmed)
+                continue
+            }
+            guard section == "permission",
+                  let (key, value) = keyValue(trimmed),
+                  key == "allow" || key == "deny",
+                  value.hasPrefix("[")
+            else { continue }
+
+            let depth = bracketDelta(value)
+            if depth <= 0 {
+                lists[key] = stringLiterals(value)
+            } else {
+                collecting = (key, value, depth)
+            }
+        }
+
+        return PermissionRules(allow: lists["allow"] ?? [], deny: lists["deny"] ?? [])
+    }
+
+    // MARK: - scanning primitives
+
+    /// `[permission]` / `[[permission.rules]]` → `permission` / `permission.rules`.
+    private static func sectionName(_ line: String) -> String {
+        var name = line.drop(while: { $0 == "[" })
+        if let close = name.firstIndex(where: { $0 == "]" }) { name = name[name.startIndex..<close] }
+        return name.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Split `key = value` on the first `=` outside a string. Bare keys only —
+    /// quoted/dotted keys never name `allow`/`deny` at the top of `[permission]`.
+    private static func keyValue(_ line: String) -> (String, String)? {
+        guard let eq = line.firstIndex(of: "=") else { return nil }
+        let key = line[line.startIndex..<eq].trimmingCharacters(in: .whitespaces)
+        let value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+        guard !key.isEmpty, !value.isEmpty else { return nil }
+        return (key, value)
+    }
+
+    /// Drop a `#` comment, respecting quoted strings.
+    private static func stripComment(_ line: String) -> String {
+        var out = ""
+        var quote: Character?
+        var escaped = false
+        for ch in line {
+            if let q = quote {
+                out.append(ch)
+                if escaped { escaped = false }
+                else if q == "\"" && ch == "\\" { escaped = true }
+                else if ch == q { quote = nil }
+                continue
+            }
+            if ch == "#" { break }
+            if ch == "\"" || ch == "'" { quote = ch }
+            out.append(ch)
+        }
+        return out
+    }
+
+    /// Net `[` minus `]` outside strings — how much of the array is still open.
+    private static func bracketDelta(_ text: String) -> Int {
+        var depth = 0
+        var quote: Character?
+        var escaped = false
+        for ch in text {
+            if let q = quote {
+                if escaped { escaped = false }
+                else if q == "\"" && ch == "\\" { escaped = true }
+                else if ch == q { quote = nil }
+                continue
+            }
+            switch ch {
+            case "\"", "'": quote = ch
+            case "[": depth += 1
+            case "]": depth -= 1
+            default: break
+            }
+        }
+        return depth
+    }
+
+    /// Every quoted string in an array body, in order. Basic strings honour the
+    /// escapes a rule can realistically contain (`\"`, `\\`); literal `'…'`
+    /// strings are taken verbatim, as TOML defines them.
+    private static func stringLiterals(_ text: String) -> [String] {
+        var out: [String] = []
+        var current: String?
+        var quote: Character?
+        var escaped = false
+        for ch in text {
+            guard let q = quote else {
+                if ch == "\"" || ch == "'" { quote = ch; current = "" }
+                continue
+            }
+            if escaped {
+                current?.append(unescape(ch))
+                escaped = false
+            } else if q == "\"" && ch == "\\" {
+                escaped = true
+            } else if ch == q {
+                out.append(current ?? "")
+                current = nil
+                quote = nil
+            } else {
+                current?.append(ch)
+            }
+        }
+        return out
+    }
+
+    private static func unescape(_ ch: Character) -> Character {
+        switch ch {
+        case "n": return "\n"
+        case "t": return "\t"
+        default: return ch      // \" \\ \/ and anything else: the character itself
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokSessionLocator.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokSessionLocator.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Finds the directory Grok Build keeps one session's files in.
+///
+/// Grok stores a session at `~/.grok/sessions/<encoded cwd>/<session id>/`,
+/// where the directory name is the working directory percent-encoded against
+/// RFC 3986's unreserved set. Unlike Claude Code's project-directory naming the
+/// encoding is lossless, so the fast path is a single `stat` — no scan.
+///
+/// The encoding rule and its rationale are ported from `agent-session-kit`
+/// (`AgentSessionLive/Adapters/Grok/GrokSessionsPath.swift`); the scan fallback
+/// mirrors `agent-sessions`' `GrokSessionDiscovery.swift`, which exists because
+/// an encoded cwd over 255 bytes is replaced by a `<slug>-<hash>` directory
+/// whose real path lives in a sibling `.cwd` file.
+public enum GrokSessionLocator {
+
+    /// The characters Grok leaves unescaped: RFC 3986's unreserved set.
+    /// Checked against the real store — `-`, `.`, `_` and `~` appear literally
+    /// in directory names there, everything else outside `[A-Za-z0-9]` escaped.
+    static let unreserved = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+    /// Encodes a working directory the way Grok names its session directory.
+    public static func encode(cwd: String) -> String? {
+        cwd.addingPercentEncoding(withAllowedCharacters: unreserved)
+    }
+
+    /// `<grok home>/sessions` — `GrokHome.url` resolves `$GROK_HOME`.
+    public static func sessionsRoot(grokHome: URL) -> URL {
+        grokHome.appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    /// The session directory for `sessionID`, or nil when nothing on disk
+    /// matches. Tries the encoded-cwd path first and only then scans, so the
+    /// common case costs one file-existence check.
+    public static func locate(sessionID: String, cwd: String?, grokHome: URL) -> URL? {
+        guard !sessionID.isEmpty, !sessionID.contains("/"), sessionID != ".", sessionID != ".."
+        else { return nil }
+        let root = sessionsRoot(grokHome: grokHome)
+
+        if let cwd, let encoded = encode(cwd: cwd) {
+            let direct = root.appendingPathComponent(encoded, isDirectory: true)
+                .appendingPathComponent(sessionID, isDirectory: true)
+            if isSessionDirectory(direct) { return direct }
+        }
+
+        // `<slug>-<hash>` naming, or a hook that never told us the cwd.
+        guard let children = try? FileManager.default.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+        else { return nil }
+        for child in children {
+            let candidate = child.appendingPathComponent(sessionID, isDirectory: true)
+            if isSessionDirectory(candidate) { return candidate }
+        }
+        return nil
+    }
+
+    /// The session directory a hook-supplied `transcriptPath` points into. Grok
+    /// names `updates.jsonl` there, so the directory is that file's parent; a
+    /// path that already is the session directory is accepted as-is.
+    public static func directory(forTranscriptPath path: String) -> URL? {
+        let url = URL(fileURLWithPath: path)
+        if isSessionDirectory(url) { return url }
+        let parent = url.deletingLastPathComponent()
+        return isSessionDirectory(parent) ? parent : nil
+    }
+
+    /// A directory is a session when Grok has written either of the two files it
+    /// creates at session start. Requiring both would miss a session observed
+    /// between the two writes.
+    static func isSessionDirectory(_ url: URL) -> Bool {
+        let fm = FileManager.default
+        return fm.fileExists(atPath: url.appendingPathComponent("summary.json").path)
+            || fm.fileExists(atPath: url.appendingPathComponent("updates.jsonl").path)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokSessionReader.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokSessionReader.swift
@@ -1,0 +1,345 @@
+import Foundation
+import VibeBuddyKit
+
+/// One subagent a Grok session spawned, as recorded by the parent.
+public struct GrokSubagent: Equatable, Sendable {
+    public let id: String
+    public let type: String?
+    public let detail: String?
+    public let finished: Bool
+    public let startedAt: Date?
+
+    public init(id: String, type: String? = nil, detail: String? = nil,
+                finished: Bool = false, startedAt: Date? = nil) {
+        self.id = id
+        self.type = type
+        self.detail = detail
+        self.finished = finished
+        self.startedAt = startedAt
+    }
+}
+
+/// Reads a Grok Build session directory (`~/.grok/sessions/<cwd>/<id>/`) into
+/// the same `TranscriptInfo` / `TranscriptEntry` shapes the Claude transcript
+/// path produces, so one enrichment step serves both agents.
+///
+/// **One source per fact** (the discipline `agent-session-kit`'s
+/// `GrokRecordMapper` documents — every interesting fact appears in at least
+/// two of a session's files, so each is read out of exactly one):
+///
+/// | Fact | Read from |
+/// | --- | --- |
+/// | model, branch, title | `summary.json` |
+/// | context window | `signals.json.contextWindowTokens` |
+/// | live context size | newest `updates` `_meta.totalTokens`, else `signals.contextTokensUsed` |
+/// | per-turn token spend | the newest `turn_completed.usage` |
+/// | the model's prose | `updates` `agent_message_chunk`, else `summary.last_turn_summary` |
+/// | tool lifecycle | `updates` `tool_call` / `tool_call_update` |
+/// | permission block | `events.jsonl` `permission_requested` / `permission_resolved` |
+/// | subagents | `subagents/<id>/meta.json`, plus `updates` `subagent_*` |
+///
+/// Every `.jsonl` read is a bounded **tail**: `agent-sessions`'
+/// `GrokSessionParser` warns that `updates.jsonl` reaches gigabytes because
+/// `tool_call_update` repeats a tool's accumulated output, and sessions on this
+/// machine are already megabytes after a single turn.
+public enum GrokSessionReader {
+
+    /// `events.jsonl` holds one small record per line; this matches
+    /// `TranscriptReader.recentEntries`' window.
+    public static let tailBytes = 262_144
+    /// `updates.jsonl` gets a wider window: a single `tool_call_update` carries a
+    /// tool's accumulated output and routinely exceeds 256 KB, which would leave
+    /// the tail holding no complete record at all.
+    public static let updatesTailBytes = 1_048_576
+    /// `summary.json` and `signals.json` are rewritten in place and stay small;
+    /// this cap only bounds a corrupted or hostile file.
+    static let objectBytes = 1_048_576
+
+    // MARK: - Public reads
+
+    /// Everything the dashboard shows for a session, plus the children the
+    /// parent recorded — both out of one pass over the `updates.jsonl` tail.
+    public struct Snapshot: Sendable {
+        public let info: TranscriptInfo
+        public let subagents: [GrokSubagent]
+    }
+
+    /// Reads a session directory, or nil when it holds none of Grok's session
+    /// files.
+    public static func read(directory: URL, summaryLimit: Int = 220,
+                            maxBytes: Int = updatesTailBytes) -> Snapshot? {
+        let summary = object(at: directory.appendingPathComponent("summary.json"))
+        let signals = object(at: directory.appendingPathComponent("signals.json"))
+        let updates = tail(at: directory.appendingPathComponent("updates.jsonl"), maxBytes: maxBytes)
+        let events = tail(at: directory.appendingPathComponent("events.jsonl"),
+                          maxBytes: tailBytes)
+        guard summary != nil || signals != nil || updates != nil else { return nil }
+
+        let facts = self.facts(updatesTail: updates ?? Data())
+        var info = TranscriptInfo()
+
+        info.model = string(summary, "current_model_id") ?? string(signals, "primaryModelId")
+        info.branch = string(summary, "head_branch")
+
+        // The newest `turn_completed` is one turn's cost, which the reducer
+        // accumulates exactly like Claude's per-turn readings.
+        info.tokens = facts.turnTokens
+
+        info.contextTokens = facts.contextTokens ?? int(signals, "contextTokensUsed")
+        info.contextWindow = int(signals, "contextWindowTokens")
+
+        info.summary = collapse(facts.lastAssistantText, limit: summaryLimit)
+            ?? collapse(string(summary, "last_turn_summary"), limit: summaryLimit)
+            ?? collapse(string(summary, "session_summary"), limit: summaryLimit)
+            ?? collapse(string(summary, "generated_title"), limit: summaryLimit)
+
+        info.activeTool = facts.runningTool
+        info.pendingPermissionTool = pendingPermissionTool(eventsTail: events ?? Data())
+        return Snapshot(info: info, subagents: subagents(directory: directory, facts: facts))
+    }
+
+    /// The session's recent output for the phone's detail pane, oldest→newest.
+    public static func recentEntries(directory: URL, limit: Int = 12,
+                                     perEntryLimit: Int = 600,
+                                     maxBytes: Int = updatesTailBytes) -> [TranscriptEntry] {
+        guard let data = tail(at: directory.appendingPathComponent("updates.jsonl"),
+                              maxBytes: maxBytes) else { return [] }
+        return recentEntries(updatesTail: data, limit: limit, perEntryLimit: perEntryLimit)
+    }
+
+    /// The subagents this session spawned. `subagents/<id>/meta.json` is the
+    /// durable record and survives the tail window; the log — already parsed for
+    /// `facts` — adds any child spawned before its directory was written.
+    static func subagents(directory: URL, facts: UpdatesFacts) -> [GrokSubagent] {
+        var byID: [String: GrokSubagent] = [:]
+        let root = directory.appendingPathComponent("subagents", isDirectory: true)
+        let children = (try? FileManager.default.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? []
+        for child in children {
+            guard let meta = object(at: child.appendingPathComponent("meta.json")) else { continue }
+            let id = string(meta, "subagent_id") ?? child.lastPathComponent
+            guard !id.isEmpty else { continue }
+            let status = string(meta, "status")
+            byID[id] = GrokSubagent(
+                id: id,
+                type: string(meta, "subagent_type"),
+                detail: string(meta, "description"),
+                finished: status != nil && status != "running",
+                startedAt: date(string(meta, "started_at")))
+        }
+
+        for spawn in facts.spawned where byID[spawn.id] == nil {
+            byID[spawn.id] = GrokSubagent(id: spawn.id, type: spawn.type, detail: spawn.detail)
+        }
+        for id in facts.finished {
+            guard let existing = byID[id], !existing.finished else { continue }
+            byID[id] = GrokSubagent(id: id, type: existing.type, detail: existing.detail,
+                                    finished: true, startedAt: existing.startedAt)
+        }
+
+        return byID.values.sorted {
+            switch ($0.startedAt, $1.startedAt) {
+            case let (a?, b?) where a != b: return a < b
+            default: return $0.id < $1.id
+            }
+        }
+    }
+
+    // MARK: - Pure parsers over already-read bytes
+
+    /// What one pass over an `updates.jsonl` tail establishes.
+    struct UpdatesFacts {
+        var lastAssistantText: String?
+        /// The newest `turn_completed`'s input+output. Verified per-prompt, not
+        /// cumulative: readings on a real four-turn session rise and fall, and
+        /// each carries its own `numTurns` count of model calls.
+        var turnTokens: Int?
+        var contextTokens: Int?
+        var runningTool: String?
+        var spawned: [(id: String, type: String?, detail: String?)] = []
+        var finished: Set<String> = []
+    }
+
+    static func facts(updatesTail data: Data) -> UpdatesFacts {
+        var facts = UpdatesFacts()
+        var prose: [String] = []
+        var openCalls: [(id: String, title: String)] = []
+
+        for line in String(decoding: data, as: UTF8.self)
+            .split(separator: "\n", omittingEmptySubsequences: true) {
+            // A tail cut mid-record simply fails to parse and is skipped.
+            guard let root = try? JSONSerialization.jsonObject(with: Data(line.utf8))
+                    as? [String: Any],
+                  let params = root["params"] as? [String: Any],
+                  let update = params["update"] as? [String: Any],
+                  let type = update["sessionUpdate"] as? String
+            else { continue }
+
+            // The live context size rides on every turn-scoped record.
+            if let total = int(params["_meta"] as? [String: Any], "totalTokens") {
+                facts.contextTokens = total
+            }
+
+            switch type {
+            case "user_message_chunk":
+                prose.removeAll()
+            case "agent_message_chunk":
+                if let text = chunkText(update) { prose.append(text) }
+            case "tool_call":
+                // A tool call closes the model's current prose block, so what
+                // survives is the newest message rather than the whole turn.
+                prose.removeAll()
+                guard let id = update["toolCallId"] as? String else { break }
+                let title = (update["title"] as? String) ?? "tool"
+                openCalls.removeAll { $0.id == id }
+                openCalls.append((id, title))
+            case "tool_call_update":
+                // The variant without `status` is a mid-flight content append.
+                guard let status = update["status"] as? String,
+                      status == "completed" || status == "failed",
+                      let id = update["toolCallId"] as? String else { break }
+                openCalls.removeAll { $0.id == id }
+            case "turn_completed":
+                if let usage = update["usage"] as? [String: Any] {
+                    facts.turnTokens = (int(usage, "inputTokens") ?? 0)
+                        + (int(usage, "outputTokens") ?? 0)
+                }
+                openCalls.removeAll()
+            case "subagent_spawned":
+                guard let id = string(update, "subagent_id") else { break }
+                facts.spawned.append((id, string(update, "subagent_type"),
+                                      string(update, "description")))
+            case "subagent_finished":
+                if let id = string(update, "subagent_id") { facts.finished.insert(id) }
+            default:
+                continue
+            }
+        }
+
+        facts.lastAssistantText = prose.isEmpty ? nil : prose.joined(separator: " ")
+        facts.runningTool = openCalls.last?.title
+        return facts
+    }
+
+    /// The tool whose permission prompt is still waiting. Grok writes no id on
+    /// these records and shows one prompt at a time, so an unmatched request is
+    /// simply the newer of the two record types.
+    static func pendingPermissionTool(eventsTail data: Data) -> String? {
+        var pending: String?
+        for line in String(decoding: data, as: UTF8.self)
+            .split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let record = try? JSONSerialization.jsonObject(with: Data(line.utf8))
+                    as? [String: Any],
+                  let type = record["type"] as? String else { continue }
+            switch type {
+            case "permission_requested": pending = string(record, "tool_name") ?? "a tool"
+            case "permission_resolved": pending = nil
+            default: continue
+            }
+        }
+        return pending
+    }
+
+    static func recentEntries(updatesTail data: Data, limit: Int = 12,
+                              perEntryLimit: Int = 600) -> [TranscriptEntry] {
+        var entries: [TranscriptEntry] = []
+        var pending: (role: String, parts: [String])?
+
+        func flush() {
+            guard let open = pending else { return }
+            pending = nil
+            guard let text = collapse(open.parts.joined(separator: " "), limit: perEntryLimit)
+            else { return }
+            entries.append(TranscriptEntry(role: open.role, text: text))
+        }
+        func append(_ role: String, _ text: String) {
+            if pending?.role != role { flush(); pending = (role, []) }
+            pending?.parts.append(text)
+        }
+
+        for line in String(decoding: data, as: UTF8.self)
+            .split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let root = try? JSONSerialization.jsonObject(with: Data(line.utf8))
+                    as? [String: Any],
+                  let params = root["params"] as? [String: Any],
+                  let update = params["update"] as? [String: Any],
+                  let type = update["sessionUpdate"] as? String
+            else { continue }
+
+            switch type {
+            case "user_message_chunk":
+                if let text = chunkText(update) { append("user", text) }
+            case "agent_message_chunk":
+                if let text = chunkText(update) { append("assistant", text) }
+            case "tool_call":
+                // Same compact marker Claude's reader emits for a tool-only turn.
+                flush()
+                entries.append(TranscriptEntry(
+                    role: "assistant", text: "⚙ \((update["title"] as? String) ?? "tool")"))
+            default:
+                // Reasoning, tool output, hook telemetry: noise for this pane.
+                continue
+            }
+        }
+        flush()
+        return Array(entries.suffix(limit))
+    }
+
+    // MARK: - Helpers
+
+    /// The last `maxBytes` of a file, or nil when it cannot be read.
+    static func tail(at url: URL, maxBytes: Int) -> Data? {
+        guard let handle = FileHandle(forReadingAtPath: url.path) else { return nil }
+        defer { try? handle.close() }
+        do {
+            let end = try handle.seekToEnd()
+            try handle.seek(toOffset: end > UInt64(maxBytes) ? end - UInt64(maxBytes) : 0)
+            return try handle.readToEnd() ?? Data()
+        } catch {
+            return nil
+        }
+    }
+
+    static func object(at url: URL) -> [String: Any]? {
+        guard let handle = FileHandle(forReadingAtPath: url.path) else { return nil }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: objectBytes), !data.isEmpty else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    /// `{"content":{"type":"text","text":…}}` on every message chunk.
+    private static func chunkText(_ update: [String: Any]) -> String? {
+        guard let content = update["content"] as? [String: Any],
+              let text = content["text"] as? String, !text.isEmpty else { return nil }
+        return text
+    }
+
+    private static func string(_ object: [String: Any]?, _ key: String) -> String? {
+        guard let value = object?[key] as? String, !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func int(_ object: [String: Any]?, _ key: String) -> Int? {
+        guard let value = object?[key] else { return nil }
+        if let number = value as? Int { return number }
+        if let number = value as? NSNumber { return number.intValue }
+        return nil
+    }
+
+    private static func date(_ raw: String?) -> Date? {
+        guard let raw else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: raw) ?? ISO8601DateFormatter().date(from: raw)
+    }
+
+    /// Collapse whitespace runs and truncate; nil when nothing is left.
+    private static func collapse(_ raw: String?, limit: Int) -> String? {
+        guard let raw else { return nil }
+        let collapsed = raw
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return collapsed.isEmpty ? nil : String(collapsed.prefix(limit))
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokToolVocabulary.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokToolVocabulary.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Translates Grok Build's tool vocabulary into the canonical (Claude Code)
+/// names and input keys that `PermissionMatcher`, `AllowRule` and
+/// `ApprovalDetails` already speak.
+///
+/// Applied exactly once, at the `/approval` route boundary, so everything
+/// downstream stays agent-agnostic — and so an "Always allow" rule written from
+/// a Grok approval (`Bash(git status)`) matches the next Grok call as well as a
+/// Claude one. It is also what makes Grok's own Claude-style rule strings
+/// (`Bash(npm *)` in `~/.grok/config.toml`) apply to `run_terminal_command`,
+/// mirroring how Grok itself aliases matchers.
+public enum GrokToolVocabulary {
+
+    /// Canonical tool name for a Grok tool name. Unknown names pass through
+    /// unchanged: the matcher's conservative default arm then forces `.ask`,
+    /// which is the safe direction.
+    public static func canonicalTool(_ raw: String) -> String {
+        let name = bareName(raw)
+        switch name {
+        // `run_terminal_cmd` is the older recording spelling; `bash`/`shell` are
+        // the aliases Grok's own permission hub accepts.
+        case "run_terminal_command", "run_terminal_cmd", "bash", "shell":
+            return "Bash"
+        case "read_file", "hashline_read":
+            return "Read"
+        case "search_replace", "hashline_edit", "edit", "apply_patch", "str_replace":
+            return "Edit"
+        case "write", "write_file", "create_file":
+            return "Write"
+        case "grep", "hashline_grep":
+            return "Grep"
+        case "list_dir", "list_directory":
+            return "Glob"
+        case "web_search":
+            return "WebSearch"
+        case "web_fetch":
+            return "WebFetch"
+        case "spawn_subagent", "task":
+            return "Task"
+        default:
+            // MCP tools reach the hook as `server__tool`; Claude's vocabulary —
+            // and therefore any rule the user already wrote — is `mcp__server__tool`.
+            if name.contains("__"), !name.hasPrefix("mcp__") { return "mcp__" + name }
+            return name
+        }
+    }
+
+    /// Canonical input keys. Grok's `search_replace` and `write` already use
+    /// `file_path` / `old_string` / `new_string` / `content` (verified against
+    /// `tool_call.rawInput` in real `updates.jsonl` records), so the only
+    /// divergence is the read/list target: `target_file` and `target_directory`.
+    /// Original keys are kept — this only *adds* the canonical spelling.
+    public static func canonicalInput(_ input: [String: Any]) -> [String: Any] {
+        var out = input
+        for key in ["target_file", "target_directory"] where out["file_path"] == nil {
+            if let value = out[key] as? String, !value.isEmpty { out["file_path"] = value }
+        }
+        return out
+    }
+
+    public static func normalize(
+        tool: String, input: [String: Any]
+    ) -> (tool: String, input: [String: Any]) {
+        (canonicalTool(tool), canonicalInput(input))
+    }
+
+    /// `GrokBuild:read_file` → `read_file`. Grok qualifies builtin tool ids with
+    /// a provider prefix in some surfaces; the hook payload usually doesn't, but
+    /// stripping it costs nothing and stops a qualified name falling through.
+    private static func bareName(_ raw: String) -> String {
+        guard let colon = raw.lastIndex(of: ":") else { return raw }
+        return String(raw[raw.index(after: colon)...])
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
@@ -1,0 +1,356 @@
+import Darwin
+import Foundation
+
+/// Pure mapping from Grok Build's billing payloads onto `AccountUsageSnapshot`.
+///
+/// Two payloads carry the same `config` object: the `_x.ai/billing` ACP
+/// response (`{"result":{"config":{…},"subscription_tier":…}}`), and the
+/// `billing: fetched credits config` record the CLI writes to
+/// `<grok home>/logs/unified.jsonl` (`ctx.config` + `ctx.subscriptionTier`).
+public enum GrokUsageResponseDecoder {
+    /// The `billing: fetched credits config` record is written on every billing
+    /// fetch; anything older than this is treated as no data rather than as a
+    /// current reading.
+    public static let logFallbackMaxAge: TimeInterval = 24 * 60 * 60
+
+    static let creditsLogMessage = "billing: fetched credits config"
+
+    /// Decodes one JSON-RPC response line for `_x.ai/billing`.
+    public static func decode(billingResponse: Data, fetchedAt: Date) throws -> AccountUsageSnapshot {
+        let envelope: BillingEnvelopeDTO
+        do {
+            envelope = try JSONDecoder().decode(BillingEnvelopeDTO.self, from: billingResponse)
+        } catch {
+            throw AccountUsageError.incompatibleFormat
+        }
+        if let error = envelope.error { throw classify(error) }
+        guard let result = envelope.result else { throw AccountUsageError.incompatibleFormat }
+        return try snapshot(
+            config: result.config,
+            tier: result.subscriptionTier ?? result.subscriptionTierSnakeCase,
+            fetchedAt: fetchedAt
+        )
+    }
+
+    /// Decodes one `~/.grok/logs/unified.jsonl` record. The record's own
+    /// timestamp becomes `fetchedAt`, so a cached reading never claims to be
+    /// newer than it is.
+    public static func decode(unifiedLogLine: Data) throws -> AccountUsageSnapshot {
+        let record: UnifiedLogRecordDTO
+        do {
+            record = try JSONDecoder().decode(UnifiedLogRecordDTO.self, from: unifiedLogLine)
+        } catch {
+            throw AccountUsageError.incompatibleFormat
+        }
+        guard record.msg == creditsLogMessage,
+              let context = record.ctx,
+              let timestamp = parseTimestamp(record.ts) else {
+            throw AccountUsageError.incompatibleFormat
+        }
+        return try snapshot(
+            config: context.config,
+            tier: context.subscriptionTier,
+            fetchedAt: timestamp
+        )
+    }
+
+    /// Returns the newest credits record in the tail of a unified log, or nil
+    /// when the file holds no usable reading.
+    public static func decodeNewestLogRecord(
+        in logURL: URL,
+        now: Date,
+        maxAge: TimeInterval = logFallbackMaxAge,
+        tailBytes: Int = 512 * 1_024
+    ) -> AccountUsageSnapshot? {
+        guard let tail = readTail(of: logURL, bytes: tailBytes) else { return nil }
+        let marker = Data(creditsLogMessage.utf8)
+        for line in tail.split(separator: 0x0A).reversed() {
+            let line = Data(line)
+            guard line.range(of: marker) != nil else { continue }
+            guard let snapshot = try? decode(unifiedLogLine: line) else { continue }
+            guard now.timeIntervalSince(snapshot.fetchedAt) <= maxAge else { return nil }
+            return snapshot
+        }
+        return nil
+    }
+
+    private static func snapshot(
+        config: BillingConfigDTO?,
+        tier: String?,
+        fetchedAt: Date
+    ) throws -> AccountUsageSnapshot {
+        guard let config else { throw AccountUsageError.incompatibleFormat }
+        let start = parseTimestamp(config.periodStart)
+        let resetsAt = parseTimestamp(config.periodEnd)
+        let durationMinutes = duration(from: start, to: resetsAt)
+
+        guard let creditPercent = config.creditPercent else {
+            throw AccountUsageError.incompatibleFormat
+        }
+        guard creditPercent.isFinite, (0...100).contains(creditPercent) else {
+            throw AccountUsageError.incompatibleFormat
+        }
+
+        var onDemand: AccountUsageWindow?
+        if let cap = config.onDemandCap?.val, cap > 0 {
+            let used = config.onDemandUsedValue ?? 0
+            let percent = min(100, max(0, used / cap * 100))
+            guard percent.isFinite else { throw AccountUsageError.incompatibleFormat }
+            onDemand = AccountUsageWindow(
+                kind: .secondary,
+                usedPercent: Int(percent.rounded()),
+                windowDurationMinutes: durationMinutes,
+                resetsAt: resetsAt
+            )
+        }
+
+        return AccountUsageSnapshot(
+            provider: .grok,
+            planType: tier.flatMap { $0.isEmpty ? nil : $0 },
+            primary: AccountUsageWindow(
+                kind: .primary,
+                usedPercent: Int(creditPercent.rounded()),
+                windowDurationMinutes: durationMinutes,
+                resetsAt: resetsAt
+            ),
+            secondary: onDemand,
+            lifetimeTokens: nil,
+            latestDailyTokens: nil,
+            fetchedAt: fetchedAt
+        )
+    }
+
+    private static func duration(from start: Date?, to end: Date?) -> Int? {
+        guard let start, let end, end > start else { return nil }
+        return Int((end.timeIntervalSince(start) / 60).rounded())
+    }
+
+    private static func classify(_ error: RPCErrorDTO) -> AccountUsageError {
+        let text = ([error.message, error.data?.text].compactMap { $0 }).joined(separator: " ")
+        let value = text.lowercased()
+        if value.contains("method not found") { return .providerUnavailable }
+        if value.contains("auth") || value.contains("grok login") { return .notLoggedIn }
+        return AccountUsageError.classify(message: text)
+    }
+
+    /// The proxy emits microsecond precision, which `ISO8601DateFormatter`
+    /// rejects outright, so a fraction-free retry is the last step.
+    static func parseTimestamp(_ raw: String?) -> Date? {
+        guard let raw else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: raw) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: raw) { return date }
+        guard let dot = raw.firstIndex(of: ".") else { return nil }
+        let afterDot = raw.index(after: dot)
+        let suffix = raw[afterDot...].firstIndex(where: { !$0.isNumber }) ?? raw.endIndex
+        return formatter.date(from: String(raw[..<dot] + raw[suffix...]))
+    }
+
+    private static func readTail(of url: URL, bytes: Int) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let size = try? handle.seekToEnd() else { return nil }
+        let offset = size > UInt64(bytes) ? size - UInt64(bytes) : 0
+        guard (try? handle.seek(toOffset: offset)) != nil else { return nil }
+        return try? handle.readToEnd()
+    }
+}
+
+// MARK: - Wire shapes
+
+private struct RPCErrorDTO: Decodable {
+    var message: String
+    var data: LenientTextDTO?
+}
+
+/// ACP puts a human-readable hint in `error.data`, which is a string for the
+/// billing handler but is free-form JSON in general.
+private struct LenientTextDTO: Decodable {
+    var text: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        text = try? container.decode(String.self)
+    }
+}
+
+private struct BillingEnvelopeDTO: Decodable {
+    var result: BillingResultDTO?
+    var error: RPCErrorDTO?
+}
+
+private struct BillingResultDTO: Decodable {
+    var config: BillingConfigDTO?
+    /// The handler answers `subscription_tier`; `/v1/settings` and some builds
+    /// spell it camelCase, and both are cheap to accept.
+    var subscriptionTier: String?
+    var subscriptionTierSnakeCase: String?
+
+    enum CodingKeys: String, CodingKey {
+        case config
+        case subscriptionTier
+        case subscriptionTierSnakeCase = "subscription_tier"
+    }
+}
+
+private struct CentDTO: Decodable {
+    var val: Double
+
+    enum CodingKeys: String, CodingKey { case val }
+
+    /// proto3 JSON omits zero-valued scalars, so `$0` arrives as `{}`.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        val = try container.decodeIfPresent(Double.self, forKey: .val) ?? 0
+    }
+}
+
+private struct UsagePeriodDTO: Decodable {
+    var start: String?
+    var end: String?
+}
+
+private struct BillingConfigDTO: Decodable {
+    var creditUsagePercent: Double?
+    var currentPeriod: UsagePeriodDTO?
+    /// Documented as deprecated but still emitted, and the only usage figures an
+    /// account without a credits percentage carries.
+    var monthlyLimit: CentDTO?
+    var used: CentDTO?
+    var onDemandCap: CentDTO?
+    var onDemandUsed: CentDTO?
+    var billingPeriodStart: String?
+    var billingPeriodEnd: String?
+
+    /// Percent of the included allowance. The credits config reports it
+    /// directly; the deprecated fields only carry an amount and a limit.
+    var creditPercent: Double? {
+        if let percent = creditUsagePercent { return percent }
+        guard let limit = monthlyLimit?.val, limit > 0, let spent = used?.val else { return nil }
+        return min(100, max(0, spent / limit * 100))
+    }
+
+    var onDemandUsedValue: Double? { onDemandUsed?.val }
+
+    var periodStart: String? { currentPeriod?.start ?? billingPeriodStart }
+
+    var periodEnd: String? { currentPeriod?.end ?? billingPeriodEnd }
+}
+
+private struct UnifiedLogContextDTO: Decodable {
+    var config: BillingConfigDTO?
+    var subscriptionTier: String?
+}
+
+private struct UnifiedLogRecordDTO: Decodable {
+    var ts: String?
+    var msg: String?
+    var ctx: UnifiedLogContextDTO?
+}
+
+// MARK: - Provider
+
+/// Reads Grok Build's weekly credit quota through the CLI's own ACP server, so
+/// the bearer token in `~/.grok/auth.json` is never touched by VibeBuddy. When
+/// the agent cannot be spawned or reached, the last billing record the CLI
+/// wrote to its unified log stands in.
+public final class GrokUsageProvider: AccountUsageProviding, Sendable {
+    private let executableURL: URL?
+    private let arguments: [String]
+    private let timeout: TimeInterval
+    private let logURL: URL
+
+    public init(
+        executableURL: URL? = nil,
+        arguments: [String] = ["agent", "--no-leader", "stdio"],
+        timeout: TimeInterval = 10,
+        logURL: URL? = nil
+    ) {
+        self.executableURL = executableURL ?? Self.resolveGrokExecutable()
+        self.arguments = arguments
+        self.timeout = timeout
+        self.logURL = logURL ?? Self.defaultLogURL()
+    }
+
+    public func fetch() async throws -> AccountUsageSnapshot {
+        try Task.checkCancellation()
+        let client = GrokACPClient()
+        let executableURL = executableURL
+        let arguments = arguments
+        let timeout = timeout
+        let logURL = logURL
+        return try await withTaskCancellationHandler {
+            do {
+                guard let executableURL else { throw AccountUsageError.providerUnavailable }
+                let response = try await withCheckedThrowingContinuation { continuation in
+                    DispatchQueue.global(qos: .utility).async {
+                        continuation.resume(with: Result {
+                            try client.exchange(
+                                executableURL: executableURL,
+                                arguments: arguments,
+                                requests: [GrokACPClient.initializeRequest, GrokACPClient.billingRequest],
+                                responseID: GrokACPClient.billingRequest.id,
+                                timeout: timeout
+                            )
+                        })
+                    }
+                }
+                try Task.checkCancellation()
+                return try GrokUsageResponseDecoder.decode(
+                    billingResponse: response,
+                    fetchedAt: Date()
+                )
+            } catch {
+                try Task.checkCancellation()
+                guard Self.allowsLogFallback(after: error) else { throw error }
+                guard let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(
+                    in: logURL,
+                    now: Date()
+                ) else { throw error }
+                return snapshot
+            }
+        } onCancel: {
+            client.cancel()
+        }
+    }
+
+    /// A refused or unreachable agent is exactly what the log record covers. A
+    /// signed-out account or an unreadable payload is reported as such instead,
+    /// because a stale reading would hide it.
+    static func allowsLogFallback(after error: any Error) -> Bool {
+        switch error {
+        case is CancellationError: return false
+        case let usage as AccountUsageError:
+            switch usage {
+            case .providerUnavailable, .timedOut, .offline, .unknown: return true
+            case .notLoggedIn, .rateLimited, .incompatibleFormat: return false
+            }
+        default: return true
+        }
+    }
+
+    public static func resolveGrokExecutable(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        grokHome: URL = GrokHome.url,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let fixed = [
+            grokHome.appendingPathComponent("bin/grok").path,
+            "/opt/homebrew/bin/grok",
+            "/usr/local/bin/grok",
+            "/usr/bin/grok",
+        ]
+        let fromPath = (environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map { String($0) + "/grok" }
+        return (fixed + fromPath)
+            .first(where: fileManager.isExecutableFile(atPath:))
+            .map { URL(fileURLWithPath: $0) }
+    }
+
+    public static func defaultLogURL(grokHome: URL = GrokHome.url) -> URL {
+        grokHome.appendingPathComponent("logs/unified.jsonl")
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookDecoder.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookDecoder.swift
@@ -9,23 +9,44 @@ import VibeBuddyKit
 /// default/passthrough and need no translation. CLIs with a different wire shape
 /// get their own pure decoder dispatched here.
 public enum HookDecoder {
+    /// A payload we understood but that carries no status change (grok's
+    /// teardown `stop`, anything fired inside a subagent's own session, a
+    /// passive audit record) is `.ignored` — distinct from `.undecodable`, which
+    /// is the only outcome that means "this CLI speaks a shape we do not know"
+    /// and is therefore the only one that may report `unknownVersion` health.
+    public enum Result: Equatable, Sendable {
+        case event(HookEvent)
+        case ignored
+        case undecodable
+
+        public var event: HookEvent? {
+            if case let .event(event) = self { return event }
+            return nil
+        }
+    }
+
     public static func decode(
         _ data: Data,
         agent: AgentKind,
         receivedAt: Date
-    ) -> HookEvent? {
+    ) -> Result {
         switch agent {
         case .codex:
-            return HookParser.parse(data, agent: .codex, receivedAt: receivedAt)
+            return result(HookParser.parse(data, agent: .codex, receivedAt: receivedAt))
         case .grok:
-            // Grok's envelope is camelCase keys with snake_case event values.
+            // Grok's envelope is camelCase keys with snake_case event values,
+            // and it is the one CLI that tells the two outcomes apart.
             return GrokParser.parse(data, receivedAt: receivedAt)
         case .antigravity:
             // Antigravity/Gemini: Claude-shape envelope but Gemini event names
             // (BeforeTool/AfterAgent/…), plus the Antigravity-2.0 spelling.
-            return AntigravityParser.parse(data, receivedAt: receivedAt)
+            return result(AntigravityParser.parse(data, receivedAt: receivedAt))
         default:
-            return HookParser.parse(data, agent: agent, receivedAt: receivedAt)
+            return result(HookParser.parse(data, agent: agent, receivedAt: receivedAt))
         }
+    }
+
+    private static func result(_ event: HookEvent?) -> Result {
+        event.map(Result.event) ?? .undecodable
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
@@ -52,6 +52,10 @@ public struct HookEvent: Sendable, Equatable {
     public let childName: String?
     public let childType: String?
     public let childAction: ChildLifecycleAction?
+    /// Per-turn identity when the CLI supplies one (Grok's `promptId`). Lets the
+    /// reducer drop a settle report that belongs to an already-superseded turn.
+    /// Nil for CLIs that do not label turns — those settle unconditionally.
+    public let turnID: String?
 
     public init(
         kind: Kind,
@@ -69,7 +73,8 @@ public struct HookEvent: Sendable, Equatable {
         childKind: ChildAgentKind? = nil,
         childName: String? = nil,
         childType: String? = nil,
-        childAction: ChildLifecycleAction? = nil
+        childAction: ChildLifecycleAction? = nil,
+        turnID: String? = nil
     ) {
         self.kind = kind
         self.sessionID = sessionID
@@ -87,5 +92,6 @@ public struct HookEvent: Sendable, Equatable {
         self.childName = childName
         self.childType = childType
         self.childAction = childAction
+        self.turnID = turnID
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
@@ -101,7 +101,30 @@ public enum ObservationHealthDetector {
                 now: now,
                 staleAfter: staleAfter,
                 fileManager: fm))
-        return [claude, codex]
+
+        // Grok keeps standalone hook files under `~/.grok/hooks/*.json`; ours is
+        // `vibebuddy.json`. The install marker is the config dir itself — grok
+        // 1.0.13 has no single settings file we can rely on.
+        let grok = agentDiagnostic(
+            agent: .grok,
+            hook: hookEvidence(
+                config: home?.appendingPathComponent(".grok/hooks/vibebuddy.json"),
+                installMarker: home?.appendingPathComponent(".grok", isDirectory: true),
+                agent: .grok,
+                signals: signals,
+                now: now,
+                staleAfter: staleAfter,
+                fileManager: fm),
+            passive: passiveEvidence(
+                root: home?.appendingPathComponent(".grok/sessions", isDirectory: true),
+                source: .transcript,
+                agent: .grok,
+                installed: home.map { fm.fileExists(atPath: $0.appendingPathComponent(".grok").path) },
+                signals: signals,
+                now: now,
+                staleAfter: staleAfter,
+                fileManager: fm))
+        return [claude, codex, grok]
     }
 
     private static func agentDiagnostic(
@@ -161,14 +184,10 @@ public enum ObservationHealthDetector {
         }
         let configurationIncomplete = !hasManagedHook
             || !requiredHookCoverage.isSubset(of: coverage)
-        let fallback: ObservationHealth
-        if agent == .codex, hasAsyncManagedHook {
-            fallback = .asyncIncompatible
-        } else if configurationIncomplete {
-            fallback = .eventsMissing
-        } else {
-            fallback = .eventsMissing
-        }
+        // Codex runs `async` hooks detached and drops their output, so an async
+        // managed hook is a configuration error rather than a missing event.
+        let fallback: ObservationHealth =
+            (agent == .codex && hasAsyncManagedHook) ? .asyncIncompatible : .eventsMissing
         return diagnostic(source: .hook, signal: signal, fallback: fallback,
                           configuredCoverage: Array(coverage), now: now,
                           staleAfter: staleAfter,
@@ -283,10 +302,13 @@ public enum ObservationHealthDetector {
             .max { $0.lastObservedAt < $1.lastObservedAt }
     }
 
+    /// Config keys are PascalCase across every CLI we install into (grok accepts
+    /// the same spelling as Claude), so one table covers them all.
     private static func eventFamily(_ event: String) -> ObservationEventCoverage? {
         switch event {
-        case "SessionStart", "SessionEnd", "PostModelSwitch", "CwdChanged": .lifecycle
-        case "UserPromptSubmit", "Stop", "StopFailure", "Interrupt": .turn
+        case "SessionStart", "SessionEnd", "PostModelSwitch", "CwdChanged",
+             "SubagentStart", "SubagentStop": .lifecycle
+        case "UserPromptSubmit", "Stop", "StopFailure", "StopCancelled", "Interrupt": .turn
         case "PreToolUse", "PostToolUse", "PostToolUseFailure", "PostToolBatch": .tool
         case "PermissionRequest", "PermissionDenied", "Notification", "Elicitation": .attention
         default: nil

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/PermissionRules.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/PermissionRules.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VibeBuddyKit
 
 /// The allow/deny lists vibebuddy uses to decide silent-vs-ask. Read from the
 /// user-level Claude Code settings; project-level merging is out of scope (its
@@ -24,5 +25,18 @@ public struct PermissionRules: Sendable {
         let allow = (perms["allow"] as? [String]) ?? []
         let deny = (perms["deny"] as? [String]) ?? []
         return PermissionRules(allow: allow, deny: deny)
+    }
+
+    /// The rules that agent actually honours. Grok Build reads its own
+    /// `~/.grok/config.toml` `[permission]` lists *and* `~/.claude/settings.json`,
+    /// so vibebuddy's gate merges the same two sources — anything less and the
+    /// phone would be asked about calls Grok runs silently. Every other agent
+    /// reads the Claude settings only.
+    public static func load(for agent: AgentKind) -> PermissionRules {
+        let claude = load()
+        guard agent == .grok else { return claude }
+        let grok = GrokPermissionConfig.load()
+        return PermissionRules(allow: claude.allow + grok.allow,
+                               deny: claude.deny + grok.deny)
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -10,6 +10,10 @@ public struct SessionReducer: Sendable {
     /// The last per-turn token reading we added to a session's cumulative spend,
     /// so the same turn (re-read on every mid-turn event) is counted only once.
     private var lastCountedTokens: [String: Int] = [:]
+    /// The turn a session is currently on, for CLIs that label turns
+    /// (`HookEvent.turnID`). Grok dispatches a cancelled turn's report off the
+    /// command loop, so it can land after the next turn already started.
+    private var currentTurnID: [String: String] = [:]
 
     public init() {}
 
@@ -38,6 +42,7 @@ public struct SessionReducer: Sendable {
             sessions[event.sessionID]?.failed = false
             sessions[event.sessionID]?.activeTool = nil
         case .userPromptSubmit:
+            if let turnID = event.turnID { currentTurnID[event.sessionID] = turnID }
             upsert(event, status: .working, waitKind: nil)
             sessions[event.sessionID]?.hasUnreadCompletion = false
             sessions[event.sessionID]?.failed = false
@@ -65,6 +70,15 @@ public struct SessionReducer: Sendable {
             sessions[event.sessionID]?.hasUnreadCompletion = false
             sessions[event.sessionID]?.activeTool = nil      // no tool running while waiting
         case .stop:
+            // A settle report for a turn the session has already moved past is
+            // stale news, not idleness: ignore it rather than showing a false
+            // done while the newer turn is still running. A stop with no turn
+            // identity (every CLI but grok, plus grok's idle backstop) settles
+            // unconditionally.
+            if let turnID = event.turnID,
+               let current = currentTurnID[event.sessionID], current != turnID {
+                break
+            }
             // Create-if-missing so a late-observed lifecycle still shows as done;
             // carry the agent's final summary when present.
             upsert(event, status: .done, waitKind: nil, summary: event.message)
@@ -81,6 +95,7 @@ public struct SessionReducer: Sendable {
             // an idle "needs you" prompt doesn't outlive the session it belonged to.
             sessions.removeValue(forKey: event.sessionID)
             lastCountedTokens[event.sessionID] = nil
+            currentTurnID[event.sessionID] = nil
         case .sessionMetadataChanged:
             // Model and cwd changes describe the same live session. They must
             // not clear its tool/wait state or manufacture a progress transition.
@@ -133,7 +148,13 @@ public struct SessionReducer: Sendable {
             let abandoned = now.timeIntervalSince(s.updatedAt) > staleAfter
             return answered || abandoned
         }.map(\.id)
-        for id in stale { sessions.removeValue(forKey: id) }
+        for id in stale {
+            sessions.removeValue(forKey: id)
+            // The per-session side tables outlive nothing: a session id that
+            // comes back (grok resumes one) must start its accounting fresh.
+            currentTurnID[id] = nil
+            lastCountedTokens[id] = nil
+        }
     }
 
     /// Layer transcript-derived metadata onto an existing session. Model and
@@ -142,6 +163,7 @@ public struct SessionReducer: Sendable {
     public mutating func enrich(sessionID: String, with info: TranscriptInfo) {
         guard var s = sessions[sessionID] else { return }
         if let model = info.model { s.model = model }
+        if let branch = info.branch { s.branch = branch }
         if let tokens = info.tokens {
             s.tokens = tokens
             // Accumulate cumulative spend, counting each fresh turn reading once.
@@ -152,21 +174,45 @@ public struct SessionReducer: Sendable {
         }
         if let contextTokens = info.contextTokens {
             s.contextTokens = contextTokens
-            s.contextWindow = Self.contextWindow(for: info.model ?? s.model)
+            // A source that records the real window (Grok's `signals.json`)
+            // wins over the model table, which only knows published defaults.
+            s.contextWindow = info.contextWindow
+                ?? Self.contextWindow(for: info.model ?? s.model)
+        }
+        // Only ever *names* a tool the hooks have not named. `PostToolUse` clears
+        // `activeTool` before the log records the matching `tool_call_update`,
+        // and a `stop` gate fires before `turn_completed` is written, so a
+        // transcript read may only fill a gap on a session that is still working.
+        if let activeTool = info.activeTool, s.activeTool == nil, s.status == .working {
+            s.activeTool = activeTool
         }
         if s.status == .needsResponse, let pendingQuestion = info.pendingQuestion {
             s.pendingQuestion = pendingQuestion
             s.pendingApproval = nil
             s.waitKind = .question
             s.summary = pendingQuestion.prompt
+        } else if s.status == .needsResponse, s.pendingApproval == nil, s.pendingQuestion == nil,
+                  let tool = info.pendingPermissionTool {
+            // The agent's own permission prompt is waiting in its terminal. We
+            // cannot answer it remotely, but the phone can at least say what for.
+            s.waitKind = .permission
+            s.summary = "Permission required: \(tool)"
         }
+        // Deliberately last, and deliberately overriding the hook's own
+        // `lastAssistantMessage`: the transcript holds the newest prose, and for
+        // grok the `stop` envelope's copy is truncated at 32 KiB and stale by
+        // the time a later turn's chunks land.
         if let summary = info.summary, s.status != .needsResponse { s.summary = summary }
         sessions[sessionID] = s
     }
 
-    /// Context-window size by model. Current Claude (Opus/Sonnet/Haiku 4.x) and
-    /// Codex models are 200k; default to that until a model needs a different value.
-    static func contextWindow(for model: String?) -> Int { 200_000 }
+    /// Context-window size by model, used only when the source records no real
+    /// window of its own. Current Claude (Opus/Sonnet/Haiku 4.x) and Codex
+    /// models are 200k; Grok's are 500k.
+    static func contextWindow(for model: String?) -> Int {
+        guard let model = model?.lowercased() else { return 200_000 }
+        return model.hasPrefix("grok") ? 500_000 : 200_000
+    }
 
     /// Mark a known session as blocked on a remote approval.
     public mutating func setPendingApproval(sessionID: String, _ approval: PendingApproval, at: Date) {
@@ -324,10 +370,10 @@ public struct SessionReducer: Sendable {
 
     /// Child events may create a parent row so topology is visible, but they
     /// never move the parent's three-state progress.
-    private mutating func ensureParentWithoutProgress(_ event: HookEvent) {
-        if sessions[event.sessionID] == nil {
-            sessions[event.sessionID] = AgentSession(
-                id: event.sessionID,
+    private mutating func ensureParentWithoutProgress(_ event: HookEvent, sessionID: String) {
+        if sessions[sessionID] == nil {
+            sessions[sessionID] = AgentSession(
+                id: sessionID,
                 agent: event.agent,
                 project: event.cwd.map(Self.projectName) ?? "—",
                 model: event.model,
@@ -337,13 +383,32 @@ public struct SessionReducer: Sendable {
             )
             return
         }
-        if let cwd = event.cwd { sessions[event.sessionID]?.project = Self.projectName(cwd) }
-        if let model = event.model { sessions[event.sessionID]?.model = model }
-        sessions[event.sessionID]?.updatedAt = event.timestamp
+        // A re-targeted child report describes the child's own working copy, so
+        // it must not relabel the parent's project or model.
+        if sessionID == event.sessionID {
+            if let cwd = event.cwd { sessions[sessionID]?.project = Self.projectName(cwd) }
+            if let model = event.model { sessions[sessionID]?.model = model }
+        }
+        sessions[sessionID]?.updatedAt = event.timestamp
+    }
+
+    /// Which session a child report belongs to. Claude reports a child from its
+    /// parent, but grok fires `subagent_stop` inside the child's *own* session
+    /// (same `subagentId`), which we never track as a session. Re-attach it to
+    /// the parent that already owns that child so the row completes instead of
+    /// spawning a phantom session.
+    private func childLifecycleTarget(_ event: HookEvent) -> String {
+        if sessions[event.sessionID] != nil { return event.sessionID }
+        guard let childID = event.childID,
+              let owner = sessions.values.first(where: {
+                  $0.childAgents?.contains { $0.id == childID } == true
+              })
+        else { return event.sessionID }
+        return owner.id
     }
 
     private mutating func applyNestedChildTool(_ event: HookEvent) {
-        ensureParentWithoutProgress(event)
+        ensureParentWithoutProgress(event, sessionID: event.sessionID)
         guard let childID = event.childID else { return }
         updateChild(sessionID: event.sessionID, id: childID, at: event.timestamp) { child in
             if let tool = event.toolName { child.lastActivity = tool }
@@ -351,20 +416,26 @@ public struct SessionReducer: Sendable {
     }
 
     private mutating func applyChildLifecycle(_ event: HookEvent) {
-        ensureParentWithoutProgress(event)
+        let sessionID = childLifecycleTarget(event)
+        // A child's *end* reported from a session we have never seen, for a child
+        // no session claims, has no topology to add — inventing a row for it would
+        // publish grok's child session as if it were a session of its own. A start
+        // still creates the parent so live topology stays visible.
+        if sessions[sessionID] == nil, event.childAction != .started { return }
+        ensureParentWithoutProgress(event, sessionID: sessionID)
         guard let action = event.childAction, let kind = event.childKind else {
-            sessions[event.sessionID]?.childTopologyDegraded = true
+            sessions[sessionID]?.childTopologyDegraded = true
             return
         }
         guard let childID = event.childID else {
-            sessions[event.sessionID]?.childTopologyDegraded = true
+            sessions[sessionID]?.childTopologyDegraded = true
             if action == .unknown {
-                markRunningChildrenUnknown(sessionID: event.sessionID, at: event.timestamp)
+                markRunningChildrenUnknown(sessionID: sessionID, at: event.timestamp)
             }
             return
         }
 
-        var children = sessions[event.sessionID]?.childAgents ?? []
+        var children = sessions[sessionID]?.childAgents ?? []
         let lastActivity = event.message ?? event.toolName
         if let index = children.firstIndex(where: { $0.id == childID }) {
             if event.timestamp < children[index].updatedAt { return }
@@ -384,7 +455,7 @@ public struct SessionReducer: Sendable {
                 updatedAt: event.timestamp
             ))
         }
-        sessions[event.sessionID]?.childAgents = children
+        sessions[sessionID]?.childAgents = children
     }
 
     private mutating func updateChild(

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -16,6 +16,13 @@ public actor SessionStore {
     /// Terminal refs remembered by session id, so a `/terminal` POST that races
     /// ahead of the session-creating `SessionStart` still lands once it exists.
     private var pendingTerminalRefs: [String: TerminalRef] = [:]
+    /// Resolved `~/.grok/sessions/<cwd>/<id>` directories. Grok's hook envelope
+    /// names no transcript on every event, and the fallback is a directory
+    /// scan, so the answer is remembered for the life of the session.
+    private var grokDirectories: [String: URL] = [:]
+    /// Grok's own data directory (`$GROK_HOME`, else `~/.grok`), not the user's
+    /// home: the session store is rooted at `<grok home>/sessions`.
+    private let grokHome: URL
     private let diagnosticsHome: URL?
     private var runtimeSignals: [AgentKind: [ObservationSource: ObservationRuntimeSignal]] = [:]
     private var diagnosticCache: (at: Date, value: [AgentObservationDiagnostic])?
@@ -25,10 +32,12 @@ public actor SessionStore {
         staleAfter: TimeInterval = 2 * 60 * 60,
         diagnosticsHome: URL? = nil,
         journalURL: URL? = nil,
+        grokHome: URL? = nil,
         now: Date = Date()
     ) {
         self.staleAfter = staleAfter
         self.diagnosticsHome = diagnosticsHome
+        self.grokHome = grokHome ?? GrokHome.url
         if let journalURL {
             let journal = LifecycleJournal(url: journalURL, now: now)
             self.lifecycleJournal = journal
@@ -52,7 +61,10 @@ public actor SessionStore {
         let before = reducer.sessions
         reducer.reconcile(now: now, lastActivity: lastActivity, staleAfter: staleAfter)
         let removed = Set(before.keys).subtracting(reducer.sessions.keys)
-        for id in removed { transcriptPaths[id] = nil }
+        for id in removed {
+            transcriptPaths[id] = nil
+            grokDirectories[id] = nil
+        }
         for id in removed {
             guard let session = before[id] else { continue }
             appendJournal(
@@ -78,15 +90,25 @@ public actor SessionStore {
     public func ingest(_ data: Data, agent: AgentKind = .claudeCode, receivedAt: Date) -> Bool {
         // Source-aware decode: the `?agent=` value tags Claude-shaped lifecycle
         // hooks directly and selects a translator only for different envelopes.
-        guard let event = HookDecoder.decode(data, agent: agent, receivedAt: receivedAt)
-        else {
+        switch HookDecoder.decode(data, agent: agent, receivedAt: receivedAt) {
+        case let .event(event):
+            ingest(event, observationSource: .hook)
+            return true
+        case .ignored:
+            // Understood, but carries no progress (grok fires several such events
+            // per session). The hook source is demonstrably alive and speaking a
+            // shape we know, so record it as healthy rather than as an unknown
+            // version — but claim no event-family coverage for it.
+            recordSignal(agent: agent, source: .hook, at: receivedAt,
+                         health: .healthy, coverage: nil)
+            broadcast()
+            return false
+        case .undecodable:
             recordSignal(agent: agent, source: .hook, at: receivedAt,
                          health: .unknownVersion, coverage: nil)
             broadcast()
             return false
         }
-        ingest(event, observationSource: .hook)
-        return true
     }
 
     /// Apply an already-normalized event from a local monitor such as the Codex
@@ -106,8 +128,13 @@ public actor SessionStore {
             // Session was removed (e.g. SessionEnd) — forget its side data.
             transcriptPaths[event.sessionID] = nil
             pendingTerminalRefs[event.sessionID] = nil
+            grokDirectories[event.sessionID] = nil
         } else {
-            if let path = event.transcriptPath {
+            // Grok keeps a session's facts in a directory of files rather than
+            // one transcript, so it enriches from that directory instead.
+            if event.agent == .grok {
+                enrichFromGrokSession(event)
+            } else if let path = event.transcriptPath {
                 let transcriptHealth = Self.sourceHealth(at: path)
                 reducer.recordObservation(sessionID: event.sessionID, source: .transcript,
                                           at: event.timestamp, health: transcriptHealth)
@@ -134,6 +161,65 @@ public actor SessionStore {
            session.status == .needsResponse, let handler = needsResponseHandler {
             Task { await handler(session) }
         }
+    }
+
+    /// Layer a Grok session directory's facts onto the session, and fold the
+    /// subagents the parent recorded into the same child topology the hook path
+    /// builds. The directory is the only source that names the children a
+    /// parent owns: `subagent_stop` fires inside the child's own session.
+    private func enrichFromGrokSession(_ event: HookEvent) {
+        guard let directory = grokSessionDirectory(for: event) else { return }
+        let health = Self.sourceHealth(
+            at: directory.appendingPathComponent("updates.jsonl").path)
+        reducer.recordObservation(sessionID: event.sessionID, source: .transcript,
+                                  at: event.timestamp, health: health)
+        recordSignal(agent: .grok, source: .transcript, at: event.timestamp,
+                     health: health, coverage: .turn)
+        guard let snapshot = GrokSessionReader.read(directory: directory) else { return }
+        reducer.enrich(sessionID: event.sessionID, with: snapshot.info)
+
+        // The hook path is authoritative on a child's *state*: `SubagentStop`
+        // fires before the child's teardown rewrites `meta.json`, so the
+        // directory still says "running" for a child we already know finished.
+        // The directory may therefore only introduce children the hooks missed,
+        // and stop children — never move one back to running.
+        let known = Set(reducer.sessions[event.sessionID]?.childAgents?.map(\.id) ?? [])
+        for child in snapshot.subagents {
+            let childID = "subagent:\(child.id)"       // same identity GrokParser mints
+            guard child.finished || !known.contains(childID) else { continue }
+            // Stamped with the observing event, not the child's own start time:
+            // the reducer drops child updates older than what it already holds,
+            // and a long-finished subagent must not rewind the parent's clock.
+            reducer.apply(HookEvent(
+                kind: .childLifecycle,
+                sessionID: event.sessionID,
+                agent: .grok,
+                message: child.detail,
+                observationSource: .transcript,
+                timestamp: event.timestamp,
+                childID: childID,
+                childKind: .subagent,
+                childName: child.type,
+                childType: child.type,
+                childAction: child.finished ? .stopped : .started
+            ), observationSource: .transcript)
+        }
+    }
+
+    /// The session directory for a Grok event: the parent of the hook's
+    /// `transcriptPath` (it names `updates.jsonl`) when there is one, else the
+    /// locator over the session's cwd. Cached once resolved.
+    private func grokSessionDirectory(for event: HookEvent) -> URL? {
+        if let cached = grokDirectories[event.sessionID] { return cached }
+        let resolved = event.transcriptPath.flatMap(GrokSessionLocator.directory(forTranscriptPath:))
+            ?? GrokSessionLocator.locate(sessionID: event.sessionID, cwd: event.cwd,
+                                         grokHome: grokHome)
+        guard let resolved else { return nil }
+        grokDirectories[event.sessionID] = resolved
+        // `sweep` measures "did the session advance" from this path's mtime.
+        transcriptPaths[event.sessionID] = resolved
+            .appendingPathComponent("updates.jsonl").path
+        return resolved
     }
 
     public func beginApproval(sessionID: String, _ approval: PendingApproval, at: Date) {
@@ -195,6 +281,9 @@ public actor SessionStore {
     /// for the detail pane. Empty when the session has no known transcript, so
     /// the UI can show a graceful "no transcript" state.
     public func recentTranscript(sessionID: String, limit: Int = 12) -> [TranscriptEntry] {
+        if let directory = grokDirectories[sessionID] {
+            return GrokSessionReader.recentEntries(directory: directory, limit: limit)
+        }
         guard let path = transcriptPaths[sessionID] else { return [] }
         return TranscriptReader.recentEntries(path: path, limit: limit) ?? []
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/TranscriptReader.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/TranscriptReader.swift
@@ -6,17 +6,39 @@ public struct TranscriptInfo: Equatable, Sendable {
     public var model: String?
     public var tokens: Int?           // turn cost: input + output
     public var contextTokens: Int?    // prompt sent: input + cache_read + cache_creation
+    /// The model's real context window, when the source records it (Grok writes
+    /// `contextWindowTokens` into `signals.json`). nil keeps the reducer's
+    /// model-table default.
+    public var contextWindow: Int?
     public var summary: String?
+    /// The checked-out branch, when the source records it (Grok's
+    /// `summary.json.head_branch`).
+    public var branch: String?
     public var pendingQuestion: PendingQuestion?
+    /// A tool whose permission prompt is waiting for an answer in the agent's
+    /// own UI (Grok's unmatched `events.jsonl` `permission_requested`).
+    public var pendingPermissionTool: String?
+    /// A tool the source saw still running. Only ever *adds* a tool to a working
+    /// session that has none: the `PreToolUse`/`PostToolUse` hooks own both
+    /// setting and clearing it, and a transcript read that races ahead of (or
+    /// behind) the log write must not blank a live tool or revive a finished one.
+    public var activeTool: String?
 
     public init(model: String? = nil, tokens: Int? = nil,
-                contextTokens: Int? = nil, summary: String? = nil,
-                pendingQuestion: PendingQuestion? = nil) {
+                contextTokens: Int? = nil, contextWindow: Int? = nil,
+                summary: String? = nil, branch: String? = nil,
+                pendingQuestion: PendingQuestion? = nil,
+                pendingPermissionTool: String? = nil,
+                activeTool: String? = nil) {
         self.model = model
         self.tokens = tokens
         self.contextTokens = contextTokens
+        self.contextWindow = contextWindow
         self.summary = summary
+        self.branch = branch
         self.pendingQuestion = pendingQuestion
+        self.pendingPermissionTool = pendingPermissionTool
+        self.activeTool = activeTool
     }
 }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -20,7 +20,9 @@ public struct VibeBuddyServer: Sendable {
     /// inject it; route tests leave it nil so they never consume host state.
     public let codexRolloutMonitor: CodexRolloutMonitor?
     public let approvalRegistry: ApprovalRegistry
-    public let rules: @Sendable () -> PermissionRules
+    /// The native allow/deny rules for one agent — the sources differ per CLI
+    /// (Grok also reads its own `config.toml`), so the lookup is agent-keyed.
+    public let rules: @Sendable (AgentKind) -> PermissionRules
     /// vibebuddy's own "always allow" store, overlaid on the native rules (ADR 0010).
     public let allowStore: VibeBuddyAllowStore
     /// Sessions the user chose to allow wholesale for their lifetime (in-memory).
@@ -39,7 +41,7 @@ public struct VibeBuddyServer: Sendable {
                 activityTokens: ActivityTokens = ActivityTokens(),
                 codexRolloutMonitor: CodexRolloutMonitor? = nil,
                 approvalRegistry: ApprovalRegistry = ApprovalRegistry(),
-                rules: @escaping @Sendable () -> PermissionRules = { PermissionRules.load() },
+                rules: @escaping @Sendable (AgentKind) -> PermissionRules = { PermissionRules.load(for: $0) },
                 allowStore: VibeBuddyAllowStore = VibeBuddyAllowStore(),
                 sessionAllow: SessionAllowList = SessionAllowList(),
                 approvalContext: ApprovalContextStore = ApprovalContextStore(),
@@ -269,6 +271,8 @@ public struct VibeBuddyServer: Sendable {
         // the token file and sends it). Parse the PreToolUse hook payload, run the
         // permission matcher, and either decide immediately (allow/deny) or hold
         // until the phone responds via `/decision` or the timeout fires.
+        // `?agent=<source>` selects the envelope shape to decode and the decision
+        // contract to answer in; no parameter means Claude Code, as before.
         let registry = self.approvalRegistry
         let rules = self.rules
         let allowStore = self.allowStore
@@ -278,17 +282,21 @@ public struct VibeBuddyServer: Sendable {
         let makeID = self.approvalID
         router.post("approval") { request, _ -> Response in
             guard Self.hookAuthorized(request, token: token) else { throw HTTPError(.unauthorized) }
+            let agent = AgentKind.fromSource(request.uri.queryParameters["agent"].map(String.init))
             let buffer = try await request.body.collect(upTo: 1 << 20)
             let data = Data(buffer: buffer)
             let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
-            let tool = obj["tool_name"] as? String ?? ""
-            let input = obj["tool_input"] as? [String: Any] ?? [:]
-            let sessionID = obj["session_id"] as? String ?? ""
-            let r = rules()
-            await store.ingest(data, receivedAt: Date())
+            let call = ApprovalPayload.decode(obj, agent: agent)
+            let tool = call.tool
+            let input = call.input
+            let sessionID = call.sessionID
+            let r = rules(agent)
+            // The blocking hook is also this agent's PreToolUse signal — ingesting
+            // it is what moves the session to `working` in the dashboard.
+            await store.ingest(data, agent: agent, receivedAt: Date())
             // Native deny always wins, over every vibebuddy overlay (ADR 0010).
             if PermissionMatcher.decide(tool: tool, input: input, allow: [], deny: r.deny) == .deny {
-                return Self.permissionResponse("deny")
+                return Self.permissionResponse("deny", agent: agent)
             }
             // vibebuddy overlay: a session-wide allow, or an exact always-allow rule the
             // user set — both bypass the matcher's pattern heuristics since the user
@@ -297,12 +305,12 @@ public struct VibeBuddyServer: Sendable {
             let storeRules = await allowStore.all()   // [String] is Sendable; match locally
             let storeAllowed = storeRules.contains { AllowRule.matchesExactly($0, tool: tool, input: input) }
             if sessionAllowed || storeAllowed {
-                return Self.permissionResponse("allow")
+                return Self.permissionResponse("allow", agent: agent)
             }
             // Otherwise the native allow/ask matching (composition-guarded).
             switch PermissionMatcher.decide(tool: tool, input: input, allow: r.allow, deny: r.deny) {
-            case .allow: return Self.permissionResponse("allow")
-            case .deny:  return Self.permissionResponse("deny")
+            case .allow: return Self.permissionResponse("allow", agent: agent)
+            case .deny:  return Self.permissionResponse("deny", agent: agent)
             case .ask:
                 let id = makeID()
                 let d = ApprovalDetails.from(tool: tool, input: input)
@@ -310,15 +318,16 @@ public struct VibeBuddyServer: Sendable {
                     PendingApproval(id: id, tool: tool,
                                     commandPreview: d.commandPreview.isEmpty ? tool : d.commandPreview,
                                     command: d.command, filePath: d.filePath,
-                                    oldText: d.oldText, newText: d.newText), at: Date())
+                                    oldText: d.oldText, newText: d.newText,
+                                    permissionMode: call.permissionMode), at: Date())
                 // Record what an "always allow" / "allow this session" would act on.
                 await approvalContext.set(id: id, sessionID: sessionID,
                                           rule: AllowRule.forApproval(tool: tool, input: input))
                 let outcome = await registry.wait(id: id, timeout: timeout)
                 await store.endApproval(sessionID: sessionID, at: Date())
                 switch outcome {
-                case .allow: return Self.permissionResponse("allow")
-                case .deny:  return Self.permissionResponse("deny")
+                case .allow: return Self.permissionResponse("allow", agent: agent)
+                case .deny:  return Self.permissionResponse("deny", agent: agent)
                 case .pass:  return Response(status: .ok)
                 }
             }
@@ -419,8 +428,22 @@ public struct VibeBuddyServer: Sendable {
         return false
     }
 
-    static func permissionResponse(_ decision: String) -> Response {
-        let json = #"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"\#(decision)","permissionDecisionReason":"vibebuddy"}}"#
+    /// The PreToolUse decision, in the shape the calling agent parses.
+    ///
+    /// Claude Code reads `hookSpecificOutput.permissionDecision`. Grok Build
+    /// accepts that form too, but its own documented contract is the flat
+    /// `{"decision":…,"reason":…}` — that is what we emit for it, so the wire is
+    /// unambiguous when read from a Grok transcript. Either way a timeout still
+    /// answers with an empty 200 body, which both CLIs read as "no opinion".
+    static func permissionResponse(_ decision: String, agent: AgentKind = .claudeCode) -> Response {
+        let json: String
+        if agent == .grok {
+            json = decision == "deny"
+                ? #"{"decision":"deny","reason":"vibebuddy"}"#
+                : #"{"decision":"\#(decision)"}"#
+        } else {
+            json = #"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"\#(decision)","permissionDecisionReason":"vibebuddy"}}"#
+        }
         return Response(status: .ok,
                         headers: [.contentType: "application/json"],
                         body: .init(byteBuffer: ByteBuffer(string: json)))

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -572,6 +572,43 @@ struct AccountUsageTests {
         #expect(permissions.intValue == 0o600)
     }
 
+    @Test("Grok is a first-class usage provider with its own cache and labels")
+    func grokProviderRegistration() {
+        #expect(AccountUsageProvider.allCases.contains(.grok))
+        #expect(AccountUsageProvider.grok.displayName == "Grok")
+        #expect(AccountUsageProvider.grok.rawValue == "grok")
+
+        let home = URL(fileURLWithPath: "/Users/example")
+        let cacheURL = AccountUsageFileCache.defaultFileURL(provider: .grok, home: home)
+        #expect(cacheURL.lastPathComponent == "grok-usage.json")
+        #expect(cacheURL != AccountUsageFileCache.defaultFileURL(provider: .codex, home: home))
+
+        #expect(
+            AccountUsageUnavailableReason.notLoggedIn.displayText(provider: .grok)
+                == "Grok is not signed in"
+        )
+    }
+
+    @Test("a Grok crossing alerts independently of the other providers")
+    func grokAlertsAreIndependent() {
+        var monitor = AccountUsageAlertMonitor()
+        _ = monitor.newlyCrossed(
+            in: .available(sampleSnapshot(provider: .grok, percent: 40), nextRefreshAt: nil),
+            thresholdPercent: 90
+        )
+        _ = monitor.newlyCrossed(
+            in: .available(sampleSnapshot(provider: .codex, percent: 95), nextRefreshAt: nil),
+            thresholdPercent: 90
+        )
+
+        let alerts = monitor.newlyCrossed(
+            in: .available(sampleSnapshot(provider: .grok, percent: 95), nextRefreshAt: nil),
+            thresholdPercent: 90
+        )
+        #expect(alerts.count == 1)
+        #expect(alerts.first?.kind == .primary)
+    }
+
     @Test("usage failures cannot mutate session progress")
     func progressIsolation() async {
         var reducer = SessionReducer()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalDetailsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalDetailsTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import VibeBuddyKit
 @testable import VibeBuddyMacCore
 
 @Suite("ApprovalDetails — tool_input → rich approval card fields")
@@ -53,5 +54,80 @@ struct ApprovalDetailsTests {
         let big = String(repeating: "x", count: 7000)
         let d = ApprovalDetails.from(tool: "Write", input: ["file_path": "/x", "content": big])
         #expect(d.newText?.count == 6 * 1024)
+    }
+
+    @Test("WebFetch falls back to the url for its preview")
+    func webFetch() {
+        let d = ApprovalDetails.from(tool: "WebFetch", input: ["url": "https://example.com/x"])
+        #expect(d.commandPreview == "https://example.com/x")
+    }
+}
+
+@Suite("ApprovalPayload — PreToolUse envelope → tool / input / session / mode")
+struct ApprovalPayloadTests {
+
+    @Test("a Claude-shape payload decodes from the snake_case keys, unchanged")
+    func claude() {
+        let obj: [String: Any] = ["tool_name": "Bash", "session_id": "s",
+                                  "tool_input": ["command": "ls"]]
+        let call = ApprovalPayload.decode(obj, agent: .claudeCode)
+        #expect(call.tool == "Bash")
+        #expect(call.sessionID == "s")
+        #expect(call.input["command"] as? String == "ls")
+        #expect(call.permissionMode == nil)
+    }
+
+    @Test("a grok payload decodes camelCase and normalizes the tool vocabulary")
+    func grokBash() {
+        let obj: [String: Any] = ["toolName": "run_terminal_command", "sessionId": "gs",
+                                  "permissionMode": "bypassPermissions", "toolUseId": "call-1",
+                                  "toolInput": ["command": "npm test", "description": "run tests"]]
+        let call = ApprovalPayload.decode(obj, agent: .grok)
+        #expect(call.tool == "Bash")
+        #expect(call.sessionID == "gs")
+        #expect(call.permissionMode == "bypassPermissions")
+
+        let d = ApprovalDetails.from(tool: call.tool, input: call.input)
+        #expect(d.command == "npm test")
+        #expect(d.commandPreview == "npm test")
+    }
+
+    @Test("grok read_file: target_file becomes the approval card's file path")
+    func grokRead() {
+        let obj: [String: Any] = ["toolName": "read_file", "sessionId": "gs",
+                                  "toolInput": ["target_file": "/x/a.swift", "limit": 40]]
+        let call = ApprovalPayload.decode(obj, agent: .grok)
+        #expect(call.tool == "Read")
+        let d = ApprovalDetails.from(tool: call.tool, input: call.input)
+        #expect(d.filePath == "/x/a.swift")
+        #expect(d.commandPreview == "/x/a.swift")
+    }
+
+    @Test("grok search_replace produces a diff preview from old_string/new_string")
+    func grokEdit() {
+        let obj: [String: Any] = ["toolName": "search_replace", "sessionId": "gs",
+                                  "toolInput": ["file_path": "/x/a.swift",
+                                                "old_string": "let a = 1",
+                                                "new_string": "let a = 2",
+                                                "replace_all": false]]
+        let call = ApprovalPayload.decode(obj, agent: .grok)
+        #expect(call.tool == "Edit")
+        let d = ApprovalDetails.from(tool: call.tool, input: call.input)
+        #expect(d.filePath == "/x/a.swift")
+        #expect(d.oldText == "let a = 1")
+        #expect(d.newText == "let a = 2")
+    }
+
+    @Test("an empty or missing permissionMode decodes as nil")
+    func modeOptional() {
+        #expect(ApprovalPayload.decode(["toolName": "grep", "permissionMode": ""],
+                                       agent: .grok).permissionMode == nil)
+        #expect(ApprovalPayload.decode(["toolName": "grep"], agent: .grok).permissionMode == nil)
+    }
+
+    @Test("a junk payload decodes to empty fields rather than failing")
+    func junk() {
+        let call = ApprovalPayload.decode([:], agent: .grok)
+        #expect(call.tool.isEmpty && call.sessionID.isEmpty && call.input.isEmpty)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Darwin
 import NIOCore
 import Hummingbird
 import HummingbirdTesting
@@ -11,15 +12,25 @@ private func bash(_ cmd: String) -> String {
     #"{"hook_event_name":"PreToolUse","session_id":"s","cwd":"/x/p","tool_name":"Bash","tool_input":{"command":"\#(cmd)"}}"#
 }
 
+/// A Grok Build PreToolUse envelope: camelCase keys, snake_case event value.
+private func grokBash(_ cmd: String, tool: String = "run_terminal_command",
+                      mode: String = "bypassPermissions") -> String {
+    #"{"hookEventName":"pre_tool_use","sessionId":"gs","cwd":"/x/p","workspaceRoot":"/x/p","#
+        + #""permissionMode":"\#(mode)","toolUseId":"call-1","toolName":"\#(tool)","#
+        + #""toolInput":{"command":"\#(cmd)","description":"d"}}"#
+}
+
 @Suite("Approval routes")
 struct ApprovalRoutesTests {
-    private func server(allow: [String] = [], deny: [String] = []) -> VibeBuddyServer {
+    private func server(allow: [String] = [], deny: [String] = [],
+                        store: SessionStore = SessionStore(),
+                        port: Int = 9876, host: String = "0.0.0.0") -> VibeBuddyServer {
         // A throwaway temp-file allow store keeps each test hermetic (ADR 0010).
         let storeURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("vbapproval-\(UUID().uuidString).json")
-        return VibeBuddyServer(store: SessionStore(), token: "t0k",
+        return VibeBuddyServer(store: store, token: "t0k", host: host, port: port,
                         approvalRegistry: ApprovalRegistry(),
-                        rules: { PermissionRules(allow: allow, deny: deny) },
+                        rules: { _ in PermissionRules(allow: allow, deny: deny) },
                         allowStore: VibeBuddyAllowStore(url: storeURL),
                         approvalTimeout: .milliseconds(200),
                         approvalID: { "s" })
@@ -131,4 +142,208 @@ struct ApprovalRoutesTests {
             }
         }
     }
+
+    // MARK: - Grok Build (?agent=grok)
+    //
+    // Same machinery, different envelope (camelCase) and different decision
+    // contract on the wire (`{"decision":…}` instead of hookSpecificOutput).
+
+    private func approve(_ client: some TestClientProtocol, body: String,
+                         agent: String? = nil) async throws -> String {
+        let uri = agent.map { "/approval?agent=\($0)" } ?? "/approval"
+        return try await client.execute(uri: uri, method: .post,
+            headers: [.authorization: "Bearer t0k"],
+            body: ByteBuffer(string: body)) { res -> String in
+            #expect(res.status == .ok)
+            return String(buffer: res.body)
+        }
+    }
+
+    @Test("an allow-listed grok call answers in grok's decision contract")
+    func grokAllowImmediate() async throws {
+        try await server(allow: ["Bash(ls:*)"]).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: grokBash("ls -la"), agent: "grok")
+            #expect(text == #"{"decision":"allow"}"#)
+        }
+    }
+
+    @Test("the blocking grok hook is also the PreToolUse signal — the session goes working")
+    func grokIngestsTheEvent() async throws {
+        let store = SessionStore()
+        try await server(allow: ["Bash(ls:*)"], store: store).buildApplication().test(.router) { client in
+            _ = try await approve(client, body: grokBash("ls -la"), agent: "grok")
+            let snapshot = await store.snapshot(now: Date())
+            let session = try #require(snapshot.sessions.first { $0.id == "gs" })
+            #expect(session.agent == .grok)
+            #expect(session.status == .working)
+        }
+    }
+
+    @Test("a grok call holds, and a phone deny answers deny + reason")
+    func grokAskThenDeny() async throws {
+        let store = SessionStore()
+        let srv = server(store: store)   // empty allow → .ask
+        try await srv.buildApplication().test(.router) { client in
+            async let held = approve(client, body: grokBash("rm -rf build", mode: "default"),
+                                     agent: "grok")
+            try await Task.sleep(for: .milliseconds(80))
+            // The pending card carries the mode, so the UI can say an allow here
+            // is not final (grok still prompts locally outside bypassPermissions).
+            let pending = await store.snapshot(now: Date()).sessions.first { $0.id == "gs" }?.pendingApproval
+            #expect(pending?.tool == "Bash")
+            #expect(pending?.command == "rm -rf build")
+            #expect(pending?.permissionMode == "default")
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"deny"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await held == #"{"decision":"deny","reason":"vibebuddy"}"#)
+        }
+    }
+
+    @Test("no decision on a grok call times out to an empty body (fail-open)")
+    func grokTimesOutEmpty() async throws {
+        try await server().buildApplication().test(.router) { client in
+            let text = try await approve(client, body: grokBash("rm -rf build"), agent: "grok")
+            #expect(text.isEmpty)
+        }
+    }
+
+    @Test("a native deny rule short-circuits a grok call without holding")
+    func grokNativeDeny() async throws {
+        try await server(deny: ["Bash(rm:*)"]).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: grokBash("rm -rf build"), agent: "grok")
+            #expect(text == #"{"decision":"deny","reason":"vibebuddy"}"#)
+        }
+    }
+
+    @Test("a Read deny rule matches grok's read_file/target_file spelling")
+    func grokNativeDenyOnPath() async throws {
+        let body = #"{"hookEventName":"pre_tool_use","sessionId":"gs","toolName":"read_file","#
+            + #""toolInput":{"target_file":"/Users/me/secrets/id_rsa"}}"#
+        try await server(deny: ["Read(/Users/me/secrets/**)"]).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: body, agent: "grok")
+            #expect(text == #"{"decision":"deny","reason":"vibebuddy"}"#)
+        }
+    }
+
+    @Test("alwaysAllow from a grok approval matches the next grok call, alias included")
+    func grokAlwaysAllowPersists() async throws {
+        try await server().buildApplication().test(.router) { client in
+            async let first = approve(client, body: grokBash("git status"), agent: "grok")
+            try await Task.sleep(for: .milliseconds(80))
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"alwaysAllow"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await first == #"{"decision":"allow"}"#)
+
+            // Same command again — and under grok's older tool spelling, which
+            // canonicalizes to the same `Bash(git status)` rule.
+            let again = try await approve(client, body: grokBash("git status", tool: "run_terminal_cmd"),
+                                          agent: "grok")
+            #expect(again == #"{"decision":"allow"}"#)
+        }
+    }
+
+    // MARK: - end-to-end through hooks/approval-hook.sh
+
+    @Test("hooks/approval-hook.sh grok posts, and prints the daemon's JSON verbatim")
+    func hookScriptEndToEnd() async throws {
+        let port = try freePort()
+        let srv = server(allow: ["Bash(ls:*)"], port: port, host: "127.0.0.1")
+        let serving = Task { try await srv.buildApplication().runService() }
+        defer { serving.cancel() }
+        try await waitUntilListening(port: port)
+
+        let out = try await runApprovalHook(source: "grok", port: port, token: "t0k",
+                                            stdin: grokBash("ls -la"))
+        #expect(out == #"{"decision":"allow"}"#)
+
+        // No argument keeps the Claude Code contract.
+        let claude = try await runApprovalHook(source: nil, port: port, token: "t0k",
+                                               stdin: bash("ls -la"))
+        #expect(claude.contains("\"permissionDecision\":\"allow\""))
+
+        // A wrong token is a 401 → nothing on stdout → the agent fails open.
+        let unauthorized = try await runApprovalHook(source: "grok", port: port, token: "wrong",
+                                                     stdin: grokBash("ls -la"))
+        #expect(unauthorized.isEmpty)
+    }
+}
+
+// MARK: - helpers for the end-to-end hook run
+
+/// The repo root, from this file's path: …/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/<file>.
+private func repoRoot(_ file: String = #filePath) -> URL {
+    URL(fileURLWithPath: file)
+        .deletingLastPathComponent()   // VibeBuddyMacCoreTests
+        .deletingLastPathComponent()   // Tests
+        .deletingLastPathComponent()   // VibeBuddyMac
+        .deletingLastPathComponent()   // repo root
+}
+
+private enum HookTestError: Error { case noFreePort }
+
+/// An ephemeral port the kernel just handed out — closed again before use, so
+/// the server can claim it. Good enough for a single-process test.
+private func freePort() throws -> Int {
+    let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+    guard fd >= 0 else { throw HookTestError.noFreePort }
+    defer { Darwin.close(fd) }
+    var addr = sockaddr_in()
+    addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_addr.s_addr = in_addr_t(0)   // INADDR_ANY
+    addr.sin_port = 0
+    let bound = withUnsafePointer(to: &addr) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+    guard bound == 0 else { throw HookTestError.noFreePort }
+    var out = sockaddr_in()
+    var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let named = withUnsafeMutablePointer(to: &out) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.getsockname(fd, $0, &len) }
+    }
+    guard named == 0 else { throw HookTestError.noFreePort }
+    return Int(UInt16(bigEndian: out.sin_port))
+}
+
+private func waitUntilListening(port: Int) async throws {
+    for _ in 0..<100 {
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/snapshot")!)
+        request.timeoutInterval = 1
+        if let (_, response) = try? await URLSession.shared.data(for: request),
+           response is HTTPURLResponse { return }
+        try await Task.sleep(for: .milliseconds(50))
+    }
+    Issue.record("server never came up on port \(port)")
+}
+
+/// Run the real hook script against the running daemon and return its stdout.
+private func runApprovalHook(source: String?, port: Int, token: String,
+                             stdin: String) async throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = [repoRoot().appendingPathComponent("hooks/approval-hook.sh").path]
+        + (source.map { [$0] } ?? [])
+    var env = ProcessInfo.processInfo.environment
+    env["VIBEBUDDY_PORT"] = String(port)
+    env["VIBEBUDDY_TOKEN"] = token
+    process.environment = env
+    let input = Pipe(), output = Pipe()
+    process.standardInput = input
+    process.standardOutput = output
+    process.standardError = Pipe()
+    try process.run()
+    input.fileHandleForWriting.write(Data(stdin.utf8))
+    try input.fileHandleForWriting.close()
+    let data = try output.fileHandleForReading.readToEnd() ?? Data()
+    process.waitUntilExit()
+    #expect(process.terminationStatus == 0)   // always fail-open
+    return String(decoding: data, as: UTF8.self)
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/EnrichmentTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/EnrichmentTests.swift
@@ -39,6 +39,79 @@ struct EnrichmentTests {
         #expect(r.sessions["s"]?.tokens == 10)
     }
 
+    @Test("a source's own context window overrides the model table")
+    func enrichHonoursReportedContextWindow() {
+        var r = SessionReducer()
+        r.apply(HookEvent(kind: .sessionStart, sessionID: "s", agent: .grok, timestamp: t0))
+        r.enrich(sessionID: "s", with: TranscriptInfo(
+            model: "grok-4.6", contextTokens: 184_960, contextWindow: 500_000))
+        #expect(r.sessions["s"]?.contextWindow == 500_000)
+        #expect(r.sessions["s"]?.contextTokens == 184_960)
+    }
+
+    @Test("without a reported window the model table answers, 500k for grok")
+    func contextWindowByModel() {
+        #expect(SessionReducer.contextWindow(for: "claude-opus-4-8") == 200_000)
+        #expect(SessionReducer.contextWindow(for: nil) == 200_000)
+        #expect(SessionReducer.contextWindow(for: "grok-4.6") == 500_000)
+
+        var r = SessionReducer()
+        r.apply(HookEvent(kind: .sessionStart, sessionID: "s", agent: .grok, timestamp: t0))
+        r.enrich(sessionID: "s", with: TranscriptInfo(model: "grok-4.6", contextTokens: 1_000))
+        #expect(r.sessions["s"]?.contextWindow == 500_000)
+    }
+
+    @Test("enrich carries a branch, and a running tool only into a working gap")
+    func enrichBranchAndTool() {
+        var r = SessionReducer()
+        r.apply(HookEvent(kind: .sessionStart, sessionID: "s", agent: .grok, timestamp: t0))
+        r.apply(HookEvent(kind: .userPromptSubmit, sessionID: "s", agent: .grok,
+                          timestamp: t0.addingTimeInterval(1)))
+        r.enrich(sessionID: "s", with: TranscriptInfo(
+            branch: "feature/fixture", activeTool: "run_terminal_command"))
+        #expect(r.sessions["s"]?.branch == "feature/fixture")
+        #expect(r.sessions["s"]?.activeTool == "run_terminal_command")
+
+        // nil is "no opinion": clearing stays with the PostToolUse hook, so a
+        // read that races the log write cannot blank a live tool.
+        r.enrich(sessionID: "s", with: TranscriptInfo(summary: "still going"))
+        #expect(r.sessions["s"]?.activeTool == "run_terminal_command")
+
+        // Nor may it rename the tool the hooks are reporting.
+        r.enrich(sessionID: "s", with: TranscriptInfo(activeTool: "read_file"))
+        #expect(r.sessions["s"]?.activeTool == "run_terminal_command")
+    }
+
+    @Test("a settled or waiting session never takes a running tool from the source")
+    func enrichNeverToolsASettledSession() {
+        // The log lags the hooks: `stop` fires before `turn_completed` is
+        // written, so a finished turn's tail still shows an open tool call.
+        for kind in [HookEvent.Kind.stop, .notification] {
+            var r = SessionReducer()
+            r.apply(HookEvent(kind: .sessionStart, sessionID: "s", agent: .grok, timestamp: t0))
+            r.apply(HookEvent(kind: .userPromptSubmit, sessionID: "s", agent: .grok,
+                              timestamp: t0.addingTimeInterval(1)))
+            r.apply(HookEvent(kind: kind, sessionID: "s", agent: .grok,
+                              message: "Permission required",
+                              timestamp: t0.addingTimeInterval(2)))
+            r.enrich(sessionID: "s", with: TranscriptInfo(activeTool: "run_terminal_command"))
+            #expect(r.sessions["s"]?.activeTool == nil)
+        }
+    }
+
+    @Test("a waiting session names the tool its own permission prompt is blocked on")
+    func enrichNamesPendingPermission() {
+        var r = SessionReducer()
+        r.apply(HookEvent(kind: .sessionStart, sessionID: "s", agent: .grok, timestamp: t0))
+        r.apply(HookEvent(kind: .notification, sessionID: "s", agent: .grok,
+                          message: "Permission required", timestamp: t0.addingTimeInterval(1)))
+        r.enrich(sessionID: "s", with: TranscriptInfo(
+            summary: "prose that must not clobber the prompt",
+            pendingPermissionTool: "run_terminal_command"))
+        #expect(r.sessions["s"]?.waitKind == .permission)
+        #expect(r.sessions["s"]?.summary == "Permission required: run_terminal_command")
+    }
+
     @Test("enrich on an unknown session is ignored")
     func enrichUnknown() {
         var r = SessionReducer()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokParserTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokParserTests.swift
@@ -4,41 +4,53 @@ import VibeBuddyKit
 @testable import VibeBuddyMacCore
 
 /// Grok Build's hook envelope is camelCase keys with snake_case event values,
-/// unlike the Claude shape. Envelopes below are recorded from
-/// `~/.grok/docs/user-guide/10-hooks.md` (grok 0.2.22).
+/// unlike the Claude shape. Envelopes below are synthesized from grok 1.0.13's
+/// `HookEventEnvelope` / `HookPayload` (`xai-grok-hooks/src/event.rs`) and the
+/// shipped hooks guide (`~/.grok/docs/user-guide/10-hooks.md`).
 @Suite("GrokParser — Grok camelCase hook envelope")
 struct GrokParserTests {
 
     let now = Date(timeIntervalSince1970: 1_700_000_000)
 
+    /// The decoded event, or nil for both "understood and skipped" and
+    /// "not a grok envelope" — `HookDecoderTests` pins which is which.
     private func parse(_ json: String) -> HookEvent? {
-        GrokParser.parse(Data(json.utf8), receivedAt: now)
+        GrokParser.parse(Data(json.utf8), receivedAt: now).event
     }
+
+    // MARK: - Envelope basics
 
     @Test("decodes the recorded pre_tool_use envelope → preToolUse tagged grok")
     func recordedPreToolUse() {
-        // Verbatim from grok's hooks doc (the "Writing Hook Scripts → Input" example).
         let e = parse(#"""
         {"hookEventName":"pre_tool_use","sessionId":"abc-123",
          "cwd":"/Users/you/project","workspaceRoot":"/Users/you/project",
-         "toolName":"run_terminal_cmd","toolInput":{"command":"npm test"},
-         "timestamp":"2026-04-14T12:00:00Z"}
+         "promptId":"prompt-1","toolName":"run_terminal_command",
+         "toolInput":{"command":"npm test"},"toolUseId":"call-1",
+         "toolInputTruncated":false,"timestamp":"2026-04-14T12:00:00Z"}
         """#)
         #expect(e?.kind == .preToolUse)
         #expect(e?.sessionID == "abc-123")
         #expect(e?.agent == .grok)
         #expect(e?.cwd == "/Users/you/project")
-        #expect(e?.toolName == "run_terminal_cmd")
+        #expect(e?.toolName == "run_terminal_command")   // raw name; normalization is the approval path's job
         #expect(e?.toolError == false)
+        #expect(e?.turnID == "prompt-1")
         #expect(e?.timestamp == now)
     }
 
-    @Test("session_start → sessionStart")
+    @Test("session_start carries modelId and transcriptPath")
     func sessionStart() {
-        let e = parse(#"{"hookEventName":"session_start","sessionId":"s","cwd":"/x/proj"}"#)
+        let e = parse(#"""
+        {"hookEventName":"session_start","sessionId":"s","cwd":"/x/proj",
+         "source":"startup","modelId":"grok-4.6","agentType":"grok-build-plan",
+         "transcriptPath":"/Users/you/.grok/sessions/%2Fx%2Fproj/s/updates.jsonl"}
+        """#)
         #expect(e?.kind == .sessionStart)
         #expect(e?.sessionID == "s")
         #expect(e?.cwd == "/x/proj")
+        #expect(e?.model == "grok-4.6")
+        #expect(e?.transcriptPath == "/Users/you/.grok/sessions/%2Fx%2Fproj/s/updates.jsonl")
     }
 
     @Test("falls back to workspaceRoot when cwd is absent")
@@ -48,10 +60,12 @@ struct GrokParserTests {
         #expect(e?.cwd == "/ws/root")
     }
 
+    // MARK: - Tools
+
     @Test("post_tool_use with toolResult.isError → flagged as a tool error")
     func toolResultError() {
         let e = parse(#"""
-        {"hookEventName":"post_tool_use","sessionId":"s","toolName":"run_terminal_cmd",
+        {"hookEventName":"post_tool_use","sessionId":"s","toolName":"run_terminal_command",
          "toolResult":{"isError":true,"output":"command not found"}}
         """#)
         #expect(e?.kind == .postToolUse)
@@ -60,7 +74,10 @@ struct GrokParserTests {
 
     @Test("post_tool_use_failure event → postToolUse flagged as a tool error")
     func postToolUseFailureEvent() {
-        let e = parse(#"{"hookEventName":"post_tool_use_failure","sessionId":"s","toolName":"run_terminal_cmd"}"#)
+        let e = parse(#"""
+        {"hookEventName":"post_tool_use_failure","sessionId":"s",
+         "toolName":"run_terminal_command","error":"exit status 1","isInterrupt":false}
+        """#)
         #expect(e?.kind == .postToolUse)
         #expect(e?.toolError == true)
     }
@@ -80,21 +97,194 @@ struct GrokParserTests {
         #expect(e?.toolError == false)
     }
 
-    @Test("unknown event (pre_compact) → nil (ignored)")
-    func unknownEvent() {
-        #expect(parse(#"{"hookEventName":"pre_compact","sessionId":"s"}"#) == nil)
+    // MARK: - Notifications
+
+    @Test("notification permission_prompt → a permission wait")
+    func permissionPrompt() {
+        let e = parse(#"""
+        {"hookEventName":"notification","sessionId":"g","notificationType":"permission_prompt",
+         "message":"Tool permission requested","level":"info"}
+        """#)
+        #expect(e?.kind == .notification)
+        #expect(e?.message == "Tool permission requested")
+        #expect(SessionReducer.waitKind(from: e?.message) == .permission)
     }
 
-    @Test("notification (grok hook-execution telemetry) → nil — not a user prompt")
-    func notificationTelemetryIgnored() {
-        // Grok fires `notification` to REPORT hook executions, not to ask the user
-        // anything (recorded live: it echoed the `stop` hooks running). Treating it
-        // as needsResponse would wrongly override `stop`→done and pollute summary.
+    @Test("a permission_prompt whose display text omits the word still reads as a permission wait")
+    func permissionPromptWording() {
+        // grok fires permission_prompt for plan approval too, with prose that
+        // never says "permission" — the reducer infers the wait kind from text.
         let e = parse(#"""
-        {"hookEventName":"notification","sessionId":"g",
-         "message":"SessionNotification { update: HookExecution { event_name: \"stop\" } }"}
+        {"hookEventName":"notification","sessionId":"g","notificationType":"permission_prompt",
+         "message":"Plan approval requested"}
+        """#)
+        #expect(e?.kind == .notification)
+        #expect(e?.message == "Permission required: Plan approval requested")
+        #expect(SessionReducer.waitKind(from: e?.message) == .permission)
+    }
+
+    @Test("notification idle_prompt → an unconditional idle settle")
+    func idlePrompt() {
+        // The documented backstop: fires ~1 min after ANY turn end, carries no
+        // promptId, and is cancelled by the next prompt.
+        let e = parse(#"""
+        {"hookEventName":"notification","sessionId":"g","notificationType":"idle_prompt",
+         "message":"Waiting for your next prompt","level":"info"}
+        """#)
+        #expect(e?.kind == .stop)
+        #expect(e?.turnID == nil)
+    }
+
+    @Test("notification task_complete → nil (a background task, not the turn)")
+    func taskCompleteIgnored() {
+        // A background shell/monitor task can finish mid-turn; settling on it
+        // would show a false idle while the agent is still working.
+        let e = parse(#"""
+        {"hookEventName":"notification","sessionId":"g","notificationType":"task_complete",
+         "message":"Background task completed: task-7"}
         """#)
         #expect(e == nil)
+    }
+
+    // MARK: - Turn ends
+
+    @Test("stop end_turn carries lastAssistantMessage as the summary")
+    func stopEndTurn() {
+        let e = parse(#"""
+        {"hookEventName":"stop","sessionId":"g","promptId":"prompt-2","reason":"end_turn",
+         "stopHookActive":false,"lastAssistantMessage":"All tests pass.",
+         "backgroundTasks":[],"sessionCrons":[]}
+        """#)
+        #expect(e?.kind == .stop)
+        #expect(e?.message == "All tests pass.")
+        #expect(e?.turnID == "prompt-2")
+    }
+
+    @Test("the teardown stop (channel_closed / shutdown) is ignored")
+    func stopTeardownIgnored() {
+        // grok fires `stop` a second time at teardown; session_end already
+        // reports that, and settling on it would resurrect a closed session.
+        #expect(parse(#"{"hookEventName":"stop","sessionId":"g","reason":"channel_closed"}"#) == nil)
+        #expect(parse(#"{"hookEventName":"stop","sessionId":"g","reason":"shutdown"}"#) == nil)
+    }
+
+    @Test("stop_failure settles the turn and reads as failed")
+    func stopFailure() {
+        let e = parse(#"""
+        {"hookEventName":"stop_failure","sessionId":"g","promptId":"p1","error":"rate_limit",
+         "errorDetails":"429 from upstream","lastAssistantMessage":"Rate limited."}
+        """#)
+        #expect(e?.kind == .stop)
+        #expect(e?.message == "Turn failed (rate_limit): 429 from upstream")
+        // The session is marked failed *only* because the heuristic matches this
+        // synthesized prose — grok's envelope carries no failure flag — so both
+        // spellings of the message are pinned against the shared marker list.
+        #expect(FailureHeuristic.looksFailed("Turn failed (rate_limit): 429 from upstream"))
+        #expect(FailureHeuristic.looksFailed("Turn failed: unknown"))
+
+        var reducer = SessionReducer()
+        reducer.apply(parse(#"{"hookEventName":"user_prompt_submit","sessionId":"g","promptId":"p1"}"#)!)
+        reducer.apply(e!)
+        #expect(reducer.sessions["g"]?.status == .done)
+        #expect(reducer.sessions["g"]?.failed == true)
+    }
+
+    @Test("stop_cancelled settles the turn without marking it failed")
+    func stopCancelled() {
+        let e = parse(#"""
+        {"hookEventName":"stop_cancelled","sessionId":"g","promptId":"p1","reason":"permission_rejected",
+         "cancelledBy":"user","lastAssistantMessage":"Stopped before the edit."}
+        """#)
+        #expect(e?.kind == .stop)
+        #expect(e?.message == "Stopped before the edit.")
+
+        var reducer = SessionReducer()
+        reducer.apply(parse(#"{"hookEventName":"user_prompt_submit","sessionId":"g","promptId":"p1"}"#)!)
+        reducer.apply(e!)
+        #expect(reducer.sessions["g"]?.status == .done)
+        #expect(reducer.sessions["g"]?.failed != true)
+    }
+
+    @Test("a cancelled turn's report that lands after the next prompt is ignored")
+    func staleStopCancelledIgnored() {
+        // grok dispatches StopCancelled off the command loop, so it can arrive
+        // after the user already sent the next prompt. promptId disambiguates.
+        var reducer = SessionReducer()
+        for json in [
+            #"{"hookEventName":"session_start","sessionId":"g","cwd":"/x/proj"}"#,
+            #"{"hookEventName":"user_prompt_submit","sessionId":"g","promptId":"p1"}"#,
+            #"{"hookEventName":"user_prompt_submit","sessionId":"g","promptId":"p2"}"#,
+            #"{"hookEventName":"stop_cancelled","sessionId":"g","promptId":"p1","reason":"user_interrupt","cancelledBy":"user"}"#,
+        ] {
+            reducer.apply(parse(json)!)
+        }
+        #expect(reducer.sessions["g"]?.status == .working)
+
+        reducer.apply(parse(#"{"hookEventName":"stop","sessionId":"g","promptId":"p2","reason":"end_turn"}"#)!)
+        #expect(reducer.sessions["g"]?.status == .done)
+    }
+
+    // MARK: - Subagents
+
+    @Test("subagent_start / subagent_stop drive parent topology, never parent status")
+    func subagentTopology() {
+        var reducer = SessionReducer()
+        for json in [
+            #"{"hookEventName":"session_start","sessionId":"parent","cwd":"/x/proj"}"#,
+            #"{"hookEventName":"user_prompt_submit","sessionId":"parent","promptId":"p1"}"#,
+            #"{"hookEventName":"subagent_start","sessionId":"parent","subagentId":"child-1","subagentType":"explore","description":"Survey the repo"}"#,
+        ] {
+            reducer.apply(parse(json)!)
+        }
+        let running = reducer.sessions["parent"]
+        #expect(running?.status == .working)
+        #expect(running?.runningChildAgentCount == 1)
+        #expect(running?.childAgents?.first?.id == "subagent:child-1")
+        #expect(running?.childAgents?.first?.kind == .subagent)
+        #expect(running?.childAgents?.first?.name == "explore")
+        #expect(running?.childAgents?.first?.lastActivity == "Survey the repo")
+
+        // subagent_stop fires inside the CHILD's own session; it must complete the
+        // parent's row rather than publish the child as a session of its own.
+        let stop = GrokParser.parse(Data(#"""
+        {"hookEventName":"subagent_stop","sessionId":"child-1","subagentId":"child-1",
+         "subagentType":"explore","phase":"gate","lastAssistantMessage":"Found 3 call sites."}
+        """#.utf8), receivedAt: now.addingTimeInterval(5)).event!
+        #expect(stop.kind == .childLifecycle)
+        #expect(stop.childAction == .stopped)
+        reducer.apply(stop)
+        #expect(reducer.sessions["child-1"] == nil)
+        #expect(reducer.sessions["parent"]?.runningChildAgentCount == 0)
+        #expect(reducer.sessions["parent"]?.childAgents?.first?.status == .completed)
+        #expect(reducer.sessions["parent"]?.status == .working)
+    }
+
+    @Test("an unplaceable subagent_stop does not publish the child as its own session")
+    func orphanSubagentStop() {
+        var reducer = SessionReducer()
+        reducer.apply(GrokParser.parse(Data(#"""
+        {"hookEventName":"subagent_stop","sessionId":"child-9","subagentId":"child-9",
+         "subagentType":"explore","phase":"gate"}
+        """#.utf8), receivedAt: now).event!)
+        #expect(reducer.sessions.isEmpty)
+    }
+
+    @Test("an ordinary event from a subagent's own session is ignored")
+    func childSessionEventIgnored() {
+        // Every event that can fire inside a subagent carries subagentType there
+        // and omits it in the main session.
+        #expect(parse(#"{"hookEventName":"post_tool_use","sessionId":"child-1","toolName":"read_file","subagentType":"explore"}"#) == nil)
+        #expect(parse(#"{"hookEventName":"stop_failure","sessionId":"child-1","error":"server_error","subagentType":"explore"}"#) == nil)
+        #expect(parse(#"{"hookEventName":"session_end","sessionId":"child-1","reason":"exit","subagentType":"explore"}"#) == nil)
+    }
+
+    // MARK: - Ignored and malformed
+
+    @Test("passive-only events are ignored")
+    func passiveEventsIgnored() {
+        #expect(parse(#"{"hookEventName":"pre_compact","sessionId":"s","source":"auto"}"#) == nil)
+        #expect(parse(#"{"hookEventName":"post_compact","sessionId":"s","source":"auto"}"#) == nil)
+        #expect(parse(#"{"hookEventName":"permission_denied","sessionId":"s","toolName":"run_terminal_command"}"#) == nil)
     }
 
     @Test("a Claude-shape payload → nil (wrong parser)")
@@ -116,14 +306,15 @@ struct GrokParserTests {
     func endToEnd() {
         var r = SessionReducer()
         let events = [
-            parse(#"{"hookEventName":"session_start","sessionId":"g","cwd":"/x/proj"}"#),
-            parse(#"{"hookEventName":"user_prompt_submit","sessionId":"g"}"#),
-            parse(#"{"hookEventName":"stop","sessionId":"g"}"#),
+            parse(#"{"hookEventName":"session_start","sessionId":"g","cwd":"/x/proj","modelId":"grok-4.6"}"#),
+            parse(#"{"hookEventName":"user_prompt_submit","sessionId":"g","promptId":"p1"}"#),
+            parse(#"{"hookEventName":"stop","sessionId":"g","promptId":"p1","reason":"end_turn"}"#),
         ].compactMap { $0 }
         #expect(events.count == 3)
         for e in events { r.apply(e) }
         #expect(r.sessions["g"]?.agent == .grok)
         #expect(r.sessions["g"]?.project == "proj")
+        #expect(r.sessions["g"]?.model == "grok-4.6")
         #expect(r.sessions["g"]?.status == .done)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionLocatorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionLocatorTests.swift
@@ -1,0 +1,207 @@
+import Testing
+import Foundation
+@testable import VibeBuddyMacCore
+
+/// A synthetic `~/.grok` tree. Shapes mirror the real store; every string is
+/// invented so no private prose from a real session reaches the repo.
+struct GrokFixture {
+    /// Grok's own data directory (`$GROK_HOME`, else `~/.grok`), which is what
+    /// the locator and `SessionStore` are rooted at.
+    let home: URL
+    let cwd: String
+    let sessionID: String
+    let directory: URL
+
+    init(
+        cwd: String = "/Users/fixture/Projects/demo app",
+        sessionID: String = "01a00000-0000-7000-8000-000000000001",
+        directoryName: String? = nil
+    ) throws {
+        self.home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("vb-grok-\(UUID().uuidString)", isDirectory: true)
+        self.cwd = cwd
+        self.sessionID = sessionID
+        let parent = directoryName ?? GrokSessionLocator.encode(cwd: cwd)!
+        self.directory = GrokSessionLocator.sessionsRoot(grokHome: home)
+            .appendingPathComponent(parent, isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    func write(_ name: String, _ contents: String) throws {
+        try contents.write(to: directory.appendingPathComponent(name),
+                           atomically: true, encoding: .utf8)
+    }
+
+    func writeSubagentMeta(id: String, _ contents: String) throws {
+        let dir = directory.appendingPathComponent("subagents", isDirectory: true)
+            .appendingPathComponent(id, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try contents.write(to: dir.appendingPathComponent("meta.json"),
+                           atomically: true, encoding: .utf8)
+    }
+
+    func cleanUp() { try? FileManager.default.removeItem(at: home) }
+
+    // MARK: - Record builders
+
+    static func summary(id: String = "01a00000-0000-7000-8000-000000000001",
+                        cwd: String = "/Users/fixture/Projects/demo app") -> String {
+        """
+        {"info":{"id":"\(id)","cwd":"\(cwd)"},"session_summary":"Fixture session",\
+        "generated_title":"Fixture title","current_model_id":"grok-4.6",\
+        "git_root_dir":"\(cwd)","head_branch":"feature/fixture","head_commit":"abc123",\
+        "last_turn_summary":"stored turn recap","agent_name":"grok-build-plan",\
+        "num_messages":12,"num_chat_messages":4}
+        """
+    }
+
+    static let signals = """
+        {"turnCount":2,"toolCallCount":5,"toolsUsed":["read_file"],"modelsUsed":["grok-4.6"],\
+        "primaryModelId":"grok-4.6","compactionCount":0,"contextTokensUsed":80944,\
+        "contextWindowTokens":500000,"contextWindowUsage":16,"errorCount":0}
+        """
+
+    /// One `updates.jsonl` line. `_meta` is a sibling of `update` inside `params`.
+    static func update(_ inner: String, meta: String? = nil,
+                       method: String = "session/update") -> String {
+        let metaPart = meta.map { ",\"_meta\":\($0)" } ?? ""
+        return """
+            {"timestamp":1788354885,"method":"\(method)","params":\
+            {"sessionId":"s","update":\(inner)\(metaPart)}}
+            """
+    }
+
+    static func userChunk(_ text: String) -> String {
+        update(#"{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"\#(text)"}}"#)
+    }
+
+    static func agentChunk(_ text: String, totalTokens: Int? = nil) -> String {
+        update(#"{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"\#(text)"}}"#,
+               meta: totalTokens.map { #"{"totalTokens":\#($0)}"# })
+    }
+
+    static func thoughtChunk(_ text: String) -> String {
+        update(#"{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"\#(text)"}}"#)
+    }
+
+    static func toolCall(id: String, title: String) -> String {
+        update(#"{"sessionUpdate":"tool_call","toolCallId":"\#(id)","title":"\#(title)","rawInput":{}}"#)
+    }
+
+    static func toolDone(id: String, status: String = "completed") -> String {
+        update(#"{"sessionUpdate":"tool_call_update","toolCallId":"\#(id)","status":"\#(status)","rawOutput":{}}"#)
+    }
+
+    /// The `tool_call_update` variant that carries no `status` (a mid-flight
+    /// content append), which must not close an open call.
+    static func toolProgress(id: String) -> String {
+        update(#"{"sessionUpdate":"tool_call_update","toolCallId":"\#(id)","kind":"execute","locations":[],"rawInput":{}}"#)
+    }
+
+    static func turnCompleted(input: Int, output: Int) -> String {
+        update("""
+            {"sessionUpdate":"turn_completed","prompt_id":"p1","stop_reason":"end_turn",\
+            "usage":{"inputTokens":\(input),"outputTokens":\(output),\
+            "totalTokens":\(input + output),"cachedReadTokens":0,"numTurns":1}}
+            """, method: "_x.ai/session/update")
+    }
+
+    static func subagentSpawned(id: String, type: String, detail: String) -> String {
+        update("""
+            {"sessionUpdate":"subagent_spawned","subagent_id":"\(id)",\
+            "parent_session_id":"s","child_session_id":"\(id)",\
+            "subagent_type":"\(type)","description":"\(detail)","model":"grok-4.6"}
+            """)
+    }
+
+    static func subagentFinished(id: String) -> String {
+        update("""
+            {"sessionUpdate":"subagent_finished","subagent_id":"\(id)",\
+            "child_session_id":"\(id)","status":"completed","tool_calls":3,"turns":1}
+            """)
+    }
+
+    static func permissionRequested(_ tool: String) -> String {
+        #"{"ts":"2026-09-02T13:14:51.807Z","type":"permission_requested","tool_name":"\#(tool)","schema_version":"1.0"}"#
+    }
+
+    static func permissionResolved(_ tool: String) -> String {
+        #"{"ts":"2026-09-02T13:14:51.809Z","type":"permission_resolved","tool_name":"\#(tool)","decision":"allow","wait_ms":1}"#
+    }
+}
+
+@Suite("Grok session locator")
+struct GrokSessionLocatorTests {
+
+    @Test("percent-encodes a cwd against the RFC 3986 unreserved set")
+    func encodesCwd() {
+        #expect(GrokSessionLocator.encode(cwd: "/Users/x/code/demo")
+                == "%2FUsers%2Fx%2Fcode%2Fdemo")
+        // `-`, `.`, `_` and `~` survive; a space does not.
+        #expect(GrokSessionLocator.encode(cwd: "/a-b/c.d/e_f/~g h")
+                == "%2Fa-b%2Fc.d%2Fe_f%2F~g%20h")
+    }
+
+    @Test("resolves the encoded-cwd path without scanning")
+    func resolvesEncodedPath() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("summary.json", GrokFixture.summary())
+
+        let found = GrokSessionLocator.locate(
+            sessionID: fixture.sessionID, cwd: fixture.cwd, grokHome: fixture.home)
+        #expect(found?.standardizedFileURL == fixture.directory.standardizedFileURL)
+    }
+
+    @Test("falls back to a scan for the slug-hash directory, and reads its .cwd")
+    func resolvesSlugHashDirectory() throws {
+        let fixture = try GrokFixture(directoryName: "demo-app-c871d1174b95948f")
+        defer { fixture.cleanUp() }
+        try fixture.write("summary.json", GrokFixture.summary())
+
+        // The encoded path does not exist, so only the scan can find it.
+        let found = GrokSessionLocator.locate(
+            sessionID: fixture.sessionID, cwd: fixture.cwd, grokHome: fixture.home)
+        #expect(found?.standardizedFileURL == fixture.directory.standardizedFileURL)
+    }
+
+    @Test("resolves without a cwd at all")
+    func resolvesWithoutCwd() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("updates.jsonl", GrokFixture.userChunk("hello"))
+
+        let found = GrokSessionLocator.locate(
+            sessionID: fixture.sessionID, cwd: nil, grokHome: fixture.home)
+        #expect(found?.standardizedFileURL == fixture.directory.standardizedFileURL)
+    }
+
+    @Test("an unknown session and a traversal id resolve to nothing")
+    func rejectsUnknownAndUnsafe() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("summary.json", GrokFixture.summary())
+
+        #expect(GrokSessionLocator.locate(sessionID: "nope", cwd: fixture.cwd,
+                                          grokHome: fixture.home) == nil)
+        #expect(GrokSessionLocator.locate(sessionID: "../..", cwd: nil,
+                                          grokHome: fixture.home) == nil)
+        #expect(GrokSessionLocator.locate(sessionID: "", cwd: nil, grokHome: fixture.home) == nil)
+    }
+
+    @Test("a hook transcript path pointing at updates.jsonl yields its directory")
+    func directoryFromTranscriptPath() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("updates.jsonl", GrokFixture.userChunk("hello"))
+
+        let path = fixture.directory.appendingPathComponent("updates.jsonl").path
+        #expect(GrokSessionLocator.directory(forTranscriptPath: path)?.standardizedFileURL
+                == fixture.directory.standardizedFileURL)
+        // The directory itself is accepted as-is.
+        #expect(GrokSessionLocator.directory(forTranscriptPath: fixture.directory.path)?
+            .standardizedFileURL == fixture.directory.standardizedFileURL)
+        #expect(GrokSessionLocator.directory(forTranscriptPath: "/tmp/not-a-session/x.jsonl") == nil)
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionReaderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionReaderTests.swift
@@ -1,0 +1,269 @@
+import Testing
+import Foundation
+@testable import VibeBuddyMacCore
+
+@Suite("Grok session reader")
+struct GrokSessionReaderTests {
+
+    private func updates(_ lines: [String]) -> Data {
+        Data(lines.joined(separator: "\n").utf8)
+    }
+
+    // MARK: - summary.json / signals.json
+
+    @Test("model, branch and the real context window come off the session files")
+    func readsSessionFiles() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("summary.json", GrokFixture.summary())
+        try fixture.write("signals.json", GrokFixture.signals)
+
+        let info = try #require(GrokSessionReader.read(directory: fixture.directory)?.info)
+        #expect(info.model == "grok-4.6")
+        #expect(info.branch == "feature/fixture")
+        #expect(info.contextWindow == 500_000)          // not the flat 200k default
+        #expect(info.contextTokens == 80_944)
+        #expect(info.summary == "stored turn recap")    // last_turn_summary fallback
+    }
+
+    @Test("an empty directory reads as nothing at all")
+    func emptyDirectory() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        #expect(GrokSessionReader.read(directory: fixture.directory) == nil)
+    }
+
+    @Test("live context size from the log beats the signals snapshot")
+    func liveContextWins() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("signals.json", GrokFixture.signals)
+        try fixture.write("updates.jsonl", [
+            GrokFixture.agentChunk("first", totalTokens: 90_000),
+            GrokFixture.agentChunk("second", totalTokens: 97_500),
+        ].joined(separator: "\n"))
+
+        let info = try #require(GrokSessionReader.read(directory: fixture.directory)?.info)
+        #expect(info.contextTokens == 97_500)
+        #expect(info.contextWindow == 500_000)
+    }
+
+    // MARK: - Tokens
+
+    @Test("the newest turn_completed is one turn's cost, which the reducer accumulates")
+    func turnTokensFromLog() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("updates.jsonl", [
+            GrokFixture.turnCompleted(input: 1_000, output: 100),
+            GrokFixture.turnCompleted(input: 2_000, output: 200),
+        ].joined(separator: "\n"))
+
+        let info = try #require(GrokSessionReader.read(directory: fixture.directory)?.info)
+        #expect(info.tokens == 2_200)
+    }
+
+    // MARK: - Prose
+
+    @Test("the summary is the model's newest message, not its reasoning")
+    func lastAssistantProse() {
+        let facts = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.userChunk("do the thing"),
+            GrokFixture.thoughtChunk("private reasoning"),
+            GrokFixture.agentChunk("starting now"),
+            GrokFixture.toolCall(id: "call-1", title: "read_file"),
+            GrokFixture.toolDone(id: "call-1"),
+            GrokFixture.agentChunk("all done"),
+        ]))
+        #expect(facts.lastAssistantText == "all done")
+    }
+
+    @Test("chunks of one message join")
+    func joinsChunks() {
+        let facts = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.userChunk("go"),
+            GrokFixture.agentChunk("part one"),
+            GrokFixture.agentChunk("part two"),
+        ]))
+        #expect(facts.lastAssistantText == "part one part two")
+    }
+
+    // MARK: - Tool state
+
+    @Test("an unclosed tool_call is the running tool")
+    func runningTool() {
+        let facts = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.toolCall(id: "call-1", title: "read_file"),
+            GrokFixture.toolDone(id: "call-1"),
+            GrokFixture.toolCall(id: "call-2", title: "run_terminal_command"),
+            GrokFixture.toolProgress(id: "call-2"),   // no `status`: still running
+        ]))
+        #expect(facts.runningTool == "run_terminal_command")
+    }
+
+    @Test("a closed or turn-ended log reports no running tool")
+    func noRunningTool() {
+        let closed = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.toolCall(id: "call-1", title: "read_file"),
+            GrokFixture.toolDone(id: "call-1", status: "failed"),
+        ]))
+        #expect(closed.runningTool == nil)
+
+        let ended = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.toolCall(id: "call-1", title: "read_file"),
+            GrokFixture.turnCompleted(input: 10, output: 1),
+        ]))
+        #expect(ended.runningTool == nil)
+    }
+
+    // MARK: - Permission
+
+    @Test("an unmatched permission_requested is a waiting prompt")
+    func pendingPermission() {
+        let pending = GrokSessionReader.pendingPermissionTool(eventsTail: Data("""
+            \(GrokFixture.permissionRequested("read_file"))
+            \(GrokFixture.permissionResolved("read_file"))
+            \(GrokFixture.permissionRequested("run_terminal_command"))
+            """.utf8))
+        #expect(pending == "run_terminal_command")
+    }
+
+    @Test("a resolved permission leaves nothing pending")
+    func resolvedPermission() {
+        let pending = GrokSessionReader.pendingPermissionTool(eventsTail: Data("""
+            \(GrokFixture.permissionRequested("run_terminal_command"))
+            \(GrokFixture.permissionResolved("run_terminal_command"))
+            """.utf8))
+        #expect(pending == nil)
+    }
+
+    // MARK: - Tail behaviour
+
+    @Test("a huge updates.jsonl is read from the tail only")
+    func readsOnlyTheTail() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+
+        // `tool_call_update` repeats a tool's accumulated output, so real logs
+        // reach gigabytes. Anything older than the window must not be reported.
+        let filler = GrokFixture.agentChunk(String(repeating: "x", count: 900))
+        var lines = [
+            GrokFixture.subagentSpawned(id: "ancient", type: "explore", detail: "Long gone"),
+            GrokFixture.turnCompleted(input: 999_999, output: 999_999),
+        ]
+        lines.append(contentsOf: Array(repeating: filler, count: 1_400))   // > 1 MB
+        lines.append(GrokFixture.userChunk("newest prompt"))
+        lines.append(GrokFixture.agentChunk("newest reply", totalTokens: 12_345))
+        lines.append(GrokFixture.turnCompleted(input: 700, output: 30))
+        try fixture.write("updates.jsonl", lines.joined(separator: "\n"))
+
+        let size = try FileManager.default
+            .attributesOfItem(atPath: fixture.directory.appendingPathComponent("updates.jsonl").path)[.size] as? Int
+        #expect((size ?? 0) > GrokSessionReader.updatesTailBytes)
+
+        let snapshot = try #require(GrokSessionReader.read(directory: fixture.directory))
+        let info = snapshot.info
+        #expect(info.tokens == 730)              // the old giant turn scrolled out
+        #expect(info.contextTokens == 12_345)
+        #expect(info.summary == "newest reply")
+
+        let entries = GrokSessionReader.recentEntries(directory: fixture.directory, limit: 3)
+        #expect(entries.last == TranscriptEntry(role: "assistant", text: "newest reply"))
+
+        // A record older than the window is genuinely never seen.
+        #expect(snapshot.subagents.isEmpty)
+    }
+
+    @Test("one tool record bigger than the events window still leaves the turn readable")
+    func oversizedToolRecord() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+
+        // A single `tool_call_update` carries the tool's accumulated output and
+        // routinely passes 256 KB. When it is the newest record, a window that
+        // small holds no complete line at all and the pane comes up empty.
+        try fixture.write("updates.jsonl", [
+            GrokFixture.userChunk("do the thing"),
+            GrokFixture.agentChunk("newest reply", totalTokens: 4_242),
+            GrokFixture.toolCall(id: "call-1", title: "run_terminal_command"),
+            GrokFixture.update(#"""
+                {"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"completed",\#
+                "rawOutput":{"stdout":"\#(String(repeating: "z", count: 400_000))"}}
+                """#),
+        ].joined(separator: "\n"))
+
+        let info = try #require(GrokSessionReader.read(directory: fixture.directory)?.info)
+        // Everything before the oversized record is still in the window.
+        #expect(info.contextTokens == 4_242)
+        #expect(info.activeTool == nil)          // the big record closed the call
+
+        let entries = GrokSessionReader.recentEntries(directory: fixture.directory)
+        #expect(entries.map(\.text) == ["do the thing", "newest reply", "⚙ run_terminal_command"])
+    }
+
+    // MARK: - Subagents
+
+    @Test("subagents come from their meta.json and from the log")
+    func subagentsFromMetaAndLog() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeSubagentMeta(id: "child-a", """
+            {"subagent_id":"child-a","parent_session_id":"s","child_session_id":"child-a",\
+            "subagent_type":"code-reviewer","description":"Review the diff","status":"completed",\
+            "started_at":"2026-09-02T13:00:00.000000Z","completed_at":"2026-09-02T13:05:00.000000Z",\
+            "duration_ms":300000,"tool_calls":9,"turns":1,"child_cwd":"/Users/fixture/Projects/demo app"}
+            """)
+        try fixture.write("updates.jsonl", [
+            GrokFixture.subagentSpawned(id: "child-a", type: "code-reviewer", detail: "Review the diff"),
+            GrokFixture.subagentFinished(id: "child-a"),
+            GrokFixture.subagentSpawned(id: "child-b", type: "explore", detail: "Find the callers"),
+        ].joined(separator: "\n"))
+
+        let children = try #require(GrokSessionReader.read(directory: fixture.directory)).subagents
+        #expect(children.count == 2)
+        let a = try #require(children.first { $0.id == "child-a" })
+        #expect(a.type == "code-reviewer")
+        #expect(a.finished)
+        let b = try #require(children.first { $0.id == "child-b" })
+        #expect(b.type == "explore")
+        #expect(b.detail == "Find the callers")
+        #expect(b.finished == false)          // spawned, never finished
+    }
+
+    @Test("a subagent that only the log knows about is still reported")
+    func subagentWithoutMeta() throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("updates.jsonl",
+                          GrokFixture.subagentSpawned(id: "child-c", type: "explore", detail: "Scan"))
+        let children = try #require(GrokSessionReader.read(directory: fixture.directory)).subagents
+        #expect(children.map(\.id) == ["child-c"])
+        #expect(children[0].finished == false)
+    }
+
+    // MARK: - Recent entries
+
+    @Test("recent entries interleave prompts, prose and tool markers")
+    func recentEntries() {
+        let entries = GrokSessionReader.recentEntries(updatesTail: updates([
+            GrokFixture.userChunk("do the thing"),
+            GrokFixture.thoughtChunk("reasoning is not shown"),
+            GrokFixture.agentChunk("on it"),
+            GrokFixture.toolCall(id: "call-1", title: "read_file"),
+            GrokFixture.toolDone(id: "call-1"),
+            GrokFixture.agentChunk("done the thing"),
+        ]))
+        #expect(entries.map(\.role) == ["user", "assistant", "assistant", "assistant"])
+        #expect(entries.map(\.text) == ["do the thing", "on it", "⚙ read_file", "done the thing"])
+    }
+
+    @Test("recent entries keep only the last N and truncate each")
+    func recentEntryLimits() {
+        let entries = GrokSessionReader.recentEntries(updatesTail: updates([
+            GrokFixture.userChunk("one"),
+            GrokFixture.toolCall(id: "c1", title: "grep"),
+            GrokFixture.agentChunk(String(repeating: "y", count: 50)),
+        ]), limit: 2, perEntryLimit: 10)
+        #expect(entries.map(\.text) == ["⚙ grep", String(repeating: "y", count: 10)])
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionStoreTests.swift
@@ -1,0 +1,228 @@
+import Testing
+import Foundation
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+@Suite("Grok session enrichment wiring")
+struct GrokSessionStoreTests {
+
+    let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func hook(_ event: String, _ fixture: GrokFixture, extra: String = "") -> Data {
+        Data("""
+            {"hookEventName":"\(event)","sessionId":"\(fixture.sessionID)",\
+            "cwd":"\(fixture.cwd)","workspaceRoot":"\(fixture.cwd)"\(extra)}
+            """.utf8)
+    }
+
+    /// The reported health of grok's hook source in the live snapshot.
+    private func hookHealth(_ store: SessionStore, at now: Date) async -> ObservationHealth? {
+        await store.snapshot(now: now).observationDiagnostics?
+            .first { $0.agent == .grok }?
+            .sources.first { $0.source == .hook }?.health
+    }
+
+    private func populated() throws -> GrokFixture {
+        let fixture = try GrokFixture()
+        try fixture.write("summary.json", GrokFixture.summary(id: fixture.sessionID, cwd: fixture.cwd))
+        try fixture.write("signals.json", GrokFixture.signals)
+        try fixture.write("updates.jsonl", [
+            GrokFixture.userChunk("do the thing"),
+            GrokFixture.agentChunk("on it"),
+            GrokFixture.toolCall(id: "call-1", title: "read_file"),
+            GrokFixture.toolDone(id: "call-1"),
+            GrokFixture.agentChunk("done the thing", totalTokens: 120_000),
+            GrokFixture.turnCompleted(input: 5_000, output: 400),
+        ].joined(separator: "\n"))
+        return fixture
+    }
+
+    @Test("a grok hook event enriches the session from its session directory")
+    func enrichesFromSessionDirectory() async throws {
+        let fixture = try populated()
+        defer { fixture.cleanUp() }
+
+        let store = SessionStore(grokHome: fixture.home)
+        await store.ingest(hook("session_start", fixture), agent: .grok, receivedAt: t0)
+
+        let session = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(session.agent == .grok)
+        #expect(session.model == "grok-4.6")
+        #expect(session.branch == "feature/fixture")
+        #expect(session.summary == "done the thing")
+        #expect(session.tokens == 5_400)
+        #expect(session.spentTokens == 5_400)
+        #expect(session.contextTokens == 120_000)
+        #expect(session.contextWindow == 500_000)     // grok's real window, not 200k
+        #expect(session.observations?.contains { $0.source == .transcript } == true)
+    }
+
+    @Test("a hook-supplied transcript path names updates.jsonl, not the directory")
+    func resolvesFromTranscriptPath() async throws {
+        let fixture = try populated()
+        defer { fixture.cleanUp() }
+        let path = fixture.directory.appendingPathComponent("updates.jsonl").path
+
+        // An empty grok home proves the path — not the locator — resolved it.
+        let store = SessionStore(grokHome: URL(fileURLWithPath: NSTemporaryDirectory()))
+        await store.ingest(
+            hook("session_start", fixture, extra: #","transcriptPath":"\#(path)""#),
+            agent: .grok, receivedAt: t0)
+
+        let session = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(session.model == "grok-4.6")
+        #expect(session.contextWindow == 500_000)
+    }
+
+    @Test("recent transcript for a grok session comes from its updates log")
+    func recentTranscriptDispatches() async throws {
+        let fixture = try populated()
+        defer { fixture.cleanUp() }
+
+        let store = SessionStore(grokHome: fixture.home)
+        await store.ingest(hook("session_start", fixture), agent: .grok, receivedAt: t0)
+
+        let entries = await store.recentTranscript(sessionID: fixture.sessionID)
+        #expect(entries.map(\.role) == ["user", "assistant", "assistant", "assistant"])
+        #expect(entries.map(\.text) == ["do the thing", "on it", "⚙ read_file", "done the thing"])
+    }
+
+    @Test("the parent's own record of its subagents becomes child topology")
+    func childTopology() async throws {
+        let fixture = try populated()
+        defer { fixture.cleanUp() }
+        try fixture.writeSubagentMeta(id: "child-a", """
+            {"subagent_id":"child-a","parent_session_id":"\(fixture.sessionID)",\
+            "child_session_id":"child-a","subagent_type":"code-reviewer",\
+            "description":"Review the diff","status":"running",\
+            "started_at":"2026-09-02T13:00:00.000000Z","tool_calls":3,"turns":1}
+            """)
+
+        let store = SessionStore(grokHome: fixture.home)
+        await store.ingest(hook("session_start", fixture), agent: .grok, receivedAt: t0)
+
+        let session = try #require(await store.snapshot(now: t0).sessions.first)
+        let child = try #require(session.childAgents?.first)
+        #expect(child.id == "subagent:child-a")     // same identity GrokParser mints
+        #expect(child.kind == .subagent)
+        #expect(child.type == "code-reviewer")
+        #expect(child.status == .running)
+        #expect(session.runningChildAgentCount == 1)
+    }
+
+    @Test("a session directory that does not exist enriches nothing and does not crash")
+    func missingDirectory() async throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+
+        let store = SessionStore(grokHome: fixture.home)
+        await store.ingest(hook("session_start", fixture), agent: .grok, receivedAt: t0)
+
+        let session = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(session.model == nil)
+        #expect(session.contextWindow == nil)
+        let entries = await store.recentTranscript(sessionID: fixture.sessionID)
+        #expect(entries.isEmpty)
+    }
+
+    @Test("re-reading the same turn does not double the session spend")
+    func cumulativeSpendIsNotDoubled() {
+        var reducer = SessionReducer()
+        reducer.apply(HookEvent(kind: .sessionStart, sessionID: "s", agent: .grok, timestamp: t0))
+        // Every mid-turn event re-reads the same newest `turn_completed`.
+        let info = TranscriptInfo(model: "grok-4.6", tokens: 5_400,
+                                  contextTokens: 80_944, contextWindow: 500_000)
+        reducer.enrich(sessionID: "s", with: info)
+        reducer.enrich(sessionID: "s", with: info)
+        #expect(reducer.sessions["s"]?.spentTokens == 5_400)
+
+        // The next turn's reading is a fresh cost and accumulates.
+        reducer.enrich(sessionID: "s", with: TranscriptInfo(tokens: 900, contextTokens: 81_000))
+        #expect(reducer.sessions["s"]?.spentTokens == 6_300)
+        #expect(reducer.sessions["s"]?.tokens == 900)
+    }
+
+    @Test("a grok session teardown leaves the hook source healthy, garbage does not")
+    func teardownDoesNotReportAnUnknownVersion() async throws {
+        let fixture = try populated()
+        defer { fixture.cleanUp() }
+        // Diagnostics age against wall-clock time, so this one runs on it.
+        let now = Date()
+        let store = SessionStore(diagnosticsHome: fixture.home, grokHome: fixture.home)
+        await store.ingest(hook("session_start", fixture), agent: .grok, receivedAt: now)
+
+        // Fires at EVERY grok session exit, and is deliberately not a status event.
+        let ignored = await store.ingest(hook("stop", fixture, extra: #","reason":"shutdown""#),
+                                         agent: .grok, receivedAt: now)
+        #expect(ignored == false)
+        #expect(await hookHealth(store, at: now) == .healthy)
+
+        let decoded = await store.ingest(Data("{not a hook".utf8), agent: .grok, receivedAt: now)
+        #expect(decoded == false)
+        #expect(await hookHealth(store, at: now) == .unknownVersion)
+    }
+
+    @Test("the session directory never rewinds a child the hooks already stopped")
+    func directoryDoesNotResurrectAStoppedChild() async throws {
+        let fixture = try populated()
+        defer { fixture.cleanUp() }
+        // `SubagentStop` fires before the child's teardown rewrites meta.json, so
+        // the directory still says "running" for a child that is already done.
+        try fixture.writeSubagentMeta(id: "child-a", """
+            {"subagent_id":"child-a","parent_session_id":"\(fixture.sessionID)",\
+            "child_session_id":"child-a","subagent_type":"explore",\
+            "description":"Survey","status":"running",\
+            "started_at":"2026-09-02T13:00:00.000000Z","tool_calls":3,"turns":1}
+            """)
+
+        let store = SessionStore(grokHome: fixture.home)
+        await store.ingest(hook("session_start", fixture), agent: .grok, receivedAt: t0)
+        await store.ingest(Data("""
+            {"hookEventName":"subagent_stop","sessionId":"child-a","subagentId":"child-a",\
+            "subagentType":"explore","phase":"gate"}
+            """.utf8), agent: .grok, receivedAt: t0.addingTimeInterval(1))
+        #expect(await store.snapshot(now: t0).sessions
+            .first?.childAgents?.first?.status == .completed)
+
+        // Any later parent event re-reads the (still stale) directory.
+        await store.ingest(hook("post_tool_use", fixture, extra: #","toolName":"read_file""#),
+                           agent: .grok, receivedAt: t0.addingTimeInterval(2))
+        let session = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(session.childAgents?.count == 1)
+        #expect(session.childAgents?.first?.status == .completed)
+        #expect(session.runningChildAgentCount == 0)
+    }
+
+    @Test("a settled session never shows a tool the log still has open")
+    func settledSessionShowsNoRunningTool() async throws {
+        let fixture = try GrokFixture()
+        defer { fixture.cleanUp() }
+        try fixture.write("signals.json", GrokFixture.signals)
+        // The stop gate fires before `turn_completed` is written, so the log is
+        // still mid-tool when the session settles.
+        try fixture.write("updates.jsonl", [
+            GrokFixture.userChunk("do the thing"),
+            GrokFixture.toolCall(id: "call-1", title: "read_file"),
+        ].joined(separator: "\n"))
+
+        let store = SessionStore(grokHome: fixture.home)
+        await store.ingest(hook("user_prompt_submit", fixture, extra: #","promptId":"p1""#),
+                           agent: .grok, receivedAt: t0)
+        // A working session with no tool of its own takes the log's opinion.
+        #expect(await store.snapshot(now: t0).sessions.first?.activeTool == "read_file")
+
+        await store.ingest(hook("stop", fixture, extra: #","promptId":"p1","reason":"end_turn""#),
+                           agent: .grok, receivedAt: t0.addingTimeInterval(1))
+        let done = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(done.status == .done)
+        #expect(done.activeTool == nil)
+
+        // Same for a session waiting on the user.
+        await store.ingest(hook("notification", fixture,
+                                extra: #","notificationType":"permission_prompt""#),
+                           agent: .grok, receivedAt: t0.addingTimeInterval(2))
+        let waiting = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(waiting.status == .needsResponse)
+        #expect(waiting.activeTool == nil)
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokToolVocabularyTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokToolVocabularyTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import Foundation
+@testable import VibeBuddyMacCore
+
+@Suite("GrokToolVocabulary — grok tool names/keys → the canonical vocabulary")
+struct GrokToolVocabularyTests {
+
+    @Test("shell tools map to Bash, both spellings and both aliases")
+    func bash() {
+        for name in ["run_terminal_command", "run_terminal_cmd", "bash", "shell"] {
+            #expect(GrokToolVocabulary.canonicalTool(name) == "Bash")
+        }
+    }
+
+    @Test("file tools map to the Read/Edit/Write/Grep/Glob names the rules use")
+    func fileTools() {
+        #expect(GrokToolVocabulary.canonicalTool("read_file") == "Read")
+        #expect(GrokToolVocabulary.canonicalTool("hashline_read") == "Read")
+        #expect(GrokToolVocabulary.canonicalTool("search_replace") == "Edit")
+        #expect(GrokToolVocabulary.canonicalTool("hashline_edit") == "Edit")
+        #expect(GrokToolVocabulary.canonicalTool("apply_patch") == "Edit")
+        #expect(GrokToolVocabulary.canonicalTool("write") == "Write")
+        #expect(GrokToolVocabulary.canonicalTool("write_file") == "Write")
+        #expect(GrokToolVocabulary.canonicalTool("create_file") == "Write")
+        #expect(GrokToolVocabulary.canonicalTool("grep") == "Grep")
+        #expect(GrokToolVocabulary.canonicalTool("list_dir") == "Glob")
+    }
+
+    @Test("web and subagent tools map to their Claude counterparts")
+    func webAndSubagents() {
+        #expect(GrokToolVocabulary.canonicalTool("web_search") == "WebSearch")
+        #expect(GrokToolVocabulary.canonicalTool("web_fetch") == "WebFetch")
+        #expect(GrokToolVocabulary.canonicalTool("spawn_subagent") == "Task")
+    }
+
+    @Test("MCP tools gain the mcp__ prefix, and keep it if already there")
+    func mcp() {
+        #expect(GrokToolVocabulary.canonicalTool("firecrawl__scrape") == "mcp__firecrawl__scrape")
+        #expect(GrokToolVocabulary.canonicalTool("mcp__firecrawl__scrape") == "mcp__firecrawl__scrape")
+    }
+
+    @Test("a provider-qualified id is stripped before mapping")
+    func qualified() {
+        #expect(GrokToolVocabulary.canonicalTool("GrokBuild:read_file") == "Read")
+    }
+
+    @Test("an unknown tool passes through unchanged (the matcher then asks)")
+    func unknown() {
+        #expect(GrokToolVocabulary.canonicalTool("todo_write") == "todo_write")
+        #expect(GrokToolVocabulary.canonicalTool("") == "")
+    }
+
+    @Test("target_file / target_directory become file_path; the original stays")
+    func inputKeys() {
+        let read = GrokToolVocabulary.canonicalInput(["target_file": "/x/a.swift", "limit": 20])
+        #expect(read["file_path"] as? String == "/x/a.swift")
+        #expect(read["target_file"] as? String == "/x/a.swift")
+        #expect(read["limit"] as? Int == 20)
+
+        let list = GrokToolVocabulary.canonicalInput(["target_directory": "/x/src"])
+        #expect(list["file_path"] as? String == "/x/src")
+    }
+
+    @Test("keys grok already spells the canonical way are left alone")
+    func nativeKeys() {
+        let edit = GrokToolVocabulary.canonicalInput(
+            ["file_path": "/x/a.swift", "old_string": "a", "new_string": "b", "replace_all": false])
+        #expect(edit["file_path"] as? String == "/x/a.swift")
+        #expect(edit["old_string"] as? String == "a")
+        #expect(edit["new_string"] as? String == "b")
+
+        let bash = GrokToolVocabulary.canonicalInput(["command": "ls", "description": "list"])
+        #expect(bash["command"] as? String == "ls")
+    }
+
+    @Test("an explicit file_path is never overwritten by target_file")
+    func filePathWins() {
+        let input = GrokToolVocabulary.canonicalInput(["file_path": "/keep", "target_file": "/other"])
+        #expect(input["file_path"] as? String == "/keep")
+    }
+
+    @Test("normalize does both halves at once")
+    func normalize() {
+        let n = GrokToolVocabulary.normalize(tool: "read_file", input: ["target_file": "/x/a"])
+        #expect(n.tool == "Read")
+        #expect(n.input["file_path"] as? String == "/x/a")
+    }
+
+    // The point of all of the above: the existing agent-agnostic machinery then
+    // matches a grok call against rules and always-allow entries unchanged.
+
+    @Test("a normalized grok call matches an ordinary Bash allow rule")
+    func matcherAcceptsNormalizedCall() {
+        let n = GrokToolVocabulary.normalize(tool: "run_terminal_command", input: ["command": "git status"])
+        #expect(PermissionMatcher.decide(tool: n.tool, input: n.input,
+                                         allow: ["Bash(git:*)"], deny: []) == .allow)
+    }
+
+    @Test("an always-allow rule written from a grok approval is the canonical one")
+    func allowRuleIsCanonical() {
+        let n = GrokToolVocabulary.normalize(tool: "search_replace",
+                                             input: ["file_path": "/x/a.swift", "old_string": "a", "new_string": "b"])
+        #expect(AllowRule.forApproval(tool: n.tool, input: n.input) == "Edit(/x/a.swift)")
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
@@ -1,0 +1,394 @@
+import Darwin
+import Foundation
+import Testing
+@testable import VibeBuddyMacCore
+
+@Suite("Grok usage adapter")
+struct GrokUsageProviderTests {
+    private let now = Date(timeIntervalSince1970: 1_788_314_400)
+
+    // MARK: - Decoding
+
+    @Test("credits config maps the weekly window, reset time, and tier")
+    func creditsConfigDecoding() throws {
+        let snapshot = try GrokUsageResponseDecoder.decode(
+            billingResponse: Self.billingResponse(),
+            fetchedAt: now
+        )
+
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.planType == "SuperGrok Heavy")
+        #expect(snapshot.primary?.usedPercent == 36)
+        #expect(snapshot.primary?.windowDurationMinutes == 10_080)
+        #expect(Self.matches(snapshot.primary?.resetsAt, "2026-09-06T11:36:49Z"))
+        // A zero on-demand cap means the account has no on-demand allowance.
+        #expect(snapshot.secondary == nil)
+        #expect(snapshot.lifetimeTokens == nil)
+        #expect(snapshot.fetchedAt == now)
+    }
+
+    @Test("an on-demand cap becomes the secondary window")
+    func onDemandWindow() throws {
+        let response = Self.billingResponse(
+            onDemandCap: #"{"val":5000}"#,
+            onDemandUsed: #"{"val":1250}"#
+        )
+        let snapshot = try GrokUsageResponseDecoder.decode(billingResponse: response, fetchedAt: now)
+
+        #expect(snapshot.secondary?.kind == .secondary)
+        #expect(snapshot.secondary?.usedPercent == 25)
+        #expect(snapshot.secondary?.windowDurationMinutes == 10_080)
+        #expect(Self.matches(snapshot.secondary?.resetsAt, "2026-09-06T11:36:49Z"))
+    }
+
+    @Test("a percentage outside zero through one hundred is rejected")
+    func percentageBounds() {
+        let response = Self.billingResponse(creditUsagePercent: "101.0")
+        #expect(throws: AccountUsageError.incompatibleFormat) {
+            try GrokUsageResponseDecoder.decode(billingResponse: response, fetchedAt: now)
+        }
+    }
+
+    @Test("a payload with no usable usage is unavailable instead of zero")
+    func missingUsage() {
+        let response = Data(#"{"jsonrpc":"2.0","id":2,"result":{"config":{"onDemandCap":{"val":100}}}}"#.utf8)
+        #expect(throws: AccountUsageError.incompatibleFormat) {
+            try GrokUsageResponseDecoder.decode(billingResponse: response, fetchedAt: now)
+        }
+    }
+
+    @Test("RPC errors map onto the shared unavailable reasons")
+    func errorMapping() {
+        let unauthenticated = Data(#"""
+        {"jsonrpc":"2.0","id":2,"error":{"code":-32000,"message":"Authentication required","data":"Billing data requires auth with grok.com. Run `grok login` to authenticate."}}
+        """#.utf8)
+        #expect(throws: AccountUsageError.notLoggedIn) {
+            try GrokUsageResponseDecoder.decode(billingResponse: unauthenticated, fetchedAt: now)
+        }
+
+        let unknownMethod = Data(#"{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"Method not found"}}"#.utf8)
+        #expect(throws: AccountUsageError.providerUnavailable) {
+            try GrokUsageResponseDecoder.decode(billingResponse: unknownMethod, fetchedAt: now)
+        }
+
+        let rateLimited = Data(#"""
+        {"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"Billing service error: HTTP 429 too many requests"}}
+        """#.utf8)
+        #expect(throws: AccountUsageError.rateLimited) {
+            try GrokUsageResponseDecoder.decode(billingResponse: rateLimited, fetchedAt: now)
+        }
+    }
+
+    @Test("the unified log record carries its own fetch time")
+    func logRecordDecoding() throws {
+        let snapshot = try GrokUsageResponseDecoder.decode(unifiedLogLine: Self.logLine())
+
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.planType == "SuperGrok Heavy")
+        #expect(snapshot.primary?.usedPercent == 36)
+        #expect(Self.matches(snapshot.fetchedAt, "2026-09-03T00:32:30Z"))
+    }
+
+    @Test("an unrelated log record is not a usage reading")
+    func unrelatedLogRecord() {
+        let line = Data(#"{"ts":"2026-09-03T00:32:30.702Z","src":"shell","lvl":"info","msg":"session: started"}"#.utf8)
+        #expect(throws: AccountUsageError.incompatibleFormat) {
+            try GrokUsageResponseDecoder.decode(unifiedLogLine: line)
+        }
+    }
+
+    @Test("the newest credits record in a log tail wins, and stale records are ignored")
+    func logTailScan() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory.appendingPathComponent("unified.jsonl")
+        let contents = [
+            #"{"ts":"2026-09-02T00:00:00.000Z","src":"shell","lvl":"info","msg":"hook: ran"}"#,
+            String(decoding: Self.logLine(timestamp: "2026-09-02T23:00:00.000Z", percent: "12.0"), as: UTF8.self),
+            #"{"ts":"2026-09-03T00:10:00.000Z","src":"shell","lvl":"info","msg":"turn: completed"}"#,
+            String(decoding: Self.logLine(), as: UTF8.self),
+            #"{"ts":"2026-09-03T00:40:00.000Z","src":"shell","lvl":"info","msg":"turn: completed"}"#,
+        ].joined(separator: "\n") + "\n"
+        try Data(contents.utf8).write(to: logURL)
+
+        let readAt = Self.timestamp("2026-09-03T01:00:00Z")!
+        let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(in: logURL, now: readAt)
+        #expect(snapshot?.primary?.usedPercent == 36)
+
+        let muchLater = readAt.addingTimeInterval(GrokUsageResponseDecoder.logFallbackMaxAge + 60)
+        #expect(GrokUsageResponseDecoder.decodeNewestLogRecord(in: logURL, now: muchLater) == nil)
+        #expect(
+            GrokUsageResponseDecoder.decodeNewestLogRecord(
+                in: directory.appendingPathComponent("absent.jsonl"),
+                now: readAt
+            ) == nil
+        )
+    }
+
+    @Test("timestamps parse at second, millisecond, and microsecond precision")
+    func timestampPrecision() {
+        // The proxy emits microseconds and a `+00:00` offset; the log emits
+        // milliseconds and `Z`. Reset times are shown to the minute, so landing
+        // within a second of the stamp is the requirement.
+        #expect(Self.matches(
+            GrokUsageResponseDecoder.parseTimestamp("2026-09-06T11:36:49.308758+00:00"),
+            "2026-09-06T11:36:49Z"
+        ))
+        #expect(Self.matches(
+            GrokUsageResponseDecoder.parseTimestamp("2026-09-03T00:32:30.702Z"),
+            "2026-09-03T00:32:30Z"
+        ))
+        #expect(
+            GrokUsageResponseDecoder.parseTimestamp("2026-09-06T11:36:49Z")
+                == Self.timestamp("2026-09-06T11:36:49Z")
+        )
+        #expect(GrokUsageResponseDecoder.parseTimestamp("not a date") == nil)
+        #expect(GrokUsageResponseDecoder.parseTimestamp(nil) == nil)
+    }
+
+    // MARK: - Provider
+
+    @Test("the provider speaks the handshake and maps the billing reply")
+    func providerHandshake() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let transcript = directory.appendingPathComponent("stdin.txt")
+        let agent = try Self.writeFakeAgent(
+            in: directory,
+            transcript: transcript,
+            reply: String(decoding: Self.billingResponse(), as: UTF8.self)
+        )
+
+        let snapshot = try await GrokUsageProvider(
+            executableURL: agent,
+            arguments: [],
+            timeout: 5,
+            logURL: directory.appendingPathComponent("absent.jsonl")
+        ).fetch()
+
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.primary?.usedPercent == 36)
+
+        let sent = try String(contentsOf: transcript, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+        #expect(sent.count == 2)
+        let initialize = try #require(sent.first.flatMap(Self.json))
+        #expect(initialize["method"] as? String == "initialize")
+        #expect((initialize["params"] as? [String: Any])?["protocolVersion"] as? Int == 1)
+        let billing = try #require(sent.last.flatMap(Self.json))
+        // The unescaped extension name is what the agent matches on.
+        #expect(billing["method"] as? String == "_x.ai/billing")
+        #expect(sent.last?.contains("_x.ai/billing") == true)
+    }
+
+    @Test("an unreachable agent falls back to the last logged billing record")
+    func logFallback() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory.appendingPathComponent("unified.jsonl")
+        let recent = Self.logLine(
+            timestamp: ISO8601DateFormatter().string(from: Date().addingTimeInterval(-600)),
+            percent: "72.0"
+        )
+        try (recent + Data("\n".utf8)).write(to: logURL)
+
+        let snapshot = try await GrokUsageProvider(
+            executableURL: directory.appendingPathComponent("no-such-binary"),
+            arguments: [],
+            timeout: 5,
+            logURL: logURL
+        ).fetch()
+        #expect(snapshot.primary?.usedPercent == 72)
+
+        // A signed-out account is reported, never masked by a stale reading.
+        #expect(!GrokUsageProvider.allowsLogFallback(after: AccountUsageError.notLoggedIn))
+        #expect(GrokUsageProvider.allowsLogFallback(after: AccountUsageError.providerUnavailable))
+        #expect(!GrokUsageProvider.allowsLogFallback(after: CancellationError()))
+    }
+
+    @Test("a signed-out agent is reported instead of falling back")
+    func signedOutIsReported() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory.appendingPathComponent("unified.jsonl")
+        try (Self.logLine(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            percent: "72.0"
+        ) + Data("\n".utf8)).write(to: logURL)
+        let agent = try Self.writeFakeAgent(
+            in: directory,
+            transcript: directory.appendingPathComponent("stdin.txt"),
+            reply: #"{"jsonrpc":"2.0","id":2,"error":{"code":-32000,"message":"Authentication required","data":"Run `grok login` to authenticate."}}"#
+        )
+
+        await #expect(throws: AccountUsageError.notLoggedIn) {
+            try await GrokUsageProvider(
+                executableURL: agent, arguments: [], timeout: 5, logURL: logURL
+            ).fetch()
+        }
+    }
+
+    @Test("a stalled agent times out and its child process is reaped")
+    func timeoutReapsChild() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pidFile = directory.appendingPathComponent("agent.pid")
+        let provider = GrokUsageProvider(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: [
+                "-c", "trap '' TERM; echo $$ > \"$1\"; exec sleep 5",
+                "vibebuddy-test", pidFile.path,
+            ],
+            timeout: 0.2,
+            logURL: directory.appendingPathComponent("absent.jsonl")
+        )
+
+        let started = ContinuousClock.now
+        await #expect(throws: AccountUsageError.timedOut) { try await provider.fetch() }
+        #expect(ContinuousClock.now - started < .seconds(2))
+
+        let pid = try #require(Int32(
+            try String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        ))
+        errno = 0
+        #expect(Darwin.kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+
+    @Test("cancellation stops the fetch and the child")
+    func cancellation() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pidFile = directory.appendingPathComponent("agent.pid")
+        let provider = GrokUsageProvider(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: [
+                "-c", "echo $$ > \"$1\"; exec sleep 10",
+                "vibebuddy-test", pidFile.path,
+            ],
+            timeout: 10,
+            logURL: directory.appendingPathComponent("absent.jsonl")
+        )
+
+        let fetch = Task { try await provider.fetch() }
+        var pid: Int32?
+        for _ in 0..<200 where pid == nil {
+            pid = (try? String(contentsOf: pidFile, encoding: .utf8))
+                .flatMap { Int32($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+            if pid == nil { try? await Task.sleep(for: .milliseconds(10)) }
+        }
+        #expect(pid != nil)
+        fetch.cancel()
+        await #expect(throws: (any Error).self) { try await fetch.value }
+
+        if let pid {
+            for _ in 0..<200 where Darwin.kill(pid, 0) == 0 {
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            errno = 0
+            #expect(Darwin.kill(pid, 0) == -1)
+            #expect(errno == ESRCH)
+        }
+    }
+
+    /// Live diagnostic: only runs with `VIBEBUDDY_GROK_LIVE=1` and a signed-in
+    /// CLI. It prints the percentage and tier only.
+    @Test("live Grok CLI reports a quota window")
+    func liveFetch() async throws {
+        guard ProcessInfo.processInfo.environment["VIBEBUDDY_GROK_LIVE"] == "1" else {
+            print("VIBEBUDDY_GROK_LIVE not set — skipping live Grok usage test")
+            return
+        }
+        let snapshot = try await GrokUsageProvider().fetch()
+        print("""
+        live grok usage: plan=\(snapshot.planType ?? "nil") \
+        primary=\(snapshot.primary.map { "\($0.usedPercent)%" } ?? "nil") \
+        windowMinutes=\(snapshot.primary?.windowDurationMinutes.map(String.init) ?? "nil") \
+        secondary=\(snapshot.secondary.map { "\($0.usedPercent)%" } ?? "nil") \
+        resetsIn=\(snapshot.primary?.resetsAt.map { Int($0.timeIntervalSinceNow / 3600) } ?? -1)h
+        """)
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.primary != nil)
+    }
+
+    // MARK: - Fixtures
+
+    private static func billingResponse(
+        creditUsagePercent: String = "36.0",
+        onDemandCap: String = #"{"val":0}"#,
+        onDemandUsed: String = #"{"val":0}"#
+    ) -> Data {
+        Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{"config":{"creditUsagePercent":\#(creditUsagePercent),\#
+        "currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-08-30T11:36:49.308758+00:00",\#
+        "end":"2026-09-06T11:36:49.308758+00:00"},"onDemandCap":\#(onDemandCap),\#
+        "onDemandUsed":\#(onDemandUsed),"prepaidBalance":{"val":0},"isUnifiedBillingUser":true,\#
+        "billingPeriodStart":"2026-08-30T11:36:49.308758+00:00",\#
+        "billingPeriodEnd":"2026-09-06T11:36:49.308758+00:00"},"subscription_tier":"SuperGrok Heavy"}}
+        """#.utf8)
+    }
+
+    private static func logLine(
+        timestamp: String = "2026-09-03T00:32:30.702Z",
+        percent: String = "36.0"
+    ) -> Data {
+        Data(#"""
+        {"ts":"\#(timestamp)","src":"shell","pid":10083,"ver":"1.0.13","lvl":"info",\#
+        "msg":"billing: fetched credits config","ctx":{"config":{"creditUsagePercent":\#(percent),\#
+        "currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-08-30T11:36:49.308758+00:00",\#
+        "end":"2026-09-06T11:36:49.308758+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},\#
+        "prepaidBalance":{"val":0},"isUnifiedBillingUser":true,"historyLen":0},"onDemandEnabled":null,\#
+        "subscriptionTier":"SuperGrok Heavy"}}
+        """#.utf8)
+    }
+
+    /// A stand-in for `grok agent --no-leader stdio`: it records the handshake
+    /// it is given and answers the second request with a canned reply.
+    private static func writeFakeAgent(
+        in directory: URL,
+        transcript: URL,
+        reply: String
+    ) throws -> URL {
+        let script = """
+        #!/bin/sh
+        read -r line || exit 1
+        printf '%s\\n' "$line" >> "\(transcript.path)"
+        printf '%s\\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1}}'
+        printf '%s\\n' '{"jsonrpc":"2.0","method":"_x.ai/mcp/servers_updated","params":{}}'
+        read -r line || exit 1
+        printf '%s\\n' "$line" >> "\(transcript.path)"
+        printf '%s\\n' '\(reply)'
+        exec sleep 5
+        """
+        let url = directory.appendingPathComponent("fake-grok")
+        try Data(script.utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebuddy-grok-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Reset times drive a minute-resolution label, so sub-second differences
+    /// between the wire precisions do not matter.
+    private static func matches(_ date: Date?, _ iso: String) -> Bool {
+        guard let date, let base = timestamp(iso) else { return false }
+        return abs(date.timeIntervalSince(base)) < 1
+    }
+
+    private static func timestamp(_ raw: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: raw)
+    }
+
+    private static func json(_ line: String) -> [String: Any]? {
+        try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HookDecoderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HookDecoderTests.swift
@@ -15,7 +15,7 @@ struct HookDecoderTests {
     func claudeShape() {
         let e = HookDecoder.decode(
             Data(#"{"hook_event_name":"PreToolUse","session_id":"abc","cwd":"/x/proj","tool_name":"Bash"}"#.utf8),
-            agent: .claudeCode, receivedAt: now)
+            agent: .claudeCode, receivedAt: now).event
         #expect(e?.kind == .preToolUse)
         #expect(e?.sessionID == "abc")
         #expect(e?.agent == .claudeCode)
@@ -25,7 +25,7 @@ struct HookDecoderTests {
     func defaultPassthroughTag() {
         let e = HookDecoder.decode(
             Data(#"{"hook_event_name":"Stop","session_id":"s"}"#.utf8),
-            agent: .qwen, receivedAt: now)
+            agent: .qwen, receivedAt: now).event
         #expect(e?.kind == .stop)
         #expect(e?.agent == .qwen)
     }
@@ -34,7 +34,7 @@ struct HookDecoderTests {
     func codexRoute() {
         let e = HookDecoder.decode(
             Data(#"{"hook_event_name":"PreToolUse","session_id":"t1","cwd":"/x/proj","tool_name":"Bash"}"#.utf8),
-            agent: .codex, receivedAt: now)
+            agent: .codex, receivedAt: now).event
         #expect(e?.kind == .preToolUse)
         #expect(e?.agent == .codex)
         #expect(e?.sessionID == "t1")
@@ -45,7 +45,7 @@ struct HookDecoderTests {
     func codexPermissionRequest() {
         let e = HookDecoder.decode(
             Data(#"{"hook_event_name":"PermissionRequest","session_id":"t9","cwd":"/x/proj","tool_name":"Bash"}"#.utf8),
-            agent: .codex, receivedAt: now)
+            agent: .codex, receivedAt: now).event
         #expect(e?.kind == .notification)
         #expect(e?.sessionID == "t9")
         #expect(e?.message == "Permission required for Bash")
@@ -55,7 +55,7 @@ struct HookDecoderTests {
     func codexStopSummary() {
         let e = HookDecoder.decode(
             Data(#"{"hook_event_name":"Stop","session_id":"t10","cwd":"/x/proj","last_assistant_message":"All tests pass."}"#.utf8),
-            agent: .codex, receivedAt: now)
+            agent: .codex, receivedAt: now).event
         #expect(e?.kind == .stop)
         #expect(e?.message == "All tests pass.")
     }
@@ -64,25 +64,68 @@ struct HookDecoderTests {
     func grokRoute() {
         let e = HookDecoder.decode(
             Data(#"{"hookEventName":"pre_tool_use","sessionId":"g1","cwd":"/x/proj","toolName":"run_terminal_cmd"}"#.utf8),
-            agent: .grok, receivedAt: now)
+            agent: .grok, receivedAt: now).event
         #expect(e?.kind == .preToolUse)
         #expect(e?.agent == .grok)
         #expect(e?.sessionID == "g1")
         #expect(e?.toolName == "run_terminal_cmd")
     }
 
+    @Test("Grok stop carries the last assistant message, like Codex's Stop summary")
+    func grokStopSummary() {
+        let e = HookDecoder.decode(
+            Data(#"{"hookEventName":"stop","sessionId":"g2","cwd":"/x/proj","promptId":"p1","reason":"end_turn","lastAssistantMessage":"All tests pass."}"#.utf8),
+            agent: .grok, receivedAt: now).event
+        #expect(e?.kind == .stop)
+        #expect(e?.message == "All tests pass.")
+        #expect(e?.turnID == "p1")
+    }
+
+    @Test("Grok's permission_prompt notification becomes a permission wait")
+    func grokPermissionPrompt() {
+        let e = HookDecoder.decode(
+            Data(#"{"hookEventName":"notification","sessionId":"g3","notificationType":"permission_prompt","message":"Tool permission requested"}"#.utf8),
+            agent: .grok, receivedAt: now).event
+        #expect(e?.kind == .notification)
+        #expect(e?.message == "Tool permission requested")
+    }
+
+    @Test("Claude-shape turn events carry no turn identity, so they always settle")
+    func claudeShapeHasNoTurnID() {
+        let e = HookDecoder.decode(
+            Data(#"{"hook_event_name":"Stop","session_id":"s"}"#.utf8),
+            agent: .claudeCode, receivedAt: now).event
+        #expect(e?.kind == .stop)
+        #expect(e?.turnID == nil)
+    }
+
     @Test("antigravity source routes to the Antigravity decoder, tagged antigravity")
     func antigravityRoute() {
         let e = HookDecoder.decode(
             Data(#"{"hook_event_name":"BeforeTool","session_id":"a1","cwd":"/x/proj","tool_name":"run_shell_command"}"#.utf8),
-            agent: .antigravity, receivedAt: now)
+            agent: .antigravity, receivedAt: now).event
         #expect(e?.kind == .preToolUse)
         #expect(e?.agent == .antigravity)
         #expect(e?.sessionID == "a1")
     }
 
-    @Test("malformed input → nil (fail-open)")
+    @Test("malformed input is undecodable, not merely ignored")
     func malformed() {
-        #expect(HookDecoder.decode(Data("{not json".utf8), agent: .grok, receivedAt: now) == nil)
+        #expect(HookDecoder.decode(Data("{not json".utf8), agent: .grok, receivedAt: now)
+                == .undecodable)
+        #expect(HookDecoder.decode(Data("{not json".utf8), agent: .claudeCode, receivedAt: now)
+                == .undecodable)
+    }
+
+    @Test("a grok event we understand but deliberately skip is ignored, not unknown")
+    func grokIgnored() {
+        // Fires at EVERY grok session teardown; reporting it as an unknown
+        // version would light up "grok hooks: unsupported version" in Settings.
+        #expect(HookDecoder.decode(
+            Data(#"{"hookEventName":"stop","sessionId":"g4","reason":"shutdown"}"#.utf8),
+            agent: .grok, receivedAt: now) == .ignored)
+        #expect(HookDecoder.decode(
+            Data(#"{"hookEventName":"post_tool_use","sessionId":"c1","subagentType":"explore"}"#.utf8),
+            agent: .grok, receivedAt: now) == .ignored)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -3,7 +3,7 @@ import Testing
 import VibeBuddyKit
 @testable import VibeBuddyMacCore
 
-@Suite("Claude and Codex observation health diagnostics")
+@Suite("Claude, Codex and Grok observation health diagnostics")
 struct ObservationHealthDetectorTests {
     let now = Date(timeIntervalSince1970: 1_700_000_000)
 
@@ -125,6 +125,75 @@ struct ObservationHealthDetectorTests {
 
         let result = ObservationHealthDetector.detect(home: home, signals: [], now: now)
         #expect(result.health(agent: .codex, source: .rollout) == .sourceUnreadable)
+    }
+
+    // MARK: - Grok
+
+    /// The event set `hooks/install-grok-hooks.py` writes.
+    private func grokHooks(_ events: [String]) -> String {
+        let groups = events.map {
+            #""\#($0)":[{"hooks":[{"type":"command","command":"/app/vibebuddy-forward.sh grok","timeout":5}]}]"#
+        }.joined(separator: ",")
+        return "{\"hooks\":{\(groups)}}"
+    }
+
+    private var grokInstalledEvents: [String] {
+        ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+         "PostToolUseFailure", "Stop", "StopFailure", "StopCancelled",
+         "Notification", "SubagentStart", "SubagentStop", "SessionEnd"]
+    }
+
+    @Test("grok reports not-installed, then missing events, then healthy")
+    func grokHookEvidence() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        #expect(ObservationHealthDetector.detect(home: home, signals: [], now: now)
+            .health(agent: .grok, source: .hook) == .notInstalled)
+
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".grok", isDirectory: true),
+            withIntermediateDirectories: true)
+        #expect(ObservationHealthDetector.detect(home: home, signals: [], now: now)
+            .health(agent: .grok, source: .hook) == .eventsMissing)
+
+        try write(grokHooks(grokInstalledEvents),
+                  to: home.appendingPathComponent(".grok/hooks/vibebuddy.json"))
+        let signal = ObservationRuntimeSignal(agent: .grok, source: .hook, lastObservedAt: now)
+        let result = ObservationHealthDetector.detect(home: home, signals: [signal], now: now)
+        #expect(result.health(agent: .grok, source: .hook) == .healthy)
+        #expect(result.diagnostic(agent: .grok, source: .hook)?.configuredCoverage
+            == ObservationEventCoverage.allCases)
+    }
+
+    @Test("grok without Notification loses attention coverage even with fresh events")
+    func grokAttentionCoverageRequired() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".grok", isDirectory: true),
+            withIntermediateDirectories: true)
+        try write(grokHooks(grokInstalledEvents.filter { $0 != "Notification" }),
+                  to: home.appendingPathComponent(".grok/hooks/vibebuddy.json"))
+        let signal = ObservationRuntimeSignal(agent: .grok, source: .hook, lastObservedAt: now)
+        let result = ObservationHealthDetector.detect(home: home, signals: [signal], now: now)
+        #expect(result.health(agent: .grok, source: .hook) == .eventsMissing)
+        #expect(result.diagnostic(agent: .grok, source: .hook)?
+            .configuredCoverage.contains(.attention) == false)
+    }
+
+    @Test("grok's session transcripts are a declared passive source")
+    func grokPassiveSource() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        #expect(ObservationHealthDetector.detect(home: home, signals: [], now: now)
+            .health(agent: .grok, source: .transcript) == .notInstalled)
+
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".grok/sessions", isDirectory: true),
+            withIntermediateDirectories: true)
+        let signal = ObservationRuntimeSignal(agent: .grok, source: .transcript, lastObservedAt: now)
+        #expect(ObservationHealthDetector.detect(home: home, signals: [signal], now: now)
+            .health(agent: .grok, source: .transcript) == .healthy)
     }
 }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PermissionRulesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PermissionRulesTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import VibeBuddyKit
 @testable import VibeBuddyMacCore
 
 @Suite("PermissionRules — load allow/deny from settings.json")
@@ -20,5 +21,89 @@ struct PermissionRulesTests {
         let rules = PermissionRules.load(settingsURL: URL(fileURLWithPath: "/no/such/file.json"))
         #expect(rules.allow.isEmpty)
         #expect(rules.deny.isEmpty)
+    }
+}
+
+@Suite("GrokPermissionConfig — [permission] allow/deny from ~/.grok/config.toml")
+struct GrokPermissionConfigTests {
+
+    @Test("reads multi-line allow/deny arrays and ignores every other section")
+    func multiLineArrays() {
+        let rules = GrokPermissionConfig.parse("""
+        [cli]
+        installer = "internal"
+
+        [ui]
+        permission_mode = "always-approve"
+        deny = ["not-a-permission-rule"]
+
+        [permission]
+        deny = [
+          "Read(/Users/you/private/**)",   # a comment
+          "Bash(rm -rf *)",
+        ]
+        allow = [
+          "Bash(git *)",
+          "Bash(gh *)",
+        ]
+
+        [models]
+        default = "grok-4.6"
+        """)
+        #expect(rules.allow == ["Bash(git *)", "Bash(gh *)"])
+        #expect(rules.deny == ["Read(/Users/you/private/**)", "Bash(rm -rf *)"])
+    }
+
+    @Test("reads the single-line array form")
+    func singleLine() {
+        let rules = GrokPermissionConfig.parse(#"""
+        [permission]
+        allow = ["Bash(ls:*)", "Read"]
+        deny = []
+        """#)
+        #expect(rules.allow == ["Bash(ls:*)", "Read"])
+        #expect(rules.deny.isEmpty)
+    }
+
+    @Test("a # inside a rule is not a comment, and escaped quotes survive")
+    func quotingEdgeCases() {
+        let rules = GrokPermissionConfig.parse(#"""
+        [permission]
+        allow = ["Bash(grep '#todo' *)", "Bash(echo \"hi\")", 'Bash(awk {print})']
+        """#)
+        #expect(rules.allow == ["Bash(grep '#todo' *)", #"Bash(echo "hi")"#, "Bash(awk {print})"])
+    }
+
+    @Test("a [permission.…] sub-table is not the [permission] table")
+    func subTablesIgnored() {
+        let rules = GrokPermissionConfig.parse("""
+        [permission.hub]
+        allow = ["Bash(anything *)"]
+
+        [[permission.rules]]
+        allow = ["Bash(also-not *)"]
+        """)
+        #expect(rules.allow.isEmpty && rules.deny.isEmpty)
+    }
+
+    @Test("a missing or unparsable file yields empty rules (everything asks)")
+    func missingFile() {
+        let rules = GrokPermissionConfig.load(configURL: URL(fileURLWithPath: "/no/such/config.toml"))
+        #expect(rules.allow.isEmpty && rules.deny.isEmpty)
+        #expect(GrokPermissionConfig.parse("not toml at all").allow.isEmpty)
+    }
+
+    @Test("grok merges its own config with the Claude settings; other agents don't")
+    func mergedForGrok() throws {
+        // Only the grok half is injectable here, so assert the merge by way of
+        // the union always containing what the Claude loader found.
+        let claude = PermissionRules.load()
+        let grok = PermissionRules.load(for: .grok)
+        #expect(grok.allow.count >= claude.allow.count)
+        #expect(grok.deny.count >= claude.deny.count)
+        #expect(claude.allow.allSatisfy { grok.allow.contains($0) })
+
+        let other = PermissionRules.load(for: .claudeCode)
+        #expect(other.allow == claude.allow && other.deny == claude.deny)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -427,4 +427,61 @@ struct SessionReducerTests {
         #expect(r.sessions["s1"]?.contextWindow == 200_000)
         #expect(r.sessions["s1"]?.tokens == 1200)
     }
+
+    // MARK: - Turn ordering
+
+    private func turn(
+        _ kind: HookEvent.Kind,
+        turnID: String?,
+        message: String? = nil,
+        at: TimeInterval
+    ) -> HookEvent {
+        HookEvent(kind: kind, sessionID: "s1", agent: .grok,
+                  cwd: "/Users/me/projects/vibebuddy", message: message,
+                  timestamp: t0.addingTimeInterval(at), turnID: turnID)
+    }
+
+    @Test("a settle report for a superseded turn does not fake an idle session")
+    func staleTurnSettleIgnored() {
+        var r = SessionReducer()
+        r.apply(ev(.sessionStart))
+        r.apply(turn(.userPromptSubmit, turnID: "p1", at: 1))
+        r.apply(turn(.userPromptSubmit, turnID: "p2", at: 2))
+        r.apply(turn(.stop, turnID: "p1", message: "cancelled", at: 3))
+        #expect(r.sessions["s1"]?.status == .working)
+
+        r.apply(turn(.stop, turnID: "p2", message: "done", at: 4))
+        #expect(r.sessions["s1"]?.status == .done)
+        #expect(r.sessions["s1"]?.summary == "done")
+    }
+
+    @Test("a stop with no turn identity always settles")
+    func untaggedStopSettles() {
+        var r = SessionReducer()
+        r.apply(ev(.sessionStart))
+        r.apply(turn(.userPromptSubmit, turnID: "p1", at: 1))
+        r.apply(turn(.userPromptSubmit, turnID: "p2", at: 2))
+        // Grok's idle_prompt backstop (and every Claude/Codex stop) carries none.
+        r.apply(turn(.stop, turnID: nil, at: 3))
+        #expect(r.sessions["s1"]?.status == .done)
+    }
+
+    @Test("a turn identity from a session with no recorded turn still settles")
+    func stopWithoutRecordedTurnSettles() {
+        var r = SessionReducer()
+        r.apply(ev(.sessionStart))
+        r.apply(turn(.stop, turnID: "p9", at: 1))
+        #expect(r.sessions["s1"]?.status == .done)
+    }
+
+    @Test("turn identity does not survive the session it belonged to")
+    func turnIdentityClearedOnSessionEnd() {
+        var r = SessionReducer()
+        r.apply(ev(.sessionStart))
+        r.apply(turn(.userPromptSubmit, turnID: "p1", at: 1))
+        r.apply(ev(.sessionEnd, at: 2))
+        r.apply(ev(.sessionStart, at: 3))
+        r.apply(turn(.stop, turnID: "p1", at: 4))
+        #expect(r.sessions["s1"]?.status == .done)
+    }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SubagentTopologyTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SubagentTopologyTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import VibeBuddyKit
 @testable import VibeBuddyMacCore
 
-@Suite("Claude parent/subagent topology")
+@Suite("Parent/subagent topology (Claude and Grok)")
 struct SubagentTopologyTests {
 
     let t0 = Date(timeIntervalSince1970: 1_700_000_000)
@@ -155,5 +155,56 @@ struct SubagentTopologyTests {
         #expect(working.sessions["parent"]?.status == .done)
         #expect(working.sessions["parent"]?.runningChildAgentCount == 1)
         #expect(working.sessions["parent"]?.activeTool == nil)
+    }
+
+    // MARK: - Grok
+
+    private func grok(_ json: String, at offset: TimeInterval = 0) -> HookEvent? {
+        GrokParser.parse(Data(json.utf8), receivedAt: t0.addingTimeInterval(offset)).event
+    }
+
+    @Test("Grok subagents produce the same ChildAgent rows as Claude's")
+    func grokChildRows() {
+        var reducer = SessionReducer()
+        for (json, offset) in [
+            (#"{"hookEventName":"session_start","sessionId":"parent","cwd":"/x/proj"}"#, 0.0),
+            (#"{"hookEventName":"user_prompt_submit","sessionId":"parent","promptId":"p1"}"#, 1.0),
+            (#"{"hookEventName":"subagent_start","sessionId":"parent","subagentId":"child-a","subagentType":"explore","description":"Survey"}"#, 2.0),
+            (#"{"hookEventName":"subagent_start","sessionId":"parent","subagentId":"child-b","subagentType":"code-reviewer","description":"Review"}"#, 3.0),
+        ] {
+            if let e = grok(json, at: offset) { reducer.apply(e) }
+        }
+        let session = reducer.sessions["parent"]
+        #expect(session?.status == .working)
+        #expect(session?.runningChildAgentCount == 2)
+        #expect(Set(session?.childAgents?.map(\.id) ?? []) == ["subagent:child-a", "subagent:child-b"])
+        #expect(session?.childAgents?.allSatisfy { $0.kind == .subagent } == true)
+        #expect(ToolActivity.childSummary(for: session!)?.contains("2") == true)
+
+        // Each child's stop arrives from the child's own session id.
+        for (json, offset) in [
+            (#"{"hookEventName":"subagent_stop","sessionId":"child-a","subagentId":"child-a","subagentType":"explore","phase":"gate"}"#, 4.0),
+            (#"{"hookEventName":"subagent_stop","sessionId":"child-b","subagentId":"child-b","subagentType":"code-reviewer","phase":"gate"}"#, 5.0),
+        ] {
+            if let e = grok(json, at: offset) { reducer.apply(e) }
+        }
+        #expect(reducer.sessions.keys.sorted() == ["parent"])
+        #expect(reducer.sessions["parent"]?.runningChildAgentCount == 0)
+        #expect(reducer.sessions["parent"]?.status == .working)
+    }
+
+    @Test("a duplicate SubagentStop phase does not resurrect or duplicate the child")
+    func grokDuplicateStopPhases() {
+        var reducer = SessionReducer()
+        for (json, offset) in [
+            (#"{"hookEventName":"session_start","sessionId":"parent","cwd":"/x/proj"}"#, 0.0),
+            (#"{"hookEventName":"subagent_start","sessionId":"parent","subagentId":"child-a","subagentType":"explore"}"#, 1.0),
+            (#"{"hookEventName":"subagent_stop","sessionId":"child-a","subagentId":"child-a","subagentType":"explore","phase":"gate"}"#, 2.0),
+            (#"{"hookEventName":"subagent_stop","sessionId":"child-a","subagentId":"child-a","subagentType":"explore","phase":"observe"}"#, 3.0),
+        ] {
+            if let e = grok(json, at: offset) { reducer.apply(e) }
+        }
+        #expect(reducer.sessions["parent"]?.childAgents?.count == 1)
+        #expect(reducer.sessions["parent"]?.runningChildAgentCount == 0)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TranscriptRecentTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TranscriptRecentTests.swift
@@ -67,4 +67,20 @@ struct TranscriptRecentTests {
         #expect(TranscriptReader.recentEntries(path: tmp)?.map(\.text) == ["hi", "hello"])
         #expect(TranscriptReader.recentEntries(path: "/no/such/file.jsonl") == nil)
     }
+
+    @Test("grok's own log produces the same entry shapes")
+    func grokEntriesMatchTheClaudeShape() {
+        let entries = GrokSessionReader.recentEntries(updatesTail: Data([
+            GrokFixture.userChunk("do the thing"),
+            GrokFixture.toolCall(id: "call-1", title: "search_replace"),
+            GrokFixture.agentChunk("done the thing"),
+        ].joined(separator: "\n").utf8))
+        #expect(entries.map(\.role) == ["user", "assistant", "assistant"])
+        #expect(entries.map(\.text) == ["do the thing", "⚙ search_replace", "done the thing"])
+    }
+
+    @Test("a grok log with no messages at all yields no entries")
+    func grokEmpty() {
+        #expect(GrokSessionReader.recentEntries(updatesTail: Data()).isEmpty)
+    }
 }

--- a/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "Deny" = "拒绝";
 "Jump" = "跳转";
 "Jump to terminal" = "跳到终端";
+"Grok will still ask in the terminal after Allow (permission mode: %@). Set permission_mode = \"always-approve\" to approve from here." = "批准后，Grok 仍会在终端里再确认一次（权限模式：%@）。设置 permission_mode = \"always-approve\" 才能直接在这里批准。";
 /* Detail pane — recent output / transcript peek ("Done" reuses the existing key) */
 "Recent output" = "最近输出";
 "No recent output" = "暂无最近输出";

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -383,6 +383,15 @@ private struct DetailView: View {
                     }
                     .buttonStyle(.bordered).controlSize(.small)
                     .help("Always allow: auto-approve this exact command in future. Allow all this session: stop asking for the rest of this run.")
+                    if session.agent == .grok, let mode = approval.permissionMode, mode != "bypassPermissions" {
+                        Label {
+                            Text("Grok will still ask in the terminal after Allow (permission mode: \(mode)). Set permission_mode = \"always-approve\" to approve from here.")
+                        } icon: {
+                            Image(systemName: "terminal")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
                 } else {
                     if let s = session.summary { Text(s).foregroundStyle(.secondary) }
                     Button("Jump to terminal") { model.jump(session) }

--- a/VibeBuddyMacApp/Sources/HookSetup.swift
+++ b/VibeBuddyMacApp/Sources/HookSetup.swift
@@ -30,6 +30,7 @@ final class HookSetup: ObservableObject {
         switch agent {
         case .claudeCode: run("--install", scriptName: "install-claude-hooks.py")
         case .codex: run("--install", scriptName: "install-codex-hooks.py")
+        case .grok: run("--install", scriptName: "install-grok-hooks.py")
         default: break
         }
     }

--- a/VibeBuddyMacApp/Sources/MacDemoData.swift
+++ b/VibeBuddyMacApp/Sources/MacDemoData.swift
@@ -84,6 +84,14 @@ enum MacDemoData {
                                updatedAt: now.addingTimeInterval(-9)),
                 ],
                 statusSince: now.addingTimeInterval(-15), updatedAt: now.addingTimeInterval(-15)),
+            AgentSession(
+                id: "demo-work-3", agent: .grok, project: "glaux-book", branch: "main",
+                model: "grok-4.6", status: .working, summary: "Running the build script…",
+                tokens: 2800, contextTokens: 96_000, contextWindow: 500_000,
+                activeTool: "run_terminal_command",
+                observations: [ObservationEvidence(
+                    source: .hook, lastObservedAt: now.addingTimeInterval(-6), health: .healthy)],
+                statusSince: now.addingTimeInterval(-6), updatedAt: now.addingTimeInterval(-6)),
 
             // ── Done ────────────────────────────────────────────────────────
             AgentSession(

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -110,12 +110,20 @@ final class MenuBarModel: ObservableObject {
         toggleGlanceHotkey = Hotkey.loadToggleGlance()
         let codexUsageEnabled = Self.loadBool(Self.usageEnabledKey(for: .codex), default: true)
         let claudeUsageEnabled = Self.loadBool(Self.usageEnabledKey(for: .claude), default: true)
-        usageCollectionEnabled = [.codex: codexUsageEnabled, .claude: claudeUsageEnabled]
+        let grokUsageEnabled = Self.loadBool(Self.usageEnabledKey(for: .grok), default: true)
+        usageCollectionEnabled = [
+            .codex: codexUsageEnabled,
+            .claude: claudeUsageEnabled,
+            .grok: grokUsageEnabled,
+        ]
         usageStates = [
             .codex: codexUsageEnabled
                 ? .unavailable(.notYetLoaded, lastAttemptAt: nil, nextRefreshAt: nil)
                 : .disabled,
             .claude: claudeUsageEnabled
+                ? .unavailable(.notYetLoaded, lastAttemptAt: nil, nextRefreshAt: nil)
+                : .disabled,
+            .grok: grokUsageEnabled
                 ? .unavailable(.notYetLoaded, lastAttemptAt: nil, nextRefreshAt: nil)
                 : .disabled,
         ]
@@ -129,6 +137,11 @@ final class MenuBarModel: ObservableObject {
                 provider: ClaudeCLIUsageProvider(),
                 cache: AccountUsageFileCache(provider: .claude),
                 enabled: claudeUsageEnabled
+            ),
+            .grok: AccountUsageCollector(
+                provider: GrokUsageProvider(),
+                cache: AccountUsageFileCache(provider: .grok),
+                enabled: grokUsageEnabled
             ),
         ]
         usageAlertMonitor = AccountUsageAlertMonitor(

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -120,7 +120,7 @@ struct AccountUsageSettings: View {
             } header: {
                 Text("Providers")
             } footer: {
-                Text("Codex reads its official local app-server. Claude runs the official read-only /usage command without session persistence or hooks. No credentials, account IDs, or raw responses are stored or logged. Turning either source off leaves session monitoring and notifications running.")
+                Text("Codex reads its official local app-server. Claude runs the official read-only /usage command without session persistence or hooks. Grok asks its own agent process for the billing summary and never reads the stored token. No credentials, account IDs, or raw responses are stored or logged. Turning a source off leaves session monitoring and notifications running.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -133,7 +133,7 @@ struct AccountUsageSettings: View {
                     Text("90%").tag(90)
                     Text("95%").tag(95)
                 }
-                Text("One threshold applies to both providers. Alerts identify the provider, respect quiet mode and quiet hours, and are not repeated after restart.")
+                Text("One threshold applies to every provider. Alerts identify the provider, respect quiet mode and quiet hours, and are not repeated after restart.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/docs/multi-cli-hook-setup.md
+++ b/docs/multi-cli-hook-setup.md
@@ -35,7 +35,7 @@ The CLI pipes its event JSON on stdin. VibeBuddy reads `hook_event_name`,
 | Qwen Code | `qwen` | `~/.qwen/` | Claude-compatible hooks | ⚠️ template |
 | Kimi | `kimi` | `~/.kimi/config.toml` | TOML hooks | ⚠️ template |
 | Antigravity (Gemini) | `antigravity` | `~/.gemini/antigravity-cli/hooks.json` | JSON `command` hooks | blocked: `agy` 1.0.5 loads but skips execution |
-| Grok | `grok` | per-CLI hooks | Claude-compatible hooks | ⚠️ template |
+| Grok Build | `grok` | `~/.grok/hooks/vibebuddy.json` | JSON `command` hooks (camelCase envelope) | ✅ tested (1.0.13) |
 | GitHub Copilot | `copilot` | — | observe mode (no hooks) | ⚠️ partial |
 
 ✅ = wired and exercised. ⚠️ template = the source routing + display are done in
@@ -61,20 +61,78 @@ workspace.
 }
 ```
 
-Other hook-compatible CLIs (OpenCode, Qwen, Grok) follow the same shape with
+Other hook-compatible CLIs (OpenCode, Qwen) follow the same shape with
 `agent=<their source>`. Kimi/Codex use their TOML hook tables; Antigravity uses
 a Gemini plugin that shells out to the same curl. Copilot has no hook surface
 yet — it appears once a future watcher observes it.
+
+### Grok Build (`~/.grok/hooks/vibebuddy.json`)
+
+```bash
+python3 hooks/install-grok-hooks.py --dry-run     # preview
+python3 hooks/install-grok-hooks.py --install     # write ~/.grok/hooks/vibebuddy.json
+python3 hooks/install-grok-hooks.py --approval    # + the blocking phone-approval gate
+python3 hooks/install-grok-hooks.py --uninstall   # revert
+```
+
+Grok loads every `~/.grok/hooks/*.json` file, so vibebuddy owns its own file and
+never edits the user's. Reload without restarting: `/hooks` → `r`. Grok's `http`
+hooks refuse loopback (SSRF guard), so these are `command` hooks piping the event
+JSON into `hooks/vibebuddy-forward.sh grok`.
+
+Installed events (grok's config keys; the wire values are snake_case):
+
+| Family | Events | What vibebuddy does with them |
+|--------|--------|-------------------------------|
+| lifecycle | `SessionStart`, `SessionEnd` | open the session (with `modelId` and `transcriptPath`), then drop it |
+| turn | `UserPromptSubmit`, `Stop`, `StopFailure`, `StopCancelled` | working → done; `StopFailure` shows the session as stuck |
+| tool | `PreToolUse`, `PostToolUse`, `PostToolUseFailure` | active tool and the stuck cue |
+| attention | `Notification` | `permission_prompt` → needs-you; `idle_prompt` → the idle backstop |
+| topology | `SubagentStart`, `SubagentStop` | child-agent rows under the parent session |
+
+Grok-specific decoding rules (`GrokParser`):
+
+- `Stop` fires a second time at teardown with `reason` `channel_closed`/`shutdown`.
+  Only `end_turn` (or a missing reason) settles a turn; `SessionEnd` reports the rest.
+- `StopCancelled` is dispatched off the command loop, so it can land *after* the
+  next turn's `UserPromptSubmit`. Every event carries `promptId`, which the reducer
+  keeps as `HookEvent.turnID` and uses to drop a report for a superseded turn.
+- `Notification`'s `task_complete` means a **background** task finished, which can
+  happen mid-turn, so it is not a turn end and is ignored.
+- Everything that can fire inside a subagent's own session carries `subagentType`
+  there and omits it in the main session; those events are dropped so a child never
+  moves the parent's status. `SubagentStart` fires in the parent and `SubagentStop`
+  in the child, both keyed by the same `subagentId`, so the child's row still completes.
+- Grok also imports `~/.claude/settings.json` hooks via `[compat.claude]`. Those
+  entries deliver the Claude shape without `?agent=grok` and currently fail fail-open
+  with `required env var(s) not set: ${PPID}` — harmless noise, never relied on.
+
+#### Remote approval (`--approval`)
+
+`--approval` replaces the fire-and-forget `PreToolUse` group with a blocking
+`hooks/approval-hook.sh grok` (`timeout: 30`, no matcher = every tool), which posts
+to `/approval?agent=grok` and answers grok's gate.
+
+**A phone decision is authoritative only when grok runs with
+`[ui] permission_mode = "always-approve"`** (`permissionMode` reads
+`bypassPermissions` on the wire). In grok's `default` mode a hook `allow` only means
+"not blocked" — grok still shows its own TUI prompt afterwards, and that prompt has
+no external answer channel. In that mode vibebuddy can still surface the wait (the
+`permission_prompt` notification) and *deny*, but the approval must be tapped on the
+Mac.
 
 ### Terminal capture (for jump-to-terminal)
 
 Jump-to-terminal needs to know which terminal each session runs in. A second hook,
 `hooks/capture-terminal.sh`, POSTs `{session_id, term_program, tty, tmux, tmux_pane}`
-to `/terminal`. `install-claude-hooks.py` wires it to **both `SessionStart` and
-`UserPromptSubmit`**: SessionStart catches new sessions, and UserPromptSubmit
+to `/terminal`. `install-claude-hooks.py` and `install-grok-hooks.py` wire it to
+**both `SessionStart` and `UserPromptSubmit`**: SessionStart catches new sessions, and UserPromptSubmit
 re-captures so a session that missed SessionStart — e.g. the hook was added while
 the session was already open — **self-heals on its next prompt** (writing the same
-ref is idempotent). A session with no captured terminal can't be jumped to (the iOS
+ref is idempotent). The script reads the session id from the payload first —
+`sessionId` (grok's envelope), then `session_id` (the Claude shape) — and only
+falls back to `$GROK_SESSION_ID`, which every process grok spawned inherits and
+would otherwise mis-attribute a Claude session started from a shell inside grok. A session with no captured terminal can't be jumped to (the iOS
 button hides; the Mac button disables; a phone jump reports "no terminal").
 
 ### Reversibility

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -8,6 +8,7 @@ fails instantly and never affects the agent.
 ```bash
 python3 hooks/install-agent-hooks.py --dry-run    # detect + preview
 python3 hooks/install-agent-hooks.py --install    # wire every detected CLI
+python3 hooks/install-agent-hooks.py --approval   # + the phone-approval gate where supported
 python3 hooks/install-agent-hooks.py --uninstall  # revert every detected CLI
 ```
 
@@ -19,6 +20,9 @@ backs up before writing. Codex uses its first-class lifecycle hooks in
 `~/.codex/hooks.json`; the separate `notify` command is never changed, so Codex
 Computer Use or another notifier keeps working. The per-CLI installers below
 remain available if you want to wire one CLI at a time.
+
+`--approval` installs the blocking phone-approval gate for the CLIs that have one
+(Claude and Grok); every other detected CLI gets a plain `--install`.
 
 Claude-shape CLIs (Claude, Qwen, Kimi) need no daemon decoder; Codex / Grok /
 Antigravity are decoded per-source inside the daemon. (Note: Antigravity `agy`
@@ -75,6 +79,47 @@ currently active desktop turns are restored; old completed rollouts are not
 replayed into the dashboard.
 
 
+## Grok Build
+
+```bash
+python3 hooks/install-grok-hooks.py --dry-run     # preview
+python3 hooks/install-grok-hooks.py --install     # write ~/.grok/hooks/vibebuddy.json
+python3 hooks/install-grok-hooks.py --approval    # + the blocking approval gate
+python3 hooks/install-grok-hooks.py --uninstall   # revert
+```
+
+Grok loads every `~/.grok/hooks/*.json`, so vibebuddy writes its own file and never
+touches yours. Reload in the TUI with `/hooks` → `r`. Installed events:
+`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`,
+`PostToolUseFailure`, `Stop`, `StopFailure`, `StopCancelled`, `Notification`,
+`SubagentStart`, `SubagentStop`, `SessionEnd` — one forwarder handler each
+(`timeout: 5`), plus `capture-terminal.sh` on `SessionStart`/`UserPromptSubmit`.
+`Stop` and `SubagentStop` are stop *gates*, so their handler exits 0 immediately;
+a timeout or crash fails open and grok stops anyway.
+
+Grok's own `Notification` event is the attention signal: `permission_prompt` shows
+the session as waiting on you, and `idle_prompt` (about a minute after any turn
+end) is the idle backstop for the turns that report no stop at all.
+`task_complete` reports a *background* task and is ignored — it can fire mid-turn.
+
+Grok also imports `~/.claude/settings.json` hooks through `[compat.claude]`. Those
+copies arrive in the Claude shape without `?agent=grok`, so nothing depends on
+them — but grok resolves an argument-less quoted `command` as a literal path
+(`~/.claude/"/…/capture-terminal.sh"`, command not found), which is why the
+Claude capture hook is installed as `"…/capture-terminal.sh" claude`: with an
+argument both CLIs shell-parse it, and the script ignores `$1`.
+
+### Grok remote approval
+
+`--approval` swaps the fire-and-forget `PreToolUse` group for the blocking
+`approval-hook.sh grok` (`timeout: 30`, every tool). A later plain `--install`
+(including the Mac app's Repair button) keeps the gate; only `--uninstall`
+removes it. **The phone's answer is
+authoritative only when grok runs with `[ui] permission_mode = "always-approve"` in
+`~/.grok/config.toml`.** In grok's `default` mode a hook `allow` only means "not
+blocked": grok still raises its own TUI prompt afterwards and no external client can
+answer it, so vibebuddy can surface the wait and deny, but not approve on your behalf.
+
 ## Daemon
 
 The hooks target `http://127.0.0.1:9876/hook` (override with `VIBEBUDDY_PORT`).
@@ -94,7 +139,9 @@ your Mac actually prompts (prompting mode); auto-mode users gain nothing.
 ## Terminal capture (jump-back)
 
 `capture-terminal.sh` is installed automatically as a second SessionStart hook by
-`--install` (and removed by `--uninstall`). On each new Claude Code session it
+`--install` (and removed by `--uninstall`) for Claude and Grok. It reads the session
+id from `$GROK_SESSION_ID`, then `sessionId`, then `session_id`, so the same script
+serves both wire shapes. On each new session it
 POSTs the session's `TERM_PROGRAM`, `TTY`, `TMUX`, and `TMUX_PANE` to
 `http://127.0.0.1:${VIBEBUDDY_PORT:-9876}/terminal`. The Mac app stores this as
 `AgentSession.terminalRef` and uses it to focus the right terminal window when you

--- a/hooks/approval-hook.sh
+++ b/hooks/approval-hook.sh
@@ -1,13 +1,26 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Blocking PreToolUse approval forwarder. Reads the hook JSON on stdin, asks the
-# local daemon, and echoes its permission decision. On any failure it prints
-# nothing and exits 0 so Claude Code proceeds with its normal flow.
+# local daemon, and echoes its permission decision verbatim. On any failure it
+# prints nothing and exits 0 so the agent proceeds with its normal flow.
+#
+# Usage: approval-hook.sh [source]
+#   no argument  → Claude Code (snake_case envelope, hookSpecificOutput reply)
+#   grok         → Grok Build  (camelCase envelope, {"decision":…} reply)
+# The source is forwarded as `/approval?agent=<source>`; the daemon picks the
+# envelope to decode and the decision contract to answer in from it.
+SOURCE="$1"
 PORT="${VIBEBUDDY_PORT:-9876}"
+URL="http://127.0.0.1:${PORT}/approval"
+[ -n "$SOURCE" ] && URL="${URL}?agent=${SOURCE}"
 # /approval is bearer-token gated (daemon-security/01); read the token at runtime.
-# No token → 401 → empty RESP → Claude proceeds with its normal flow (fail-open).
+# No token → 401 → empty RESP → the agent proceeds with its normal flow (fail-open).
 TOKEN_FILE="${VIBEBUDDY_TOKEN_FILE:-$HOME/Library/Application Support/vibebuddy/token}"
 TOKEN="${VIBEBUDDY_TOKEN:-$(cat "$TOKEN_FILE" 2>/dev/null)}"
-AUTH=(); [ -n "$TOKEN" ] && AUTH=(-H "Authorization: Bearer $TOKEN")
-RESP=$(curl -sS --max-time 30 "${AUTH[@]}" -X POST --data-binary @- "http://127.0.0.1:${PORT}/approval" 2>/dev/null)
+if [ -n "$TOKEN" ]; then
+  RESP=$(curl -sS --max-time 30 -H "Authorization: Bearer $TOKEN" \
+    -X POST --data-binary @- "$URL" 2>/dev/null)
+else
+  RESP=$(curl -sS --max-time 30 -X POST --data-binary @- "$URL" 2>/dev/null)
+fi
 [ -n "$RESP" ] && printf '%s' "$RESP"
 exit 0

--- a/hooks/capture-terminal.sh
+++ b/hooks/capture-terminal.sh
@@ -4,7 +4,14 @@
 # back to reading TMUX/TMUX_PANE/TERM_PROGRAM from an ancestor process (the shell
 # or `claude` running in the pane) via `ps eww`.
 INPUT=$(cat)
-SID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+# Session id, in order of trust: the payload describes *this* event — grok's own
+# envelope spells it camelCase, Claude-shape CLIs snake_case. $GROK_SESSION_ID is
+# only the last resort, because it is inherited by every process grok spawned:
+# a Claude session started from a shell inside grok would otherwise report its
+# terminal under grok's session id.
+SID=$(printf '%s' "$INPUT" | sed -n 's/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+[ -z "$SID" ] && SID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+[ -z "$SID" ] && SID="${GROK_SESSION_ID:-}"
 [ -z "$SID" ] && exit 0
 
 # Read $1 from this process's env, else walk up ancestors and read theirs.

--- a/hooks/install-agent-hooks.py
+++ b/hooks/install-agent-hooks.py
@@ -9,6 +9,8 @@ rather than duplicated.
 
   --dry-run    list detected CLIs and what each would do
   --install    install vibebuddy hooks into every detected CLI
+  --approval   install, and add the blocking phone-approval gate where the CLI
+               supports one (Claude, Grok); every other CLI gets --install
   --uninstall  remove vibebuddy hooks from every detected CLI
 
 Idempotent: every per-CLI installer is idempotent, so a re-run is a no-op.
@@ -33,6 +35,11 @@ CLIS = [
 ]
 
 
+# CLIs whose installer understands `--approval` (a blocking PreToolUse gate that
+# asks the phone). Everything else is installed status-only.
+APPROVAL_CAPABLE = {"claude", "grok"}
+
+
 def present(path):
     return os.path.exists(os.path.expanduser(path))
 
@@ -45,7 +52,8 @@ def run(script, mode):
 
 
 def main():
-    mode = next((a for a in sys.argv[1:] if a in {"--dry-run", "--install", "--uninstall"}), "--dry-run")
+    mode = next((a for a in sys.argv[1:]
+                 if a in {"--dry-run", "--install", "--uninstall", "--approval"}), "--dry-run")
     found = [(n, p, s) for (n, p, s) in CLIS if present(p)]
     skipped = [n for (n, p, s) in CLIS if not present(p)]
 
@@ -57,7 +65,10 @@ def main():
     failures = 0
     for (n, p, s) in found:
         print(f"\n=== {n}  ({s}) ===")
-        r = run(s, mode)
+        cli_mode = mode
+        if mode == "--approval" and n not in APPROVAL_CAPABLE:
+            cli_mode = "--install"
+        r = run(s, cli_mode)
         out = (r.stdout or "").strip()
         err = (r.stderr or "").strip()
         if out:

--- a/hooks/install-claude-hooks.py
+++ b/hooks/install-claude-hooks.py
@@ -85,7 +85,12 @@ def install(data):
         added.append(ev)
     for ev in CAPTURE_EVENTS:
         arr = hooks.setdefault(ev, [])
-        expected = {"hooks": [{"type": "command", "command": f'"{CAPTURE_HOOK}"',
+        # The inert `claude` argument is there for Grok's `[compat.claude]`
+        # bridge, which imports these hooks and resolves a quoted, argument-less
+        # command as a literal path (`~/.claude/"/…/capture-terminal.sh"`,
+        # command not found). With an argument the command is shell-parsed by
+        # both CLIs; `capture-terminal.sh` reads stdin and the env, never `$1`.
+        expected = {"hooks": [{"type": "command", "command": f'"{CAPTURE_HOOK}" claude',
                                 "timeout": 5, "async": True}]}
         owned = [g for g in arr if has_marker(g, CAPTURE_MARKER)]
         if owned != [expected]:

--- a/hooks/install-grok-hooks.py
+++ b/hooks/install-grok-hooks.py
@@ -1,12 +1,29 @@
 #!/usr/bin/env python3
-"""Install/uninstall vibebuddy hooks for Grok Build.
+"""Install/uninstall vibebuddy hooks for Grok Build (1.0.13).
 
 Grok discovers standalone hook files from `~/.grok/hooks/*.json`. We write a
 dedicated `vibebuddy.json` whose command hooks pipe each lifecycle event to the
 shared forwarder (`hooks/vibebuddy-forward.sh grok`); the daemon's source-aware
 HookDecoder runs the grok camelCase decoder. Grok's `http` hooks reject loopback
 (SSRF guard), so **command** hooks are required. The forwarder is fail-open and
-exits 0 with no stdout, so PreToolUse never blocks grok.
+exits 0 with no stdout, so neither the PreToolUse gate nor the Stop gate blocks.
+
+Event set (grok's own names; the decoder maps them to the shared HookEvent):
+  - lifecycle: SessionStart, SessionEnd
+  - turn:      UserPromptSubmit, Stop, StopFailure, StopCancelled
+  - tool:      PreToolUse, PostToolUse, PostToolUseFailure
+  - attention: Notification (permission_prompt waits, idle_prompt backstop)
+  - topology:  SubagentStart, SubagentStop
+`Stop` and `SubagentStop` are gates, so their handler must exit 0 fast; the
+forwarder caps its local POST well inside the 5 s timeout we set.
+
+`--approval` additionally routes PreToolUse through the blocking
+`hooks/approval-hook.sh grok`, which asks the phone and answers grok's
+permission gate. It replaces (not joins) the fire-and-forget PreToolUse group,
+and a later plain `--install` keeps it (only `--uninstall` removes it).
+Phone answers are only authoritative when grok runs with
+`[ui] permission_mode = "always-approve"`; in `default` mode an `allow` decision
+merely means "not blocked" and grok still shows its own TUI prompt.
 
 Do NOT rely on Grok's `[compat.claude]` auto-bridge of `~/.claude/settings.json`:
 it forwards the wrong (Claude) shape and omits `?agent=grok`.
@@ -17,6 +34,7 @@ a pre-existing non-vibebuddy file is backed up once).
 Usage:
     python3 install-grok-hooks.py --dry-run
     python3 install-grok-hooks.py --install
+    python3 install-grok-hooks.py --approval
     python3 install-grok-hooks.py --uninstall
 """
 import json
@@ -24,28 +42,59 @@ import os
 import shutil
 import sys
 
-HOOKS_DIR = os.path.expanduser("~/.grok/hooks")
+# Grok resolves its data directory from $GROK_HOME, falling back to ~/.grok, and
+# reads standalone hook files from `<grok home>/hooks/*.json`. Honouring the same
+# variable is what lets an isolated Grok (a test rig, a second profile) get its
+# own hooks without touching the user's.
+GROK_HOME = os.path.expanduser(os.environ.get("GROK_HOME") or "~/.grok")
+HOOKS_DIR = os.path.join(GROK_HOME, "hooks")
 TARGET = os.path.join(HOOKS_DIR, "vibebuddy.json")
 BACKUP = TARGET + ".vibebuddy-backup"
-FORWARDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vibebuddy-forward.sh")
+HERE = os.path.dirname(os.path.abspath(__file__))
+FORWARDER = os.path.join(HERE, "vibebuddy-forward.sh")
 COMMAND = f'"{FORWARDER}" grok'
+APPROVAL_HOOK = os.path.join(HERE, "approval-hook.sh")
+APPROVAL_COMMAND = f'"{APPROVAL_HOOK}" grok'
+CAPTURE_HOOK = os.path.join(HERE, "capture-terminal.sh")
+# Grok reads a single-token `command` as a *path* — no shell, so the surrounding
+# quotes stay in the string and it resolves to `<grok home>/hooks/"…"`, failing
+# with `command not found` (verified against 1.0.13). A command with an argument
+# is shell-parsed instead, which strips the quotes and survives spaces in the
+# path, so the capture hook takes the same inert `grok` argument the forwarder
+# does. `capture-terminal.sh` reads stdin and the env, never `$1`.
+CAPTURE_COMMAND = f'"{CAPTURE_HOOK}" grok'
 MARKER = "vibebuddy-forward.sh"
+APPROVAL_MARKER = "approval-hook.sh"
 
-# Passive events report status; tool events (omitted matcher → match every tool)
-# carry the working / stuck cues. PostToolUseFailure → the grok decoder flags it.
-# NB: no `Notification` — grok's notification event is hook-execution telemetry
-# (it echoes which hooks ran), not a user-attention signal, so we neither forward
-# nor decode it (see GrokParser).
-PASSIVE_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"]
-TOOL_EVENTS = ["PreToolUse", "PostToolUse", "PostToolUseFailure"]
+# Status events. Grok accepts the PascalCase config keys and delivers the
+# snake_case value in `hookEventName`.
+EVENTS = [
+    "SessionStart", "UserPromptSubmit",
+    "PreToolUse", "PostToolUse", "PostToolUseFailure",
+    "Stop", "StopFailure", "StopCancelled",
+    "Notification", "SubagentStart", "SubagentStop",
+    "SessionEnd",
+]
+# Terminal capture runs on SessionStart (new sessions) AND UserPromptSubmit (a
+# session that missed SessionStart self-heals on its next prompt; writing the
+# same ref is idempotent), matching the Claude installer.
+CAPTURE_EVENTS = ["SessionStart", "UserPromptSubmit"]
 
 
-def group():
-    return {"hooks": [{"type": "command", "command": COMMAND, "timeout": 5}]}
+def group(command, timeout=5):
+    return {"hooks": [{"type": "command", "command": command, "timeout": timeout}]}
 
 
-def build():
-    hooks = {ev: [group()] for ev in PASSIVE_EVENTS + TOOL_EVENTS}
+def build(approval=False):
+    hooks = {ev: [group(COMMAND)] for ev in EVENTS}
+    if approval:
+        # The blocking gate subsumes the fire-and-forget PreToolUse update: it
+        # reports the tool to the daemon via /approval?agent=grok itself. No
+        # matcher = every tool. 30 s covers the phone round trip; a timeout
+        # fails open.
+        hooks["PreToolUse"] = [group(APPROVAL_COMMAND, timeout=30)]
+    for ev in CAPTURE_EVENTS:
+        hooks[ev].append(group(CAPTURE_COMMAND))
     return {"hooks": hooks}
 
 
@@ -57,26 +106,64 @@ def is_ours(path):
         return False
 
 
+def has_approval(path):
+    """True when *our* file already wires the blocking approval gate."""
+    try:
+        with open(path) as f:
+            content = f.read()
+    except OSError:
+        return False
+    return MARKER in content and APPROVAL_MARKER in content
+
+
+def write(payload):
+    os.makedirs(HOOKS_DIR, exist_ok=True)
+    # Back up a foreign file once; our own file is just overwritten.
+    if os.path.exists(TARGET) and not is_ours(TARGET) and not os.path.exists(BACKUP):
+        shutil.copy2(TARGET, BACKUP)
+        print("backup written:", BACKUP)
+    with open(TARGET, "w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+
+def reload_hint():
+    print("reload in grok: /hooks → 'r', or start a new session.")
+
+
 def main():
-    mode = sys.argv[1] if len(sys.argv) > 1 else "--dry-run"
-    payload = build()
+    args = sys.argv[1:]
+    approval = "--approval" in args
+    rest = [a for a in args if a != "--approval"]
+    if rest:
+        mode = rest[0]
+    elif approval:
+        # Bare `--approval` installs (mirrors install-claude-hooks.py); pair it
+        # with `--dry-run` to preview the approval wiring.
+        mode = "--install"
+    else:
+        mode = "--dry-run"
+
+    # We rewrite the file wholesale, so a plain re-install (the Mac app's Repair
+    # button among them) would silently drop an approval gate the user asked for.
+    # Claude's installer preserves its gate the same way.
+    if mode == "--install" and not approval and has_approval(TARGET):
+        approval = True
+        print("keeping the existing approval gate (--uninstall removes it)")
 
     if mode == "--dry-run":
         print("would write:", TARGET)
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(build(approval), indent=2))
         return
 
     if mode == "--install":
-        os.makedirs(HOOKS_DIR, exist_ok=True)
-        # Back up a foreign file once; our own file is just overwritten.
-        if os.path.exists(TARGET) and not is_ours(TARGET) and not os.path.exists(BACKUP):
-            shutil.copy2(TARGET, BACKUP)
-            print("backup written:", BACKUP)
-        with open(TARGET, "w") as f:
-            json.dump(payload, f, indent=2)
-            f.write("\n")
-        print("installed vibebuddy grok hooks:", TARGET)
-        print("reload in grok: press Ctrl+L → Hooks tab → 'l', or restart the session.")
+        write(build(approval))
+        label = "grok hooks + approval gate" if approval else "grok hooks"
+        print(f"installed vibebuddy {label}:", TARGET)
+        if approval:
+            print('phone answers are authoritative only with '
+                  '[ui] permission_mode = "always-approve" in ~/.grok/config.toml.')
+        reload_hint()
         return
 
     if mode == "--uninstall":

--- a/hooks/test_install_agent_hooks.py
+++ b/hooks/test_install_agent_hooks.py
@@ -37,6 +37,12 @@ USER_CLAUDE_HOOK = "echo i-am-a-user-hook"
 USER_CODEX_NOTIFY = ["/Applications/Existing Notifier.app/Contents/MacOS/notifier", "turn-ended"]
 USER_CODEX_HOOK = "echo i-am-a-user-codex-hook"
 USER_KIMI_HOOK = "/Users/nobody/my-own-hook --source kimi"
+# The grok 1.0.13 event set install-grok-hooks.py registers.
+GROK_EVENTS = [
+    "SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+    "PostToolUseFailure", "Stop", "StopFailure", "StopCancelled",
+    "Notification", "SubagentStart", "SubagentStop", "SessionEnd",
+]
 
 
 def seed_home(home):
@@ -65,8 +71,41 @@ def seed_home(home):
 
 def run(mode, home):
     env = {**os.environ, "HOME": home}
+    # An ambient $GROK_HOME would redirect the grok installer away from the
+    # throwaway $HOME this pass asserts against.
+    env.pop("GROK_HOME", None)
     return subprocess.run([sys.executable, UNIVERSAL, mode], env=env,
                           capture_output=True, text=True)
+
+
+def check_grok_home(fails):
+    """install-grok-hooks.py writes under $GROK_HOME, not just ~/.grok."""
+    installer = os.path.join(HOOKS, "install-grok-hooks.py")
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as grok_home:
+        env = {**os.environ, "HOME": home, "GROK_HOME": grok_home}
+        r = subprocess.run([sys.executable, installer, "--install"], env=env,
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            fails.append(f"GROK_HOME install exited {r.returncode}: {r.stderr}")
+        target = os.path.join(grok_home, "hooks/vibebuddy.json")
+        if not os.path.exists(target):
+            fails.append("install-grok-hooks.py ignored $GROK_HOME")
+            return
+        if os.path.exists(os.path.join(home, ".grok/hooks/vibebuddy.json")):
+            fails.append("$GROK_HOME install also wrote to ~/.grok")
+        hooks = json.loads(open(target).read())["hooks"]
+        for event in GROK_EVENTS:
+            commands = [hook.get("command", "") for group in hooks.get(event, [])
+                        for hook in group.get("hooks", [])]
+            if not any('vibebuddy-forward.sh" grok' in command for command in commands):
+                fails.append(f"$GROK_HOME install missed the {event} hook")
+        # uninstall must clean the same redirected location
+        ru = subprocess.run([sys.executable, installer, "--uninstall"], env=env,
+                            capture_output=True, text=True)
+        if ru.returncode != 0:
+            fails.append(f"GROK_HOME uninstall exited {ru.returncode}: {ru.stderr}")
+        if os.path.exists(target):
+            fails.append("uninstall left vibebuddy.json under $GROK_HOME")
 
 
 def snapshot(home):
@@ -159,6 +198,91 @@ def main():
         if USER_KIMI_HOOK not in kimi or "vibebuddy-forward.sh kimi" not in kimi:
             fails.append("install broke kimi user hook or missed vibebuddy hook")
 
+        # grok: the full 1.0.13 event set through the forwarder, plus terminal
+        # capture on the two events the Claude installer uses.
+        grok_hooks = json.loads(open(os.path.join(home, ".grok/hooks/vibebuddy.json")).read())["hooks"]
+        for event in GROK_EVENTS:
+            commands = [hook.get("command", "") for group in grok_hooks.get(event, [])
+                        for hook in group.get("hooks", [])]
+            if not any('vibebuddy-forward.sh" grok' in command for command in commands):
+                fails.append(f"install missed the vibebuddy grok {event} hook")
+        for event in ["SessionStart", "UserPromptSubmit"]:
+            commands = [hook.get("command", "") for group in grok_hooks.get(event, [])
+                        for hook in group.get("hooks", [])]
+            capture = [c for c in commands if "capture-terminal.sh" in c]
+            if not capture:
+                fails.append(f"install missed the grok {event} terminal capture")
+            # Grok resolves an argument-less command as a literal path relative to
+            # the hooks dir, quotes included, so a bare `"…/capture-terminal.sh"`
+            # never runs. It must carry an argument to be shell-parsed.
+            elif capture[0].strip().endswith('"'):
+                fails.append(f"grok {event} capture is a bare quoted path (grok "
+                             "resolves it relative to the hooks dir and it never runs)")
+        approval_commands = [hook.get("command", "") for group in grok_hooks.get("PreToolUse", [])
+                             for hook in group.get("hooks", [])]
+        if any("approval-hook.sh" in command for command in approval_commands):
+            fails.append("plain --install must not add the grok approval gate")
+
+        # --approval: the blocking gate replaces the fire-and-forget PreToolUse
+        # group for the CLIs that support it, and leaves the rest installed.
+        ra = run("--approval", home)
+        if ra.returncode != 0:
+            fails.append(f"--approval exited {ra.returncode}: {ra.stderr}")
+        grok_hooks = json.loads(open(os.path.join(home, ".grok/hooks/vibebuddy.json")).read())["hooks"]
+        pre_tool = [hook for group in grok_hooks.get("PreToolUse", [])
+                    for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in hook.get("command", "") for hook in pre_tool):
+            fails.append("--approval did not add the grok approval gate")
+        if any("vibebuddy-forward.sh" in hook.get("command", "") for hook in pre_tool):
+            fails.append("--approval left the fire-and-forget grok PreToolUse group")
+        if not all(hook.get("timeout") == 30 for hook in pre_tool):
+            fails.append("grok approval gate must allow 30s for the phone round trip")
+        if not any(hook.get("command", "").endswith('" grok') for hook in pre_tool):
+            fails.append("grok approval gate must pass the grok source argument")
+        claude_pre_tool = [hook for group in json.loads(
+                               open(os.path.join(home, ".claude/settings.json")).read()
+                           ).get("hooks", {}).get("PreToolUse", [])
+                           for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in hook.get("command", "") for hook in claude_pre_tool):
+            fails.append("--approval did not add the claude approval gate")
+        if "Stop" not in grok_hooks:
+            fails.append("--approval dropped the grok status hooks")
+
+        # A plain re-install (the Mac app's Repair button) rewrites the grok file
+        # wholesale; it must not silently drop the gate the user opted into.
+        rr = run("--install", home)
+        if rr.returncode != 0:
+            fails.append(f"re-install after --approval exited {rr.returncode}: {rr.stderr}")
+        grok_hooks = json.loads(open(os.path.join(home, ".grok/hooks/vibebuddy.json")).read())["hooks"]
+        pre_tool = [hook for group in grok_hooks.get("PreToolUse", [])
+                    for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in hook.get("command", "") for hook in pre_tool):
+            fails.append("plain --install dropped the existing grok approval gate")
+        if "Stop" not in grok_hooks:
+            fails.append("re-install after --approval dropped the grok status hooks")
+        claude_pre_tool = [hook for group in json.loads(
+                               open(os.path.join(home, ".claude/settings.json")).read()
+                           ).get("hooks", {}).get("PreToolUse", [])
+                           for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in hook.get("command", "") for hook in claude_pre_tool):
+            fails.append("plain --install dropped the existing claude approval gate")
+
+        # Grok imports ~/.claude/settings.json hooks and resolves a quoted,
+        # argument-less command as a literal path, so the Claude capture hook
+        # carries an inert argument too.
+        claude_capture = [hook.get("command", "")
+                          for event in ["SessionStart", "UserPromptSubmit"]
+                          for group in json.loads(
+                              open(os.path.join(home, ".claude/settings.json")).read()
+                          ).get("hooks", {}).get(event, [])
+                          for hook in group.get("hooks", [])
+                          if "capture-terminal.sh" in hook.get("command", "")]
+        if len(claude_capture) != 2:
+            fails.append("claude capture hook missing on SessionStart/UserPromptSubmit")
+        if any(command.strip().endswith('"') for command in claude_capture):
+            fails.append("claude capture is a bare quoted path (grok's compat "
+                         "bridge resolves it as a literal path and it never runs)")
+
         # 2 + 3b. uninstall: clean of vibebuddy, user content preserved
         ru = run("--uninstall", home)
         if ru.returncode != 0:
@@ -192,12 +316,15 @@ def main():
         if os.path.exists(os.path.join(home, ".config/opencode/plugins/vibebuddy.js")):
             fails.append("uninstall left opencode plugin")
 
+    check_grok_home(fails)
+
     if fails:
         print("FAIL:")
         for f in fails:
             print("  -", f)
         sys.exit(1)
-    print("PASS: install idempotent, uninstall clean, user hooks preserved (7 CLIs)")
+    print("PASS: install idempotent, approval gates wired, uninstall clean, "
+          "user hooks preserved (7 CLIs)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Grok Build 1.0.13 is now integrated at the same depth as Claude Code and Codex: live status via the current hook contract, on-disk session enrichment, remote approvals from the phone, and account usage in the Mac Usage view.

- **Hooks**: full 12-event set (Notification permission_prompt/idle_prompt, StopFailure/StopCancelled with promptId ordering, SubagentStart/Stop topology), terminal capture, `--approval`, `$GROK_HOME`; decoder distinguishes ignored vs undecodable input so health diagnostics stay honest.
- **Enrichment**: `GrokSessionLocator` + `GrokSessionReader` read `summary.json` / `signals.json` and tail `updates.jsonl` / `events.jsonl` for model, branch, tokens, live context vs the real 500k window, final answer, running tool, pending permission and subagents.
- **Approvals**: `approval-hook.sh grok` → `/approval?agent=grok`, Grok tool names normalised onto the Bash/Read/Edit vocabulary so rules and "Always allow" match; rules merged from `~/.grok/config.toml [permission]` and `~/.claude/settings.json`. Both apps show a note when Allow only unblocks (non always-approve mode).
- **Usage**: `GrokUsageProvider` via ACP `grok agent stdio` (`_x.ai/billing`), log-line fallback.
- Fix found on the way: Grok treats a quoted argument-less hook command as a literal path, so the capture hook never ran; both installers now pass an inert argument.

## Verification
- `swift test` VibeBuddyMac 408/408, VibeBuddyKit 142/142, `hooks/test_install_agent_hooks.py` PASS, Mac + iOS app builds green.
- Live E2E against a real headless Grok session in an isolated `GROK_HOME`: status working → done, model grok-4.6, contextWindow 500000, branch, activeTool; phone Allow released the command in 556 ms, Deny produced "Hook denied: vibebuddy"; usage 37% SuperGrok Heavy.

Ported from / verified against `xai-org/grok-build` source, CodexBar (usage), agent-session-kit and agent-sessions (session parsing), CodeIsland (installer).