### PR TITLE
Linux dev environment: build/test/run the Swift packages on Cloud Agents

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "iOS-vibebuddy (Linux Swift + agent hooks)",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for iOS-vibebuddy.
+#
+# The product is a macOS/iOS Swift app, but its shared SwiftPM packages
+# (VibeBuddyKit wire model + the vibebuddyd Hummingbird daemon in VibeBuddyMac)
+# build, test, and RUN on Linux, and the agent-hook tooling is Python/Bash. This
+# installs a Linux Swift toolchain + the C/C++ deps swift-crypto needs, then warms
+# the package builds. The Xcode apps (VibeBuddyMacApp / VibeBuddyApp) still require
+# a macOS host with Xcode and are not built here.
+set -euo pipefail
+
+SWIFT_VERSION="6.3.3"
+SWIFT_ROOT="/opt/swift"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+log "System dependencies (Swift runtime + swift-crypto C/C++ build)"
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+# libstdc++-14-dev matches the GCC toolchain the bundled clang selects, so the
+# BoringSSL C++ in swift-crypto finds <memory> and friends.
+sudo apt-get install -y --no-install-recommends \
+  binutils git curl gnupg2 g++ libstdc++-14-dev \
+  libc6-dev libcurl4-openssl-dev libedit2 libgcc-13-dev libstdc++-13-dev \
+  libpython3-dev libxml2-dev libz3-dev pkg-config tzdata zlib1g-dev libncurses-dev
+
+if [ ! -x "${SWIFT_ROOT}/usr/bin/swift" ]; then
+  log "Installing Swift ${SWIFT_VERSION} (Ubuntu 24.04, x86_64)"
+  URL="https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu24.04.tar.gz"
+  tmp="$(mktemp -d)"
+  for attempt in 1 2 3 4; do
+    if curl -fL --retry 3 -o "${tmp}/swift.tar.gz" "$URL"; then break; fi
+    echo "download attempt ${attempt} failed; retrying"; sleep $((attempt * 4))
+  done
+  sudo mkdir -p "$SWIFT_ROOT"
+  sudo tar xzf "${tmp}/swift.tar.gz" -C "$SWIFT_ROOT" --strip-components=1
+  rm -rf "$tmp"
+else
+  log "Swift already present at ${SWIFT_ROOT}; skipping download"
+fi
+
+log "Linking Swift onto PATH"
+sudo ln -sf "${SWIFT_ROOT}/usr/bin/swift" /usr/local/bin/swift
+sudo ln -sf "${SWIFT_ROOT}/usr/bin/swiftc" /usr/local/bin/swiftc
+sudo ln -sf "${SWIFT_ROOT}/usr/bin/sourcekit-lsp" /usr/local/bin/sourcekit-lsp 2>/dev/null || true
+swift --version
+
+log "Building shared package: VibeBuddyKit"
+swift build --package-path "${REPO_DIR}/VibeBuddyKit"
+
+log "Building daemon + core: VibeBuddyMac (vibebuddyd)"
+swift build --package-path "${REPO_DIR}/VibeBuddyMac"
+
+log "Bootstrap complete. Try:"
+echo "  swift test --package-path VibeBuddyKit"
+echo "  swift test --package-path VibeBuddyMac"
+echo "  VIBEBUDDY_TOKEN=devtoken swift run --package-path VibeBuddyMac vibebuddyd"
+echo "  python3 hooks/test_install_agent_hooks.py"

--- a/VibeBuddyKit/Sources/VibeBuddyKit/GeminiRealtimeSession.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/GeminiRealtimeSession.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+// URLSessionWebSocketTask is Apple-platform Foundation only; the realtime voice
+// clients are excluded from the Linux build of the shared package.
+#if canImport(Darwin)
+
 /// Google Gemini Live API (`BidiGenerateContent`) speech-to-speech. A different
 /// schema from the OpenAI-style providers: a `setup` message configures the
 /// session, audio goes up as `realtimeInput.audio` (16 kHz PCM), and audio comes
@@ -165,3 +169,5 @@ public actor GeminiRealtimeSession: RealtimeVoiceProvider {
         }
     }
 }
+
+#endif

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(Security)
 import Security
+#endif
 
 /// Minimal Keychain wrapper for the one secret we hold: the user's own DashScope
 /// API key. Never written to UserDefaults or committed; read at runtime only.
@@ -7,6 +9,7 @@ import Security
 public enum KeychainStore {
     private static let service = "com.vibebuddy.secrets"
 
+#if canImport(Security)
     public static func set(_ value: String?, for key: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -35,6 +38,27 @@ public enum KeychainStore {
         else { return nil }
         return s
     }
+#else
+    /// Linux has no Keychain. VibeBuddy's real secret storage is Apple-only;
+    /// this process-lifetime in-memory fallback keeps the shared package
+    /// buildable and testable on Linux without persisting anything to disk.
+    private final class InMemoryStore: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [String: String] = [:]
+        func set(_ value: String?, for key: String) {
+            lock.lock(); defer { lock.unlock() }
+            if let value, !value.isEmpty { values[key] = value } else { values[key] = nil }
+        }
+        func get(_ key: String) -> String? {
+            lock.lock(); defer { lock.unlock() }
+            return values[key]
+        }
+    }
+    private static let backing = InMemoryStore()
+
+    public static func set(_ value: String?, for key: String) { backing.set(value, for: key) }
+    public static func get(_ key: String) -> String? { backing.get(key) }
+#endif
 }
 
 /// The language the voice companion converses in — drives speech recognition,

--- a/VibeBuddyKit/Sources/VibeBuddyKit/OpenAIRealtimeSession.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/OpenAIRealtimeSession.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+// URLSessionWebSocketTask is Apple-platform Foundation only; the realtime voice
+// clients are excluded from the Linux build of the shared package.
+#if canImport(Darwin)
+
 /// OpenAI Realtime (GA) speech-to-speech over `wss://api.openai.com/v1/realtime`.
 /// The GA API nests audio config under `session.audio.input/output` and renames
 /// the audio events to `response.output_audio.*` (the beta shape is disabled).
@@ -141,3 +145,5 @@ public actor OpenAIRealtimeSession: RealtimeVoiceProvider {
         }
     }
 }
+
+#endif

--- a/VibeBuddyKit/Sources/VibeBuddyKit/RealtimeVoice.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/RealtimeVoice.swift
@@ -31,6 +31,11 @@ public protocol RealtimeVoiceProvider: Actor {
     func close()
 }
 
+// URLSessionWebSocketTask is Apple-platform Foundation only; the concrete
+// realtime voice client is excluded from the Linux build. The provider-agnostic
+// `RealtimeVoiceEvent`/`RealtimeVoiceProvider` types above remain cross-platform.
+#if canImport(Darwin)
+
 /// Alibaba Bailian / DashScope Qwen-Omni-Realtime over its OpenAI-Realtime-style
 /// WebSocket (`wss://…/api-ws/v1/realtime`). One model handles ears + brain +
 /// mouth: 16 kHz PCM in, 24 kHz PCM out, server-side semantic VAD.
@@ -176,3 +181,5 @@ public actor QwenRealtimeSession: RealtimeVoiceProvider {
         }
     }
 }
+
+#endif

--- a/VibeBuddyKit/Sources/VibeBuddyKit/TaskStatusSwiftUI.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/TaskStatusSwiftUI.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 public extension Color {
@@ -97,3 +98,4 @@ public struct TaskStatusIndicator: View {
         return contrast == .increased ? 1 : 0
     }
 }
+#endif

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/APNs.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/APNs.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import VibeBuddyKit
 
 /// APNs provider config. Filled from env once the user has a paid account +

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 import VibeBuddyKit
 
@@ -287,10 +291,10 @@ public actor AccountUsageFileCache: AccountUsageCaching {
         let temporary = try Self.writeOwnerOnlyTemporary(data, beside: fileURL)
         var shouldRemoveTemporary = true
         defer {
-            if shouldRemoveTemporary { _ = Darwin.unlink(temporary.path) }
+            if shouldRemoveTemporary { _ = unlink(temporary.path) }
         }
         let committed = try permit.commit {
-            guard Darwin.rename(temporary.path, fileURL.path) == 0 else {
+            guard rename(temporary.path, fileURL.path) == 0 else {
                 throw Self.posixError()
             }
         }
@@ -318,7 +322,7 @@ public actor AccountUsageFileCache: AccountUsageCaching {
     ) throws -> URL {
         let temporary = destination.deletingLastPathComponent()
             .appendingPathComponent(".account-usage-\(UUID().uuidString).tmp")
-        var descriptor = Darwin.open(
+        var descriptor = open(
             temporary.path,
             O_WRONLY | O_CREAT | O_EXCL,
             mode_t(S_IRUSR | S_IWUSR)
@@ -326,15 +330,15 @@ public actor AccountUsageFileCache: AccountUsageCaching {
         guard descriptor >= 0 else { throw posixError() }
         var shouldRemoveTemporary = true
         defer {
-            if descriptor >= 0 { _ = Darwin.close(descriptor) }
-            if shouldRemoveTemporary { _ = Darwin.unlink(temporary.path) }
+            if descriptor >= 0 { _ = close(descriptor) }
+            if shouldRemoveTemporary { _ = unlink(temporary.path) }
         }
 
         try data.withUnsafeBytes { bytes in
             guard let baseAddress = bytes.baseAddress else { return }
             var written = 0
             while written < bytes.count {
-                let count = Darwin.write(
+                let count = write(
                     descriptor,
                     baseAddress.advanced(by: written),
                     bytes.count - written
@@ -343,11 +347,11 @@ public actor AccountUsageFileCache: AccountUsageCaching {
                 written += count
             }
         }
-        guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+        guard fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
             throw posixError()
         }
-        guard Darwin.fsync(descriptor) == 0 else { throw posixError() }
-        guard Darwin.close(descriptor) == 0 else { throw posixError() }
+        guard fsync(descriptor) == 0 else { throw posixError() }
+        guard close(descriptor) == 0 else { throw posixError() }
         descriptor = -1
         shouldRemoveTemporary = false
         return temporary

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ClaudeCLIUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ClaudeCLIUsageProvider.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 
 public enum ClaudeUsageResponseDecoder {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerUsageProvider.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 
 public enum CodexUsageResponseDecoder {
@@ -52,7 +56,7 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
         self.arguments = arguments
         self.timeout = timeout
         afterProcessInstall = nil
-        signalProcess = { Darwin.kill($0, $1) }
+        signalProcess = { kill($0, $1) }
     }
 
     init(
@@ -60,7 +64,7 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
         arguments: [String],
         timeout: TimeInterval,
         afterProcessInstall: @escaping @Sendable () -> Void,
-        signalProcess: @escaping @Sendable (pid_t, Int32) -> Int32 = { Darwin.kill($0, $1) }
+        signalProcess: @escaping @Sendable (pid_t, Int32) -> Int32 = { kill($0, $1) }
     ) {
         self.executableURL = executableURL
         self.arguments = arguments
@@ -169,13 +173,13 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
     private static func spawn(executableURL: URL, arguments: [String]) throws -> SpawnedCodexProcess {
         var stdinDescriptors = [Int32](repeating: -1, count: 2)
         var stdoutDescriptors = [Int32](repeating: -1, count: 2)
-        guard Darwin.pipe(&stdinDescriptors) == 0 else { throw AccountUsageError.providerUnavailable }
-        guard Darwin.pipe(&stdoutDescriptors) == 0 else {
+        guard pipe(&stdinDescriptors) == 0 else { throw AccountUsageError.providerUnavailable }
+        guard pipe(&stdoutDescriptors) == 0 else {
             closeIfOpen(stdinDescriptors[0])
             closeIfOpen(stdinDescriptors[1])
             throw AccountUsageError.providerUnavailable
         }
-        let nullDescriptor = Darwin.open("/dev/null", O_WRONLY)
+        let nullDescriptor = open("/dev/null", O_WRONLY)
         guard nullDescriptor >= 0 else {
             closeIfOpen(stdinDescriptors[0])
             closeIfOpen(stdinDescriptors[1])
@@ -184,7 +188,11 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
             throw AccountUsageError.providerUnavailable
         }
 
+        #if canImport(Darwin)
         var actions: posix_spawn_file_actions_t? = nil
+        #else
+        var actions = posix_spawn_file_actions_t()
+        #endif
         guard posix_spawn_file_actions_init(&actions) == 0 else {
             closeIfOpen(stdinDescriptors[0])
             closeIfOpen(stdinDescriptors[1])
@@ -195,7 +203,11 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
         }
         defer { posix_spawn_file_actions_destroy(&actions) }
 
+        #if canImport(Darwin)
         var attributes: posix_spawnattr_t? = nil
+        #else
+        var attributes = posix_spawnattr_t()
+        #endif
         guard posix_spawnattr_init(&attributes) == 0 else {
             closeIfOpen(stdinDescriptors[0])
             closeIfOpen(stdinDescriptors[1])
@@ -266,7 +278,7 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
                 executableURL.path,
                 &actions,
                 &attributes,
-                buffer.baseAddress,
+                buffer.baseAddress!,
                 environ
             )
         }
@@ -280,9 +292,11 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
             throw AccountUsageError.providerUnavailable
         }
 
-        _ = Darwin.fcntl(stdinDescriptors[1], F_SETNOSIGPIPE, 1)
-        _ = Darwin.fcntl(stdinDescriptors[1], F_SETFD, FD_CLOEXEC)
-        _ = Darwin.fcntl(stdoutDescriptors[0], F_SETFD, FD_CLOEXEC)
+        #if canImport(Darwin)
+        _ = fcntl(stdinDescriptors[1], F_SETNOSIGPIPE, 1)
+        #endif
+        _ = fcntl(stdinDescriptors[1], F_SETFD, FD_CLOEXEC)
+        _ = fcntl(stdoutDescriptors[0], F_SETFD, FD_CLOEXEC)
         return SpawnedCodexProcess(
             processID: processID,
             input: FileHandle(fileDescriptor: stdinDescriptors[1], closeOnDealloc: true),
@@ -291,7 +305,7 @@ public final class CodexAppServerUsageProvider: AccountUsageProviding, @unchecke
     }
 
     private static func closeIfOpen(_ descriptor: Int32) {
-        if descriptor >= 0 { _ = Darwin.close(descriptor) }
+        if descriptor >= 0 { _ = close(descriptor) }
     }
 
     private static func throwRPCErrorIfPresent(in data: Data) throws {
@@ -325,8 +339,8 @@ private final class CodexAppServerProcessLifecycle: @unchecked Sendable {
 
     init(signalProcess: @escaping @Sendable (pid_t, Int32) -> Int32) {
         self.signalProcess = signalProcess
-        _ = Darwin.fcntl(cancellationPipe.fileHandleForReading.fileDescriptor, F_SETFD, FD_CLOEXEC)
-        _ = Darwin.fcntl(cancellationPipe.fileHandleForWriting.fileDescriptor, F_SETFD, FD_CLOEXEC)
+        _ = fcntl(cancellationPipe.fileHandleForReading.fileDescriptor, F_SETFD, FD_CLOEXEC)
+        _ = fcntl(cancellationPipe.fileHandleForWriting.fileDescriptor, F_SETFD, FD_CLOEXEC)
     }
 
     var cancellationDescriptor: Int32 {
@@ -389,7 +403,7 @@ private final class CodexAppServerProcessLifecycle: @unchecked Sendable {
             let exited = reapIfExitedLocked(processID: processID)
             lock.unlock()
             if exited { return }
-            Darwin.usleep(10_000)
+            usleep(10_000)
         }
 
         lock.lock()
@@ -420,7 +434,7 @@ private final class CodexAppServerProcessLifecycle: @unchecked Sendable {
     private func reapIfExitedLocked(processID: pid_t) -> Bool {
         var status: Int32 = 0
         while true {
-            let result = Darwin.waitpid(processID, &status, WNOHANG)
+            let result = waitpid(processID, &status, WNOHANG)
             if result == processID {
                 markReapedLocked()
                 return true
@@ -441,7 +455,7 @@ private final class CodexAppServerProcessLifecycle: @unchecked Sendable {
     private func reapBlocking(processID: pid_t) {
         var status: Int32 = 0
         while true {
-            let result = Darwin.waitpid(processID, &status, 0)
+            let result = waitpid(processID, &status, 0)
             if result == processID || (result == -1 && errno == ECHILD) {
                 lock.lock()
                 markReapedLocked()
@@ -509,7 +523,7 @@ private final class LineRPCClient {
         ]
         let milliseconds = Int32(min(remaining * 1_000, Double(Int32.max)))
         let pollResult = descriptors.withUnsafeMutableBufferPointer {
-            Darwin.poll($0.baseAddress, nfds_t($0.count), max(1, milliseconds))
+            poll($0.baseAddress, nfds_t($0.count), max(1, milliseconds))
         }
         if pollResult == 0 { throw AccountUsageError.timedOut }
         if pollResult < 0 {
@@ -519,7 +533,7 @@ private final class LineRPCClient {
         if descriptors[1].revents != 0 { throw CancellationError() }
 
         var bytes = [UInt8](repeating: 0, count: 8_192)
-        let count = Darwin.read(output.fileDescriptor, &bytes, bytes.count)
+        let count = read(output.fileDescriptor, &bytes, bytes.count)
         guard count > 0 else { throw AccountUsageError.providerUnavailable }
         buffer.append(bytes, count: count)
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -1,6 +1,10 @@
 import Foundation
 import Dispatch
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import VibeBuddyKit
 
 /// Pure, incremental decoder for Codex rollout JSONL. Codex Desktop writes this
@@ -594,6 +598,7 @@ public struct CodexRolloutParser: Sendable {
     }
 }
 
+#if canImport(Darwin)
 private final class RolloutFileWatcher: @unchecked Sendable {
     private let source: DispatchSourceFileSystemObject
     private let cancelled = DispatchGroup()
@@ -604,7 +609,7 @@ private final class RolloutFileWatcher: @unchecked Sendable {
         onEvent: @escaping @Sendable (UInt) -> Void,
         onCancel: @escaping @Sendable () -> Void
     ) {
-        let descriptor = Darwin.open(file.path, O_EVTONLY)
+        let descriptor = open(file.path, O_EVTONLY)
         guard descriptor >= 0 else { return nil }
         source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: descriptor,
@@ -614,7 +619,7 @@ private final class RolloutFileWatcher: @unchecked Sendable {
         cancelled.enter()
         source.setEventHandler { [source] in onEvent(source.data.rawValue) }
         source.setCancelHandler { [cancelled] in
-            Darwin.close(descriptor)
+            close(descriptor)
             onCancel()
             cancelled.leave()
         }
@@ -626,6 +631,23 @@ private final class RolloutFileWatcher: @unchecked Sendable {
         cancelled.wait()
     }
 }
+#else
+/// Linux has no `DispatchSource` kqueue file-system watcher. The initializer
+/// returns nil so `ensureWatcher` degrades to the monitor's polling/recovery
+/// task, which already exists as the slow-path backstop on macOS.
+private final class RolloutFileWatcher: @unchecked Sendable {
+    init?(
+        file: URL,
+        queue: DispatchQueue,
+        onEvent: @escaping @Sendable (UInt) -> Void,
+        onCancel: @escaping @Sendable () -> Void
+    ) {
+        return nil
+    }
+
+    func cancelAndWait() {}
+}
+#endif
 
 /// Runtime evidence for the monitor's low-power and resource-lifecycle contract.
 public struct CodexRolloutMonitorDiagnostics: Equatable, Sendable {
@@ -876,12 +898,14 @@ public actor CodexRolloutMonitor {
     ) {
         guard isRunning, watchers[path]?.id == id else { return }
         watcherEventCount += 1
+        #if canImport(Darwin)
         let events = DispatchSource.FileSystemEvent(rawValue: rawEvents)
         if !events.intersection([.delete, .rename, .revoke]).isEmpty,
            let registration = watchers.removeValue(forKey: path) {
             watcherRecoveryCount += 1
             registration.watcher.cancelAndWait()
         }
+        #endif
         scheduleDebouncedRefresh(path: path)
     }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GlanceMode.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GlanceMode.swift
@@ -1,3 +1,5 @@
+// CoreGraphics (CGFloat) drives the macOS notch-glance geometry; excluded on Linux.
+#if canImport(CoreGraphics)
 import CoreGraphics
 
 /// How the glance renders: hugging the hardware notch, or a floating pill.
@@ -6,3 +8,4 @@ public enum GlanceMode: Sendable {
     case notch, pill
     public static func from(topInset: CGFloat) -> GlanceMode { topInset > 0 ? .notch : .pill }
 }
+#endif

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokACPClient.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokACPClient.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 
 /// One newline-delimited JSON-RPC exchange with `grok agent --no-leader stdio`.
@@ -86,7 +90,9 @@ final class GrokACPClient: @unchecked Sendable {
         if cancelledBeforeInstall { throw CancellationError() }
 
         let inputDescriptor = input.fileHandleForWriting.fileDescriptor
-        _ = Darwin.fcntl(inputDescriptor, F_SETNOSIGPIPE, 1)
+        #if canImport(Darwin)
+        _ = fcntl(inputDescriptor, F_SETNOSIGPIPE, 1)
+        #endif
         for request in requests {
             try write(request, to: inputDescriptor)
         }
@@ -103,7 +109,11 @@ final class GrokACPClient: @unchecked Sendable {
             guard let baseAddress = bytes.baseAddress else { return }
             var written = 0
             while written < bytes.count {
+                #if canImport(Darwin)
                 let count = Darwin.write(descriptor, baseAddress.advanced(by: written), bytes.count - written)
+                #else
+                let count = Glibc.write(descriptor, baseAddress.advanced(by: written), bytes.count - written)
+                #endif
                 if count > 0 {
                     written += count
                     continue
@@ -133,14 +143,14 @@ final class GrokACPClient: @unchecked Sendable {
             var descriptors = [pollfd(fd: descriptor, events: Int16(POLLIN | POLLHUP), revents: 0)]
             let milliseconds = Int32(min(remaining * 1_000, Double(Int32.max)))
             let pollResult = descriptors.withUnsafeMutableBufferPointer {
-                Darwin.poll($0.baseAddress, nfds_t($0.count), max(1, milliseconds))
+                poll($0.baseAddress, nfds_t($0.count), max(1, milliseconds))
             }
             if pollResult == 0 { throw AccountUsageError.timedOut }
             if pollResult < 0 {
                 if errno == EINTR { continue }
                 throw AccountUsageError.unknown
             }
-            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            let count = read(descriptor, &bytes, bytes.count)
             if count < 0, errno == EINTR { continue }
             guard count > 0 else {
                 if cancellationRequested { throw CancellationError() }
@@ -157,15 +167,15 @@ final class GrokACPClient: @unchecked Sendable {
         try? output.fileHandleForReading.close()
         let graceDeadline = ContinuousClock.now + .milliseconds(200)
         while process.isRunning, ContinuousClock.now < graceDeadline {
-            Darwin.usleep(5_000)
+            usleep(5_000)
         }
         if process.isRunning { process.terminate() }
         let terminationDeadline = ContinuousClock.now + .milliseconds(200)
         while process.isRunning, ContinuousClock.now < terminationDeadline {
-            Darwin.usleep(5_000)
+            usleep(5_000)
         }
         if process.isRunning {
-            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+            _ = kill(process.processIdentifier, SIGKILL)
         }
         process.waitUntilExit()
         lock.lock()

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 
 /// Pure mapping from Grok Build's billing payloads onto `AccountUsageSnapshot`.

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/LANAddress.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/LANAddress.swift
@@ -1,6 +1,8 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
+#else
+import Glibc
 #endif
 
 /// Finds the Mac's LAN IPv4 to put in the pairing QR.
@@ -27,11 +29,17 @@ public enum LANAddress {
             defer { cursor = ptr.pointee.ifa_next }
             guard let addr = ptr.pointee.ifa_addr,
                   addr.pointee.sa_family == sa_family_t(AF_INET),
-                  (Int32(ptr.pointee.ifa_flags) & IFF_UP) == IFF_UP
+                  (Int32(ptr.pointee.ifa_flags) & Int32(IFF_UP)) == Int32(IFF_UP)
             else { continue }
 
+            #if canImport(Darwin)
+            let addrLen = socklen_t(addr.pointee.sa_len)
+            #else
+            // Linux `sockaddr` has no `sa_len`; the family is AF_INET here.
+            let addrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+            #endif
             var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-            if getnameinfo(addr, socklen_t(addr.pointee.sa_len),
+            if getnameinfo(addr, addrLen,
                            &host, socklen_t(host.count), nil, 0, NI_NUMERICHOST) == 0 {
                 candidates.append((String(cString: ptr.pointee.ifa_name), Self.string(from: host)))
             }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/LifecycleJournal.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/LifecycleJournal.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import VibeBuddyKit
 
 /// One privacy-minimized lifecycle transition. The journal deliberately stores
@@ -177,7 +181,7 @@ struct LifecycleJournal {
         let stagingURL = directory.appendingPathComponent(
             ".\(url.lastPathComponent).\(UUID().uuidString).tmp"
         )
-        let descriptor = Darwin.open(
+        let descriptor = open(
             stagingURL.path,
             O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
             mode_t(0o600)
@@ -187,24 +191,24 @@ struct LifecycleJournal {
         var isOpen = true
         var stagingExists = true
         defer {
-            if isOpen { _ = Darwin.close(descriptor) }
-            if stagingExists { _ = stagingURL.path.withCString(Darwin.unlink) }
+            if isOpen { _ = close(descriptor) }
+            if stagingExists { _ = stagingURL.path.withCString(unlink) }
         }
 
-        guard Darwin.fchmod(descriptor, mode_t(0o600)) == 0 else {
+        guard fchmod(descriptor, mode_t(0o600)) == 0 else {
             throw Self.currentPOSIXError()
         }
         try Self.requireOwnerOnly(descriptor)
         try Self.writeAll(data, to: descriptor)
-        guard Darwin.fsync(descriptor) == 0 else { throw Self.currentPOSIXError() }
+        guard fsync(descriptor) == 0 else { throw Self.currentPOSIXError() }
         try Self.requireOwnerOnly(descriptor)
-        let closeResult = Darwin.close(descriptor)
+        let closeResult = close(descriptor)
         isOpen = false
         guard closeResult == 0 else { throw Self.currentPOSIXError() }
 
         guard stagingURL.path.withCString({ stagingPath in
             url.path.withCString { destinationPath in
-                Darwin.rename(stagingPath, destinationPath)
+                rename(stagingPath, destinationPath)
             }
         }) == 0 else {
             throw Self.currentPOSIXError()
@@ -217,7 +221,7 @@ struct LifecycleJournal {
             guard var cursor = buffer.baseAddress else { return }
             var remaining = buffer.count
             while remaining > 0 {
-                let written = Darwin.write(descriptor, cursor, remaining)
+                let written = write(descriptor, cursor, remaining)
                 if written < 0, errno == EINTR { continue }
                 guard written > 0 else { throw currentPOSIXError() }
                 cursor = cursor.advanced(by: written)
@@ -228,7 +232,7 @@ struct LifecycleJournal {
 
     private static func requireOwnerOnly(_ descriptor: Int32) throws {
         var status = stat()
-        guard Darwin.fstat(descriptor, &status) == 0 else { throw currentPOSIXError() }
+        guard fstat(descriptor, &status) == 0 else { throw currentPOSIXError() }
         guard status.st_mode & mode_t(0o777) == mode_t(0o600) else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(EPERM))
         }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/NotificationDelivery.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/NotificationDelivery.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Honest send outcomes. API success is never a device receipt — that would
 /// claim the banner was shown, which this process cannot know.
@@ -114,7 +117,28 @@ public protocol APNsHTTPClient: Sendable {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)
 }
 
+#if canImport(FoundationNetworking)
+// swift-corelibs-foundation on Linux lacks the async `data(for:)` overload, so
+// bridge the completion-handler API into the async requirement.
+extension URLSession: APNsHTTPClient {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = dataTask(with: request) { data, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let data, let response {
+                    continuation.resume(returning: (data, response))
+                } else {
+                    continuation.resume(throwing: URLError(.badServerResponse))
+                }
+            }
+            task.resume()
+        }
+    }
+}
+#else
 extension URLSession: APNsHTTPClient {}
+#endif
 
 /// Latches one diagnostic per failure reason. Recovery (`scheduled` / `accepted`)
 /// clears health. This never posts a notification of its own.

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/POSIXCommandSupervisor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/POSIXCommandSupervisor.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 
 enum POSIXCommandError: Error {
@@ -26,7 +30,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
     private var cancellationDescriptors = [Int32](repeating: -1, count: 2)
 
     init() throws {
-        guard Darwin.pipe(&cancellationDescriptors) == 0 else {
+        guard pipe(&cancellationDescriptors) == 0 else {
             throw POSIXCommandError.spawnFailed
         }
         do {
@@ -43,7 +47,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
 
     deinit {
         for descriptor in cancellationDescriptors where descriptor >= 0 {
-            _ = Darwin.close(descriptor)
+            _ = close(descriptor)
         }
     }
 
@@ -56,7 +60,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
         }
         guard shouldWake else { return }
         var byte: UInt8 = 1
-        _ = Darwin.write(cancellationDescriptors[1], &byte, 1)
+        _ = write(cancellationDescriptors[1], &byte, 1)
     }
 
     func run(
@@ -209,7 +213,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
         let remaining = max(0, deadline.timeIntervalSinceNow)
         let milliseconds = Int32(max(1, min(50, remaining * 1_000)))
         let result = descriptors.withUnsafeMutableBufferPointer {
-            Darwin.poll($0.baseAddress, nfds_t($0.count), milliseconds)
+            poll($0.baseAddress, nfds_t($0.count), milliseconds)
         }
         if result < 0, errno != EINTR { throw POSIXCommandError.waitFailed }
     }
@@ -221,8 +225,8 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
     ) throws -> SpawnedCommand {
         var stdoutDescriptors = [Int32](repeating: -1, count: 2)
         var stderrDescriptors = [Int32](repeating: -1, count: 2)
-        guard Darwin.pipe(&stdoutDescriptors) == 0 else { throw POSIXCommandError.spawnFailed }
-        guard Darwin.pipe(&stderrDescriptors) == 0 else {
+        guard pipe(&stdoutDescriptors) == 0 else { throw POSIXCommandError.spawnFailed }
+        guard pipe(&stderrDescriptors) == 0 else {
             closeIfOpen(&stdoutDescriptors[0])
             closeIfOpen(&stdoutDescriptors[1])
             throw POSIXCommandError.spawnFailed
@@ -237,7 +241,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
             closeIfOpen(&stderrDescriptors[1])
             throw error
         }
-        var nullDescriptor = Darwin.open("/dev/null", O_RDONLY)
+        var nullDescriptor = open("/dev/null", O_RDONLY)
         guard nullDescriptor >= 0 else {
             closeIfOpen(&stdoutDescriptors[0])
             closeIfOpen(&stdoutDescriptors[1])
@@ -246,7 +250,11 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
             throw POSIXCommandError.spawnFailed
         }
 
+        #if canImport(Darwin)
         var actions: posix_spawn_file_actions_t? = nil
+        #else
+        var actions = posix_spawn_file_actions_t()
+        #endif
         guard posix_spawn_file_actions_init(&actions) == 0 else {
             closeIfOpen(&stdoutDescriptors[0])
             closeIfOpen(&stdoutDescriptors[1])
@@ -257,7 +265,11 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
         }
         defer { posix_spawn_file_actions_destroy(&actions) }
 
+        #if canImport(Darwin)
         var attributes: posix_spawnattr_t? = nil
+        #else
+        var attributes = posix_spawnattr_t()
+        #endif
         guard posix_spawnattr_init(&attributes) == 0 else {
             closeIfOpen(&stdoutDescriptors[0])
             closeIfOpen(&stdoutDescriptors[1])
@@ -324,8 +336,8 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
                     executableURL.path,
                     &actions,
                     &attributes,
-                    argumentsBuffer.baseAddress,
-                    environmentBuffer.baseAddress
+                    argumentsBuffer.baseAddress!,
+                    environmentBuffer.baseAddress!
                 )
             }
         }
@@ -348,8 +360,15 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
     private static func childHasExited(_ processID: pid_t) throws -> Bool {
         var info = siginfo_t()
         while true {
-            let result = Darwin.waitid(P_PID, id_t(processID), &info, WEXITED | WNOHANG | WNOWAIT)
+            let result = waitid(P_PID, id_t(processID), &info, WEXITED | WNOHANG | WNOWAIT)
+            #if canImport(Darwin)
             if result == 0 { return info.si_pid == processID }
+            #else
+            // Linux `siginfo_t` keeps `si_pid` in an anonymous union Swift does not
+            // surface; a peeked exit for our P_PID target sets `si_signo` to SIGCHLD,
+            // while WNOHANG with no state change zeroes it.
+            if result == 0 { return info.si_signo == SIGCHLD }
+            #endif
             if errno == EINTR { continue }
             throw POSIXCommandError.waitFailed
         }
@@ -364,7 +383,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
         guard descriptor >= 0, !reachedEOF else { return }
         var bytes = [UInt8](repeating: 0, count: 8_192)
         while true {
-            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            let count = read(descriptor, &bytes, bytes.count)
             if count > 0 {
                 guard count <= remainingOutputBytes else {
                     throw POSIXCommandError.outputLimitExceeded
@@ -395,7 +414,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
         remainingOutputBytes: inout Int,
         deadline: Date
     ) {
-        _ = Darwin.kill(-processID, SIGTERM)
+        _ = kill(-processID, SIGTERM)
         let graceDeadline = min(deadline, Date().addingTimeInterval(0.2))
         while Date() < graceDeadline {
             var stdoutEOF = stdoutDescriptor < 0
@@ -412,9 +431,9 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
                 reachedEOF: &stderrEOF,
                 remainingOutputBytes: &remainingOutputBytes
             )
-            Darwin.usleep(10_000)
+            usleep(10_000)
         }
-        _ = Darwin.kill(-processID, SIGKILL)
+        _ = kill(-processID, SIGKILL)
     }
 
     private static func terminateAndReap(
@@ -441,7 +460,7 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
     private static func reap(_ processID: pid_t) throws -> Int32 {
         var status: Int32 = 0
         while true {
-            let result = Darwin.waitpid(processID, &status, 0)
+            let result = waitpid(processID, &status, 0)
             if result == processID { return status }
             if result == -1, errno == EINTR { continue }
             throw POSIXCommandError.waitFailed
@@ -450,18 +469,18 @@ final class POSIXCommandSupervisor: @unchecked Sendable {
 
     private static func closeIfOpen(_ descriptor: inout Int32) {
         if descriptor >= 0 {
-            _ = Darwin.close(descriptor)
+            _ = close(descriptor)
             descriptor = -1
         }
     }
 
     private static func configureNonBlocking(_ descriptor: Int32) throws {
-        guard Darwin.fcntl(descriptor, F_SETFD, FD_CLOEXEC) == 0 else {
+        guard fcntl(descriptor, F_SETFD, FD_CLOEXEC) == 0 else {
             throw POSIXCommandError.spawnFailed
         }
-        let flags = Darwin.fcntl(descriptor, F_GETFL)
+        let flags = fcntl(descriptor, F_GETFL)
         guard flags >= 0,
-              Darwin.fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
+              fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
             throw POSIXCommandError.spawnFailed
         }
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/Pairing.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/Pairing.swift
@@ -1,6 +1,8 @@
 import Foundation
+#if canImport(CoreImage)
 import CoreImage
 import CoreGraphics
+#endif
 import VibeBuddyKit
 
 /// Builds the pairing payload and its QR image. The phone scans the QR, decodes
@@ -17,6 +19,7 @@ public enum Pairing {
         return String(decoding: data, as: UTF8.self)
     }
 
+#if canImport(CoreImage)
     /// Render a string into a QR CGImage (10x scaled, black-on-white).
     /// CIQRCodeGenerator outputs black modules on a *transparent* background, so
     /// we composite over opaque white — otherwise it's invisible/unscannable on
@@ -31,4 +34,5 @@ public enum Pairing {
         let scaled = onWhite.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
         return CIContext().createCGImage(scaled, from: scaled.extent)
     }
+#endif
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SingleInstanceLock.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SingleInstanceLock.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 
 /// A process-local owner for an advisory file lock. Keep the returned object

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/TerminalJumper.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/TerminalJumper.swift
@@ -1,3 +1,6 @@
+// TerminalJumper raises macOS terminal windows via AppKit/NSWorkspace and is
+// excluded from the Linux build; the daemon falls back to a no-op jump there.
+#if canImport(AppKit)
 import AppKit
 import Foundation
 import VibeBuddyKit
@@ -391,3 +394,5 @@ public enum TerminalJumper {
             .first?.activate(options: [.activateAllWindows]) ?? false
     }
 }
+
+#endif

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -47,7 +47,14 @@ public struct VibeBuddyServer: Sendable {
                 approvalContext: ApprovalContextStore = ApprovalContextStore(),
                 approvalTimeout: Duration = .seconds(25),
                 approvalID: @escaping @Sendable () -> String = { UUID().uuidString },
-                onJump: @escaping @Sendable (TerminalRef) async -> JumpOutcome = { await TerminalJumper.jump($0) },
+                onJump: @escaping @Sendable (TerminalRef) async -> JumpOutcome = {
+                    #if canImport(AppKit)
+                    await TerminalJumper.jump($0)
+                    #else
+                    _ = $0
+                    return .unsupported
+                    #endif
+                },
                 onAnswer: @escaping @Sendable (TerminalRef, String) -> Void = { ref, answer in TerminalInjector.inject(answer, into: ref) },
                 onDevicePaired: @escaping @Sendable (DeviceRegistrationPayload) -> Void = { _ in }) {
         self.store = store

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/APNsLiveTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/APNsLiveTests.swift
@@ -1,5 +1,8 @@
 import Testing
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import VibeBuddyMacCore
 
 /// Live diagnostic: only runs when APNS_* env vars are set. Sends a push to a

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 import Testing
 import VibeBuddyKit
@@ -489,7 +493,7 @@ struct AccountUsageTests {
         barrier.releaseWorker()
         try? await Task.sleep(for: .milliseconds(300))
         if let cancellationPID {
-            #expect(Darwin.kill(cancellationPID, 0) == 0)
+            #expect(kill(cancellationPID, 0) == 0)
         }
         signalGate.allowTermination()
         await cancellationRequest.value
@@ -726,7 +730,7 @@ struct AccountUsageTests {
         guard let pid else { return }
         for _ in 0..<500 {
             errno = 0
-            if Darwin.kill(pid, 0) == -1, errno == ESRCH { return }
+            if kill(pid, 0) == -1, errno == ESRCH { return }
             try? await Task.sleep(for: .milliseconds(10))
         }
         Issue.record("process \(pid) was never reaped")
@@ -829,7 +833,7 @@ private final class ProcessSignalGate: @unchecked Sendable {
         lock.lock()
         signals.append(signal)
         lock.unlock()
-        return Darwin.kill(processID, signal)
+        return kill(processID, signal)
     }
 
     func waitUntilTerminationStarts() async {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -1,6 +1,13 @@
 import Testing
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import NIOCore
 import Hummingbird
 import HummingbirdTesting
@@ -308,24 +315,30 @@ private enum HookTestError: Error { case noFreePort }
 /// An ephemeral port the kernel just handed out — closed again before use, so
 /// the server can claim it. Good enough for a single-process test.
 private func freePort() throws -> Int {
-    let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+    #if canImport(Darwin)
+    let fd = socket(AF_INET, SOCK_STREAM, 0)
+    #else
+    let fd = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+    #endif
     guard fd >= 0 else { throw HookTestError.noFreePort }
-    defer { Darwin.close(fd) }
+    defer { close(fd) }
     var addr = sockaddr_in()
+    #if canImport(Darwin)
     addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    #endif
     addr.sin_family = sa_family_t(AF_INET)
     addr.sin_addr.s_addr = in_addr_t(0)   // INADDR_ANY
     addr.sin_port = 0
     let bound = withUnsafePointer(to: &addr) {
         $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-            Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
         }
     }
     guard bound == 0 else { throw HookTestError.noFreePort }
     var out = sockaddr_in()
     var len = socklen_t(MemoryLayout<sockaddr_in>.size)
     let named = withUnsafeMutablePointer(to: &out) {
-        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.getsockname(fd, $0, &len) }
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(fd, $0, &len) }
     }
     guard named == 0 else { throw HookTestError.noFreePort }
     return Int(UInt16(bigEndian: out.sin_port))

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -1,3 +1,8 @@
+// This suite drives the Codex Desktop rollout file-watcher, which is built on the
+// Apple-only DispatchSource kqueue mechanism. On Linux the monitor intentionally
+// falls back to polling (no per-file watcher), so these watcher-count assertions
+// do not apply there.
+#if canImport(Darwin)
 import Foundation
 import Testing
 import VibeBuddyKit
@@ -699,3 +704,5 @@ private func eventually(
     }
     return await condition()
 }
+
+#endif

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GlanceModeTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GlanceModeTests.swift
@@ -1,3 +1,4 @@
+#if canImport(CoreGraphics)
 import Testing
 import Foundation
 @testable import VibeBuddyMacCore
@@ -10,3 +11,4 @@ struct GlanceModeTests {
     @Test("zero top inset (no notch) → .pill")
     func pill() { #expect(GlanceMode.from(topInset: 0) == .pill) }
 }
+#endif

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 import Testing
 @testable import VibeBuddyMacCore
@@ -253,7 +257,7 @@ struct GrokUsageProviderTests {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
         ))
         errno = 0
-        #expect(Darwin.kill(pid, 0) == -1)
+        #expect(kill(pid, 0) == -1)
         #expect(errno == ESRCH)
     }
 
@@ -284,11 +288,11 @@ struct GrokUsageProviderTests {
         await #expect(throws: (any Error).self) { try await fetch.value }
 
         if let pid {
-            for _ in 0..<200 where Darwin.kill(pid, 0) == 0 {
+            for _ in 0..<200 where kill(pid, 0) == 0 {
                 try? await Task.sleep(for: .milliseconds(10))
             }
             errno = 0
-            #expect(Darwin.kill(pid, 0) == -1)
+            #expect(kill(pid, 0) == -1)
             #expect(errno == ESRCH)
         }
     }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/NotificationDeliveryTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/NotificationDeliveryTests.swift
@@ -1,5 +1,8 @@
 import Crypto
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 import VibeBuddyKit
 @testable import VibeBuddyMacCore

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PairingTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PairingTests.swift
@@ -53,8 +53,10 @@ struct PairingTests {
         #expect(decoded == payload)
     }
 
+    #if canImport(CoreImage)
     @Test("a QR image is generated from a string")
     func qrImage() {
         #expect(Pairing.qrImage(from: "vibebuddy://pair") != nil)
     }
+    #endif
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TerminalJumperTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TerminalJumperTests.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit)
 import Testing
 import VibeBuddyKit
 @testable import VibeBuddyMacCore
@@ -288,3 +289,4 @@ struct TerminalJumperTests {
                 == .unsupported)
     }
 }
+#endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

This repo is a macOS/iOS Swift app, but Cloud Agents run on Linux. This PR makes the **cross-platform subset** of the codebase fully usable on a Linux Cloud Agent so agents can build, test, and actually **run** the daemon here — while the Xcode apps remain macOS-only.

On Ubuntu 24.04 with Swift 6.3.3 this branch now:
- Builds and tests `VibeBuddyKit` (shared wire model): **218 tests pass**.
- Builds and **runs** the `vibebuddyd` daemon from `VibeBuddyMac` (Hummingbird/NIO/swift-crypto are Linux-native): **406 tests pass**.
- Keeps the Python/Bash agent-hook tooling working (it already ran on Linux).

## Changes

All source changes are portability guards; no macOS/iOS behavior changes (every `#if canImport(...)` branch is true on Apple platforms).

- `VibeBuddyKit`: guard `Security` (Keychain → in-memory fallback on Linux), `SwiftUI`, and the `URLSessionWebSocketTask`-based realtime voice clients (`canImport(Darwin)`); the provider-agnostic event/protocol types stay cross-platform.
- `VibeBuddyMac` (daemon core): `Darwin`/`Glibc` import shims; `FoundationNetworking` + an async `URLSession` shim for APNs; `posix_spawn` file-actions/attr optionality and `siginfo_t` handling; `LANAddress` `IFF_UP`/`sa_len` differences; guard AppKit `TerminalJumper`, CoreImage QR in `Pairing`, CoreGraphics `GlanceMode` (server `onJump` → `.unsupported` on Linux); the Codex Desktop rollout watcher (DispatchSource kqueue) is Apple-only, Linux uses the existing polling fallback.
- Tests: matching guards; the kqueue-watcher suite is scoped to Apple platforms.
- `.cursor/environment.json` + `.cursor/install.sh`: install the Swift toolchain and swift-crypto's C/C++ deps (`libstdc++-14-dev` matches the bundled clang's GCC selection), then warm both package builds. Idempotent, repo-managed (activates on merge).

## Validation

Local (this VM):
- `swift test` VibeBuddyKit → **218 passed**; VibeBuddyMac → **406 passed**.
- Ran `vibebuddyd`, POSTed real Claude-shape hook events; the reducer bucketed sessions into needs-response / working / done with correct project/model/summary; token gating returns **401**.
- `python3 hooks/test_install_agent_hooks.py` → pass.

Environment builds (`.cursor` config, both from my branch):
- Snapshot-based build `bld-20260903-7e17fe39` → **SUCCEEDED**.
- Cold build with no snapshot `bld-20260903-740f2018` → **SUCCEEDED** (downloaded Swift 6.3.3 from scratch, built both packages).
- A fresh Cloud Agent booted from the build passed all runtime checks: Swift 6.3.3, 218 VibeBuddyKit tests, `vibebuddyd` build + end-to-end hook→snapshot (S1=needsResponse, S2=done), 401 gating, and the Python hook test.

## Out of scope

The macOS menu-bar app and iOS app (`VibeBuddyMacApp`, `VibeBuddyApp`, xcodegen) still require a macOS host with Xcode and cannot be built on a Linux Cloud Agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b327bf9a-32e9-4da8-b6c4-f8e76f1c9871?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b327bf9a-32e9-4da8-b6c4-f8e76f1c9871&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

