### PR TITLE
feat(codex): jump to a Desktop thread in ChatGPT.app instead of hiding the button

### DIFF
--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -374,9 +374,10 @@ final class DashboardStore: ObservableObject {
 
     func jump(_ sessionId: String) {
         guard let pairing else { showToast(String(localized: "Couldn't reach your Mac")); return }
+        let desktopThread = allSessions.first { $0.id == sessionId }?.jumpsToDesktopThread ?? false
         Task {
             let outcome = await decisionClient.jump(pairing, sessionId: sessionId)
-            showToast(Self.jumpMessage(outcome))
+            showToast(Self.jumpMessage(outcome, desktopThread: desktopThread))
         }
     }
 
@@ -405,7 +406,19 @@ final class DashboardStore: ObservableObject {
     /// say so; `nil` means the Mac wasn't reachable. `activatedApp` is the case
     /// worth naming: the right app is now in front, but the session's own window
     /// wasn't reachable, so the user still has to find the tab themselves.
-    static func jumpMessage(_ outcome: JumpOutcome?) -> String {
+    static func jumpMessage(_ outcome: JumpOutcome?, desktopThread: Bool = false) -> String {
+        // A Codex Desktop session has no terminal at either end: the Mac opened
+        // its thread in ChatGPT, so saying "terminal" here would name a thing
+        // the user never had.
+        if desktopThread {
+            switch outcome {
+            case .focused:      return String(localized: "Opened the thread in ChatGPT on your Mac")
+            case .activatedApp: return String(localized: "Opened ChatGPT on your Mac — find the thread there")
+            case .unsupported:  return String(localized: "Couldn't open the thread — is ChatGPT running on your Mac?")
+            case .noTerminal:   return String(localized: "No thread for this session")
+            case nil:           return String(localized: "Couldn't reach your Mac")
+            }
+        }
         switch outcome {
         case .focused:      return String(localized: "Focused the terminal on your Mac")
         case .activatedApp: return String(localized: "Opened the app on your Mac — find the tab there")

--- a/VibeBuddyApp/Sources/DashboardView.swift
+++ b/VibeBuddyApp/Sources/DashboardView.swift
@@ -295,10 +295,13 @@ private struct SessionRow: View {
                     .padding(.top, 2)
                 }
 
-                if session.terminalRef != nil {
-                    Button("Jump to terminal") { dashboard.jump(session.id) }
-                        .buttonStyle(.bordered).font(.subheadline)
-                        .padding(.top, 4)
+                if session.canJump {
+                    Button(session.jumpsToDesktopThread
+                           ? "Open thread in ChatGPT" : "Jump to terminal") {
+                        dashboard.jump(session.id)
+                    }
+                    .buttonStyle(.bordered).font(.subheadline)
+                    .padding(.top, 4)
                 }
             }
         }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -326,6 +326,13 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     public var pendingApproval: PendingApproval?
     public var pendingQuestion: PendingQuestion?
     public var terminalRef: TerminalRef?
+    /// The Codex Desktop thread this session *is*, when it was observed from a
+    /// rollout rather than a terminal. Codex Desktop runs no CLI hook, so such a
+    /// session never gets a `terminalRef` and there is no window to script —
+    /// but the thread id (which is the session id) addresses the conversation
+    /// itself, and ChatGPT.app opens it from `codex://threads/<id>`. Optional so
+    /// payloads from older Macs decode as "not a Desktop session".
+    public var desktopThreadID: String?
     public var summary: String?
     public var tokens: Int?
     /// Context consumed on the last turn (input + cache_read + cache_creation)
@@ -369,6 +376,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         pendingApproval: PendingApproval? = nil,
         pendingQuestion: PendingQuestion? = nil,
         terminalRef: TerminalRef? = nil,
+        desktopThreadID: String? = nil,
         summary: String? = nil,
         tokens: Int? = nil,
         contextTokens: Int? = nil,
@@ -393,6 +401,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.pendingApproval = pendingApproval
         self.pendingQuestion = pendingQuestion
         self.terminalRef = terminalRef
+        self.desktopThreadID = desktopThreadID
         self.summary = summary
         self.tokens = tokens
         self.contextTokens = contextTokens
@@ -407,6 +416,16 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.statusSince = statusSince
         self.updatedAt = updatedAt
     }
+
+    /// Whether a jump has anywhere to land: a terminal to raise, or a Codex
+    /// Desktop thread to open. The one thing every jump control is gated on, so
+    /// a Desktop session's button is live for the same reason a terminal
+    /// session's is — there is a real target behind it.
+    public var canJump: Bool { terminalRef != nil || desktopThreadID != nil }
+
+    /// A jump to this session lands in ChatGPT.app's thread view, not a
+    /// terminal. Drives the wording and the symbol of every jump control.
+    public var jumpsToDesktopThread: Bool { terminalRef == nil && desktopThreadID != nil }
 
     /// Whether to treat this session as failed/stuck (Optional `failed` is "no").
     public var isStuck: Bool { failed == true }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexDesktopJumper.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexDesktopJumper.swift
@@ -1,0 +1,67 @@
+import AppKit
+import Foundation
+import VibeBuddyKit
+
+/// Jumps to a Codex Desktop session by opening its thread in ChatGPT.app.
+///
+/// Desktop sessions are observed from `~/.codex/sessions` rollouts, not from a
+/// CLI hook, so there is no `TerminalRef` and no window to script. What they do
+/// have is a thread id — the rollout's own session id — and ChatGPT.app claims
+/// the `codex` URL scheme, which makes `codex://threads/<id>` an exact target:
+/// it both raises the app and switches it to that conversation.
+///
+/// The URL is delivered to ChatGPT.app's bundle rather than handed to a generic
+/// `open`. LaunchServices on a machine that has updated ChatGPT a few times
+/// keeps several stale claims on `codex:` (this Mac has four), and resolving the
+/// scheme by policy could land the jump in a copy that no longer exists.
+public enum CodexDesktopJumper {
+
+    /// ChatGPT.app. The bundle id is `com.openai.codex` — the Codex team's, not
+    /// the chat app's, which is why it does not read like ChatGPT.
+    public static let chatGPTBundleID = "com.openai.codex"
+
+    /// `codex://threads/<id>`, or nil when the id is not one.
+    ///
+    /// Thread ids are UUIDs. They are checked against a closed allowlist rather
+    /// than escaped, on the same principle as the terminal jumper: the value
+    /// arrives from a file on disk, and nothing that isn't recognisably an id
+    /// should be able to steer a URL we hand to another application.
+    static func threadURL(_ threadID: String) -> URL? {
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-")
+        guard !threadID.isEmpty, threadID.count <= 128,
+              threadID.allSatisfy(allowed.contains) else { return nil }
+        return URL(string: "codex://threads/\(threadID)")
+    }
+
+    /// Open a thread and report what that achieved.
+    ///
+    /// `.focused` is the honest verdict for a success: unlike a terminal, where
+    /// raising the app rarely means raising the session's own surface, the URL
+    /// names the conversation itself — ChatGPT comes forward showing that thread.
+    ///
+    /// ChatGPT.app must already be running, exactly as a terminal must: opening
+    /// the URL would otherwise launch it, and a jump that starts an app is a
+    /// different action from returning to work in progress. Not running, not
+    /// installed, or an open that fails all report `.unsupported`, which the UI
+    /// words as a thread that couldn't be opened rather than failing silently.
+    public static func jump(threadID: String) async -> JumpOutcome {
+        guard let url = threadURL(threadID),
+              let application = NSWorkspace.shared.urlForApplication(withBundleIdentifier: chatGPTBundleID),
+              !NSRunningApplication.runningApplications(withBundleIdentifier: chatGPTBundleID).isEmpty
+        else { return .unsupported }
+        return await open(url, in: application) ? .focused : .unsupported
+    }
+
+    /// Hands the URL to one specific application bundle and waits for
+    /// LaunchServices to say whether it took it.
+    private static func open(_ url: URL, in application: URL) async -> Bool {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        return await withCheckedContinuation { continuation in
+            NSWorkspace.shared.open([url], withApplicationAt: application,
+                                    configuration: configuration) { _, error in
+                continuation.resume(returning: error == nil)
+            }
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -202,12 +202,17 @@ public struct CodexRolloutParser: Sendable {
         childAction: HookEvent.ChildLifecycleAction? = nil,
         enrichment: TranscriptInfo? = nil
     ) -> HookEvent {
+        // Every event that reaches here comes from a rollout the parser has
+        // already classified as Codex Desktop, so the session id is also the
+        // thread id ChatGPT.app opens — the one jump target these sessions have.
         HookEvent(kind: kind, sessionID: sessionID, agent: .codex,
                   cwd: cwd, toolName: toolName, message: message, model: model,
+                  observationSource: .rollout,
                   toolError: toolError, timestamp: timestamp,
                   childID: childID, childKind: childKind, childName: childName,
                   childType: childType, childAction: childAction,
-                  enrichment: enrichment)
+                  enrichment: enrichment,
+                  desktopThreadID: sessionID)
     }
 
     private struct PendingCollab {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
@@ -60,6 +60,12 @@ public struct HookEvent: Sendable, Equatable {
     /// (the Codex rollout's `token_count`). Applied through the reducer's
     /// enrichment path, never as a progress transition.
     public let enrichment: TranscriptInfo?
+    /// The Codex Desktop thread this event belongs to. Only the rollout tailer
+    /// sets it, and only for sessions the rollout itself declares as Desktop —
+    /// which is the sole place that fact is known. Nil everywhere else, and the
+    /// reducer reads it as "this session is a Desktop thread, jumpable through
+    /// ChatGPT.app rather than through a terminal".
+    public let desktopThreadID: String?
 
     public init(
         kind: Kind,
@@ -79,7 +85,8 @@ public struct HookEvent: Sendable, Equatable {
         childType: String? = nil,
         childAction: ChildLifecycleAction? = nil,
         turnID: String? = nil,
-        enrichment: TranscriptInfo? = nil
+        enrichment: TranscriptInfo? = nil,
+        desktopThreadID: String? = nil
     ) {
         self.kind = kind
         self.sessionID = sessionID
@@ -99,5 +106,6 @@ public struct HookEvent: Sendable, Equatable {
         self.childAction = childAction
         self.turnID = turnID
         self.enrichment = enrichment
+        self.desktopThreadID = desktopThreadID
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -108,6 +108,13 @@ public struct SessionReducer: Sendable {
             applyChildLifecycle(event)
         }
         if event.kind != .sessionEnd {
+            // A Desktop thread id is a durable fact about the session, not about
+            // this event: carry it onto the session so `/jump` can resolve a
+            // target for a source that never runs a hook and so never has a
+            // `terminalRef`.
+            if let thread = event.desktopThreadID {
+                sessions[event.sessionID]?.desktopThreadID = thread
+            }
             recordObservation(
                 sessionID: event.sessionID,
                 source: observationSource ?? event.observationSource ?? .hook,

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -272,6 +272,12 @@ public actor SessionStore {
         reducer.sessions[sessionID]?.terminalRef
     }
 
+    /// The Codex Desktop thread a session is, when it is one. The rollout tailer
+    /// is the only writer, through the events it already sends.
+    public func desktopThreadID(for sessionID: String) -> String? {
+        reducer.sessions[sessionID]?.desktopThreadID
+    }
+
     /// Authoritative read acknowledgement. Snapshot delivery and passive list
     /// visibility never call this; only explicit selection/open/jump actions do.
     @discardableResult

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -32,6 +32,9 @@ public struct VibeBuddyServer: Sendable {
     public let approvalTimeout: Duration
     public let approvalID: @Sendable () -> String
     public let onJump: @Sendable (TerminalRef) async -> JumpOutcome
+    /// The other kind of jump: a Codex Desktop session has no terminal, only the
+    /// thread it *is*, opened in ChatGPT.app.
+    public let onJumpToDesktopThread: @Sendable (String) async -> JumpOutcome
     public let onAnswer: @Sendable (TerminalRef, String) -> Void
     public let onDevicePaired: @Sendable (DeviceRegistrationPayload) -> Void
 
@@ -48,6 +51,7 @@ public struct VibeBuddyServer: Sendable {
                 approvalTimeout: Duration = .seconds(25),
                 approvalID: @escaping @Sendable () -> String = { UUID().uuidString },
                 onJump: @escaping @Sendable (TerminalRef) async -> JumpOutcome = { await TerminalJumper.jump($0) },
+                onJumpToDesktopThread: @escaping @Sendable (String) async -> JumpOutcome = { await CodexDesktopJumper.jump(threadID: $0) },
                 onAnswer: @escaping @Sendable (TerminalRef, String) -> Void = { ref, answer in TerminalInjector.inject(answer, into: ref) },
                 onDevicePaired: @escaping @Sendable (DeviceRegistrationPayload) -> Void = { _ in }) {
         self.store = store
@@ -66,6 +70,7 @@ public struct VibeBuddyServer: Sendable {
         self.approvalTimeout = approvalTimeout
         self.approvalID = approvalID
         self.onJump = onJump
+        self.onJumpToDesktopThread = onJumpToDesktopThread
         self.onAnswer = onAnswer
         self.onDevicePaired = onDevicePaired
     }
@@ -365,6 +370,7 @@ public struct VibeBuddyServer: Sendable {
         }
 
         let onJump = self.onJump
+        let onJumpToDesktopThread = self.onJumpToDesktopThread
         // Terminal-ref capture — bearer-token gated (the capture hook reads the
         // token file and sends it). Without it any local process could hijack a
         // session's terminal target. (daemon-security/01, ADR-0009.)
@@ -402,6 +408,10 @@ public struct VibeBuddyServer: Sendable {
             let outcome: JumpOutcome
             if let ref = await store.terminalRef(for: sid) {
                 outcome = await onJump(ref)
+            } else if let thread = await store.desktopThreadID(for: sid) {
+                // Codex Desktop runs no hook, so this session will never have a
+                // ref; its thread id is the target instead.
+                outcome = await onJumpToDesktopThread(thread)
             } else {
                 outcome = .noTerminal
             }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/JumpRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/JumpRoutesTests.swift
@@ -178,6 +178,47 @@ struct JumpRoutesTests {
         }
     }
 
+    /// A Codex Desktop session is observed from its rollout, never from a hook,
+    /// so `/terminal` is never called for it and the terminal jumper has nothing
+    /// to work with. The route has to resolve its thread instead — that is the
+    /// whole difference between a live jump button and a hidden one.
+    @Test("/jump opens the thread for a Codex Desktop session that has no terminal ref")
+    func jumpsToDesktopThread() async throws {
+        final class Box: @unchecked Sendable {
+            var threads: [String] = []
+            var terminalJumps = 0
+        }
+        let box = Box()
+        let store = SessionStore()
+        let thread = "01a06114-dcc2-7402-8146-169c43e0cd2c"
+        let server = VibeBuddyServer(
+            store: store, token: "t0k",
+            onJump: { _ in box.terminalJumps += 1; return .focused },
+            onJumpToDesktopThread: { box.threads.append($0); return .focused })
+        // The rollout tailer's own path into the store, thread id and all.
+        await store.ingest(HookEvent(kind: .userPromptSubmit, sessionID: thread,
+                                     agent: .codex, cwd: "/x/p",
+                                     observationSource: .rollout,
+                                     timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+                                     desktopThreadID: thread))
+        try await server.buildApplication().test(.router) { client in
+            #expect(await store.terminalRef(for: thread) == nil)
+            try await client.execute(uri: "/jump", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"sessionId":"\#(thread)"}"#)) { res in
+                #expect(res.status == .ok)
+                #expect(self.outcome(res.body) == "focused")
+            }
+        }
+        #expect(box.threads == [thread])
+        #expect(box.terminalJumps == 0)
+        // The phone gates its button on this, so it has to survive to the wire.
+        let session = try #require(await store.snapshot(now: .now).sessions.first)
+        #expect(session.desktopThreadID == thread)
+        #expect(session.canJump)
+        #expect(session.jumpsToDesktopThread)
+    }
+
     @Test("a session with no terminal ref reports noTerminal and never runs the jumper")
     func reportsNoTerminal() async throws {
         final class Box: @unchecked Sendable { var jumped = 0 }

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -374,7 +374,9 @@ private struct DetailView: View {
                             .keyboardShortcut("a", modifiers: []).tint(.green)
                         Button("Deny") { model.decide(approval.id, .deny) }
                             .keyboardShortcut("d", modifiers: []).tint(.red)
-                        Button("Jump to terminal") { model.jump(session) }
+                        Button(session.jumpsToDesktopThread ? "Open thread in ChatGPT" : "Jump to terminal") {
+                            model.jump(session)
+                        }
                     }
                     .buttonStyle(.borderedProminent)
                     HStack(spacing: 10) {
@@ -394,13 +396,15 @@ private struct DetailView: View {
                     }
                 } else {
                     if let s = session.summary { Text(s).foregroundStyle(.secondary) }
-                    Button("Jump to terminal") { model.jump(session) }
+                    Button(session.jumpsToDesktopThread ? "Open thread in ChatGPT" : "Jump to terminal") {
+                        model.jump(session)
+                    }
                 }
                 // What the last jump actually achieved — focused the pane, only
                 // raised the app, or found nothing to raise. Same wording as the
                 // glance rows.
                 if let outcome = model.jumpFeedback[session.id] {
-                    Label(outcome.macMessage(for: session.terminalRef), systemImage: "arrow.uturn.forward")
+                    Label(outcome.macMessage(for: session), systemImage: "arrow.uturn.forward")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .contentTransition(.opacity)

--- a/VibeBuddyMacApp/Sources/GlanceView.swift
+++ b/VibeBuddyMacApp/Sources/GlanceView.swift
@@ -86,13 +86,13 @@ struct GlanceView: View {
                             .tint(.white).buttonStyle(.bordered).controlSize(.regular)
                             .help("Always allow this exact command in future")
                         Button { model.jump(p) } label: {
-                            Label("Jump", systemImage: "terminal")
+                            Label("Jump", systemImage: p.jumpsToDesktopThread ? "bubble.left" : "terminal")
                         }
                         .tint(.white).buttonStyle(.bordered).controlSize(.regular)
-                        .help("Jump to terminal")
+                        .help(p.jumpsToDesktopThread ? "Open this thread in ChatGPT" : "Jump to terminal")
                     }
                     if let outcome = model.jumpFeedback[p.id] {
-                        Text(outcome.macMessage(for: p.terminalRef))
+                        Text(outcome.macMessage(for: p))
                             .font(.system(size: 10 * s, weight: .medium))
                             .foregroundStyle(.white.opacity(0.68))
                     }
@@ -198,22 +198,25 @@ private struct GlanceSessionRow: View {
     private var s: CGFloat { scale }
 
     /// How precisely this row's click can land, told at a glance:
-    /// `terminal` = its own pane/tab, `macwindow` = only the app around it,
-    /// nothing = no terminal was ever recorded. Quiet on purpose — the status
-    /// dot owns the row's colour.
+    /// `terminal` = its own pane/tab, `bubble.left` = its Codex Desktop thread,
+    /// `macwindow` = only the app around it, nothing = no target was ever
+    /// recorded. Quiet on purpose — the status dot owns the row's colour.
     private var targetSymbol: String? {
-        guard let ref = session.terminalRef else { return nil }
+        guard let ref = session.terminalRef else {
+            return session.desktopThreadID != nil ? "bubble.left" : nil
+        }
         if ref.hasExactTarget { return "terminal" }
         return (ref.hostBundleId ?? ref.termProgram) != nil ? "macwindow" : nil
     }
 
     private var subtitle: String {
-        feedback?.macMessage(for: session.terminalRef) ?? ToolActivity.label(for: session)
+        feedback?.macMessage(for: session) ?? ToolActivity.label(for: session)
     }
 
     private var helpText: String {
         switch targetSymbol {
         case "terminal": return "Jump to this session's terminal"
+        case "bubble.left": return "Open this thread in ChatGPT"
         case "macwindow": return "Bring this session's app to the front"
         default: return "No terminal recorded for this session"
         }

--- a/VibeBuddyMacApp/Sources/JumpOutcomeCopy.swift
+++ b/VibeBuddyMacApp/Sources/JumpOutcomeCopy.swift
@@ -6,18 +6,29 @@ import VibeBuddyKit
 /// never reports differently depending on where it was started from.
 ///
 /// The wording promises only what happened: `.focused` means the session's own
-/// pane came forward, `.activatedApp` means we could only raise the app around
-/// it, and the two failure cases say which kind of failure it was.
+/// pane (or, for a Codex Desktop session, its thread) came forward,
+/// `.activatedApp` means we could only raise the app around it, and the two
+/// failure cases say which kind of failure it was.
 extension JumpOutcome {
     @MainActor
-    func macMessage(for ref: TerminalRef?) -> String {
+    func macMessage(for session: AgentSession) -> String {
+        // A Codex Desktop session's jump lands in a ChatGPT thread, not a
+        // terminal, so every outcome has to be worded for where it went.
+        if session.jumpsToDesktopThread {
+            switch self {
+            case .focused: return "Opened thread in ChatGPT"
+            case .activatedApp: return "Brought ChatGPT to front"
+            case .unsupported: return "Couldn't open the thread — is ChatGPT running?"
+            case .noTerminal: return "No thread recorded for this session"
+            }
+        }
         switch self {
         case .focused:
             return "Focused terminal"
         case .activatedApp:
             // The app's own name when macOS can tell us (it is running — that is
             // what `.activatedApp` means), otherwise the honest generic.
-            if let name = ref?.hostBundleId.flatMap(Self.runningAppName) {
+            if let name = session.terminalRef?.hostBundleId.flatMap(Self.runningAppName) {
                 return "Brought \(name) to front"
             }
             return "Brought app to front"

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -378,21 +378,29 @@ final class MenuBarModel: ObservableObject {
     /// Back-compat for voice + existing callers.
     func decide(_ approvalId: String, approve: Bool) { decide(approvalId, approve ? .allow : .deny) }
 
-    /// Jump to a session's terminal without blocking the UI: the click is
-    /// acknowledged immediately and the AppleScript/`tmux` work happens off the
-    /// main actor, publishing what it actually achieved when it lands.
+    /// Jump to where a session lives without blocking the UI: the click is
+    /// acknowledged immediately and the AppleScript/`tmux`/LaunchServices work
+    /// happens off the main actor, publishing what it actually achieved when it
+    /// lands.
     ///
-    /// Never refuses. A session with no ref is a real answer ("no terminal
-    /// recorded"), not a dead control — that silence was the bug.
+    /// Two kinds of target, and a session has at most one. A terminal session
+    /// has a ref; a Codex Desktop session has only the thread it is, which
+    /// ChatGPT.app opens. Never refuses. A session with neither is a real answer
+    /// ("no terminal recorded"), not a dead control — that silence was the bug.
     func jump(_ session: AgentSession) {
         acknowledge(session.id)
-        guard let ref = session.terminalRef else {
+        if let ref = session.terminalRef {
+            Task { [weak self] in
+                let outcome = await TerminalJumper.jump(ref)
+                self?.showJumpFeedback(outcome, for: session.id)
+            }
+        } else if let thread = session.desktopThreadID {
+            Task { [weak self] in
+                let outcome = await CodexDesktopJumper.jump(threadID: thread)
+                self?.showJumpFeedback(outcome, for: session.id)
+            }
+        } else {
             showJumpFeedback(.noTerminal, for: session.id)
-            return
-        }
-        Task { [weak self] in
-            let outcome = await TerminalJumper.jump(ref)
-            self?.showJumpFeedback(outcome, for: session.id)
         }
     }
 


### PR DESCRIPTION
## Summary
- Codex Desktop sessions have a rollout thread id but no `terminalRef`, so the jump control used to vanish. They now carry `desktopThreadID` and jump via `codex://threads/<id>` delivered to the ChatGPT.app bundle (`com.openai.codex`), not a generic `open`.
- Mac and iPhone jump controls gate on `canJump` and word the Desktop case as opening a thread. ChatGPT not running or an open failure reports `.unsupported` instead of failing silently.
- Rebased onto `origin/main` after PR #8. `HookEvent` keeps both `enrichment` and `desktopThreadID`; the rollout `event(...)` helper passes `model`, `enrichment`, `observationSource: .rollout`, and `desktopThreadID`.

## Test plan
- [x] `cd VibeBuddyKit && swift test` — 218 tests / 26 suites
- [x] `cd VibeBuddyMac && swift test` — 466 tests / 44 suites (observation + Jump routes green)
- [x] macOS App Debug build
- [x] iOS Simulator Debug build
- [x] Real jump: `CodexDesktopJumper.jump` on a live Desktop thread id while ChatGPT.app was running → `.focused`, `isActive` false→true
- [ ] iPhone visual / whether ChatGPT actually switched to that thread (window title is just "ChatGPT") — install acceptance


Made with [Cursor](https://cursor.com)