### PR TITLE
fix(grok): resolve diagnostics from GROK_HOME and dedupe turn tokens by prompt id

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalRegistry.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalRegistry.swift
@@ -7,11 +7,17 @@ public actor ApprovalRegistry {
     public enum Outcome: String, Sendable { case allow, deny, pass }
 
     private var waiters: [String: CheckedContinuation<Outcome, Never>] = [:]
+    /// Decisions that arrived before their request started waiting. The pending
+    /// card is broadcast an actor hop *before* `/approval` registers its waiter,
+    /// so a decision can legitimately land in that window; without this it would
+    /// be dropped and the hook would fail open on the timeout instead.
+    private var earlyDecisions: [String: Outcome] = [:]
 
     public init() {}
 
     public func wait(id: String, timeout: Duration) async -> Outcome {
-        await withCheckedContinuation { (cont: CheckedContinuation<Outcome, Never>) in
+        if let early = earlyDecisions.removeValue(forKey: id) { return early }
+        return await withCheckedContinuation { (cont: CheckedContinuation<Outcome, Never>) in
             waiters[id] = cont
             Task { [weak self] in
                 try? await Task.sleep(for: timeout)
@@ -25,7 +31,19 @@ public actor ApprovalRegistry {
     }
 
     private func resume(id: String, with outcome: Outcome) {
-        guard let cont = waiters.removeValue(forKey: id) else { return }
+        guard let cont = waiters.removeValue(forKey: id) else {
+            // A timeout for an id nobody is waiting on is spent; a real decision
+            // is held briefly for the request that is about to wait on it.
+            guard outcome != .pass else { return }
+            earlyDecisions[id] = outcome
+            Task { [weak self] in
+                try? await Task.sleep(for: .seconds(60))
+                await self?.forgetEarlyDecision(id)
+            }
+            return
+        }
         cont.resume(returning: outcome)
     }
+
+    private func forgetEarlyDecision(_ id: String) { earlyDecisions[id] = nil }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokSessionReader.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokSessionReader.swift
@@ -82,8 +82,10 @@ public enum GrokSessionReader {
         info.branch = string(summary, "head_branch")
 
         // The newest `turn_completed` is one turn's cost, which the reducer
-        // accumulates exactly like Claude's per-turn readings.
+        // accumulates exactly like Claude's per-turn readings — keyed by the
+        // turn's own id, so two turns that cost the same both count.
         info.tokens = facts.turnTokens
+        info.tokensTurnID = facts.turnTokensID
 
         info.contextTokens = facts.contextTokens ?? int(signals, "contextTokensUsed")
         info.contextWindow = int(signals, "contextWindowTokens")
@@ -154,6 +156,10 @@ public enum GrokSessionReader {
         /// cumulative: readings on a real four-turn session rise and fall, and
         /// each carries its own `numTurns` count of model calls.
         var turnTokens: Int?
+        /// Which turn `turnTokens` was read off: `turn_completed.prompt_id`,
+        /// falling back to the record's `_meta` identity. Without it the reducer
+        /// cannot tell a re-read from a second turn of identical cost.
+        var turnTokensID: String?
         var contextTokens: Int?
         var runningTool: String?
         var spawned: [(id: String, type: String?, detail: String?)] = []
@@ -175,8 +181,9 @@ public enum GrokSessionReader {
                   let type = update["sessionUpdate"] as? String
             else { continue }
 
+            let meta = params["_meta"] as? [String: Any]
             // The live context size rides on every turn-scoped record.
-            if let total = int(params["_meta"] as? [String: Any], "totalTokens") {
+            if let total = int(meta, "totalTokens") {
                 facts.contextTokens = total
             }
 
@@ -203,6 +210,12 @@ public enum GrokSessionReader {
                 if let usage = update["usage"] as? [String: Any] {
                     facts.turnTokens = (int(usage, "inputTokens") ?? 0)
                         + (int(usage, "outputTokens") ?? 0)
+                    // `prompt_id` names the turn; `_meta` is the backstop for a
+                    // record written without one (its `eventId` is per-record,
+                    // and one `turn_completed` is one turn either way).
+                    facts.turnTokensID = string(update, "prompt_id")
+                        ?? string(meta, "promptId")
+                        ?? string(meta, "eventId")
                 }
                 openCalls.removeAll()
             case "subagent_spawned":

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
@@ -56,6 +56,7 @@ public enum ObservationHealthDetector {
         signals: [ObservationRuntimeSignal],
         now: Date,
         staleAfter: TimeInterval = 10 * 60,
+        grokHome: URL = GrokHome.url,
         fileManager fm: FileManager = .default
     ) -> [AgentObservationDiagnostic] {
         let claude = agentDiagnostic(
@@ -102,24 +103,26 @@ public enum ObservationHealthDetector {
                 staleAfter: staleAfter,
                 fileManager: fm))
 
-        // Grok keeps standalone hook files under `~/.grok/hooks/*.json`; ours is
-        // `vibebuddy.json`. The install marker is the config dir itself — grok
-        // 1.0.13 has no single settings file we can rely on.
+        // Grok keeps standalone hook files under `<grok home>/hooks/*.json`;
+        // ours is `vibebuddy.json`. The install marker is the config dir itself
+        // — grok 1.0.13 has no single settings file we can rely on. Everything
+        // here hangs off the *resolved* grok home (`$GROK_HOME`, else `~/.grok`)
+        // so an isolated profile is inspected where its hooks were installed.
         let grok = agentDiagnostic(
             agent: .grok,
             hook: hookEvidence(
-                config: home?.appendingPathComponent(".grok/hooks/vibebuddy.json"),
-                installMarker: home?.appendingPathComponent(".grok", isDirectory: true),
+                config: grokHome.appendingPathComponent("hooks/vibebuddy.json"),
+                installMarker: grokHome,
                 agent: .grok,
                 signals: signals,
                 now: now,
                 staleAfter: staleAfter,
                 fileManager: fm),
             passive: passiveEvidence(
-                root: home?.appendingPathComponent(".grok/sessions", isDirectory: true),
+                root: GrokSessionLocator.sessionsRoot(grokHome: grokHome),
                 source: .transcript,
                 agent: .grok,
-                installed: home.map { fm.fileExists(atPath: $0.appendingPathComponent(".grok").path) },
+                installed: fm.fileExists(atPath: grokHome.path),
                 signals: signals,
                 now: now,
                 staleAfter: staleAfter,

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -7,9 +7,13 @@ import VibeBuddyKit
 /// tokens, branch) is layered on by the server, not here.
 public struct SessionReducer: Sendable {
     public private(set) var sessions: [String: AgentSession] = [:]
-    /// The last per-turn token reading we added to a session's cumulative spend,
-    /// so the same turn (re-read on every mid-turn event) is counted only once.
-    private var lastCountedTokens: [String: Int] = [:]
+    /// The last turn whose token reading we added to a session's cumulative
+    /// spend, so the same turn (re-read on every mid-turn event) is counted only
+    /// once. Identified by the source's own turn id when it has one (Grok's
+    /// `turn_completed.prompt_id`), else by the reading itself — all Claude's
+    /// transcript offers, where consecutive turns of identical cost are the
+    /// price of having no turn identity at all.
+    private var lastCountedTurn: [String: String] = [:]
     /// The turn a session is currently on, for CLIs that label turns
     /// (`HookEvent.turnID`). Grok dispatches a cancelled turn's report off the
     /// command loop, so it can land after the next turn already started.
@@ -94,7 +98,7 @@ public struct SessionReducer: Sendable {
             // The session is over (exit / clear / logout). Drop it entirely so
             // an idle "needs you" prompt doesn't outlive the session it belonged to.
             sessions.removeValue(forKey: event.sessionID)
-            lastCountedTokens[event.sessionID] = nil
+            lastCountedTurn[event.sessionID] = nil
             currentTurnID[event.sessionID] = nil
         case .sessionMetadataChanged:
             // Model and cwd changes describe the same live session. They must
@@ -153,7 +157,7 @@ public struct SessionReducer: Sendable {
             // The per-session side tables outlive nothing: a session id that
             // comes back (grok resumes one) must start its accounting fresh.
             currentTurnID[id] = nil
-            lastCountedTokens[id] = nil
+            lastCountedTurn[id] = nil
         }
     }
 
@@ -166,10 +170,11 @@ public struct SessionReducer: Sendable {
         if let branch = info.branch { s.branch = branch }
         if let tokens = info.tokens {
             s.tokens = tokens
-            // Accumulate cumulative spend, counting each fresh turn reading once.
-            if lastCountedTokens[sessionID] != tokens {
+            // Accumulate cumulative spend, counting each fresh turn once.
+            let turn = info.tokensTurnID ?? String(tokens)
+            if lastCountedTurn[sessionID] != turn {
                 s.spentTokens = (s.spentTokens ?? 0) + tokens
-                lastCountedTokens[sessionID] = tokens
+                lastCountedTurn[sessionID] = turn
             }
         }
         if let contextTokens = info.contextTokens {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -363,7 +363,7 @@ public actor SessionStore {
         }
         let value = ObservationHealthDetector.detect(
             home: diagnosticsHome, signals: signals, now: now,
-            staleAfter: Self.diagnosticStaleAfter)
+            staleAfter: Self.diagnosticStaleAfter, grokHome: grokHome)
         diagnosticCache = (now, value)
         return value
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/TranscriptReader.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/TranscriptReader.swift
@@ -5,6 +5,11 @@ import VibeBuddyKit
 public struct TranscriptInfo: Equatable, Sendable {
     public var model: String?
     public var tokens: Int?           // turn cost: input + output
+    /// Which turn `tokens` belongs to, when the source names one (Grok's
+    /// `turn_completed.prompt_id`). The reducer needs it to tell a re-read of
+    /// one turn from a genuinely new turn that happened to cost the same.
+    /// Claude's transcript names no turn, so it stays nil there.
+    public var tokensTurnID: String?
     public var contextTokens: Int?    // prompt sent: input + cache_read + cache_creation
     /// The model's real context window, when the source records it (Grok writes
     /// `contextWindowTokens` into `signals.json`). nil keeps the reducer's
@@ -25,6 +30,7 @@ public struct TranscriptInfo: Equatable, Sendable {
     public var activeTool: String?
 
     public init(model: String? = nil, tokens: Int? = nil,
+                tokensTurnID: String? = nil,
                 contextTokens: Int? = nil, contextWindow: Int? = nil,
                 summary: String? = nil, branch: String? = nil,
                 pendingQuestion: PendingQuestion? = nil,
@@ -32,6 +38,7 @@ public struct TranscriptInfo: Equatable, Sendable {
                 activeTool: String? = nil) {
         self.model = model
         self.tokens = tokens
+        self.tokensTurnID = tokensTurnID
         self.contextTokens = contextTokens
         self.contextWindow = contextWindow
         self.summary = summary

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -314,15 +314,17 @@ public struct VibeBuddyServer: Sendable {
             case .ask:
                 let id = makeID()
                 let d = ApprovalDetails.from(tool: tool, input: input)
+                // Record what an "always allow" / "allow this session" would act
+                // on *before* the pending card is broadcast — a decision can only
+                // follow the card, so the context is always there when it lands.
+                await approvalContext.set(id: id, sessionID: sessionID,
+                                          rule: AllowRule.forApproval(tool: tool, input: input))
                 await store.beginApproval(sessionID: sessionID,
                     PendingApproval(id: id, tool: tool,
                                     commandPreview: d.commandPreview.isEmpty ? tool : d.commandPreview,
                                     command: d.command, filePath: d.filePath,
                                     oldText: d.oldText, newText: d.newText,
                                     permissionMode: call.permissionMode), at: Date())
-                // Record what an "always allow" / "allow this session" would act on.
-                await approvalContext.set(id: id, sessionID: sessionID,
-                                          rule: AllowRule.forApproval(tool: tool, input: input))
                 let outcome = await registry.wait(id: id, timeout: timeout)
                 await store.endApproval(sessionID: sessionID, at: Date())
                 switch outcome {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -682,14 +682,19 @@ struct AccountUsageTests {
         return nil
     }
 
+    /// A killed child (and any descendant that inherited the process group) dies
+    /// asynchronously, so poll for its reaping rather than sampling once — under a
+    /// loaded parallel test run the signal has often not landed yet.
     private func expectProcessExited(pidFile: URL) async {
         let pid = await waitForPID(in: pidFile)
         #expect(pid != nil)
-        if let pid {
+        guard let pid else { return }
+        for _ in 0..<500 {
             errno = 0
-            #expect(Darwin.kill(pid, 0) == -1)
-            #expect(errno == ESRCH)
+            if Darwin.kill(pid, 0) == -1, errno == ESRCH { return }
+            try? await Task.sleep(for: .milliseconds(10))
         }
+        Issue.record("process \(pid) was never reaped")
     }
 }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRegistryTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRegistryTests.swift
@@ -20,9 +20,12 @@ struct ApprovalRegistryTests {
         #expect(outcome == .pass)
     }
 
-    @Test("resolving an unknown id is a harmless no-op")
-    func unknownResolve() async {
+    @Test("a decision that beats its request is held for it")
+    func resolveBeforeWait() async {
         let reg = ApprovalRegistry()
-        await reg.resolve(id: "ghost", with: .deny)   // must not crash
+        await reg.resolve(id: "a", with: .allow)
+        #expect(await reg.wait(id: "a", timeout: .seconds(5)) == .allow)
+        // Spent: the next hold on the same id waits on its own decision.
+        #expect(await reg.wait(id: "a", timeout: .milliseconds(50)) == .pass)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -24,6 +24,7 @@ private func grokBash(_ cmd: String, tool: String = "run_terminal_command",
 struct ApprovalRoutesTests {
     private func server(allow: [String] = [], deny: [String] = [],
                         store: SessionStore = SessionStore(),
+                        approvalTimeout: Duration = .seconds(5),
                         port: Int = 9876, host: String = "0.0.0.0") -> VibeBuddyServer {
         // A throwaway temp-file allow store keeps each test hermetic (ADR 0010).
         let storeURL = FileManager.default.temporaryDirectory
@@ -32,8 +33,21 @@ struct ApprovalRoutesTests {
                         approvalRegistry: ApprovalRegistry(),
                         rules: { _ in PermissionRules(allow: allow, deny: deny) },
                         allowStore: VibeBuddyAllowStore(url: storeURL),
-                        approvalTimeout: .milliseconds(200),
+                        approvalTimeout: approvalTimeout,
                         approvalID: { "s" })
+    }
+
+    /// Wait until the held approval is visible as a pending card. The server
+    /// registers the decision context before broadcasting the card, so from this
+    /// point a `/decision` always finds what it needs — a fixed sleep does not,
+    /// and the whole-suite run is parallel enough to lose that race.
+    private func waitForPendingApproval(_ store: SessionStore, session: String) async throws {
+        for _ in 0..<1000 {
+            let sessions = await store.snapshot(now: Date()).sessions
+            if sessions.first(where: { $0.id == session })?.pendingApproval != nil { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        Issue.record("no approval ever became pending for session \(session)")
     }
 
     @Test("allow-listed command returns an allow decision immediately")
@@ -52,14 +66,15 @@ struct ApprovalRoutesTests {
     @Test("an un-listed command holds, then a /decision approve releases it")
     func askThenApprove() async throws {
         let body = #"{"hook_event_name":"PreToolUse","session_id":"s","cwd":"/x/p","tool_name":"Bash","tool_input":{"command":"rm -rf build"}}"#
-        let srv = server()   // empty allow → .ask
+        let store = SessionStore()
+        let srv = server(store: store)   // empty allow → .ask
         try await srv.buildApplication().test(.router) { client in
             async let approval = client.execute(uri: "/approval", method: .post,
                                                 headers: [.authorization: "Bearer t0k"], body: ByteBuffer(string: body)) { res -> String in
                 #expect(res.status == .ok)
                 return String(buffer: res.body)
             }
-            try await Task.sleep(for: .milliseconds(80))
+            try await waitForPendingApproval(store, session: "s")
             let decision = #"{"approvalId":"s","decision":"allow"}"#
             try await client.execute(uri: "/decision", method: .post,
                                      headers: [.authorization: "Bearer t0k"],
@@ -74,7 +89,7 @@ struct ApprovalRoutesTests {
     @Test("no decision times out to an empty body (hook prints nothing)")
     func timesOutEmpty() async throws {
         let body = #"{"hook_event_name":"PreToolUse","session_id":"s","cwd":"/x/p","tool_name":"Bash","tool_input":{"command":"rm -rf build"}}"#
-        try await server().buildApplication().test(.router) { client in
+        try await server(approvalTimeout: .milliseconds(200)).buildApplication().test(.router) { client in
             try await client.execute(uri: "/approval", method: .post,
                                      headers: [.authorization: "Bearer t0k"], body: ByteBuffer(string: body)) { res in
                 #expect(res.status == .ok)
@@ -97,13 +112,14 @@ struct ApprovalRoutesTests {
 
     @Test("alwaysAllow persists a rule so the next identical call auto-allows")
     func alwaysAllowPersists() async throws {
-        let srv = server()   // empty native allow → first call holds
+        let store = SessionStore()
+        let srv = server(store: store)   // empty native allow → first call holds
         try await srv.buildApplication().test(.router) { client in
             async let first = client.execute(uri: "/approval", method: .post,
                 headers: [.authorization: "Bearer t0k"], body: ByteBuffer(string: bash("git status"))) { res -> String in
                 String(buffer: res.body)
             }
-            try await Task.sleep(for: .milliseconds(80))
+            try await waitForPendingApproval(store, session: "s")
             try await client.execute(uri: "/decision", method: .post,
                 headers: [.authorization: "Bearer t0k"],
                 body: ByteBuffer(string: #"{"approvalId":"s","decision":"alwaysAllow"}"#)) { res in
@@ -121,13 +137,14 @@ struct ApprovalRoutesTests {
 
     @Test("allowSession auto-allows a different command in the same session")
     func allowSessionAllowsSiblings() async throws {
-        let srv = server()
+        let store = SessionStore()
+        let srv = server(store: store)
         try await srv.buildApplication().test(.router) { client in
             async let first = client.execute(uri: "/approval", method: .post,
                 headers: [.authorization: "Bearer t0k"], body: ByteBuffer(string: bash("git status"))) { res -> String in
                 String(buffer: res.body)
             }
-            try await Task.sleep(for: .milliseconds(80))
+            try await waitForPendingApproval(store, session: "s")
             try await client.execute(uri: "/decision", method: .post,
                 headers: [.authorization: "Bearer t0k"],
                 body: ByteBuffer(string: #"{"approvalId":"s","decision":"allowSession"}"#)) { res in
@@ -186,7 +203,7 @@ struct ApprovalRoutesTests {
         try await srv.buildApplication().test(.router) { client in
             async let held = approve(client, body: grokBash("rm -rf build", mode: "default"),
                                      agent: "grok")
-            try await Task.sleep(for: .milliseconds(80))
+            try await waitForPendingApproval(store, session: "gs")
             // The pending card carries the mode, so the UI can say an allow here
             // is not final (grok still prompts locally outside bypassPermissions).
             let pending = await store.snapshot(now: Date()).sessions.first { $0.id == "gs" }?.pendingApproval
@@ -204,7 +221,7 @@ struct ApprovalRoutesTests {
 
     @Test("no decision on a grok call times out to an empty body (fail-open)")
     func grokTimesOutEmpty() async throws {
-        try await server().buildApplication().test(.router) { client in
+        try await server(approvalTimeout: .milliseconds(200)).buildApplication().test(.router) { client in
             let text = try await approve(client, body: grokBash("rm -rf build"), agent: "grok")
             #expect(text.isEmpty)
         }
@@ -230,9 +247,10 @@ struct ApprovalRoutesTests {
 
     @Test("alwaysAllow from a grok approval matches the next grok call, alias included")
     func grokAlwaysAllowPersists() async throws {
-        try await server().buildApplication().test(.router) { client in
+        let store = SessionStore()
+        try await server(store: store).buildApplication().test(.router) { client in
             async let first = approve(client, body: grokBash("git status"), agent: "grok")
-            try await Task.sleep(for: .milliseconds(80))
+            try await waitForPendingApproval(store, session: "gs")
             try await client.execute(uri: "/decision", method: .post,
                 headers: [.authorization: "Bearer t0k"],
                 body: ByteBuffer(string: #"{"approvalId":"s","decision":"alwaysAllow"}"#)) { res in

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionLocatorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionLocatorTests.swift
@@ -99,12 +99,16 @@ struct GrokFixture {
         update(#"{"sessionUpdate":"tool_call_update","toolCallId":"\#(id)","kind":"execute","locations":[],"rawInput":{}}"#)
     }
 
-    static func turnCompleted(input: Int, output: Int) -> String {
-        update("""
-            {"sessionUpdate":"turn_completed","prompt_id":"p1","stop_reason":"end_turn",\
+    /// `promptID: nil` writes the record without a `prompt_id`, leaving `_meta`
+    /// as the only turn identity — the shape the reader has to fall back to.
+    static func turnCompleted(input: Int, output: Int, promptID: String? = "p1",
+                              eventID: String? = nil) -> String {
+        let prompt = promptID.map { #""prompt_id":"\#($0)","# } ?? ""
+        return update("""
+            {"sessionUpdate":"turn_completed",\(prompt)"stop_reason":"end_turn",\
             "usage":{"inputTokens":\(input),"outputTokens":\(output),\
             "totalTokens":\(input + output),"cachedReadTokens":0,"numTurns":1}}
-            """, method: "_x.ai/session/update")
+            """, meta: eventID.map { #"{"eventId":"\#($0)"}"# }, method: "_x.ai/session/update")
     }
 
     static func subagentSpawned(id: String, type: String, detail: String) -> String {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionReaderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionReaderTests.swift
@@ -50,17 +50,41 @@ struct GrokSessionReaderTests {
 
     // MARK: - Tokens
 
-    @Test("the newest turn_completed is one turn's cost, which the reducer accumulates")
+    @Test("the newest turn_completed is one turn's cost, tagged with its prompt id")
     func turnTokensFromLog() throws {
         let fixture = try GrokFixture()
         defer { fixture.cleanUp() }
         try fixture.write("updates.jsonl", [
-            GrokFixture.turnCompleted(input: 1_000, output: 100),
-            GrokFixture.turnCompleted(input: 2_000, output: 200),
+            GrokFixture.turnCompleted(input: 1_000, output: 100, promptID: "p1"),
+            GrokFixture.turnCompleted(input: 2_000, output: 200, promptID: "p2"),
         ].joined(separator: "\n"))
 
         let info = try #require(GrokSessionReader.read(directory: fixture.directory)?.info)
         #expect(info.tokens == 2_200)
+        #expect(info.tokensTurnID == "p2")   // the reducer dedupes on this, not the total
+    }
+
+    @Test("two turns of identical cost are told apart by their prompt ids")
+    func equalCostTurnsKeepDistinctIDs() {
+        let first = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.turnCompleted(input: 1_000, output: 100, promptID: "p1"),
+        ]))
+        let second = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.turnCompleted(input: 1_000, output: 100, promptID: "p2"),
+        ]))
+        #expect(first.turnTokens == second.turnTokens)
+        #expect(first.turnTokensID == "p1")
+        #expect(second.turnTokensID == "p2")
+    }
+
+    @Test("without a prompt_id the record's _meta identity stands in")
+    func turnIDFallsBackToMeta() {
+        let facts = GrokSessionReader.facts(updatesTail: updates([
+            GrokFixture.turnCompleted(input: 10, output: 1, promptID: nil,
+                                      eventID: "session-1-2587"),
+        ]))
+        #expect(facts.turnTokens == 11)
+        #expect(facts.turnTokensID == "session-1-2587")
     }
 
     // MARK: - Prose

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionStoreTests.swift
@@ -125,20 +125,26 @@ struct GrokSessionStoreTests {
         #expect(entries.isEmpty)
     }
 
-    @Test("re-reading the same turn does not double the session spend")
-    func cumulativeSpendIsNotDoubled() {
+    @Test("the turn id separates a re-read from a second turn of the same cost")
+    func cumulativeSpendCountsEachTurnOnce() {
         var reducer = SessionReducer()
         reducer.apply(HookEvent(kind: .sessionStart, sessionID: "s", agent: .grok, timestamp: t0))
         // Every mid-turn event re-reads the same newest `turn_completed`.
-        let info = TranscriptInfo(model: "grok-4.6", tokens: 5_400,
+        let info = TranscriptInfo(model: "grok-4.6", tokens: 5_400, tokensTurnID: "p1",
                                   contextTokens: 80_944, contextWindow: 500_000)
         reducer.enrich(sessionID: "s", with: info)
         reducer.enrich(sessionID: "s", with: info)
         #expect(reducer.sessions["s"]?.spentTokens == 5_400)
 
+        // A different turn that happened to cost exactly as much is still spend.
+        reducer.enrich(sessionID: "s", with: TranscriptInfo(
+            tokens: 5_400, tokensTurnID: "p2", contextTokens: 86_000))
+        #expect(reducer.sessions["s"]?.spentTokens == 10_800)
+
         // The next turn's reading is a fresh cost and accumulates.
-        reducer.enrich(sessionID: "s", with: TranscriptInfo(tokens: 900, contextTokens: 81_000))
-        #expect(reducer.sessions["s"]?.spentTokens == 6_300)
+        reducer.enrich(sessionID: "s", with: TranscriptInfo(tokens: 900, tokensTurnID: "p3",
+                                                            contextTokens: 81_000))
+        #expect(reducer.sessions["s"]?.spentTokens == 11_700)
         #expect(reducer.sessions["s"]?.tokens == 900)
     }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -6,12 +6,33 @@ import VibeBuddyKit
 @Suite("Claude, Codex and Grok observation health diagnostics")
 struct ObservationHealthDetectorTests {
     let now = Date(timeIntervalSince1970: 1_700_000_000)
+    /// A `$GROK_HOME` that never exists, so a Claude or Codex test cannot reach
+    /// the developer's real `~/.grok`.
+    let absentGrokHome = URL(fileURLWithPath: "/nonexistent/vb-grok-absent")
 
     private func tempHome() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("vb-health-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    /// A directory path that does not exist yet; `write` creates it on demand.
+    private func unwrittenDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("vb-grok-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    /// Every call goes through here so grok's home is always explicit.
+    private func detect(
+        home: URL?,
+        grokHome: URL? = nil,
+        signals: [ObservationRuntimeSignal] = [],
+        staleAfter: TimeInterval = 10 * 60
+    ) -> [AgentObservationDiagnostic] {
+        ObservationHealthDetector.detect(
+            home: home, signals: signals, now: now, staleAfter: staleAfter,
+            grokHome: grokHome ?? absentGrokHome)
     }
 
     private func write(_ text: String, to url: URL) throws {
@@ -24,12 +45,12 @@ struct ObservationHealthDetectorTests {
     func missingInstallationAndEvents() throws {
         let home = try tempHome()
         defer { try? FileManager.default.removeItem(at: home) }
-        let absent = ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        let absent = detect(home: home)
         #expect(absent.health(agent: .claudeCode, source: .hook) == .notInstalled)
 
         try write(#"{"hooks":{"Stop":[{"hooks":[{"command":"echo user"}]}]}}"#,
                   to: home.appendingPathComponent(".claude/settings.json"))
-        let missingEvents = ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        let missingEvents = detect(home: home)
         #expect(missingEvents.health(agent: .claudeCode, source: .hook) == .eventsMissing)
     }
 
@@ -41,7 +62,7 @@ struct ObservationHealthDetectorTests {
         try write(#"{"hooks":{"SessionStart":[{"hooks":[{"command":"/app/vibebuddy-forward.sh codex","async":true}]}]}}"#,
                   to: home.appendingPathComponent(".codex/hooks.json"))
 
-        let result = ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        let result = detect(home: home)
         #expect(result.health(agent: .codex, source: .hook) == .asyncIncompatible)
     }
 
@@ -54,7 +75,7 @@ struct ObservationHealthDetectorTests {
         try write(#"{"type":"session_meta","payload":{"cli_version":"1.2.3"}}"#, to: rollout)
         try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: rollout.path)
 
-        let result = ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        let result = detect(home: home)
         #expect(result.health(agent: .codex, source: .rollout) == .sourceUnreadable)
     }
 
@@ -66,15 +87,13 @@ struct ObservationHealthDetectorTests {
         let old = ObservationRuntimeSignal(agent: .codex, source: .rollout,
                                            lastObservedAt: now.addingTimeInterval(-601),
                                            observedCoverage: [.turn])
-        let stale = ObservationHealthDetector.detect(home: home, signals: [old], now: now,
-                                                     staleAfter: 600)
+        let stale = detect(home: home, signals: [old], staleAfter: 600)
         #expect(stale.health(agent: .codex, source: .rollout) == .temporarilySilent)
 
         let fresh = ObservationRuntimeSignal(agent: .codex, source: .rollout,
                                              lastObservedAt: now,
                                              observedCoverage: [.turn, .tool])
-        let healthy = ObservationHealthDetector.detect(home: home, signals: [fresh], now: now,
-                                                       staleAfter: 600)
+        let healthy = detect(home: home, signals: [fresh], staleAfter: 600)
         #expect(healthy.health(agent: .codex, source: .rollout) == .healthy)
         #expect(healthy.diagnostic(agent: .codex, source: .rollout)?.observedCoverage == [.turn, .tool])
     }
@@ -89,8 +108,7 @@ struct ObservationHealthDetectorTests {
             #"{"type":"session_meta","payload":{"cli_version":"0.999.0"}}"# + "\n" +
             #"{"type":"event_msg","payload":{"type":"task_started"}}"#,
             to: future)
-        let futureResult = ObservationHealthDetector.detect(
-            home: futureHome, signals: [], now: now)
+        let futureResult = detect(home: futureHome)
         #expect(futureResult.health(agent: .codex, source: .rollout) == .unknownVersion)
 
         let metadataHome = try tempHome()
@@ -99,16 +117,14 @@ struct ObservationHealthDetectorTests {
         let metadata = metadataHome.appendingPathComponent(".codex/sessions/2023/11/14/rollout-metadata.jsonl")
         try write(#"{"type":"session_meta","payload":{"cli_version":"0.151.0-alpha.7.2"}}"#,
                   to: metadata)
-        let metadataResult = ObservationHealthDetector.detect(
-            home: metadataHome, signals: [], now: now)
+        let metadataResult = detect(home: metadataHome)
         #expect(metadataResult.health(agent: .codex, source: .rollout) == .eventsMissing)
 
         try write(
             #"{"type":"session_meta","payload":{"cli_version":"0.151.0-alpha.7.2"}}"# + "\n" +
             #"{"type":"event_msg","payload":{"type":"task_started"}}"#,
             to: metadata)
-        let supportedResult = ObservationHealthDetector.detect(
-            home: metadataHome, signals: [], now: now)
+        let supportedResult = detect(home: metadataHome)
         #expect(supportedResult.health(agent: .codex, source: .rollout) == .healthy)
     }
 
@@ -123,7 +139,7 @@ struct ObservationHealthDetectorTests {
         defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700],
                                                         ofItemAtPath: directory.path) }
 
-        let result = ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        let result = detect(home: home)
         #expect(result.health(agent: .codex, source: .rollout) == .sourceUnreadable)
     }
 
@@ -147,19 +163,19 @@ struct ObservationHealthDetectorTests {
     func grokHookEvidence() throws {
         let home = try tempHome()
         defer { try? FileManager.default.removeItem(at: home) }
-        #expect(ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        let grokHome = unwrittenDirectory()
+        defer { try? FileManager.default.removeItem(at: grokHome) }
+        #expect(detect(home: home, grokHome: grokHome)
             .health(agent: .grok, source: .hook) == .notInstalled)
 
-        try FileManager.default.createDirectory(
-            at: home.appendingPathComponent(".grok", isDirectory: true),
-            withIntermediateDirectories: true)
-        #expect(ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        try FileManager.default.createDirectory(at: grokHome, withIntermediateDirectories: true)
+        #expect(detect(home: home, grokHome: grokHome)
             .health(agent: .grok, source: .hook) == .eventsMissing)
 
         try write(grokHooks(grokInstalledEvents),
-                  to: home.appendingPathComponent(".grok/hooks/vibebuddy.json"))
+                  to: grokHome.appendingPathComponent("hooks/vibebuddy.json"))
         let signal = ObservationRuntimeSignal(agent: .grok, source: .hook, lastObservedAt: now)
-        let result = ObservationHealthDetector.detect(home: home, signals: [signal], now: now)
+        let result = detect(home: home, grokHome: grokHome, signals: [signal])
         #expect(result.health(agent: .grok, source: .hook) == .healthy)
         #expect(result.diagnostic(agent: .grok, source: .hook)?.configuredCoverage
             == ObservationEventCoverage.allCases)
@@ -167,15 +183,12 @@ struct ObservationHealthDetectorTests {
 
     @Test("grok without Notification loses attention coverage even with fresh events")
     func grokAttentionCoverageRequired() throws {
-        let home = try tempHome()
-        defer { try? FileManager.default.removeItem(at: home) }
-        try FileManager.default.createDirectory(
-            at: home.appendingPathComponent(".grok", isDirectory: true),
-            withIntermediateDirectories: true)
+        let grokHome = unwrittenDirectory()
+        defer { try? FileManager.default.removeItem(at: grokHome) }
         try write(grokHooks(grokInstalledEvents.filter { $0 != "Notification" }),
-                  to: home.appendingPathComponent(".grok/hooks/vibebuddy.json"))
+                  to: grokHome.appendingPathComponent("hooks/vibebuddy.json"))
         let signal = ObservationRuntimeSignal(agent: .grok, source: .hook, lastObservedAt: now)
-        let result = ObservationHealthDetector.detect(home: home, signals: [signal], now: now)
+        let result = detect(home: nil, grokHome: grokHome, signals: [signal])
         #expect(result.health(agent: .grok, source: .hook) == .eventsMissing)
         #expect(result.diagnostic(agent: .grok, source: .hook)?
             .configuredCoverage.contains(.attention) == false)
@@ -183,17 +196,45 @@ struct ObservationHealthDetectorTests {
 
     @Test("grok's session transcripts are a declared passive source")
     func grokPassiveSource() throws {
-        let home = try tempHome()
-        defer { try? FileManager.default.removeItem(at: home) }
-        #expect(ObservationHealthDetector.detect(home: home, signals: [], now: now)
+        let grokHome = unwrittenDirectory()
+        defer { try? FileManager.default.removeItem(at: grokHome) }
+        #expect(detect(home: nil, grokHome: grokHome)
             .health(agent: .grok, source: .transcript) == .notInstalled)
 
         try FileManager.default.createDirectory(
-            at: home.appendingPathComponent(".grok/sessions", isDirectory: true),
+            at: grokHome.appendingPathComponent("sessions", isDirectory: true),
             withIntermediateDirectories: true)
         let signal = ObservationRuntimeSignal(agent: .grok, source: .transcript, lastObservedAt: now)
-        #expect(ObservationHealthDetector.detect(home: home, signals: [signal], now: now)
+        #expect(detect(home: nil, grokHome: grokHome, signals: [signal])
             .health(agent: .grok, source: .transcript) == .healthy)
+    }
+
+    @Test("grok diagnostics follow the resolved grok home, not the user's ~/.grok")
+    func grokHomeRedirects() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let grokHome = unwrittenDirectory()
+        defer { try? FileManager.default.removeItem(at: grokHome) }
+
+        // A complete install sitting at `~/.grok` is the wrong profile when
+        // `$GROK_HOME` points elsewhere, and must not be reported as evidence.
+        try write(grokHooks(grokInstalledEvents),
+                  to: home.appendingPathComponent(".grok/hooks/vibebuddy.json"))
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".grok/sessions", isDirectory: true),
+            withIntermediateDirectories: true)
+        let ignored = detect(home: home, grokHome: grokHome)
+        #expect(ignored.health(agent: .grok, source: .hook) == .notInstalled)
+        #expect(ignored.health(agent: .grok, source: .transcript) == .notInstalled)
+
+        // The same files under the redirected home are what gets inspected.
+        try write(grokHooks(grokInstalledEvents),
+                  to: grokHome.appendingPathComponent("hooks/vibebuddy.json"))
+        let signal = ObservationRuntimeSignal(agent: .grok, source: .hook, lastObservedAt: now)
+        let found = detect(home: home, grokHome: grokHome, signals: [signal])
+        #expect(found.health(agent: .grok, source: .hook) == .healthy)
+        #expect(found.diagnostic(agent: .grok, source: .hook)?.configuredCoverage
+            == ObservationEventCoverage.allCases)
     }
 }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -113,6 +113,7 @@ struct SessionReducerTests {
     func spentAccumulates() {
         var r = SessionReducer()
         r.apply(ev(.sessionStart))
+        // Claude's transcript names no turn, so the reading itself is the identity.
         r.enrich(sessionID: "s1", with: TranscriptInfo(tokens: 1000))   // turn 1
         r.enrich(sessionID: "s1", with: TranscriptInfo(tokens: 1000))   // same turn re-read → not double-counted
         r.enrich(sessionID: "s1", with: TranscriptInfo(tokens: 1500))   // turn 2


### PR DESCRIPTION
Follow-up to #4 addressing the two Codex review threads there: Grok observation diagnostics now derive their paths from the resolved Grok home, and per-turn token accumulation is keyed by `turn_completed.prompt_id` instead of the token total.