### PR TITLE
feat(codex): close four Codex Desktop rollout gaps

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -11,6 +11,12 @@ public struct CodexRolloutParser: Sendable {
     public private(set) var cwd: String?
     public private(set) var isDesktopSession = false
     public private(set) var turnActive = false
+    /// Latest model named by `turn_context` / `thread_settings_applied`.
+    public private(set) var model: String?
+    private var tokenRecordCount = 0
+    private var cumulativeTokens: Int?
+    private var contextTokens: Int?
+    private var contextWindow: Int?
     private var activeTurnIDs: Set<String> = []
     private var anonymousTurnCount = 0
     private var pendingCollab: [String: PendingCollab] = [:]
@@ -37,15 +43,33 @@ public struct CodexRolloutParser: Sendable {
             sessionID = payload["id"] as? String
             cwd = payload["cwd"] as? String
             let originator = (payload["originator"] as? String)?.lowercased()
-            let source = (payload["source"] as? String)?.lowercased()
-            isDesktopSession = originator == "codex desktop" || source == "vscode"
+            let source = payload["source"]
+            // Desktop stamps `originator`; its `source` is the `vscode` enum
+            // default. A spawned subagent thread carries the same originator and
+            // is only told apart by `thread_source` / `source.subagent`. The
+            // parent's collaboration records already own that child, so its own
+            // rollout must not surface as a second session.
+            let isSubagent = (payload["thread_source"] as? String)?.lowercased() == "subagent"
+                || (source as? [String: Any])?["subagent"] != nil
+            isDesktopSession = !isSubagent
+                && (originator == "codex desktop" || (source as? String)?.lowercased() == "vscode")
             return []
         }
 
         guard let sessionID, isDesktopSession else { return [] }
 
+        if recordType == "turn_context" {
+            return modelEvents(payload["model"] as? String, sessionID: sessionID, timestamp: timestamp)
+        }
+
         if recordType == "event_msg", let eventType = payload["type"] as? String {
             switch eventType {
+            case "thread_settings_applied":
+                let settings = payload["thread_settings"] as? [String: Any]
+                return modelEvents(settings?["model"] as? String, sessionID: sessionID, timestamp: timestamp)
+            case "token_count":
+                guard let info = payload["info"] as? [String: Any] else { return [] }
+                return usageEvents(info, sessionID: sessionID, timestamp: timestamp)
             case "task_started":
                 startTurn(payload["turn_id"] as? String)
                 return [event(.userPromptSubmit, sessionID: sessionID, timestamp: timestamp)]
@@ -94,6 +118,50 @@ public struct CodexRolloutParser: Sendable {
         return []
     }
 
+    /// One metadata event carrying the latest model and the cumulative token
+    /// spend, for a session restored from an already-active rollout.
+    func restorableMetadataEvent(timestamp: Date) -> HookEvent? {
+        guard let sessionID, model != nil || cumulativeTokens != nil || contextWindow != nil else {
+            return nil
+        }
+        let enrichment = TranscriptInfo(
+            tokens: cumulativeTokens,
+            tokensTurnID: "token_count:bootstrap:\(tokenRecordCount)",
+            contextTokens: contextTokens,
+            contextWindow: contextWindow)
+        return event(.sessionMetadataChanged, sessionID: sessionID, model: model,
+                     timestamp: timestamp, enrichment: enrichment)
+    }
+
+    private mutating func modelEvents(_ raw: String?, sessionID: String, timestamp: Date) -> [HookEvent] {
+        guard let name = Self.nonEmpty(raw), name != model else { return [] }
+        model = name
+        return [event(.sessionMetadataChanged, sessionID: sessionID, model: name, timestamp: timestamp)]
+    }
+
+    /// `token_count` is bookkeeping, not activity: it feeds the model, context
+    /// and spend columns through the enrichment path and never moves progress.
+    private mutating func usageEvents(_ info: [String: Any], sessionID: String, timestamp: Date) -> [HookEvent] {
+        let last = info["last_token_usage"] as? [String: Any]
+        let total = info["total_token_usage"] as? [String: Any]
+        let lastTotal = Self.int(last?["total_tokens"])
+        // Codex measures context occupancy without the reasoning tokens.
+        let inContext = lastTotal.map { $0 - (Self.int(last?["reasoning_output_tokens"]) ?? 0) }
+        let window = Self.int(info["model_context_window"])
+        guard lastTotal != nil || window != nil else { return [] }
+        tokenRecordCount += 1
+        cumulativeTokens = Self.int(total?["total_tokens"]) ?? cumulativeTokens
+        contextTokens = inContext ?? contextTokens
+        contextWindow = window ?? contextWindow
+        let enrichment = TranscriptInfo(
+            tokens: lastTotal,
+            tokensTurnID: "token_count:\(tokenRecordCount)",
+            contextTokens: inContext,
+            contextWindow: window)
+        return [event(.sessionMetadataChanged, sessionID: sessionID, timestamp: timestamp,
+                      enrichment: enrichment)]
+    }
+
     func restorableChildEvents(timestamp: Date) -> [HookEvent] {
         guard let sessionID else { return [] }
         var events: [HookEvent] = []
@@ -124,19 +192,22 @@ public struct CodexRolloutParser: Sendable {
         sessionID: String,
         toolName: String? = nil,
         message: String? = nil,
+        model: String? = nil,
         toolError: Bool = false,
         timestamp: Date,
         childID: String? = nil,
         childKind: ChildAgentKind? = nil,
         childName: String? = nil,
         childType: String? = nil,
-        childAction: HookEvent.ChildLifecycleAction? = nil
+        childAction: HookEvent.ChildLifecycleAction? = nil,
+        enrichment: TranscriptInfo? = nil
     ) -> HookEvent {
         HookEvent(kind: kind, sessionID: sessionID, agent: .codex,
-                  cwd: cwd, toolName: toolName, message: message,
+                  cwd: cwd, toolName: toolName, message: message, model: model,
                   toolError: toolError, timestamp: timestamp,
                   childID: childID, childKind: childKind, childName: childName,
-                  childType: childType, childAction: childAction)
+                  childType: childType, childAction: childAction,
+                  enrichment: enrichment)
     }
 
     private struct PendingCollab {
@@ -476,6 +547,12 @@ public struct CodexRolloutParser: Sendable {
         return nil
     }
 
+    private static func int(_ value: Any?) -> Int? {
+        if let number = value as? NSNumber { return number.intValue }
+        if let text = value as? String { return Int(text) }
+        return nil
+    }
+
     private static func bool(_ value: Any?) -> Bool? {
         if let flag = value as? Bool { return flag }
         if let number = value as? NSNumber { return number.boolValue }
@@ -502,6 +579,9 @@ public struct CodexRolloutParser: Sendable {
 
     private static let progressMarkers: [Data] = [
             #""type":"session_meta""#,
+            #""type":"turn_context""#,
+            #""type":"thread_settings_applied""#,
+            #""type":"token_count""#,
             #""type":"task_started""#,
             #""type":"task_complete""#,
             #""type":"turn_aborted""#,
@@ -662,6 +742,10 @@ public actor CodexRolloutMonitor {
         var parser = CodexRolloutParser()
         var identity: FileIdentity?
         var checkpoint = Data()
+        /// True once a progress event for this rollout has been delivered.
+        /// Metadata (model, `token_count`) is only forwarded for a surfaced
+        /// session: an idle thread's bookkeeping must not conjure a row.
+        var surfaced = false
 
         mutating func consume(_ data: Data, receivedAt: Date) -> [HookEvent] {
             remainder.append(data)
@@ -670,7 +754,17 @@ public actor CodexRolloutMonitor {
             while let newline = remainder[lineStart...].firstIndex(of: 0x0A) {
                 if newline > lineStart {
                     let line = Data(remainder[lineStart..<newline])
-                    events.append(contentsOf: parser.parseEvents(line, receivedAt: receivedAt))
+                    for event in parser.parseEvents(line, receivedAt: receivedAt) {
+                        switch event.kind {
+                        case .sessionMetadataChanged:
+                            if surfaced { events.append(event) }
+                        case .childLifecycle:
+                            events.append(event)
+                        default:
+                            surfaced = true
+                            events.append(event)
+                        }
+                    }
                 }
                 lineStart = remainder.index(after: newline)
                 if lineStart == remainder.endIndex { break }
@@ -800,10 +894,11 @@ public actor CodexRolloutMonitor {
         discoveryPassCount += 1
         let files = candidateFiles(now: now)
         let livePaths = Set(files.map(\.path))
+        var emitted: [HookEvent] = []
         for path in Array(cursors.keys) where !livePaths.contains(path) {
+            emitted.append(contentsOf: endedEvents(path: path, now: now))
             removeTracking(path: path)
         }
-        var emitted: [HookEvent] = []
 
         for file in files {
             emitted.append(contentsOf: refresh(file: file, now: now, installWatcher: installWatchers))
@@ -814,8 +909,9 @@ public actor CodexRolloutMonitor {
     private func refresh(file: URL, now: Date, installWatcher: Bool) -> [HookEvent] {
         let path = file.path
         guard let state = Self.fileState(file) else {
+            let ended = endedEvents(path: path, now: now)
             removeTracking(path: path)
-            return []
+            return ended
         }
 
         var emitted: [HookEvent] = []
@@ -846,6 +942,18 @@ public actor CodexRolloutMonitor {
 
         if installWatcher { ensureWatcher(for: file, identity: state.identity) }
         return emitted
+    }
+
+    /// A rollout that vanished — Codex moves it to `archived_sessions/` when the
+    /// thread is archived — ends the session it surfaced. A rollout that merely
+    /// aged out of the recency window still exists and is only untracked.
+    private func endedEvents(path: String, now: Date) -> [HookEvent] {
+        guard let cursor = cursors[path], cursor.surfaced,
+              let sessionID = cursor.parser.sessionID,
+              !FileManager.default.fileExists(atPath: path)
+        else { return [] }
+        return [HookEvent(kind: .sessionEnd, sessionID: sessionID, agent: .codex,
+                          cwd: cursor.parser.cwd, timestamp: now)]
     }
 
     private func ensureWatcher(for file: URL, identity: FileIdentity) {
@@ -966,31 +1074,26 @@ public actor CodexRolloutMonitor {
         sink = nil
     }
 
+    /// Rollouts live under their *start* date, and a resumed thread keeps
+    /// appending to that old file, so discovery walks every date directory and
+    /// keeps whatever was written inside the recency window.
     private func candidateFiles(now: Date) -> [URL] {
         let fm = FileManager.default
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = .current
+        let keys: Set<URLResourceKey> = [.isRegularFileKey, .contentModificationDateKey]
         var files: [URL] = []
 
-        for daysAgo in 0...1 {
-            guard let day = calendar.date(byAdding: .day, value: -daysAgo, to: now) else { continue }
-            let parts = calendar.dateComponents([.year, .month, .day], from: day)
-            guard let year = parts.year, let month = parts.month, let dayNumber = parts.day else { continue }
-            let directory = root
-                .appendingPathComponent(String(format: "%04d", year), isDirectory: true)
-                .appendingPathComponent(String(format: "%02d", month), isDirectory: true)
-                .appendingPathComponent(String(format: "%02d", dayNumber), isDirectory: true)
-            guard let entries = try? fm.contentsOfDirectory(
-                at: directory,
-                includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
-                options: [.skipsHiddenFiles]
-            ) else { continue }
-            files.append(contentsOf: entries.filter {
-                guard $0.lastPathComponent.hasPrefix("rollout-"), $0.pathExtension == "jsonl",
-                      let values = try? $0.resourceValues(forKeys: [.contentModificationDateKey]),
-                      let modified = values.contentModificationDate else { return false }
-                return now.timeIntervalSince(modified) <= recoveryWindow
-            })
+        if let enumerator = fm.enumerator(
+            at: root, includingPropertiesForKeys: Array(keys), options: [.skipsHiddenFiles]
+        ) {
+            for case let url as URL in enumerator {
+                guard url.lastPathComponent.hasPrefix("rollout-"), url.pathExtension == "jsonl",
+                      let values = try? url.resourceValues(forKeys: keys),
+                      values.isRegularFile == true,
+                      let modified = values.contentModificationDate,
+                      now.timeIntervalSince(modified) <= recoveryWindow
+                else { continue }
+                files.append(url)
+            }
         }
         // Retain only active rollouts beyond the recency window. Completed or
         // abandoned files age out, bounding watcher descriptors over time.
@@ -1034,7 +1137,7 @@ public actor CodexRolloutMonitor {
             while let chunk = try handle.read(upToCount: 64 * 1_024), !chunk.isEmpty {
                 cursor.offset += UInt64(chunk.count)
                 for event in cursor.consume(chunk, receivedAt: receivedAt) {
-                    if event.kind == .childLifecycle { continue }
+                    if event.kind == .childLifecycle || event.kind == .sessionMetadataChanged { continue }
                     if event.kind != .stop && event.kind != .sessionEnd {
                         latestParent = event
                     }
@@ -1044,10 +1147,15 @@ public actor CodexRolloutMonitor {
             return nil
         }
         cursor.checkpoint = checkpoint(file: file, endingAt: cursor.offset)
+        cursor.surfaced = false
         guard cursor.parser.isDesktopSession else { return (cursor, []) }
         var events: [HookEvent] = []
         if cursor.parser.turnActive, let latestParent {
+            cursor.surfaced = true
             events.append(latestParent)
+            if let metadata = cursor.parser.restorableMetadataEvent(timestamp: receivedAt) {
+                events.append(metadata)
+            }
         }
         events.append(contentsOf: cursor.parser.restorableChildEvents(timestamp: receivedAt))
         return (cursor, events)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
@@ -56,6 +56,10 @@ public struct HookEvent: Sendable, Equatable {
     /// reducer drop a settle report that belongs to an already-superseded turn.
     /// Nil for CLIs that do not label turns — those settle unconditionally.
     public let turnID: String?
+    /// Model, token, and context facts a local source read alongside the event
+    /// (the Codex rollout's `token_count`). Applied through the reducer's
+    /// enrichment path, never as a progress transition.
+    public let enrichment: TranscriptInfo?
 
     public init(
         kind: Kind,
@@ -74,7 +78,8 @@ public struct HookEvent: Sendable, Equatable {
         childName: String? = nil,
         childType: String? = nil,
         childAction: ChildLifecycleAction? = nil,
-        turnID: String? = nil
+        turnID: String? = nil,
+        enrichment: TranscriptInfo? = nil
     ) {
         self.kind = kind
         self.sessionID = sessionID
@@ -93,5 +98,6 @@ public struct HookEvent: Sendable, Equatable {
         self.childType = childType
         self.childAction = childAction
         self.turnID = turnID
+        self.enrichment = enrichment
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -124,6 +124,9 @@ public actor SessionStore {
         let wasWaiting = reducer.sessions[event.sessionID]?.status == .needsResponse
         if let path = event.transcriptPath { transcriptPaths[event.sessionID] = path }
         reducer.apply(event, observationSource: observationSource)
+        if let enrichment = event.enrichment {
+            reducer.enrich(sessionID: event.sessionID, with: enrichment)
+        }
         recordSignal(agent: event.agent, source: observationSource, at: event.timestamp,
                      health: .healthy, coverage: Self.coverage(for: event.kind))
         if reducer.sessions[event.sessionID] == nil {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -302,6 +302,139 @@ struct CodexRolloutMonitorTests {
         #expect(ids == ["desktop-today", "desktop-yesterday"])
     }
 
+    @Test("a spawned subagent thread is folded, never surfaced as its own session")
+    func subagentRolloutIsSkipped() {
+        var parser = CodexRolloutParser()
+        let meta = #"{"type":"session_meta","payload":{"id":"child-1","cwd":"/x/project","originator":"Codex Desktop","parent_thread_id":"thread-1","thread_source":"subagent","source":{"subagent":{"thread_spawn":{"parent_thread_id":"thread-1","agent_path":"/root/research"}}}}}"#
+        #expect(parser.parseEvents(Data(meta.utf8), receivedAt: now).isEmpty)
+        #expect(!parser.isDesktopSession)
+        #expect(parser.parseEvents(Data(taskStarted(id: "turn-1").utf8), receivedAt: now).isEmpty)
+    }
+
+    @Test("turn_context and token_count enrich model and context without moving progress")
+    func usageEnrichment() {
+        var parser = CodexRolloutParser()
+        var reducer = SessionReducer()
+        let lines = [
+            sessionMeta(id: "thread-1"),
+            taskStarted(id: "turn-1"),
+            turnContext(model: "gpt-5.6-sol"),
+            tokenCount(lastTotal: 170_674, reasoning: 4_385, cumulative: 500_000, window: 258_400),
+        ]
+        var events: [HookEvent] = []
+        for line in lines {
+            for event in parser.parseEvents(Data(line.utf8), receivedAt: now) {
+                events.append(event)
+                reducer.apply(event)
+                if let enrichment = event.enrichment {
+                    reducer.enrich(sessionID: event.sessionID, with: enrichment)
+                }
+            }
+        }
+        #expect(events.map(\.kind) == [.userPromptSubmit, .sessionMetadataChanged, .sessionMetadataChanged])
+        #expect(events[1].model == "gpt-5.6-sol")
+        #expect(events[2].enrichment?.tokens == 170_674)
+        #expect(events[2].enrichment?.contextTokens == 166_289)
+        #expect(events[2].enrichment?.contextWindow == 258_400)
+        let session = reducer.sessions["thread-1"]
+        #expect(session?.status == .working)
+        #expect(session?.model == "gpt-5.6-sol")
+        #expect(session?.contextTokens == 166_289)
+        #expect(session?.contextWindow == 258_400)
+        #expect(session?.spentTokens == 170_674)
+
+        // The same model again is not news; a switch is.
+        #expect(parser.parseEvents(Data(turnContext(model: "gpt-5.6-sol").utf8), receivedAt: now).isEmpty)
+        #expect(parser.parseEvents(Data(turnContext(model: "gpt-5.6-mini").utf8), receivedAt: now).first?.model == "gpt-5.6-mini")
+    }
+
+    @Test("usage bookkeeping never surfaces an idle desktop thread")
+    func usageDoesNotSurfaceIdleThreads() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let idle = try fixture.write(
+            named: "rollout-idle.jsonl",
+            lines: [sessionMeta(id: "desktop-idle"), taskStarted(id: "t1"), taskComplete(id: "t1")]
+        )
+        let working = try fixture.write(
+            named: "rollout-working.jsonl",
+            lines: [sessionMeta(id: "desktop-working"), taskStarted(id: "t1")]
+        )
+        let monitor = CodexRolloutMonitor(root: fixture.root)
+        #expect(await monitor.poll(now: now).map(\.sessionID) == ["desktop-working"])
+
+        try append(tokenCount(lastTotal: 10, reasoning: 0, cumulative: 10, window: 100), to: idle)
+        try append(tokenCount(lastTotal: 20, reasoning: 0, cumulative: 20, window: 100), to: working)
+        let events = await monitor.poll(now: now)
+        #expect(events.map(\.sessionID) == ["desktop-working"])
+        #expect(events.first?.kind == .sessionMetadataChanged)
+        #expect(events.first?.enrichment?.tokens == 20)
+    }
+
+    @Test("bootstrap restores the model and cumulative spend of an active turn")
+    func bootstrapRestoresUsage() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-active.jsonl",
+            lines: [
+                sessionMeta(id: "desktop-active"),
+                turnContext(model: "gpt-5.6-sol"),
+                taskStarted(id: "t1"),
+                tokenCount(lastTotal: 100, reasoning: 10, cumulative: 100, window: 1_000),
+                taskComplete(id: "t1"),
+                taskStarted(id: "t2"),
+                tokenCount(lastTotal: 300, reasoning: 0, cumulative: 400, window: 1_000),
+            ]
+        )
+        let monitor = CodexRolloutMonitor(root: fixture.root)
+        let events = await monitor.poll(now: now)
+        #expect(events.map(\.kind) == [.userPromptSubmit, .sessionMetadataChanged])
+        #expect(events.last?.model == "gpt-5.6-sol")
+        #expect(events.last?.enrichment?.tokens == 400)
+        #expect(events.last?.enrichment?.contextTokens == 300)
+        #expect(events.last?.enrichment?.contextWindow == 1_000)
+    }
+
+    @Test("a thread resumed from an older date directory is discovered")
+    func resumedOldThreadDiscovery() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-old.jsonl",
+            lines: [sessionMeta(id: "desktop-old"), taskStarted(id: "old")],
+            daysAgo: 12
+        )
+        let stale = try fixture.write(
+            named: "rollout-stale.jsonl",
+            lines: [sessionMeta(id: "desktop-stale"), taskStarted(id: "stale")],
+            daysAgo: 12
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-3 * 60 * 60)], ofItemAtPath: stale.path)
+
+        let monitor = CodexRolloutMonitor(root: fixture.root)
+        #expect(await monitor.poll(now: now).map(\.sessionID) == ["desktop-old"])
+    }
+
+    @Test("archiving a rollout ends the session it surfaced")
+    func archivedRolloutEndsSession() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let active = try fixture.write(
+            named: "rollout-active.jsonl",
+            lines: [sessionMeta(id: "desktop-active"), taskStarted(id: "t1")]
+        )
+        let monitor = CodexRolloutMonitor(root: fixture.root)
+        #expect(await monitor.poll(now: now).map(\.kind) == [.userPromptSubmit])
+
+        try FileManager.default.removeItem(at: active)
+        let ended = await monitor.poll(now: now)
+        #expect(ended.map(\.kind) == [.sessionEnd])
+        #expect(ended.first?.sessionID == "desktop-active")
+        #expect(await monitor.poll(now: now).isEmpty)
+    }
+
     @Test("daemon restart bootstraps an already-active rollout")
     func daemonRestart() async throws {
         let fixture = try RolloutFixture(now: now)
@@ -674,6 +807,14 @@ private func sessionMeta(id: String, cwd: String = "/x/project") -> String {
 
 private func taskStarted(id: String) -> String {
     #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"\#(id)"}}"#
+}
+
+private func turnContext(model: String) -> String {
+    #"{"type":"turn_context","payload":{"turn_id":"t","cwd":"/x/project","model":"\#(model)","approval_policy":"never"}}"#
+}
+
+private func tokenCount(lastTotal: Int, reasoning: Int, cumulative: Int, window: Int) -> String {
+    #"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":\#(cumulative)},"last_token_usage":{"input_tokens":1,"output_tokens":1,"reasoning_output_tokens":\#(reasoning),"total_tokens":\#(lastTotal)},"model_context_window":\#(window)},"rate_limits":null}}"#
 }
 
 private func taskComplete(id: String) -> String {

--- a/docs/planning/prior-art.md
+++ b/docs/planning/prior-art.md
@@ -3,6 +3,65 @@
 **Last Updated**: 2026-09-02
 **Method**: every GitHub project below was verified live with `gh` (existence, stars, license, last push). App Store apps are closed-source and were not code-verifiable. Claims I could not verify are marked as such — per the project rule to separate verified facts from candidates.
 
+## 2026-09-03 Codex Desktop survey
+
+Question: can VibeBuddy monitor Codex Desktop sessions, and what do mature
+projects do differently? Twelve projects were inspected at default-branch HEAD
+with `gh`, together with the openai/codex `main` sources and this Mac's own
+`~/.codex` (no transcript content read).
+
+**Ground truth (openai/codex, verified locally).** Codex Desktop is now the
+Codex Framework inside `ChatGPT.app`; it spawns `codex app-server` over stdio
+with no `--listen`, so no other process can attach to its live threads
+(`app-server-control.sock` belongs to the CLI daemon, `ipc/ipc.sock` is an
+IDE-context router). openai/codex issue #25914 documents that a second
+app-server sees Desktop threads only as `notLoaded`. Rollouts persist only
+`task_started`, `task_complete`, `turn_aborted`, `item_completed`,
+`token_count`, `thread_settings_applied` and a few `*End` records
+(`codex-rs/rollout/src/policy.rs`); approval and `request_user_input` prompts
+are explicitly not persisted. Desktop rollouts carry
+`originator: "Codex Desktop"` with `source: "vscode"` (the enum default), and
+subagent threads reuse the same originator with `thread_source: "subagent"`.
+The core `threads` table lives in `~/.codex/state_5.sqlite`;
+`~/.codex/sqlite/codex-dev.db` is the Electron app's private catalog.
+
+| Project | Desktop support | Signal | States | Model / tokens | Remote actions |
+|---|---|---|---|---|---|
+| [CodexBar](https://github.com/steipete/CodexBar) (20k+) | label only, via originator + ChatGPT app-server process | process table + today/yesterday rollouts + `state_5.sqlite` | active/idle (120 s mtime) | model from sqlite, cost from `token_count` | none |
+| [Agent Signal Bar](https://github.com/guan-ops/Agent-Signal-Bar) | yes, hook-free desktop monitor | recursive rollout tail with ctime/offset cursors | thinking/working/tool_done/done/permission/attention | `token_count`, tool from `function_call` | none |
+| [open-vibe-island](https://github.com/Octane0411/open-vibe-island) (2k) | partial | incremental rollout fold + own app-server (own threads only) + `archived_sessions/` | running/approval/question/completed | usage module | none |
+| [agentsview](https://github.com/kenn-io/agentsview) (5k+) | ingests, no discrimination | FSEvents + byte cursors + `history.jsonl` hot list | awaiting_user / tool_call_pending + recency | `turn_context.model`, `last_token_usage` | `codex resume` in a terminal |
+| [notchi](https://github.com/sk-ruban/notchi) (1k) | no (hook ingress) | hooks, then rollout `DispatchSource`, `state_*.sqlite` | hook-driven | `turn_context` + `token_count` | none |
+| [codestatus](https://github.com/henriquegpb/codestatus) | no, by design | hooks only | working/free/approval/answer | none | none |
+| [parallex](https://github.com/Jiply/parallex) | yes | `lsof` on open rollouts + backward tail scan | active/inactive | — | none |
+| [pocket-codex](https://github.com/acking-you/pocket-codex) | observe + destructive takeover | own app-server + rollout tail + `lsof` | owned/resumable 2×2 | `tokenUsage / modelContextWindow` | own threads only |
+| MioIsland, CodexLens, ccpocket | none / label only | — | — | — | own threads only |
+
+**Consensus.** Every project observes Desktop through the rollout JSONL and
+none can act on a Desktop thread; approval waits are inferred (pending tool
+call plus a quiet file) and admitted to be heuristic; liveness needs a second
+signal beyond mtime (`lsof`, the ChatGPT app-server process, or the
+`archived_sessions/` move); `token_count` is bookkeeping, never activity.
+
+**Where VibeBuddy stood.** `CodexRolloutMonitor` already had the strongest
+turn model in the sample (concurrent `turn_id`s, event-driven watchers,
+bootstrap of only active turns, collaboration topology). Four gaps were real:
+discovery only looked at today's and yesterday's date directories although
+resumed threads append under their start date (10 such files in the last week
+on this Mac); Desktop rows had no model, context or spend; subagent rollouts
+surfaced as extra top-level sessions; an archived rollout was untracked
+silently.
+
+**Adopted on 2026-09-03.** Recursive discovery bounded by the recency window;
+`turn_context` / `thread_settings_applied` → model, `token_count` → context
+and spend through the reducer's enrichment path, gated so an idle thread's
+bookkeeping never creates a row; `thread_source`/`source.subagent` filter;
+`sessionEnd` when a surfaced rollout vanishes. Not adopted: `lsof` liveness
+(process-table cost for a signal the 2 h stale reconcile already
+approximates), approval inference from a quiet file (false "needs you" is
+worse than none), and any app-server attachment (impossible on macOS without
+patching ChatGPT.app).
+
 ## 2026-09-02 activity-monitoring refresh
 
 The current mature implementations converge on a **hybrid event model**, not

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -74,12 +74,33 @@ does not read or forge Codex's trust state.
 
 ### Codex Desktop
 
-Codex Desktop does not execute the user's CLI `hooks.json`. VibeBuddy therefore
-tails the local `~/.codex/sessions/**/rollout-*.jsonl` stream in addition to the
-CLI hooks. `task_started`, tool records, `task_complete`, and `turn_aborted` feed
-the same reducer, so desktop work appears without `/hooks` trust. On startup only
+Codex Desktop (the Codex GUI inside ChatGPT.app, running `codex app-server`
+over stdio) does not execute the user's CLI `hooks.json`, and its app-server
+exposes no socket another process could attach to. VibeBuddy therefore tails the
+local `~/.codex/sessions/**/rollout-*.jsonl` stream in addition to the CLI hooks.
+`task_started`, tool records, `task_complete`, and `turn_aborted` feed the same
+reducer, so desktop work appears without `/hooks` trust. On startup only
 currently active desktop turns are restored; old completed rollouts are not
 replayed into the dashboard.
+
+What the rollout does and does not tell us:
+
+- A Desktop thread is recognised by `session_meta.originator == "Codex Desktop"`
+  (`source` is the `vscode` enum default and cannot be used). A spawned subagent
+  thread carries the same originator and is skipped by `thread_source ==
+  "subagent"` / `source.subagent`; the parent's collaboration records own it.
+- Rollouts sit under their *start* date and a resumed thread keeps appending to
+  that old file, so discovery walks every date directory and keeps files written
+  within the last 30 minutes.
+- `turn_context.model` / `thread_settings_applied` fill the model column;
+  `token_count` fills context usage (`last_token_usage` minus reasoning tokens
+  over `model_context_window`) and spend. Both are metadata only and never
+  surface an idle thread.
+- Archiving a thread moves its rollout to `~/.codex/archived_sessions/`; the
+  vanished file ends the session.
+- Codex does **not** persist approval or `request_user_input` prompts in the
+  rollout, so a Desktop approval wait is invisible and cannot be answered from
+  the phone. Only the `request_user_input` tool call itself is visible.
 
 
 ## Grok Build


### PR DESCRIPTION
## Summary

Codex Desktop (now embedded in ChatGPT.app, `codex app-server` over stdio) cannot be attached to and does not reliably run CLI hooks, so the rollout tailer is its only signal. A survey of twelve open-source monitors and the openai/codex sources (written up in `docs/planning/prior-art.md`) showed `CodexRolloutMonitor` already had the strongest turn model in the sample, with four real gaps, all closed here:

- **Resumed threads were invisible.** Discovery only looked at today's and yesterday's date directories, but a resumed thread keeps appending under its start date (10 such files in the last week on the dev Mac). Discovery now walks every directory, bounded by the recency window.
- **No model / context / spend on Desktop rows.** `turn_context` and `thread_settings_applied` name the model; `token_count` feeds context occupancy and spend through a new `HookEvent.enrichment` channel that `SessionStore` applies via the reducer's enrich path. Metadata is only forwarded for a surfaced session, so an idle thread's bookkeeping never creates a row.
- **Subagent threads surfaced as extra sessions.** They carry the same `Codex Desktop` originator; they are now skipped by `thread_source == subagent` / `source.subagent` and remain owned by the parent's collaboration topology.
- **Archived rollouts were untracked silently.** A surfaced rollout that no longer exists now ends its session; one that merely aged out is only untracked.

Follow-up tickets live in `.scratch/codex-desktop-monitoring/issues/` (local tracker).

## Verification

- `VibeBuddyMac`: `swift test` 465/465 (6 new tests: subagent skip, usage enrichment, idle threads never surfaced, bootstrap restores model + spend, old-directory discovery, archive ends session).
- `VibeBuddyMacApp`: Debug build succeeded.
- Not yet exercised against a live Codex Desktop turn (ticket 01).