### PR TITLE
fix(mac): fail closed on empty bearer token, shared Bool-default helper, deterministic child-reaping test

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
@@ -547,3 +547,11 @@ public enum NotificationQuietMode {
         return quietHours.isQuiet(at: now, calendar: calendar)
     }
 }
+
+extension UserDefaults {
+    /// A Bool default that treats an absent key as `fallback` (so first launch
+    /// reads as on/off per the caller's choice, not always `false`).
+    public func bool(forKey key: String, default fallback: Bool) -> Bool {
+        object(forKey: key) == nil ? fallback : bool(forKey: key)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -463,6 +463,12 @@ struct BearerAuth: Sendable {
     let allowsQueryToken: Bool
 
     func authorizes(_ request: Request) -> Bool {
+        // An empty configured token must never authorize anything (an empty
+        // `Authorization: Bearer ` header or `?token=` would otherwise match it).
+        // Fail closed rather than `precondition`: the menu-bar app's TokenStore
+        // always yields a non-empty token, but `vibebuddyd` takes VIBEBUDDY_TOKEN
+        // from the environment and an empty value must 401, not kill the process.
+        guard !token.isEmpty else { return false }
         if request.headers[.authorization] == "Bearer \(token)" { return true }
         if allowsQueryToken, request.uri.queryParameters["token"].map(String.init) == token { return true }
         return false

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -157,10 +157,20 @@ struct AccountUsageTests {
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
 
+        // Outcomes below are decided by the thrown error / decoded snapshot, never
+        // by elapsed wall-clock time: a regression that waits for pipe EOF or the
+        // full timeout surfaces as `.timedOut` instead of the expected result.
+        // Timeouts are long enough that a loaded test host cannot hit them on the
+        // success path, leaked sleeps outlive the timeout so a leak cannot look
+        // like success, and the child's exit is polled (bounded) in expectProcessExited.
         let timeoutPIDFile = directory.appendingPathComponent("timeout.pid")
-        let timeoutProvider = claudeSleepingProvider(pidFile: timeoutPIDFile, timeout: 0.1)
+        let timeoutProvider = claudeSleepingProvider(pidFile: timeoutPIDFile, timeout: 1)
+        let timeoutFetch = Task { try await timeoutProvider.fetch() }
+        // The child must have written its pid before the timeout kills it, or
+        // there is nothing to check for reaping.
+        #expect(await waitForPID(in: timeoutPIDFile) != nil)
         do {
-            _ = try await timeoutProvider.fetch()
+            _ = try await timeoutFetch.value
             Issue.record("Expected a timeout")
         } catch let error as AccountUsageError {
             #expect(error == .timedOut)
@@ -186,12 +196,11 @@ struct AccountUsageTests {
         let overflowProvider = ClaudeCLIUsageProvider(
             executableURL: URL(fileURLWithPath: "/bin/sh"),
             arguments: [
-                "-c", "echo $$ > \"$1\"; (yes o | head -c 700000) & (yes e | head -c 700000 >&2) & wait; exec sleep 5",
+                "-c", "echo $$ > \"$1\"; (yes o | head -c 700000) & (yes e | head -c 700000 >&2) & wait; exec sleep 30",
                 "vibebuddy-test", overflowPIDFile.path,
             ],
-            timeout: 2
+            timeout: 5
         )
-        let overflowStarted = ContinuousClock.now
         do {
             _ = try await overflowProvider.fetch()
             Issue.record("Expected the output limit to be enforced")
@@ -200,7 +209,6 @@ struct AccountUsageTests {
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
-        #expect(ContinuousClock.now - overflowStarted < .seconds(2))
         await expectProcessExited(pidFile: overflowPIDFile)
 
         let descendantPIDFile = directory.appendingPathComponent("descendant.pid")
@@ -215,31 +223,29 @@ struct AccountUsageTests {
         let inheritedWriterProvider = ClaudeCLIUsageProvider(
             executableURL: URL(fileURLWithPath: "/bin/sh"),
             arguments: [
-                "-c", "(trap '' TERM; exec sleep 5) & echo $! > \"$1\"; exec /usr/bin/printf '%s' \"$2\"",
+                "-c", "(trap '' TERM; exec sleep 30) & echo $! > \"$1\"; exec /usr/bin/printf '%s' \"$2\"",
                 "vibebuddy-test", descendantPIDFile.path,
                 liveEnvelope.map { String(decoding: $0, as: UTF8.self) } ?? "",
             ],
-            timeout: 1
+            timeout: 5
         )
-        let inheritedWriterStarted = ContinuousClock.now
         do {
             let snapshot = try await inheritedWriterProvider.fetch()
             #expect(snapshot.primary?.usedPercent == 10)
         } catch {
             Issue.record("Inherited writer should be cleaned up after valid output: \(error)")
         }
-        #expect(ContinuousClock.now - inheritedWriterStarted < .seconds(1))
         await expectProcessExited(pidFile: descendantPIDFile)
 
         let detachedPIDFile = directory.appendingPathComponent("detached-descendant.pid")
         let detachedProvider = ClaudeCLIUsageProvider(
             executableURL: URL(fileURLWithPath: "/bin/sh"),
             arguments: [
-                "-c", "(trap '' TERM; exec sleep 5 </dev/null >/dev/null 2>&1) & echo $! > \"$1\"; exec /usr/bin/printf '%s' \"$2\"",
+                "-c", "(trap '' TERM; exec sleep 30 </dev/null >/dev/null 2>&1) & echo $! > \"$1\"; exec /usr/bin/printf '%s' \"$2\"",
                 "vibebuddy-test", detachedPIDFile.path,
                 liveEnvelope.map { String(decoding: $0, as: UTF8.self) } ?? "",
             ],
-            timeout: 1
+            timeout: 5
         )
         do {
             let snapshot = try await detachedProvider.fetch()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/VibeBuddyServerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/VibeBuddyServerTests.swift
@@ -281,4 +281,26 @@ struct VibeBuddyServerTests {
             }
         }
     }
+
+    @Test("/snapshot does not accept the token as a ?token= query param")
+    func snapshotRejectsQueryToken() async throws {
+        try await server(token: "t0k").buildApplication().test(.router) { client in
+            try await client.execute(uri: "/snapshot?token=t0k", method: .get) { res in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
+
+    @Test("an empty configured token fails closed on both auth surfaces")
+    func emptyTokenFailsClosed() async throws {
+        try await server(token: "").buildApplication().test(.router) { client in
+            try await client.execute(uri: "/snapshot", method: .get,
+                                     headers: [.authorization: "Bearer "]) { res in
+                #expect(res.status == .unauthorized)
+            }
+            try await client.execute(uri: "/hook?token=", method: .post) { res in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
 }

--- a/VibeBuddyMacApp/Sources/AccountUsageCoordinator.swift
+++ b/VibeBuddyMacApp/Sources/AccountUsageCoordinator.swift
@@ -27,9 +27,9 @@ final class AccountUsageCoordinator: ObservableObject {
     init(store: SessionStore, notifier: UserNotificationsNotifier) {
         self.store = store
         self.notifier = notifier
-        let codexEnabled = Self.loadBool(Self.enabledKey(for: .codex), default: true)
-        let claudeEnabled = Self.loadBool(Self.enabledKey(for: .claude), default: true)
-        let grokEnabled = Self.loadBool(Self.enabledKey(for: .grok), default: true)
+        let codexEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey(for: .codex), default: true)
+        let claudeEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey(for: .claude), default: true)
+        let grokEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey(for: .grok), default: true)
         collectionEnabled = [
             .codex: codexEnabled,
             .claude: claudeEnabled,
@@ -179,13 +179,6 @@ final class AccountUsageCoordinator: ObservableObject {
         for window in windows {
             notifier.notifyUsage(provider: provider, window: window, threshold: threshold)
         }
-    }
-
-    /// A Bool default that treats an absent key as `default` (so first launch is on).
-    private static func loadBool(_ key: String, default fallback: Bool) -> Bool {
-        UserDefaults.standard.object(forKey: key) == nil
-            ? fallback
-            : UserDefaults.standard.bool(forKey: key)
     }
 
     private static func loadAlertedWindows() -> Set<String> {

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -104,7 +104,7 @@ final class MenuBarModel: ObservableObject {
         let base: CGFloat = saved > 0 ? saved : Self.defaultGlanceScale()
         // Snap to one of the 3 presets so the menu Picker selection always matches.
         glanceScale = [0.8, 1.0, 1.2].min(by: { abs($0 - base) < abs($1 - base) }) ?? 1.0
-        showGlance = Self.loadBool("showGlance", default: true)
+        showGlance = UserDefaults.standard.bool(forKey: "showGlance", default: true)
         openDashboardHotkey = Hotkey.loadOpenDashboard()
         toggleGlanceHotkey = Hotkey.loadToggleGlance()
         usage = AccountUsageCoordinator(store: store, notifier: notifier)
@@ -159,11 +159,6 @@ final class MenuBarModel: ObservableObject {
                 NotificationCenter.default.post(name: .openDashboard, object: nil)
             }
         }
-    }
-
-    /// A Bool default that treats an absent key as `default` (so first launch is on).
-    private static func loadBool(_ key: String, default fallback: Bool) -> Bool {
-        UserDefaults.standard.object(forKey: key) == nil ? fallback : UserDefaults.standard.bool(forKey: key)
     }
 
     /// Quiet right now if the user toggled it, or the nightly window is active.


### PR DESCRIPTION
Follow-up hardening for #9 and #10, plus the one known flaky test.

## Hardening (`8ad7ddb`)
- `BearerAuth.authorizes` returns `false` when the configured token is empty, so an empty `Authorization: Bearer ` header or `?token=` can never match. **Fail closed, not `precondition()`**: the menu-bar app's `TokenStore.loadOrCreate()` (falls back to `Token.generate()`) always yields a non-empty token, but `vibebuddyd` reads `VIBEBUDDY_TOKEN` from the environment, and `VIBEBUDDY_TOKEN=` would have killed the process at startup. Every request 401s instead.
- New test: `/snapshot` (authed group) rejects `?token=`. `hookAuthed` (`/hook`, `/approval`, `/terminal`) is untouched and still accepts the query token (ADR-0009, Qwen-style native http hooks).
- New test: empty configured token 401s on both surfaces.
- `UserDefaults.bool(forKey:default:)` in `VibeBuddyMacCore` replaces the two identical private `loadBool` copies in `MenuBarModel` and `AccountUsageCoordinator`. Same semantics (absent key → default, present → stored). Only `extension UserDefaults` in the repo; the `default:` label does not collide with Foundation.

## Flaky test (`008ec00`)
`AccountUsageTests` "Claude CLI timeout and cancellation reap their child process" decided outcomes by wall-clock (0.1s timeout racing the child's pid-file write; `< 1s` / `< 2s` elapsed asserts). Now every outcome is decided by the thrown error or decoded snapshot; child exit is polled (bounded) as before. Timeouts widened to 5s, leaked sleeps lengthened to 30s so a leak surfaces as `.timedOut` rather than a slow pass, and the timeout case waits for the pid file before the timeout can kill the child.

## Verification
- `VibeBuddyKit` swift test: 218 tests / 26 suites passed
- `VibeBuddyMac` swift test ×2: 461 tests / 44 suites passed both times (459 baseline + 2 new)
- `VibeBuddyMacApp` xcodegen + xcodebuild Debug: BUILD SUCCEEDED

Automated tests only; not exercised in a running app.
