### PR TITLE
Make Codex Desktop observation trustworthy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,7 +63,7 @@ code, and tests — don't drift to synonyms.
 ## Observability (2026-09)
 
 - **ObservationSource / ObservationHealth** — which signal currently backs a
-  session (`hook`, `rollout`, `transcript`, `restored`) plus its last-seen time
+  session (`hook`, `rollout`, `transcript`, `recovery`) plus its last-seen time
   and a health verdict (healthy / degraded / unsupported / eventsMissing). Never
   guessed from process existence; shown in Mac Settings and on session rows.
   One bounded exception: a ChatGPT.app-bundled `codex app-server` probe (and a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,14 @@ code, and tests — don't drift to synonyms.
   session (`hook`, `rollout`, `transcript`, `restored`) plus its last-seen time
   and a health verdict (healthy / degraded / unsupported / eventsMissing). Never
   guessed from process existence; shown in Mac Settings and on session rows.
+  One bounded exception: a ChatGPT.app-bundled `codex app-server` probe (and a
+  missing `thread-writer-locks/<id>.lock`) may only *retire* an already-working
+  Desktop session when that writer is gone. They must not create a session,
+  move one into `working`, or change ObservationHealth.
+- **Abandoned** — a Desktop session that left `working` for `done` because its
+  writer disappeared (Desktop quit/crash, or the thread lock is gone). Carried
+  as `summary == "Abandoned"`. Not `failed`: that flag is a real tool-error
+  signal, and being abandoned is not one.
 - **ChildAgent / childTopologyDegraded** — a subagent, task, or teammate under a
   parent session (`subagent:<id>` / `task:<id>` / `teammate:<team>/<name>`),
   with `running` / `completed` / `unknown`. Missing identity sets the degraded

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -362,6 +362,10 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     /// True when a child event arrived without a stable identity. Optional so
     /// older payloads stay decodable and default to "not degraded".
     public var childTopologyDegraded: Bool?
+    /// True when the Mac probe retired this session. Optional so older
+    /// snapshots decode as a normal completion. Distinct from a real stop
+    /// whose last message happened to be "Abandoned".
+    public var probeRetired: Bool?
     public var statusSince: Date
     public var updatedAt: Date
 
@@ -388,6 +392,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         observations: [ObservationEvidence]? = nil,
         childAgents: [ChildAgent]? = nil,
         childTopologyDegraded: Bool? = nil,
+        probeRetired: Bool? = nil,
         statusSince: Date,
         updatedAt: Date
     ) {
@@ -413,6 +418,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.observations = observations
         self.childAgents = childAgents
         self.childTopologyDegraded = childTopologyDegraded
+        self.probeRetired = probeRetired
         self.statusSince = statusSince
         self.updatedAt = updatedAt
     }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
@@ -136,7 +136,7 @@ public final class SoundPolicy {
         // (`appActive`) or this session's own terminal window is (`focusedSessionIDs`).
         let watching = input.appActive || input.focusedSessionIDs.contains(session.id)
         guard let prev, prev.status != .done, !watching else { return nil }
-        if session.summary == "Abandoned" { return nil }
+        if session.probeRetired == true { return nil }
 
         // Real signal first (a tool/turn error reported by the hook), then the
         // prose heuristic as a fallback. Either way failures ring regardless of runtime.

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
@@ -136,6 +136,7 @@ public final class SoundPolicy {
         // (`appActive`) or this session's own terminal window is (`focusedSessionIDs`).
         let watching = input.appActive || input.focusedSessionIDs.contains(session.id)
         guard let prev, prev.status != .done, !watching else { return nil }
+        if session.summary == "Abandoned" { return nil }
 
         // Real signal first (a tool/turn error reported by the hook), then the
         // prose heuristic as a fallback. Either way failures ring regardless of runtime.

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
@@ -11,9 +11,10 @@ struct SoundPolicyTests {
     private func session(_ id: String, _ status: SessionStatus,
                          wait: WaitKind? = nil,
                          since: TimeInterval = 0,
-                         summary: String? = nil) -> AgentSession {
+                         summary: String? = nil,
+                         probeRetired: Bool? = nil) -> AgentSession {
         AgentSession(id: id, agent: .claudeCode, project: id, status: status,
-                     waitKind: wait, summary: summary,
+                     waitKind: wait, summary: summary, probeRetired: probeRetired,
                      statusSince: Date(timeIntervalSince1970: since),
                      updatedAt: Date(timeIntervalSince1970: since))
     }
@@ -105,7 +106,8 @@ struct SoundPolicyTests {
     func abandonedDoneSilent() {
         let p = SoundPolicy()
         _ = p.evaluate(input([session("a", .working, since: 0)], now: 0))
-        let alerts = p.evaluate(input([session("a", .done, since: 40, summary: "Abandoned")],
+        let alerts = p.evaluate(input([session("a", .done, since: 40, summary: "Abandoned",
+                                               probeRetired: true)],
                                       now: 40, appActive: false))
         #expect(alerts.isEmpty)
     }

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
@@ -101,6 +101,15 @@ struct SoundPolicyTests {
 
     // MARK: done — only when it actually ran, and you're not watching
 
+    @Test("an abandoned writer does not ring agent_done")
+    func abandonedDoneSilent() {
+        let p = SoundPolicy()
+        _ = p.evaluate(input([session("a", .working, since: 0)], now: 0))
+        let alerts = p.evaluate(input([session("a", .done, since: 40, summary: "Abandoned")],
+                                      now: 40, appActive: false))
+        #expect(alerts.isEmpty)
+    }
+
     @Test("done after a >30s run while the app is backgrounded rings agent_done")
     func doneBackgrounded() {
         let p = SoundPolicy()

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutDiscovery.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutDiscovery.swift
@@ -3,9 +3,12 @@ import Foundation
 /// Shared rollout discovery for the Desktop monitor and Settings diagnostics.
 ///
 /// Rollouts live under their *start* date, and a resumed thread keeps appending
-/// to that old file. Both callers must walk the injected `sessions` root
-/// recursively and keep whatever was written inside the recency window — they
-/// must not each invent a date-directory assumption.
+/// to that old file. Both callers walk the injected `sessions` root recursively
+/// — they must not each invent a date-directory assumption.
+///
+/// `candidates` keeps the monitor's recency window (what to tail). `latest` is
+/// unbounded by mtime so diagnostics can still classify a stale rollout after
+/// an app or daemon restart.
 ///
 /// The root is `~/.codex/sessions` (or a test/CODEX_HOME stand-in), never the
 /// Codex home itself: that tree also holds `archived_sessions`, cache, backups,
@@ -34,10 +37,12 @@ enum CodexRolloutDiscovery {
         case unreadable
     }
 
+    /// `window` bounds which files the monitor should tail. Pass `nil` to keep
+    /// every rollout so diagnostics can classify stale evidence after a restart.
     static func candidates(
         in root: URL,
         now: Date,
-        window: TimeInterval = recencyWindow,
+        window: TimeInterval? = recencyWindow,
         fileManager fm: FileManager = .default
     ) -> Lookup {
         guard fm.fileExists(atPath: root.path) else { return .empty }
@@ -79,9 +84,9 @@ enum CodexRolloutDiscovery {
 
             guard url.lastPathComponent.hasPrefix("rollout-"), url.pathExtension == "jsonl",
                   values.isRegularFile == true,
-                  let modified = values.contentModificationDate,
-                  now.timeIntervalSince(modified) <= window
+                  let modified = values.contentModificationDate
             else { continue }
+            if let window, now.timeIntervalSince(modified) > window { continue }
             files.append(Candidate(url: url, modifiedAt: modified))
         }
 
@@ -89,15 +94,15 @@ enum CodexRolloutDiscovery {
         return .found(files)
     }
 
-    /// Diagnostics inspect one file: the newest candidate. Same three-way
-    /// result as `candidates` — `.unreadable` must not collapse into `.empty`.
+    /// Diagnostics inspect one file: the newest rollout by mtime, including
+    /// files outside the monitor recency window. Same three-way result as
+    /// `candidates` — `.unreadable` must not collapse into `.empty`.
     static func latest(
         in root: URL,
         now: Date,
-        window: TimeInterval = recencyWindow,
         fileManager fm: FileManager = .default
     ) -> Latest {
-        switch candidates(in: root, now: now, window: window, fileManager: fm) {
+        switch candidates(in: root, now: now, window: nil, fileManager: fm) {
         case .empty: return .empty
         case .unreadable: return .unreadable
         case .found(let files):

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutDiscovery.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutDiscovery.swift
@@ -26,7 +26,10 @@ enum CodexRolloutDiscovery {
     /// scan that found no files only because some directories could not be read)
     /// must not collapse into `.empty`.
     enum Lookup: Equatable {
-        case found([Candidate])
+        /// `incomplete` is true when some subdirectory could not be read.
+        /// The monitor still tails the accessible files; `latest` treats that
+        /// as `.unreadable` so a hidden newer rollout cannot look healthy.
+        case found([Candidate], incomplete: Bool)
         case empty
         case unreadable
     }
@@ -91,7 +94,7 @@ enum CodexRolloutDiscovery {
         }
 
         if files.isEmpty { return sawUnreadable ? .unreadable : .empty }
-        return .found(files)
+        return .found(files, incomplete: sawUnreadable)
     }
 
     /// Diagnostics inspect one file: the newest rollout by mtime, including
@@ -104,8 +107,8 @@ enum CodexRolloutDiscovery {
     ) -> Latest {
         switch candidates(in: root, now: now, window: nil, fileManager: fm) {
         case .empty: return .empty
-        case .unreadable: return .unreadable
-        case .found(let files):
+        case .unreadable, .found(_, incomplete: true): return .unreadable
+        case .found(let files, incomplete: false):
             guard let newest = files.max(by: { $0.modifiedAt < $1.modifiedAt }) else {
                 return .empty
             }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutDiscovery.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutDiscovery.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Shared rollout discovery for the Desktop monitor and Settings diagnostics.
+///
+/// Rollouts live under their *start* date, and a resumed thread keeps appending
+/// to that old file. Both callers must walk the injected `sessions` root
+/// recursively and keep whatever was written inside the recency window — they
+/// must not each invent a date-directory assumption.
+///
+/// The root is `~/.codex/sessions` (or a test/CODEX_HOME stand-in), never the
+/// Codex home itself: that tree also holds `archived_sessions`, cache, backups,
+/// and memories.
+enum CodexRolloutDiscovery {
+    static let recencyWindow: TimeInterval = 30 * 60
+
+    struct Candidate: Equatable {
+        let url: URL
+        let modifiedAt: Date
+    }
+
+    /// Distinguishes "nothing to see" from "could not look". `FileManager.enumerator`
+    /// skips unreadable subdirectories without error, so an unreadable root (or a
+    /// scan that found no files only because some directories could not be read)
+    /// must not collapse into `.empty`.
+    enum Lookup: Equatable {
+        case found([Candidate])
+        case empty
+        case unreadable
+    }
+
+    enum Latest: Equatable {
+        case found(url: URL, modifiedAt: Date)
+        case empty
+        case unreadable
+    }
+
+    static func candidates(
+        in root: URL,
+        now: Date,
+        window: TimeInterval = recencyWindow,
+        fileManager fm: FileManager = .default
+    ) -> Lookup {
+        guard fm.fileExists(atPath: root.path) else { return .empty }
+        guard isReadableDirectory(root, fileManager: fm) else { return .unreadable }
+
+        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey, .contentModificationDateKey]
+        var files: [Candidate] = []
+        var sawUnreadable = false
+
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in
+                sawUnreadable = true
+                return true
+            }
+        ) else { return .unreadable }
+
+        for case let url as URL in enumerator {
+            let values: URLResourceValues
+            do {
+                values = try url.resourceValues(forKeys: keys)
+            } catch {
+                if url.lastPathComponent.hasPrefix("rollout-"), url.pathExtension == "jsonl" {
+                    return .unreadable
+                }
+                sawUnreadable = true
+                continue
+            }
+
+            if values.isDirectory == true {
+                if !isReadableDirectory(url, fileManager: fm) {
+                    sawUnreadable = true
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
+
+            guard url.lastPathComponent.hasPrefix("rollout-"), url.pathExtension == "jsonl",
+                  values.isRegularFile == true,
+                  let modified = values.contentModificationDate,
+                  now.timeIntervalSince(modified) <= window
+            else { continue }
+            files.append(Candidate(url: url, modifiedAt: modified))
+        }
+
+        if files.isEmpty { return sawUnreadable ? .unreadable : .empty }
+        return .found(files)
+    }
+
+    /// Diagnostics inspect one file: the newest candidate. Same three-way
+    /// result as `candidates` — `.unreadable` must not collapse into `.empty`.
+    static func latest(
+        in root: URL,
+        now: Date,
+        window: TimeInterval = recencyWindow,
+        fileManager fm: FileManager = .default
+    ) -> Latest {
+        switch candidates(in: root, now: now, window: window, fileManager: fm) {
+        case .empty: return .empty
+        case .unreadable: return .unreadable
+        case .found(let files):
+            guard let newest = files.max(by: { $0.modifiedAt < $1.modifiedAt }) else {
+                return .empty
+            }
+            return .found(url: newest.url, modifiedAt: newest.modifiedAt)
+        }
+    }
+
+    static func isReadableDirectory(_ url: URL, fileManager fm: FileManager) -> Bool {
+        guard fm.isReadableFile(atPath: url.path),
+              let attributes = try? fm.attributesOfItem(atPath: url.path),
+              (attributes[.type] as? FileAttributeType) == .typeDirectory,
+              let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue,
+              permissions & 0o444 != 0,
+              permissions & 0o111 != 0 else { return false }
+        return true
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -829,7 +829,7 @@ public actor CodexRolloutMonitor {
     /// never change ObservationHealth. ObservationSource is still never
     /// guessed from process existence — this is a bounded exception for
     /// "the writer is gone, leave working".
-    private let desktopAppServerIdentity: @Sendable () -> CodexDesktopAppServer.Identity?
+    private let desktopAppServerIdentities: @Sendable () -> [CodexDesktopAppServer.Identity]
     private let hasWriterLock: @Sendable (String) -> Bool
     private let watcherQueue = DispatchQueue(
         label: "com.vibebuddy.codex-rollout-watchers",
@@ -858,11 +858,11 @@ public actor CodexRolloutMonitor {
     private var ownerlessObserved: Set<String> = []
     /// Last observed ChatGPT.app-bundled app-server. A different live identity
     /// between scans is a replacement, not continued ownership.
-    private var lastAppServerIdentity: CodexDesktopAppServer.Identity?
-    /// Identity observed when this path last consumed a rollout append.
+    private var lastAppServerIdentities: Set<CodexDesktopAppServer.Identity> = []
+    /// Identities live when this path last consumed a rollout append.
     /// Watcher refreshes stamp `Date()`, so this — not `lastOwnedAt == now` —
     /// is what exempts a resumed turn from replacement marking.
-    private var lastOwnedIdentity: [String: CodexDesktopAppServer.Identity] = [:]
+    private var lastOwnedIdentities: [String: Set<CodexDesktopAppServer.Identity>] = [:]
 
     public init(
         root: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -874,15 +874,15 @@ public actor CodexRolloutMonitor {
         isDesktopAppServerAlive: (@Sendable () -> Bool)? = nil,
         hasWriterLock: (@Sendable (String) -> Bool)? = nil
     ) {
-        let identity: @Sendable () -> CodexDesktopAppServer.Identity?
+        let identities: @Sendable () -> [CodexDesktopAppServer.Identity]
         if let isDesktopAppServerAlive {
-            identity = {
+            identities = {
                 isDesktopAppServerAlive()
-                    ? CodexDesktopAppServer.Identity(pid: 1, startSec: 0, startUsec: 0)
-                    : nil
+                    ? [CodexDesktopAppServer.Identity(pid: 1, startSec: 0, startUsec: 0)]
+                    : []
             }
         } else {
-            identity = { CodexDesktopAppServer.identity() }
+            identities = { CodexDesktopAppServer.identities() }
         }
         self.init(
             root: root,
@@ -890,7 +890,7 @@ public actor CodexRolloutMonitor {
             debounceInterval: debounceInterval,
             recoveryWindow: recoveryWindow,
             ownerlessAfter: ownerlessAfter,
-            desktopAppServerIdentity: identity,
+            desktopAppServerIdentities: identities,
             hasWriterLock: hasWriterLock)
     }
 
@@ -900,7 +900,8 @@ public actor CodexRolloutMonitor {
         debounceInterval: Duration = .milliseconds(100),
         recoveryWindow: TimeInterval = 30 * 60,
         ownerlessAfter: TimeInterval = 60,
-        desktopAppServerIdentity: @escaping @Sendable () -> CodexDesktopAppServer.Identity?,
+        desktopAppServerIdentity: (@Sendable () -> CodexDesktopAppServer.Identity?)? = nil,
+        desktopAppServerIdentities: (@Sendable () -> [CodexDesktopAppServer.Identity])? = nil,
         hasWriterLock: (@Sendable (String) -> Bool)? = nil
     ) {
         self.root = root
@@ -908,7 +909,15 @@ public actor CodexRolloutMonitor {
         self.debounceInterval = debounceInterval
         self.recoveryWindow = recoveryWindow
         self.ownerlessAfter = ownerlessAfter
-        self.desktopAppServerIdentity = desktopAppServerIdentity
+        if let desktopAppServerIdentities {
+            self.desktopAppServerIdentities = desktopAppServerIdentities
+        } else if let desktopAppServerIdentity {
+            self.desktopAppServerIdentities = {
+                desktopAppServerIdentity().map { [$0] } ?? []
+            }
+        } else {
+            self.desktopAppServerIdentities = { CodexDesktopAppServer.identities() }
+        }
         // Production `root` is ~/.codex/sessions; CODEX_HOME and test fixtures
         // follow the same sibling. A missing lock directory is not "no locks".
         let lockRoot = root.deletingLastPathComponent()
@@ -1056,19 +1065,23 @@ public actor CodexRolloutMonitor {
     /// rollout mtime is also ownerless (ChatGPT already relaunched).
     private func retireOwnerless(now: Date, previouslyTracked: Set<String>) -> [HookEvent] {
         var events: [HookEvent] = []
-        let identity = desktopAppServerIdentity()
-        let appServerAlive = identity != nil
-        let firstSighting = lastAppServerIdentity == nil
-        if let previous = lastAppServerIdentity, let identity, previous != identity {
+        let currentIdentities = Set(desktopAppServerIdentities())
+        let appServerAlive = !currentIdentities.isEmpty
+        let firstSighting = lastAppServerIdentities.isEmpty
+        if !lastAppServerIdentities.isEmpty, !currentIdentities.isEmpty,
+           lastAppServerIdentities.isDisjoint(with: currentIdentities) {
             for (path, cursor) in cursors {
-                guard previouslyTracked.contains(path), lastOwnedIdentity[path] != identity else { continue }
+                guard previouslyTracked.contains(path) else { continue }
+                if let owned = lastOwnedIdentities[path], !owned.isDisjoint(with: currentIdentities) {
+                    continue
+                }
                 guard cursor.surfaced, cursor.parser.turnActive, !cursor.parser.awaitingUser,
                       cursor.parser.isDesktopSession
                 else { continue }
                 ownerlessObserved.insert(path)
             }
         }
-        lastAppServerIdentity = identity
+        lastAppServerIdentities = currentIdentities
         for (path, cursor) in cursors {
             guard cursor.surfaced, cursor.parser.turnActive,
                   cursor.parser.isDesktopSession,
@@ -1081,8 +1094,9 @@ public actor CodexRolloutMonitor {
             // Probes may only retire a working turn. A pending approval or
             // request_user_input stays needsResponse until the user answers.
             if cursor.parser.awaitingUser { continue }
-            if firstSighting, let identity,
-               let modified = Self.fileModifiedAt(path), identity.startedAt > modified {
+            if firstSighting, !currentIdentities.isEmpty,
+               let modified = Self.fileModifiedAt(path),
+               currentIdentities.allSatisfy({ $0.startedAt > modified }) {
                 ownerlessObserved.insert(path)
             }
             if !appServerAlive || !hasWriterLock(sessionID) {
@@ -1138,7 +1152,7 @@ public actor CodexRolloutMonitor {
                 cursor.checkpoint = Self.checkpoint(file: file, endingAt: cursor.offset)
                 ownerlessObserved.remove(path)
                 lastOwnedAt[path] = now
-                lastOwnedIdentity[path] = desktopAppServerIdentity()
+                lastOwnedIdentities[path] = Set(desktopAppServerIdentities())
             }
             cursor.identity = state.identity
             cursors[path] = cursor
@@ -1257,7 +1271,7 @@ public actor CodexRolloutMonitor {
     private func removeTracking(path: String) {
         cursors[path] = nil
         lastOwnedAt[path] = nil
-        lastOwnedIdentity[path] = nil
+        lastOwnedIdentities[path] = nil
         ownerlessObserved.remove(path)
         debounceTasks.removeValue(forKey: path)?.task.cancel()
         if let registration = watchers.removeValue(forKey: path) {
@@ -1289,8 +1303,8 @@ public actor CodexRolloutMonitor {
         cursors.removeAll()
         lastOwnedAt.removeAll()
         ownerlessObserved.removeAll()
-        lastOwnedIdentity.removeAll()
-        lastAppServerIdentity = nil
+        lastOwnedIdentities.removeAll()
+        lastAppServerIdentities.removeAll()
         recoveryGateForTesting = nil
         sink = nil
     }
@@ -1397,7 +1411,7 @@ public actor CodexRolloutMonitor {
 /// The ChatGPT.app-bundled `codex` binary. Homebrew CLI and ssh `app-server`
 /// proxies must not count — this machine routinely runs all three.
 enum CodexDesktopAppServer {
-    struct Identity: Equatable, Sendable {
+    struct Identity: Equatable, Hashable, Sendable {
         var pid: pid_t
         var startSec: UInt64
         var startUsec: UInt64
@@ -1407,16 +1421,18 @@ enum CodexDesktopAppServer {
         }
     }
 
-    static func isAlive() -> Bool { identity() != nil }
+    static func isAlive() -> Bool { !identities().isEmpty }
 
-    static func identity() -> Identity? {
+    static func identity() -> Identity? { identities().min(by: { $0.pid < $1.pid }) }
+
+    static func identities() -> [Identity] {
         let needed = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
-        guard needed > 0 else { return nil }
+        guard needed > 0 else { return [] }
         var pids = [pid_t](repeating: 0, count: Int(needed) / MemoryLayout<pid_t>.stride)
         let filled = proc_listpids(
             UInt32(PROC_ALL_PIDS), 0, &pids,
             Int32(pids.count * MemoryLayout<pid_t>.stride))
-        guard filled > 0 else { return nil }
+        guard filled > 0 else { return [] }
         let count = Int(filled) / MemoryLayout<pid_t>.stride
         var pathBuffer = [UInt8](repeating: 0, count: Int(4 * MAXPATHLEN))
         var matches: [Identity] = []
@@ -1434,6 +1450,6 @@ enum CodexDesktopAppServer {
                 startSec: info.pbi_start_tvsec,
                 startUsec: info.pbi_start_tvusec))
         }
-        return matches.min(by: { $0.pid < $1.pid })
+        return matches
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -11,6 +11,9 @@ public struct CodexRolloutParser: Sendable {
     public private(set) var cwd: String?
     public private(set) var isDesktopSession = false
     public private(set) var turnActive = false
+    /// True after an approval or `request_user_input` notification. Probes may
+    /// only retire a `working` turn, so a waiting session is left alone.
+    public private(set) var awaitingUser = false
     /// Latest model named by `turn_context` / `thread_settings_applied`.
     public private(set) var model: String?
     private var tokenRecordCount = 0
@@ -85,14 +88,14 @@ public struct CodexRolloutParser: Sendable {
                 return [event(.stop, sessionID: sessionID,
                               message: "Turn aborted", timestamp: timestamp)]
             case "exec_approval_request":
-                return [event(.notification, sessionID: sessionID, toolName: "Shell",
-                              message: "Permission required for Shell", timestamp: timestamp)]
+                return waiting(event(.notification, sessionID: sessionID, toolName: "Shell",
+                                     message: "Permission required for Shell", timestamp: timestamp))
             case "apply_patch_approval_request":
-                return [event(.notification, sessionID: sessionID, toolName: "File change",
-                              message: "Permission required for file change", timestamp: timestamp)]
+                return waiting(event(.notification, sessionID: sessionID, toolName: "File change",
+                                     message: "Permission required for file change", timestamp: timestamp))
             case "request_user_input", "elicitation_request":
-                return [event(.notification, sessionID: sessionID,
-                              message: "Waiting for your input", timestamp: timestamp)]
+                return waiting(event(.notification, sessionID: sessionID,
+                                     message: "Waiting for your input", timestamp: timestamp))
             case "item_completed":
                 guard let item = payload["item"] as? [String: Any] else { return [] }
                 return eventsForCompletedItem(item, sessionID: sessionID, timestamp: timestamp)
@@ -238,9 +241,10 @@ public struct CodexRolloutParser: Sendable {
         let itemType = payload["type"] as? String ?? "function_call"
         let name = Self.startedToolName(payload, itemType: itemType)
         if name.split(separator: "/").last?.lowercased() == "request_user_input" {
-            return [event(.notification, sessionID: sessionID, toolName: name,
-                          message: "Waiting for your input", timestamp: timestamp)]
+            return waiting(event(.notification, sessionID: sessionID, toolName: name,
+                                 message: "Waiting for your input", timestamp: timestamp))
         }
+        awaitingUser = false
         let namespace = (payload["namespace"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         if namespace?.lowercased() == "collaboration" {
             return eventsForCollabCall(payload, toolName: name, sessionID: sessionID, timestamp: timestamp)
@@ -634,7 +638,13 @@ public struct CodexRolloutParser: Sendable {
         }
     }
 
+    private mutating func waiting(_ event: HookEvent) -> [HookEvent] {
+        awaitingUser = true
+        return [event]
+    }
+
     private mutating func startTurn(_ turnID: String?) {
+        awaitingUser = false
         if let turnID, !turnID.isEmpty { activeTurnIDs.insert(turnID) }
         else { anonymousTurnCount += 1 }
         refreshTurnState()
@@ -666,6 +676,7 @@ public struct CodexRolloutParser: Sendable {
     mutating func abandonActiveTurns() {
         activeTurnIDs.removeAll()
         anonymousTurnCount = 0
+        awaitingUser = false
         refreshTurnState()
     }
 
@@ -1032,7 +1043,8 @@ public actor CodexRolloutMonitor {
         if let previous = lastAppServerIdentity, let identity, previous != identity {
             for (path, cursor) in cursors {
                 guard previouslyTracked.contains(path), lastOwnedAt[path] != now else { continue }
-                guard cursor.surfaced, cursor.parser.turnActive, cursor.parser.isDesktopSession
+                guard cursor.surfaced, cursor.parser.turnActive, !cursor.parser.awaitingUser,
+                      cursor.parser.isDesktopSession
                 else { continue }
                 ownerlessObserved.insert(path)
             }
@@ -1047,6 +1059,9 @@ public actor CodexRolloutMonitor {
                 ownerlessObserved.remove(path)
                 continue
             }
+            // Probes may only retire a working turn. A pending approval or
+            // request_user_input stays needsResponse until the user answers.
+            if cursor.parser.awaitingUser { continue }
             if !appServerAlive || !hasWriterLock(sessionID) {
                 ownerlessObserved.insert(path)
             }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -831,7 +831,10 @@ public actor CodexRolloutMonitor {
     private var watcherEventCount = 0
     private var debouncedRefreshCount = 0
     private var watcherRecoveryCount = 0
-    private var ownerlessSince: [String: Date] = [:]
+    /// Last scan that still saw a writer, or the first ownerless observation
+    /// if this thread was never confirmed owned. The abandon deadline is
+    /// `ownerlessAfter` after that instant — not after the first ownerless scan.
+    private var lastOwnedAt: [String: Date] = [:]
 
     public init(
         root: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -949,6 +952,13 @@ public actor CodexRolloutMonitor {
     /// A Desktop turn with no writer leaves `working` on the existing discovery
     /// cadence (default 30s), not a new one-second poll.
     ///
+    /// The clock starts at the last scan that still saw a writer (or the first
+    /// ownerless observation, if we never saw one). Abandon once that instant
+    /// is `ownerlessAfter` old. Worst case with the default 30s cadence: the
+    /// writer vanishes just after a scan; the pass at +60s retires it. Starting
+    /// the clock on the first ownerless scan would miss that bound by one
+    /// interval (~90s).
+    ///
     /// Lock files persist after turns and their mtime does not follow writes, so
     /// a lock's *presence* is not proof of a writer. A missing lock (only when
     /// the lock directory itself exists), or a dead ChatGPT.app-bundled
@@ -962,22 +972,22 @@ public actor CodexRolloutMonitor {
                   cursor.parser.isDesktopSession,
                   let sessionID = cursor.parser.sessionID
             else {
-                ownerlessSince[path] = nil
+                lastOwnedAt[path] = nil
                 continue
             }
             let ownerless = !appServerAlive || !hasWriterLock(sessionID)
-            guard ownerless else {
-                ownerlessSince[path] = nil
+            if !ownerless {
+                lastOwnedAt[path] = now
                 continue
             }
-            let since = ownerlessSince[path] ?? now
-            ownerlessSince[path] = since
-            guard now.timeIntervalSince(since) >= ownerlessAfter else { continue }
+            let confirmedAt = lastOwnedAt[path] ?? now
+            lastOwnedAt[path] = confirmedAt
+            guard now.timeIntervalSince(confirmedAt) >= ownerlessAfter else { continue }
 
             var updated = cursor
             updated.parser.abandonActiveTurns()
             cursors[path] = updated
-            ownerlessSince[path] = nil
+            lastOwnedAt[path] = nil
             events.append(HookEvent(
                 kind: .stop, sessionID: sessionID, agent: .codex,
                 cwd: cursor.parser.cwd, message: "Abandoned",
@@ -1123,7 +1133,7 @@ public actor CodexRolloutMonitor {
 
     private func removeTracking(path: String) {
         cursors[path] = nil
-        ownerlessSince[path] = nil
+        lastOwnedAt[path] = nil
         debounceTasks.removeValue(forKey: path)?.task.cancel()
         if let registration = watchers.removeValue(forKey: path) {
             registration.watcher.cancelAndWait()
@@ -1152,7 +1162,7 @@ public actor CodexRolloutMonitor {
         eventQueue.removeAll()
         eventQueueHead = 0
         cursors.removeAll()
-        ownerlessSince.removeAll()
+        lastOwnedAt.removeAll()
         recoveryGateForTesting = nil
         sink = nil
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -875,8 +875,9 @@ public actor CodexRolloutMonitor {
     /// between scans is a replacement, not continued ownership.
     private var lastAppServerIdentities: Set<CodexDesktopAppServer.Identity> = []
     /// Identities live when this path was last bootstrapped or consumed an
-    /// append. Watcher refreshes stamp `Date()`, so this — not `lastOwnedAt == now`
-    /// — exempts a resumed turn from replacement marking.
+    /// append, limited to processes that already existed at the file mtime.
+    /// Watcher refreshes stamp `Date()`, so this — not `lastOwnedAt == now` —
+    /// exempts a resumed turn from replacement marking.
     private var lastOwnedIdentities: [String: Set<CodexDesktopAppServer.Identity>] = [:]
 
     public init(
@@ -1285,7 +1286,12 @@ public actor CodexRolloutMonitor {
     }
 
     private func recordOwnedIdentities(path: String) {
-        lastOwnedIdentities[path] = Set(desktopAppServerIdentities())
+        let current = Set(desktopAppServerIdentities())
+        if let modified = Self.fileModifiedAt(path) {
+            lastOwnedIdentities[path] = current.filter { $0.startedAt <= modified }
+        } else {
+            lastOwnedIdentities[path] = current
+        }
     }
 
     private func removeTracking(path: String) {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -859,6 +859,10 @@ public actor CodexRolloutMonitor {
     /// Last observed ChatGPT.app-bundled app-server. A different live identity
     /// between scans is a replacement, not continued ownership.
     private var lastAppServerIdentity: CodexDesktopAppServer.Identity?
+    /// Identity observed when this path last consumed a rollout append.
+    /// Watcher refreshes stamp `Date()`, so this — not `lastOwnedAt == now` —
+    /// is what exempts a resumed turn from replacement marking.
+    private var lastOwnedIdentity: [String: CodexDesktopAppServer.Identity] = [:]
 
     public init(
         root: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -978,6 +982,13 @@ public actor CodexRolloutMonitor {
         )
     }
 
+    /// Watcher debounce calls `refresh` with a wall-clock `Date()` and does
+    /// not run `retireOwnerless`. Tests use this to stamp ownership under a
+    /// replacement identity before the next discovery pass.
+    func consumeForTesting(file: URL, now: Date) -> [HookEvent] {
+        refresh(file: file, now: now, installWatcher: false)
+    }
+
     func invalidateWatcherForTesting(at file: URL) {
         let path = file.path
         watcherRecoveryCount += 1
@@ -1050,7 +1061,7 @@ public actor CodexRolloutMonitor {
         let firstSighting = lastAppServerIdentity == nil
         if let previous = lastAppServerIdentity, let identity, previous != identity {
             for (path, cursor) in cursors {
-                guard previouslyTracked.contains(path), lastOwnedAt[path] != now else { continue }
+                guard previouslyTracked.contains(path), lastOwnedIdentity[path] != identity else { continue }
                 guard cursor.surfaced, cursor.parser.turnActive, !cursor.parser.awaitingUser,
                       cursor.parser.isDesktopSession
                 else { continue }
@@ -1127,6 +1138,7 @@ public actor CodexRolloutMonitor {
                 cursor.checkpoint = Self.checkpoint(file: file, endingAt: cursor.offset)
                 ownerlessObserved.remove(path)
                 lastOwnedAt[path] = now
+                lastOwnedIdentity[path] = desktopAppServerIdentity()
             }
             cursor.identity = state.identity
             cursors[path] = cursor
@@ -1245,6 +1257,7 @@ public actor CodexRolloutMonitor {
     private func removeTracking(path: String) {
         cursors[path] = nil
         lastOwnedAt[path] = nil
+        lastOwnedIdentity[path] = nil
         ownerlessObserved.remove(path)
         debounceTasks.removeValue(forKey: path)?.task.cancel()
         if let registration = watchers.removeValue(forKey: path) {
@@ -1276,6 +1289,7 @@ public actor CodexRolloutMonitor {
         cursors.removeAll()
         lastOwnedAt.removeAll()
         ownerlessObserved.removeAll()
+        lastOwnedIdentity.removeAll()
         lastAppServerIdentity = nil
         recoveryGateForTesting = nil
         sink = nil

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -990,6 +990,7 @@ public actor CodexRolloutMonitor {
         discoveryPassCount += 1
         let files = candidateFiles(now: now)
         let livePaths = Set(files.map(\.path))
+        let previouslyTracked = Set(cursors.keys)
         var result = ScanResult()
         for path in Array(cursors.keys) where !livePaths.contains(path) {
             result.observed.append(contentsOf: endedEvents(path: path, now: now))
@@ -999,7 +1000,7 @@ public actor CodexRolloutMonitor {
         for file in files {
             result.observed.append(contentsOf: refresh(file: file, now: now, installWatcher: installWatchers))
         }
-        result.retired = retireOwnerless(now: now)
+        result.retired = retireOwnerless(now: now, previouslyTracked: previouslyTracked)
         return result
     }
 
@@ -1019,15 +1020,18 @@ public actor CodexRolloutMonitor {
     /// `codex app-server`, is enough to call the thread ownerless. Leftover
     /// locks are ignored once that process is already gone. A live app-server
     /// whose pid/start identity changed between scans is also ownerless — the
-    /// quit-and-relaunch happened between observations. After a thread has
-    /// been observed ownerless, a relaunched app-server plus that leftover lock
-    /// still does not reset the clock — only a rollout append re-arms ownership.
-    private func retireOwnerless(now: Date) -> [HookEvent] {
+    /// quit-and-relaunch happened between observations. A path that was new this
+    /// scan, or that got a rollout append in this same pass, is already owned by
+    /// the replacement server and must not be marked. After a thread has been
+    /// observed ownerless, a relaunched app-server plus that leftover lock still
+    /// does not reset the clock — only a rollout append re-arms ownership.
+    private func retireOwnerless(now: Date, previouslyTracked: Set<String>) -> [HookEvent] {
         var events: [HookEvent] = []
         let identity = desktopAppServerIdentity()
         let appServerAlive = identity != nil
         if let previous = lastAppServerIdentity, let identity, previous != identity {
             for (path, cursor) in cursors {
+                guard previouslyTracked.contains(path), lastOwnedAt[path] != now else { continue }
                 guard cursor.surfaced, cursor.parser.turnActive, cursor.parser.isDesktopSession
                 else { continue }
                 ownerlessObserved.insert(path)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -799,7 +799,12 @@ public actor CodexRolloutMonitor {
         let task: Task<Void, Never>
     }
 
-    private typealias EventSink = @Sendable (HookEvent) async -> Void
+    private struct QueuedEvent {
+        let event: HookEvent
+        let recordsEvidence: Bool
+    }
+
+    private typealias EventSink = @Sendable (HookEvent, Bool) async -> Void
 
     private let root: URL
     private let discoveryInterval: Duration
@@ -822,7 +827,7 @@ public actor CodexRolloutMonitor {
     private var debounceTasks: [String: DebounceRegistration] = [:]
     private var recoveryTask: Task<Void, Never>?
     private var deliveryTask: Task<Void, Never>?
-    private var eventQueue: [HookEvent] = []
+    private var eventQueue: [QueuedEvent] = []
     private var eventQueueHead = 0
     private var recoveryGateForTesting: (@Sendable () async -> Void)?
     private var sink: EventSink?
@@ -870,14 +875,22 @@ public actor CodexRolloutMonitor {
     }
 
     public func run(store: SessionStore) async {
-        await run { event in await store.ingest(event) }
+        await runDelivering { event, recordsEvidence in
+            await store.ingest(event, recordsEvidence: recordsEvidence)
+        }
     }
 
     func run(_ onEvent: @escaping @Sendable (HookEvent) async -> Void) async {
+        await runDelivering { event, _ in await onEvent(event) }
+    }
+
+    private func runDelivering(
+        _ onEvent: @escaping @Sendable (HookEvent, Bool) async -> Void
+    ) async {
         guard !isRunning else { return }
         isRunning = true
         sink = onEvent
-        enqueue(scan(now: Date(), installWatchers: true))
+        enqueueScan(scan(now: Date(), installWatchers: true))
 
         let interval = discoveryInterval
         recoveryTask = Task { [weak self] in
@@ -899,7 +912,7 @@ public actor CodexRolloutMonitor {
     /// One deterministic discovery/recovery pass, public so the file-tail
     /// contract can be tested without timers or a running HTTP server.
     public func poll(now: Date) -> [HookEvent] {
-        scan(now: now, installWatchers: isRunning)
+        scan(now: now, installWatchers: isRunning).events
     }
 
     public func diagnostics() -> CodexRolloutMonitorDiagnostics {
@@ -932,24 +945,30 @@ public actor CodexRolloutMonitor {
         guard isRunning, !Task.isCancelled else { return }
         if let recoveryGateForTesting { await recoveryGateForTesting() }
         guard isRunning, !Task.isCancelled else { return }
-        enqueue(scan(now: now, installWatchers: true))
+        enqueueScan(scan(now: now, installWatchers: true))
     }
 
-    private func scan(now: Date, installWatchers: Bool) -> [HookEvent] {
+    private struct ScanResult {
+        var observed: [HookEvent] = []
+        var retired: [HookEvent] = []
+        var events: [HookEvent] { observed + retired }
+    }
+
+    private func scan(now: Date, installWatchers: Bool) -> ScanResult {
         discoveryPassCount += 1
         let files = candidateFiles(now: now)
         let livePaths = Set(files.map(\.path))
-        var emitted: [HookEvent] = []
+        var result = ScanResult()
         for path in Array(cursors.keys) where !livePaths.contains(path) {
-            emitted.append(contentsOf: endedEvents(path: path, now: now))
+            result.observed.append(contentsOf: endedEvents(path: path, now: now))
             removeTracking(path: path)
         }
 
         for file in files {
-            emitted.append(contentsOf: refresh(file: file, now: now, installWatcher: installWatchers))
+            result.observed.append(contentsOf: refresh(file: file, now: now, installWatcher: installWatchers))
         }
-        emitted.append(contentsOf: retireOwnerless(now: now))
-        return emitted
+        result.retired = retireOwnerless(now: now)
+        return result
     }
 
     /// A Desktop turn with no writer leaves `working` on the existing discovery
@@ -1122,9 +1141,16 @@ public actor CodexRolloutMonitor {
         enqueue(refresh(file: file, now: Date(), installWatcher: true))
     }
 
-    private func enqueue(_ events: [HookEvent]) {
+    private func enqueueScan(_ result: ScanResult) {
+        enqueue(result.observed)
+        enqueue(result.retired, recordsEvidence: false)
+    }
+
+    private func enqueue(_ events: [HookEvent], recordsEvidence: Bool = true) {
         guard isRunning, !events.isEmpty else { return }
-        eventQueue.append(contentsOf: events)
+        eventQueue.append(contentsOf: events.map {
+            QueuedEvent(event: $0, recordsEvidence: recordsEvidence)
+        })
         guard deliveryTask == nil else { return }
         deliveryTask = Task { [weak self] in
             await self?.drainEventQueue()
@@ -1133,9 +1159,9 @@ public actor CodexRolloutMonitor {
 
     private func drainEventQueue() async {
         while !Task.isCancelled, isRunning, eventQueueHead < eventQueue.count, let sink {
-            let event = eventQueue[eventQueueHead]
+            let queued = eventQueue[eventQueueHead]
             eventQueueHead += 1
-            await sink(event)
+            await sink(queued.event, queued.recordsEvidence)
         }
         eventQueue.removeAll(keepingCapacity: isRunning)
         eventQueueHead = 0

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -22,6 +22,8 @@ public struct CodexRolloutParser: Sendable {
     private var contextWindow: Int?
     private var activeTurnIDs: Set<String> = []
     private var anonymousTurnCount = 0
+    /// A tool record after probe retirement, with no new `task_started`.
+    private var resumedActivity = false
     private var pendingCollab: [String: PendingCollab] = [:]
     private var attributedCollabCalls: Set<String> = []
     private var collabChildren: [String: CollabChild] = [:]
@@ -245,6 +247,7 @@ public struct CodexRolloutParser: Sendable {
                                  message: "Waiting for your input", timestamp: timestamp))
         }
         awaitingUser = false
+        rearmIfIdle()
         let namespace = (payload["namespace"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         if namespace?.lowercased() == "collaboration" {
             return eventsForCollabCall(payload, toolName: name, sessionID: sessionID, timestamp: timestamp)
@@ -295,6 +298,7 @@ public struct CodexRolloutParser: Sendable {
         timestamp: Date
     ) -> [HookEvent] {
         awaitingUser = false
+        rearmIfIdle()
         let callID = Self.nonEmpty(payload["call_id"] as? String)
         guard let callID, let pending = pendingCollab.removeValue(forKey: callID) else {
             return [event(.postToolUse, sessionID: sessionID, toolName: "Tool", timestamp: timestamp)]
@@ -355,6 +359,7 @@ public struct CodexRolloutParser: Sendable {
         }
         guard let toolName = Self.completedToolName(item) else { return [] }
         awaitingUser = false
+        rearmIfIdle()
         return [event(.postToolUse, sessionID: sessionID, toolName: toolName,
                       toolError: Self.itemFailed(item), timestamp: timestamp)]
     }
@@ -647,12 +652,14 @@ public struct CodexRolloutParser: Sendable {
 
     private mutating func startTurn(_ turnID: String?) {
         awaitingUser = false
+        resumedActivity = false
         if let turnID, !turnID.isEmpty { activeTurnIDs.insert(turnID) }
         else { anonymousTurnCount += 1 }
         refreshTurnState()
     }
 
     private mutating func finishTurn(_ turnID: String?) {
+        resumedActivity = false
         if let turnID, !turnID.isEmpty {
             activeTurnIDs.remove(turnID)
         } else if anonymousTurnCount > 0 {
@@ -664,13 +671,20 @@ public struct CodexRolloutParser: Sendable {
     }
 
     private mutating func finishUnknownTurn() {
+        resumedActivity = false
         if anonymousTurnCount > 0 { anonymousTurnCount -= 1 }
         else if activeTurnIDs.count == 1 { activeTurnIDs.removeAll() }
         refreshTurnState()
     }
 
     private mutating func refreshTurnState() {
-        turnActive = anonymousTurnCount > 0 || !activeTurnIDs.isEmpty
+        turnActive = anonymousTurnCount > 0 || !activeTurnIDs.isEmpty || resumedActivity
+    }
+
+    private mutating func rearmIfIdle() {
+        guard !turnActive else { return }
+        resumedActivity = true
+        refreshTurnState()
     }
 
     /// Drop every in-flight turn without inventing a Codex completion record.
@@ -679,6 +693,7 @@ public struct CodexRolloutParser: Sendable {
         activeTurnIDs.removeAll()
         anonymousTurnCount = 0
         awaitingUser = false
+        resumedActivity = false
         refreshTurnState()
     }
 
@@ -859,9 +874,9 @@ public actor CodexRolloutMonitor {
     /// Last observed ChatGPT.app-bundled app-server. A different live identity
     /// between scans is a replacement, not continued ownership.
     private var lastAppServerIdentities: Set<CodexDesktopAppServer.Identity> = []
-    /// Identities live when this path last consumed a rollout append.
-    /// Watcher refreshes stamp `Date()`, so this — not `lastOwnedAt == now` —
-    /// is what exempts a resumed turn from replacement marking.
+    /// Identities live when this path was last bootstrapped or consumed an
+    /// append. Watcher refreshes stamp `Date()`, so this — not `lastOwnedAt == now`
+    /// — exempts a resumed turn from replacement marking.
     private var lastOwnedIdentities: [String: Set<CodexDesktopAppServer.Identity>] = [:]
 
     public init(
@@ -1140,6 +1155,7 @@ public actor CodexRolloutMonitor {
                 if let bootstrapped = Self.bootstrap(file: file, state: state, receivedAt: now) {
                     cursor = bootstrapped.cursor
                     emitted = bootstrapped.events
+                    recordOwnedIdentities(path: path)
                 } else {
                     removeTracking(path: path)
                     return []
@@ -1151,13 +1167,14 @@ public actor CodexRolloutMonitor {
                 cursor.checkpoint = Self.checkpoint(file: file, endingAt: cursor.offset)
                 ownerlessObserved.remove(path)
                 lastOwnedAt[path] = now
-                lastOwnedIdentities[path] = Set(desktopAppServerIdentities())
+                recordOwnedIdentities(path: path)
             }
             cursor.identity = state.identity
             cursors[path] = cursor
         } else if let bootstrapped = Self.bootstrap(file: file, state: state, receivedAt: now) {
             cursors[path] = bootstrapped.cursor
             emitted = bootstrapped.events
+            recordOwnedIdentities(path: path)
         }
 
         if installWatcher { ensureWatcher(for: file, identity: state.identity) }
@@ -1265,6 +1282,10 @@ public actor CodexRolloutMonitor {
         eventQueue.removeAll(keepingCapacity: isRunning)
         eventQueueHead = 0
         deliveryTask = nil
+    }
+
+    private func recordOwnedIdentities(path: String) {
+        lastOwnedIdentities[path] = Set(desktopAppServerIdentities())
     }
 
     private func removeTracking(path: String) {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -835,6 +835,9 @@ public actor CodexRolloutMonitor {
     /// if this thread was never confirmed owned. The abandon deadline is
     /// `ownerlessAfter` after that instant — not after the first ownerless scan.
     private var lastOwnedAt: [String: Date] = [:]
+    /// Paths already seen without a writer. A later live app-server plus leftover
+    /// lock does not clear this; only a rollout append (`cursor.consume`) does.
+    private var ownerlessObserved: Set<String> = []
 
     public init(
         root: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -963,7 +966,9 @@ public actor CodexRolloutMonitor {
     /// a lock's *presence* is not proof of a writer. A missing lock (only when
     /// the lock directory itself exists), or a dead ChatGPT.app-bundled
     /// `codex app-server`, is enough to call the thread ownerless. Leftover
-    /// locks are ignored once that process is already gone.
+    /// locks are ignored once that process is already gone. After a thread has
+    /// been observed ownerless, a relaunched app-server plus that leftover lock
+    /// still does not reset the clock — only a rollout append re-arms ownership.
     private func retireOwnerless(now: Date) -> [HookEvent] {
         var events: [HookEvent] = []
         let appServerAlive = isDesktopAppServerAlive()
@@ -973,10 +978,13 @@ public actor CodexRolloutMonitor {
                   let sessionID = cursor.parser.sessionID
             else {
                 lastOwnedAt[path] = nil
+                ownerlessObserved.remove(path)
                 continue
             }
-            let ownerless = !appServerAlive || !hasWriterLock(sessionID)
-            if !ownerless {
+            if !appServerAlive || !hasWriterLock(sessionID) {
+                ownerlessObserved.insert(path)
+            }
+            if !ownerlessObserved.contains(path) {
                 lastOwnedAt[path] = now
                 continue
             }
@@ -988,6 +996,7 @@ public actor CodexRolloutMonitor {
             updated.parser.abandonActiveTurns()
             cursors[path] = updated
             lastOwnedAt[path] = nil
+            ownerlessObserved.remove(path)
             events.append(HookEvent(
                 kind: .stop, sessionID: sessionID, agent: .codex,
                 cwd: cursor.parser.cwd, message: "Abandoned",
@@ -1023,6 +1032,8 @@ public actor CodexRolloutMonitor {
                 cursor.offset += UInt64(appended.count)
                 emitted = cursor.consume(appended, receivedAt: now)
                 cursor.checkpoint = Self.checkpoint(file: file, endingAt: cursor.offset)
+                ownerlessObserved.remove(path)
+                lastOwnedAt[path] = now
             }
             cursor.identity = state.identity
             cursors[path] = cursor
@@ -1134,6 +1145,7 @@ public actor CodexRolloutMonitor {
     private func removeTracking(path: String) {
         cursors[path] = nil
         lastOwnedAt[path] = nil
+        ownerlessObserved.remove(path)
         debounceTasks.removeValue(forKey: path)?.task.cancel()
         if let registration = watchers.removeValue(forKey: path) {
             registration.watcher.cancelAndWait()
@@ -1163,6 +1175,7 @@ public actor CodexRolloutMonitor {
         eventQueueHead = 0
         cursors.removeAll()
         lastOwnedAt.removeAll()
+        ownerlessObserved.removeAll()
         recoveryGateForTesting = nil
         sink = nil
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -840,8 +840,6 @@ public actor CodexRolloutMonitor {
         debounceInterval: Duration = .milliseconds(100),
         recoveryWindow: TimeInterval = 30 * 60,
         ownerlessAfter: TimeInterval = 60,
-        lockRoot: URL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex/thread-writer-locks", isDirectory: true),
         isDesktopAppServerAlive: (@Sendable () -> Bool)? = nil,
         hasWriterLock: (@Sendable (String) -> Bool)? = nil
     ) {
@@ -851,8 +849,16 @@ public actor CodexRolloutMonitor {
         self.recoveryWindow = recoveryWindow
         self.ownerlessAfter = ownerlessAfter
         self.isDesktopAppServerAlive = isDesktopAppServerAlive ?? { CodexDesktopAppServer.isAlive() }
+        // Production `root` is ~/.codex/sessions; CODEX_HOME and test fixtures
+        // follow the same sibling. A missing lock directory is not "no locks".
+        let lockRoot = root.deletingLastPathComponent()
+            .appendingPathComponent("thread-writer-locks", isDirectory: true)
         self.hasWriterLock = hasWriterLock ?? { id in
-            FileManager.default.fileExists(
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: lockRoot.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else { return true }
+            return FileManager.default.fileExists(
                 atPath: lockRoot.appendingPathComponent("\(id).lock").path)
         }
     }
@@ -944,9 +950,10 @@ public actor CodexRolloutMonitor {
     /// cadence (default 30s), not a new one-second poll.
     ///
     /// Lock files persist after turns and their mtime does not follow writes, so
-    /// a lock's *presence* is not proof of a writer. A missing lock, or a dead
-    /// ChatGPT.app-bundled `codex app-server`, is enough to call the thread
-    /// ownerless. Leftover locks are ignored once that process is already gone.
+    /// a lock's *presence* is not proof of a writer. A missing lock (only when
+    /// the lock directory itself exists), or a dead ChatGPT.app-bundled
+    /// `codex app-server`, is enough to call the thread ownerless. Leftover
+    /// locks are ignored once that process is already gone.
     private func retireOwnerless(now: Date) -> [HookEvent] {
         var events: [HookEvent] = []
         let appServerAlive = isDesktopAppServerAlive()

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -294,6 +294,7 @@ public struct CodexRolloutParser: Sendable {
         sessionID: String,
         timestamp: Date
     ) -> [HookEvent] {
+        awaitingUser = false
         let callID = Self.nonEmpty(payload["call_id"] as? String)
         guard let callID, let pending = pendingCollab.removeValue(forKey: callID) else {
             return [event(.postToolUse, sessionID: sessionID, toolName: "Tool", timestamp: timestamp)]
@@ -353,6 +354,7 @@ public struct CodexRolloutParser: Sendable {
             return eventsForCollabItem(item, sessionID: sessionID, timestamp: timestamp)
         }
         guard let toolName = Self.completedToolName(item) else { return [] }
+        awaitingUser = false
         return [event(.postToolUse, sessionID: sessionID, toolName: toolName,
                       toolError: Self.itemFailed(item), timestamp: timestamp)]
     }
@@ -1036,10 +1038,13 @@ public actor CodexRolloutMonitor {
     /// the replacement server and must not be marked. After a thread has been
     /// observed ownerless, a relaunched app-server plus that leftover lock still
     /// does not reset the clock — only a rollout append re-arms ownership.
+    /// On the monitor's first sighting, a live server whose start is after the
+    /// rollout mtime is also ownerless (ChatGPT already relaunched).
     private func retireOwnerless(now: Date, previouslyTracked: Set<String>) -> [HookEvent] {
         var events: [HookEvent] = []
         let identity = desktopAppServerIdentity()
         let appServerAlive = identity != nil
+        let firstSighting = lastAppServerIdentity == nil
         if let previous = lastAppServerIdentity, let identity, previous != identity {
             for (path, cursor) in cursors {
                 guard previouslyTracked.contains(path), lastOwnedAt[path] != now else { continue }
@@ -1062,6 +1067,10 @@ public actor CodexRolloutMonitor {
             // Probes may only retire a working turn. A pending approval or
             // request_user_input stays needsResponse until the user answers.
             if cursor.parser.awaitingUser { continue }
+            if firstSighting, let identity,
+               let modified = Self.fileModifiedAt(path), identity.startedAt > modified {
+                ownerlessObserved.insert(path)
+            }
             if !appServerAlive || !hasWriterLock(sessionID) {
                 ownerlessObserved.insert(path)
             }
@@ -1289,6 +1298,10 @@ public actor CodexRolloutMonitor {
         return files.sorted { $0.path < $1.path }
     }
 
+    private static func fileModifiedAt(_ path: String) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+    }
+
     private static func fileState(_ file: URL) -> FileState? {
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: file.path),
               let size = (attributes[.size] as? NSNumber)?.uint64Value,
@@ -1371,6 +1384,10 @@ enum CodexDesktopAppServer {
         var pid: pid_t
         var startSec: UInt64
         var startUsec: UInt64
+
+        var startedAt: Date {
+            Date(timeIntervalSince1970: TimeInterval(startSec) + TimeInterval(startUsec) / 1_000_000)
+        }
     }
 
     static func isAlive() -> Bool { identity() != nil }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -1080,25 +1080,15 @@ public actor CodexRolloutMonitor {
     }
 
     /// Rollouts live under their *start* date, and a resumed thread keeps
-    /// appending to that old file, so discovery walks every date directory and
-    /// keeps whatever was written inside the recency window.
+    /// appending to that old file. Discovery is the shared recursive walk;
+    /// an already-tracked active turn is retained past the recency window.
     private func candidateFiles(now: Date) -> [URL] {
         let fm = FileManager.default
-        let keys: Set<URLResourceKey> = [.isRegularFileKey, .contentModificationDateKey]
         var files: [URL] = []
-
-        if let enumerator = fm.enumerator(
-            at: root, includingPropertiesForKeys: Array(keys), options: [.skipsHiddenFiles]
+        if case .found(let candidates) = CodexRolloutDiscovery.candidates(
+            in: root, now: now, window: recoveryWindow, fileManager: fm
         ) {
-            for case let url as URL in enumerator {
-                guard url.lastPathComponent.hasPrefix("rollout-"), url.pathExtension == "jsonl",
-                      let values = try? url.resourceValues(forKeys: keys),
-                      values.isRegularFile == true,
-                      let modified = values.contentModificationDate,
-                      now.timeIntervalSince(modified) <= recoveryWindow
-                else { continue }
-                files.append(url)
-            }
+            files = candidates.map(\.url)
         }
         // Retain only active rollouts beyond the recency window. Completed or
         // abandoned files age out, bounding watcher descriptors over time.

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -914,6 +914,9 @@ public actor CodexRolloutMonitor {
             guard FileManager.default.fileExists(atPath: lockRoot.path, isDirectory: &isDirectory),
                   isDirectory.boolValue
             else { return true }
+            // Unreadable/unsearchable is unknown, same as a missing directory —
+            // not proof that this thread has no lock.
+            guard CodexRolloutDiscovery.isReadableDirectory(lockRoot, fileManager: .default) else { return true }
             return FileManager.default.fileExists(
                 atPath: lockRoot.appendingPathComponent("\(id).lock").path)
         }
@@ -1091,7 +1094,7 @@ public actor CodexRolloutMonitor {
                 kind: .stop, sessionID: sessionID, agent: .codex,
                 cwd: cursor.parser.cwd, message: "Abandoned",
                 observationSource: .rollout, timestamp: now,
-                desktopThreadID: sessionID))
+                desktopThreadID: sessionID, probeRetirement: true))
         }
         return events
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -1054,11 +1054,10 @@ public actor CodexRolloutMonitor {
     /// a lock's *presence* is not proof of a writer. A missing lock (only when
     /// the lock directory itself exists), or a dead ChatGPT.app-bundled
     /// `codex app-server`, is enough to call the thread ownerless. Leftover
-    /// locks are ignored once that process is already gone. A live app-server
-    /// whose pid/start identity changed between scans is also ownerless — the
-    /// quit-and-relaunch happened between observations. A path that was new this
-    /// scan, or that got a rollout append in this same pass, is already owned by
-    /// the replacement server and must not be marked. After a thread has been
+    /// locks are ignored once that process is already gone. If any previously
+    /// seen app-server identity disappears while another is still live,
+    /// previously tracked turns become ownerless unless their last append was
+    /// already under a still-live identity. After a thread has been
     /// observed ownerless, a relaunched app-server plus that leftover lock still
     /// does not reset the clock — only a rollout append re-arms ownership.
     /// On the monitor's first sighting, a live server whose start is after the
@@ -1068,8 +1067,8 @@ public actor CodexRolloutMonitor {
         let currentIdentities = Set(desktopAppServerIdentities())
         let appServerAlive = !currentIdentities.isEmpty
         let firstSighting = lastAppServerIdentities.isEmpty
-        if !lastAppServerIdentities.isEmpty, !currentIdentities.isEmpty,
-           lastAppServerIdentities.isDisjoint(with: currentIdentities) {
+        let disappeared = lastAppServerIdentities.subtracting(currentIdentities)
+        if !currentIdentities.isEmpty, !disappeared.isEmpty {
             for (path, cursor) in cursors {
                 guard previouslyTracked.contains(path) else { continue }
                 if let owned = lastOwnedIdentities[path], !owned.isDisjoint(with: currentIdentities) {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -661,6 +661,14 @@ public struct CodexRolloutParser: Sendable {
         turnActive = anonymousTurnCount > 0 || !activeTurnIDs.isEmpty
     }
 
+    /// Drop every in-flight turn without inventing a Codex completion record.
+    /// Used when a Desktop writer is gone; the monitor then emits `stop`.
+    mutating func abandonActiveTurns() {
+        activeTurnIDs.removeAll()
+        anonymousTurnCount = 0
+        refreshTurnState()
+    }
+
     private static func itemFailed(_ item: [String: Any]) -> Bool {
         if let exit = item["exit_code"] as? NSNumber, exit.intValue != 0 { return true }
         if let status = (item["status"] as? String)?.lowercased(),
@@ -797,6 +805,14 @@ public actor CodexRolloutMonitor {
     private let discoveryInterval: Duration
     private let debounceInterval: Duration
     private let recoveryWindow: TimeInterval
+    private let ownerlessAfter: TimeInterval
+    /// Process/lock probes may only retire an already-working Desktop thread.
+    /// They must never create a session, never move one into `working`, and
+    /// never change ObservationHealth. ObservationSource is still never
+    /// guessed from process existence — this is a bounded exception for
+    /// "the writer is gone, leave working".
+    private let isDesktopAppServerAlive: @Sendable () -> Bool
+    private let hasWriterLock: @Sendable (String) -> Bool
     private let watcherQueue = DispatchQueue(
         label: "com.vibebuddy.codex-rollout-watchers",
         qos: .utility
@@ -815,18 +831,30 @@ public actor CodexRolloutMonitor {
     private var watcherEventCount = 0
     private var debouncedRefreshCount = 0
     private var watcherRecoveryCount = 0
+    private var ownerlessSince: [String: Date] = [:]
 
     public init(
         root: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".codex/sessions", isDirectory: true),
         discoveryInterval: Duration = .seconds(30),
         debounceInterval: Duration = .milliseconds(100),
-        recoveryWindow: TimeInterval = 30 * 60
+        recoveryWindow: TimeInterval = 30 * 60,
+        ownerlessAfter: TimeInterval = 60,
+        lockRoot: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/thread-writer-locks", isDirectory: true),
+        isDesktopAppServerAlive: (@Sendable () -> Bool)? = nil,
+        hasWriterLock: (@Sendable (String) -> Bool)? = nil
     ) {
         self.root = root
         self.discoveryInterval = discoveryInterval
         self.debounceInterval = debounceInterval
         self.recoveryWindow = recoveryWindow
+        self.ownerlessAfter = ownerlessAfter
+        self.isDesktopAppServerAlive = isDesktopAppServerAlive ?? { CodexDesktopAppServer.isAlive() }
+        self.hasWriterLock = hasWriterLock ?? { id in
+            FileManager.default.fileExists(
+                atPath: lockRoot.appendingPathComponent("\(id).lock").path)
+        }
     }
 
     public func run(store: SessionStore) async {
@@ -908,7 +936,48 @@ public actor CodexRolloutMonitor {
         for file in files {
             emitted.append(contentsOf: refresh(file: file, now: now, installWatcher: installWatchers))
         }
+        emitted.append(contentsOf: retireOwnerless(now: now))
         return emitted
+    }
+
+    /// A Desktop turn with no writer leaves `working` on the existing discovery
+    /// cadence (default 30s), not a new one-second poll.
+    ///
+    /// Lock files persist after turns and their mtime does not follow writes, so
+    /// a lock's *presence* is not proof of a writer. A missing lock, or a dead
+    /// ChatGPT.app-bundled `codex app-server`, is enough to call the thread
+    /// ownerless. Leftover locks are ignored once that process is already gone.
+    private func retireOwnerless(now: Date) -> [HookEvent] {
+        var events: [HookEvent] = []
+        let appServerAlive = isDesktopAppServerAlive()
+        for (path, cursor) in cursors {
+            guard cursor.surfaced, cursor.parser.turnActive,
+                  cursor.parser.isDesktopSession,
+                  let sessionID = cursor.parser.sessionID
+            else {
+                ownerlessSince[path] = nil
+                continue
+            }
+            let ownerless = !appServerAlive || !hasWriterLock(sessionID)
+            guard ownerless else {
+                ownerlessSince[path] = nil
+                continue
+            }
+            let since = ownerlessSince[path] ?? now
+            ownerlessSince[path] = since
+            guard now.timeIntervalSince(since) >= ownerlessAfter else { continue }
+
+            var updated = cursor
+            updated.parser.abandonActiveTurns()
+            cursors[path] = updated
+            ownerlessSince[path] = nil
+            events.append(HookEvent(
+                kind: .stop, sessionID: sessionID, agent: .codex,
+                cwd: cursor.parser.cwd, message: "Abandoned",
+                observationSource: .rollout, timestamp: now,
+                desktopThreadID: sessionID))
+        }
+        return events
     }
 
     private func refresh(file: URL, now: Date, installWatcher: Bool) -> [HookEvent] {
@@ -1047,6 +1116,7 @@ public actor CodexRolloutMonitor {
 
     private func removeTracking(path: String) {
         cursors[path] = nil
+        ownerlessSince[path] = nil
         debounceTasks.removeValue(forKey: path)?.task.cancel()
         if let registration = watchers.removeValue(forKey: path) {
             registration.watcher.cancelAndWait()
@@ -1075,6 +1145,7 @@ public actor CodexRolloutMonitor {
         eventQueue.removeAll()
         eventQueueHead = 0
         cursors.removeAll()
+        ownerlessSince.removeAll()
         recoveryGateForTesting = nil
         sink = nil
     }
@@ -1171,5 +1242,28 @@ public actor CodexRolloutMonitor {
         } catch {
             return Data()
         }
+    }
+}
+
+/// The ChatGPT.app-bundled `codex` binary. Homebrew CLI and ssh `app-server`
+/// proxies must not count — this machine routinely runs all three.
+enum CodexDesktopAppServer {
+    static func isAlive() -> Bool {
+        let needed = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+        guard needed > 0 else { return false }
+        var pids = [pid_t](repeating: 0, count: Int(needed) / MemoryLayout<pid_t>.stride)
+        let filled = proc_listpids(
+            UInt32(PROC_ALL_PIDS), 0, &pids,
+            Int32(pids.count * MemoryLayout<pid_t>.stride))
+        guard filled > 0 else { return false }
+        let count = Int(filled) / MemoryLayout<pid_t>.stride
+        var pathBuffer = [UInt8](repeating: 0, count: Int(4 * MAXPATHLEN))
+        for pid in pids.prefix(count) where pid > 0 {
+            let len = proc_pidpath(pid, &pathBuffer, UInt32(pathBuffer.count))
+            guard len > 0 else { continue }
+            let path = String(decoding: pathBuffer.prefix(Int(len)), as: UTF8.self)
+            if path.hasSuffix("/ChatGPT.app/Contents/Resources/codex") { return true }
+        }
+        return false
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -816,7 +816,7 @@ public actor CodexRolloutMonitor {
     /// never change ObservationHealth. ObservationSource is still never
     /// guessed from process existence — this is a bounded exception for
     /// "the writer is gone, leave working".
-    private let isDesktopAppServerAlive: @Sendable () -> Bool
+    private let desktopAppServerIdentity: @Sendable () -> CodexDesktopAppServer.Identity?
     private let hasWriterLock: @Sendable (String) -> Bool
     private let watcherQueue = DispatchQueue(
         label: "com.vibebuddy.codex-rollout-watchers",
@@ -843,6 +843,9 @@ public actor CodexRolloutMonitor {
     /// Paths already seen without a writer. A later live app-server plus leftover
     /// lock does not clear this; only a rollout append (`cursor.consume`) does.
     private var ownerlessObserved: Set<String> = []
+    /// Last observed ChatGPT.app-bundled app-server. A different live identity
+    /// between scans is a replacement, not continued ownership.
+    private var lastAppServerIdentity: CodexDesktopAppServer.Identity?
 
     public init(
         root: URL = FileManager.default.homeDirectoryForCurrentUser
@@ -854,12 +857,41 @@ public actor CodexRolloutMonitor {
         isDesktopAppServerAlive: (@Sendable () -> Bool)? = nil,
         hasWriterLock: (@Sendable (String) -> Bool)? = nil
     ) {
+        let identity: @Sendable () -> CodexDesktopAppServer.Identity?
+        if let isDesktopAppServerAlive {
+            identity = {
+                isDesktopAppServerAlive()
+                    ? CodexDesktopAppServer.Identity(pid: 1, startSec: 0, startUsec: 0)
+                    : nil
+            }
+        } else {
+            identity = { CodexDesktopAppServer.identity() }
+        }
+        self.init(
+            root: root,
+            discoveryInterval: discoveryInterval,
+            debounceInterval: debounceInterval,
+            recoveryWindow: recoveryWindow,
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentity: identity,
+            hasWriterLock: hasWriterLock)
+    }
+
+    init(
+        root: URL,
+        discoveryInterval: Duration = .seconds(30),
+        debounceInterval: Duration = .milliseconds(100),
+        recoveryWindow: TimeInterval = 30 * 60,
+        ownerlessAfter: TimeInterval = 60,
+        desktopAppServerIdentity: @escaping @Sendable () -> CodexDesktopAppServer.Identity?,
+        hasWriterLock: (@Sendable (String) -> Bool)? = nil
+    ) {
         self.root = root
         self.discoveryInterval = discoveryInterval
         self.debounceInterval = debounceInterval
         self.recoveryWindow = recoveryWindow
         self.ownerlessAfter = ownerlessAfter
-        self.isDesktopAppServerAlive = isDesktopAppServerAlive ?? { CodexDesktopAppServer.isAlive() }
+        self.desktopAppServerIdentity = desktopAppServerIdentity
         // Production `root` is ~/.codex/sessions; CODEX_HOME and test fixtures
         // follow the same sibling. A missing lock directory is not "no locks".
         let lockRoot = root.deletingLastPathComponent()
@@ -985,12 +1017,23 @@ public actor CodexRolloutMonitor {
     /// a lock's *presence* is not proof of a writer. A missing lock (only when
     /// the lock directory itself exists), or a dead ChatGPT.app-bundled
     /// `codex app-server`, is enough to call the thread ownerless. Leftover
-    /// locks are ignored once that process is already gone. After a thread has
+    /// locks are ignored once that process is already gone. A live app-server
+    /// whose pid/start identity changed between scans is also ownerless — the
+    /// quit-and-relaunch happened between observations. After a thread has
     /// been observed ownerless, a relaunched app-server plus that leftover lock
     /// still does not reset the clock — only a rollout append re-arms ownership.
     private func retireOwnerless(now: Date) -> [HookEvent] {
         var events: [HookEvent] = []
-        let appServerAlive = isDesktopAppServerAlive()
+        let identity = desktopAppServerIdentity()
+        let appServerAlive = identity != nil
+        if let previous = lastAppServerIdentity, let identity, previous != identity {
+            for (path, cursor) in cursors {
+                guard cursor.surfaced, cursor.parser.turnActive, cursor.parser.isDesktopSession
+                else { continue }
+                ownerlessObserved.insert(path)
+            }
+        }
+        lastAppServerIdentity = identity
         for (path, cursor) in cursors {
             guard cursor.surfaced, cursor.parser.turnActive,
                   cursor.parser.isDesktopSession,
@@ -1202,6 +1245,7 @@ public actor CodexRolloutMonitor {
         cursors.removeAll()
         lastOwnedAt.removeAll()
         ownerlessObserved.removeAll()
+        lastAppServerIdentity = nil
         recoveryGateForTesting = nil
         sink = nil
     }
@@ -1212,7 +1256,7 @@ public actor CodexRolloutMonitor {
     private func candidateFiles(now: Date) -> [URL] {
         let fm = FileManager.default
         var files: [URL] = []
-        if case .found(let candidates) = CodexRolloutDiscovery.candidates(
+        if case .found(let candidates, _) = CodexRolloutDiscovery.candidates(
             in: root, now: now, window: recoveryWindow, fileManager: fm
         ) {
             files = candidates.map(\.url)
@@ -1304,22 +1348,39 @@ public actor CodexRolloutMonitor {
 /// The ChatGPT.app-bundled `codex` binary. Homebrew CLI and ssh `app-server`
 /// proxies must not count — this machine routinely runs all three.
 enum CodexDesktopAppServer {
-    static func isAlive() -> Bool {
+    struct Identity: Equatable, Sendable {
+        var pid: pid_t
+        var startSec: UInt64
+        var startUsec: UInt64
+    }
+
+    static func isAlive() -> Bool { identity() != nil }
+
+    static func identity() -> Identity? {
         let needed = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
-        guard needed > 0 else { return false }
+        guard needed > 0 else { return nil }
         var pids = [pid_t](repeating: 0, count: Int(needed) / MemoryLayout<pid_t>.stride)
         let filled = proc_listpids(
             UInt32(PROC_ALL_PIDS), 0, &pids,
             Int32(pids.count * MemoryLayout<pid_t>.stride))
-        guard filled > 0 else { return false }
+        guard filled > 0 else { return nil }
         let count = Int(filled) / MemoryLayout<pid_t>.stride
         var pathBuffer = [UInt8](repeating: 0, count: Int(4 * MAXPATHLEN))
+        var matches: [Identity] = []
         for pid in pids.prefix(count) where pid > 0 {
             let len = proc_pidpath(pid, &pathBuffer, UInt32(pathBuffer.count))
             guard len > 0 else { continue }
             let path = String(decoding: pathBuffer.prefix(Int(len)), as: UTF8.self)
-            if path.hasSuffix("/ChatGPT.app/Contents/Resources/codex") { return true }
+            guard path.hasSuffix("/ChatGPT.app/Contents/Resources/codex") else { continue }
+            var info = proc_bsdinfo()
+            let size = Int32(MemoryLayout<proc_bsdinfo>.stride)
+            let got = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size)
+            guard got == size else { continue }
+            matches.append(Identity(
+                pid: pid,
+                startSec: info.pbi_start_tvsec,
+                startUsec: info.pbi_start_tvusec))
         }
-        return false
+        return matches.min(by: { $0.pid < $1.pid })
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
@@ -66,6 +66,9 @@ public struct HookEvent: Sendable, Equatable {
     /// reducer reads it as "this session is a Desktop thread, jumpable through
     /// ChatGPT.app rather than through a terminal".
     public let desktopThreadID: String?
+    /// True only for the Desktop probe's synthetic stop. Distinct from an
+    /// agent that happened to finish with the word "Abandoned".
+    public let probeRetirement: Bool
 
     public init(
         kind: Kind,
@@ -86,7 +89,8 @@ public struct HookEvent: Sendable, Equatable {
         childAction: ChildLifecycleAction? = nil,
         turnID: String? = nil,
         enrichment: TranscriptInfo? = nil,
-        desktopThreadID: String? = nil
+        desktopThreadID: String? = nil,
+        probeRetirement: Bool = false
     ) {
         self.kind = kind
         self.sessionID = sessionID
@@ -107,5 +111,6 @@ public struct HookEvent: Sendable, Equatable {
         self.turnID = turnID
         self.enrichment = enrichment
         self.desktopThreadID = desktopThreadID
+        self.probeRetirement = probeRetirement
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
@@ -39,12 +39,6 @@ public enum ObservationHealthDetector {
         "function_call_output", "custom_tool_call_output", "local_shell_call_output",
     ]
 
-    private enum RolloutLookup {
-        case found(url: URL, modifiedAt: Date)
-        case empty
-        case unreadable
-    }
-
     private enum RolloutInspection {
         case supportedEvent
         case metadataOnly
@@ -223,14 +217,14 @@ public enum ObservationHealthDetector {
 
         // Claude transcript paths arrive on hooks and are tracked as runtime
         // signals. Do not recursively walk every historical project transcript
-        // during a Settings refresh. Codex uses date-partitioned directories, so
-        // inspecting today and yesterday is bounded.
+        // during a Settings refresh. Codex rollouts reuse the monitor's recency
+        // window, so a resumed old-date file is visible without walking home.
         guard source == .rollout else {
             return diagnostic(source: source, signal: signal, fallback: .eventsMissing,
                               now: now, staleAfter: staleAfter)
         }
 
-        switch latestRollout(in: root, now: now, fileManager: fm) {
+        switch CodexRolloutDiscovery.latest(in: root, now: now, fileManager: fm) {
         case .unreadable:
             return diagnostic(source: source, signal: signal, fallback: .sourceUnreadable,
                               now: now, staleAfter: staleAfter, forceFallback: true)
@@ -336,73 +330,6 @@ public enum ObservationHealthDetector {
               let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         return try? handle.read(upToCount: count)
-    }
-
-    private static func latestRollout(
-        in root: URL,
-        now: Date,
-        fileManager fm: FileManager
-    ) -> RolloutLookup {
-        guard fm.fileExists(atPath: root.path) else { return .empty }
-        guard isReadableDirectory(root, fileManager: fm) else { return .unreadable }
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = .current
-        var latest: (URL, Date)?
-        for daysAgo in 0...1 {
-            guard let day = calendar.date(byAdding: .day, value: -daysAgo, to: now) else { continue }
-            let parts = calendar.dateComponents([.year, .month, .day], from: day)
-            guard let year = parts.year, let month = parts.month, let dayNumber = parts.day else { continue }
-            var directory = root
-            var directoryExists = true
-            for component in [
-                String(format: "%04d", year),
-                String(format: "%02d", month),
-                String(format: "%02d", dayNumber),
-            ] {
-                directory.appendPathComponent(component, isDirectory: true)
-                guard fm.fileExists(atPath: directory.path) else {
-                    directoryExists = false
-                    break
-                }
-                guard isReadableDirectory(directory, fileManager: fm) else {
-                    return .unreadable
-                }
-            }
-            guard directoryExists else { continue }
-            let urls: [URL]
-            do {
-                urls = try fm.contentsOfDirectory(
-                    at: directory,
-                    includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
-                    options: [.skipsHiddenFiles])
-            } catch {
-                return .unreadable
-            }
-            for url in urls where url.pathExtension == "jsonl" {
-                let values: URLResourceValues
-                do {
-                    values = try url.resourceValues(
-                        forKeys: [.isRegularFileKey, .contentModificationDateKey])
-                } catch {
-                    return .unreadable
-                }
-                guard values.isRegularFile == true,
-                      let modified = values.contentModificationDate else { continue }
-                if latest == nil || modified > latest!.1 { latest = (url, modified) }
-            }
-        }
-        if let latest { return .found(url: latest.0, modifiedAt: latest.1) }
-        return .empty
-    }
-
-    private static func isReadableDirectory(_ url: URL, fileManager fm: FileManager) -> Bool {
-        guard fm.isReadableFile(atPath: url.path),
-              let attributes = try? fm.attributesOfItem(atPath: url.path),
-              (attributes[.type] as? FileAttributeType) == .typeDirectory,
-              let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue,
-              permissions & 0o444 != 0,
-              permissions & 0o111 != 0 else { return false }
-        return true
     }
 
     private static func inspectRollout(

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
@@ -217,8 +217,9 @@ public enum ObservationHealthDetector {
 
         // Claude transcript paths arrive on hooks and are tracked as runtime
         // signals. Do not recursively walk every historical project transcript
-        // during a Settings refresh. Codex rollouts reuse the monitor's recency
-        // window, so a resumed old-date file is visible without walking home.
+        // during a Settings refresh. Codex diagnostics take the newest rollout
+        // by mtime, including files outside the monitor recency window, so a
+        // restart still has freshness evidence.
         guard source == .rollout else {
             return diagnostic(source: source, signal: signal, fallback: .eventsMissing,
                               now: now, staleAfter: staleAfter)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -92,6 +92,7 @@ public struct SessionReducer: Sendable {
             // completion — no unread-complete badge and no agentDone cue.
             if event.message == "Abandoned" {
                 sessions[event.sessionID]?.hasUnreadCompletion = false
+                sessions[event.sessionID]?.failed = false
                 break
             }
             // Carry the last tool's outcome; also treat a failure-looking stop

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -88,6 +88,12 @@ public struct SessionReducer: Sendable {
             // carry the agent's final summary when present.
             upsert(event, status: .done, waitKind: nil, summary: event.message)
             sessions[event.sessionID]?.activeTool = nil
+            // Probe retirement is done, not failed, and not a successful
+            // completion — no unread-complete badge and no agentDone cue.
+            if event.message == "Abandoned" {
+                sessions[event.sessionID]?.hasUnreadCompletion = false
+                break
+            }
             // Carry the last tool's outcome; also treat a failure-looking stop
             // message as stuck even when no tool error was reported.
             if FailureHeuristic.looksFailed(event.message) { sessions[event.sessionID]?.failed = true }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -35,7 +35,8 @@ public struct SessionReducer: Sendable {
 
     public mutating func apply(
         _ event: HookEvent,
-        observationSource: ObservationSource? = nil
+        observationSource: ObservationSource? = nil,
+        recordsEvidence: Bool = true
     ) {
         switch event.kind {
         case .sessionStart:
@@ -115,11 +116,13 @@ public struct SessionReducer: Sendable {
             if let thread = event.desktopThreadID {
                 sessions[event.sessionID]?.desktopThreadID = thread
             }
-            recordObservation(
-                sessionID: event.sessionID,
-                source: observationSource ?? event.observationSource ?? .hook,
-                at: event.timestamp,
-                health: .healthy)
+            if recordsEvidence {
+                recordObservation(
+                    sessionID: event.sessionID,
+                    source: observationSource ?? event.observationSource ?? .hook,
+                    at: event.timestamp,
+                    health: .healthy)
+            }
         }
     }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -99,6 +99,7 @@ public struct SessionReducer: Sendable {
                 sessions[event.sessionID]?.probeRetired = true
                 break
             }
+            sessions[event.sessionID]?.probeRetired = nil
             // Carry the last tool's outcome; also treat a failure-looking stop
             // message as stuck even when no tool error was reported.
             if FailureHeuristic.looksFailed(event.message) { sessions[event.sessionID]?.failed = true }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -45,12 +45,14 @@ public struct SessionReducer: Sendable {
             // buckets that is `done` until UserPromptSubmit arrives.
             upsert(event, status: .done, waitKind: nil)
             sessions[event.sessionID]?.failed = false
+            sessions[event.sessionID]?.probeRetired = nil
             sessions[event.sessionID]?.activeTool = nil
         case .userPromptSubmit:
             if let turnID = event.turnID { currentTurnID[event.sessionID] = turnID }
             upsert(event, status: .working, waitKind: nil)
             sessions[event.sessionID]?.hasUnreadCompletion = false
             sessions[event.sessionID]?.failed = false
+            sessions[event.sessionID]?.probeRetired = nil
             sessions[event.sessionID]?.activeTool = nil
         case .preToolUse, .postToolUse:
             if event.childID != nil {
@@ -90,9 +92,10 @@ public struct SessionReducer: Sendable {
             sessions[event.sessionID]?.activeTool = nil
             // Probe retirement is done, not failed, and not a successful
             // completion — no unread-complete badge and no agentDone cue.
-            if event.message == "Abandoned" {
+            if event.probeRetirement {
                 sessions[event.sessionID]?.hasUnreadCompletion = false
                 sessions[event.sessionID]?.failed = false
+                sessions[event.sessionID]?.probeRetired = true
                 break
             }
             // Carry the last tool's outcome; also treat a failure-looking stop

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -61,6 +61,7 @@ public struct SessionReducer: Sendable {
             } else {
                 upsert(event, status: .working, waitKind: nil)
                 sessions[event.sessionID]?.hasUnreadCompletion = false
+                sessions[event.sessionID]?.probeRetired = nil
                 if event.kind == .preToolUse {
                     sessions[event.sessionID]?.activeTool = event.toolName
                 } else {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -115,20 +115,28 @@ public actor SessionStore {
 
     /// Apply an already-normalized event from a local monitor such as the Codex
     /// Desktop rollout tailer. Hook payload parsing remains in the Data overload.
-    public func ingest(_ event: HookEvent) {
+    /// Probe retirement passes `recordsEvidence: false` so a synthetic stop
+    /// still migrates progress without minting rollout health evidence.
+    public func ingest(_ event: HookEvent, recordsEvidence: Bool = true) {
         let inferredSource = event.observationSource ?? (event.agent == .codex ? .rollout : .hook)
-        ingest(event, observationSource: inferredSource)
+        ingest(event, observationSource: inferredSource, recordsEvidence: recordsEvidence)
     }
 
-    private func ingest(_ event: HookEvent, observationSource: ObservationSource) {
+    private func ingest(
+        _ event: HookEvent,
+        observationSource: ObservationSource,
+        recordsEvidence: Bool = true
+    ) {
         let wasWaiting = reducer.sessions[event.sessionID]?.status == .needsResponse
         if let path = event.transcriptPath { transcriptPaths[event.sessionID] = path }
-        reducer.apply(event, observationSource: observationSource)
+        reducer.apply(event, observationSource: observationSource, recordsEvidence: recordsEvidence)
         if let enrichment = event.enrichment {
             reducer.enrich(sessionID: event.sessionID, with: enrichment)
         }
-        recordSignal(agent: event.agent, source: observationSource, at: event.timestamp,
-                     health: .healthy, coverage: Self.coverage(for: event.kind))
+        if recordsEvidence {
+            recordSignal(agent: event.agent, source: observationSource, at: event.timestamp,
+                         health: .healthy, coverage: Self.coverage(for: event.kind))
+        }
         if reducer.sessions[event.sessionID] == nil {
             // Session was removed (e.g. SessionEnd) — forget its side data.
             transcriptPaths[event.sessionID] = nil

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -64,6 +64,20 @@ struct CodexRolloutMonitorTests {
         #expect(customOutput?.kind == .postToolUse)
     }
 
+    @Test("a tool call after probe retirement re-arms parser activity")
+    func toolCallRearmsAfterAbandon() {
+        var parser = CodexRolloutParser()
+        _ = parser.parseLine(Data(sessionMeta(id: "thread-1").utf8), receivedAt: now)
+        _ = parser.parseLine(Data(taskStarted(id: "turn-1").utf8), receivedAt: now)
+        #expect(parser.turnActive)
+        parser.abandonActiveTurns()
+        #expect(!parser.turnActive)
+
+        let call = parser.parseLine(Data(#"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"c1"}}"#.utf8), receivedAt: now)
+        #expect(call?.kind == .preToolUse)
+        #expect(parser.turnActive)
+    }
+
     @Test("request_user_input is attention, not background work")
     func requestUserInput() {
         var parser = CodexRolloutParser()
@@ -617,6 +631,35 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-overlap-exit"]?.summary == "Abandoned")
     }
 
+    @Test("a rollout bootstrapped during overlap stays owned after the old server exits")
+    func rolloutBootstrappedDuringOverlapStaysOwned() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let ownerlessAfter: TimeInterval = 60
+        let server = IdentityFlag(pid: 81)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentities: { server.identities },
+            hasWriterLock: { _ in true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+
+        server.overlap(pid: 82, startedAt: now.addingTimeInterval(1))
+        _ = try fixture.write(
+            named: "rollout-overlap-boot.jsonl",
+            lines: [sessionMeta(id: "desktop-overlap-boot"), taskStarted(id: "t1")]
+        )
+        for event in await monitor.poll(now: now.addingTimeInterval(30)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap-boot"]?.status == .working)
+
+        server.dropOldest()
+        for event in await monitor.poll(now: now.addingTimeInterval(90)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap-boot"]?.status == .working)
+        #expect(reducer.sessions["desktop-overlap-boot"]?.summary != "Abandoned")
+    }
+
     @Test("an overlapping replacement process does not abandon a turn that wrote during the overlap")
     func overlappingAppServerAppendStaysOwned() async throws {
         let fixture = try RolloutFixture(now: now)
@@ -769,6 +812,43 @@ struct CodexRolloutMonitorTests {
         for event in await monitor.poll(now: now.addingTimeInterval(61)) { reducer.apply(event) }
         #expect(reducer.sessions["desktop-approved"]?.status == .done)
         #expect(reducer.sessions["desktop-approved"]?.summary == "Abandoned")
+    }
+
+    @Test("a probe-retired turn that resumes with a tool can retire again")
+    func resumedAbandonedTurnCanRetireAgain() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let file = try fixture.write(
+            named: "rollout-rearm.jsonl",
+            lines: [sessionMeta(id: "desktop-rearm"), taskStarted(id: "t1")]
+        )
+        let writer = WriterFlag(isAlive: true)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            isDesktopAppServerAlive: { writer.isAlive },
+            hasWriterLock: { _ in writer.isAlive }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .working)
+
+        writer.isAlive = false
+        for event in await monitor.poll(now: now.addingTimeInterval(60)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .done)
+        #expect(reducer.sessions["desktop-rearm"]?.summary == "Abandoned")
+
+        writer.isAlive = true
+        try append(
+            #"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"c1"}}"#,
+            to: file)
+        for event in await monitor.poll(now: now.addingTimeInterval(61)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .working)
+        #expect(reducer.sessions["desktop-rearm"]?.probeRetired != true)
+
+        writer.isAlive = false
+        for event in await monitor.poll(now: now.addingTimeInterval(121)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .done)
+        #expect(reducer.sessions["desktop-rearm"]?.summary == "Abandoned")
     }
 
     @Test("bootstrapping after ChatGPT already relaunched retires the interrupted turn")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -587,6 +587,36 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-replaced-live"]?.summary != "Abandoned")
     }
 
+    @Test("when the owning app-server exits during overlap, the interrupted turn still retires")
+    func owningServerExitDuringOverlapRetires() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-overlap-exit.jsonl",
+            lines: [sessionMeta(id: "desktop-overlap-exit"), taskStarted(id: "t1")]
+        )
+        let ownerlessAfter: TimeInterval = 60
+        let server = IdentityFlag(pid: 71)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentities: { server.identities },
+            hasWriterLock: { _ in true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap-exit"]?.status == .working)
+
+        server.overlap(pid: 72, startedAt: now.addingTimeInterval(1))
+        for event in await monitor.poll(now: now.addingTimeInterval(30)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap-exit"]?.status == .working)
+
+        server.dropOldest()
+        for event in await monitor.poll(now: now.addingTimeInterval(90)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap-exit"]?.status == .done)
+        #expect(reducer.sessions["desktop-overlap-exit"]?.summary == "Abandoned")
+    }
+
     @Test("an overlapping replacement process does not abandon a turn that wrote during the overlap")
     func overlappingAppServerAppendStaysOwned() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -639,6 +639,65 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-rearm"]?.summary != "Abandoned")
     }
 
+    @Test("a tool output after approval clears waiting so a later quit can retire")
+    func toolOutputClearsWaitingAndAllowsRetirement() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let file = try fixture.write(
+            named: "rollout-approved.jsonl",
+            lines: [
+                sessionMeta(id: "desktop-approved"),
+                taskStarted(id: "t1"),
+                #"{"type":"event_msg","payload":{"type":"exec_approval_request"}}"#,
+            ]
+        )
+        let writer = WriterFlag(isAlive: true)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            isDesktopAppServerAlive: { writer.isAlive },
+            hasWriterLock: { _ in writer.isAlive }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-approved"]?.status == .needsResponse)
+
+        try append(
+            #"{"type":"response_item","payload":{"type":"function_call_output","call_id":"c1","output":"ok"}}"#,
+            to: file)
+        for event in await monitor.poll(now: now.addingTimeInterval(1)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-approved"]?.status == .working)
+
+        writer.isAlive = false
+        for event in await monitor.poll(now: now.addingTimeInterval(61)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-approved"]?.status == .done)
+        #expect(reducer.sessions["desktop-approved"]?.summary == "Abandoned")
+    }
+
+    @Test("bootstrapping after ChatGPT already relaunched retires the interrupted turn")
+    func bootstrapAfterAppServerReplacementRetires() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let file = try fixture.write(
+            named: "rollout-stale-server.jsonl",
+            lines: [sessionMeta(id: "desktop-stale-server"), taskStarted(id: "t1")]
+        )
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: file.path)
+        let server = IdentityFlag(pid: 41, startedAt: now.addingTimeInterval(3600))
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            desktopAppServerIdentity: { server.current },
+            hasWriterLock: { _ in true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-stale-server"]?.status == .working)
+
+        for event in await monitor.poll(now: now.addingTimeInterval(60)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-stale-server"]?.status == .done)
+        #expect(reducer.sessions["desktop-stale-server"]?.summary == "Abandoned")
+        #expect(reducer.sessions["desktop-stale-server"]?.failed != true)
+    }
+
     @Test("a Desktop turn waiting for input is not abandoned when the writer vanishes")
     func waitingTurnIsNotAbandoned() async throws {
         let fixture = try RolloutFixture(now: now)
@@ -1031,12 +1090,16 @@ private final class WriterFlag: @unchecked Sendable {
 
 private final class IdentityFlag: @unchecked Sendable {
     var current: CodexDesktopAppServer.Identity?
-    init(pid: pid_t) {
-        current = CodexDesktopAppServer.Identity(pid: pid, startSec: 0, startUsec: 0)
+    init(pid: pid_t, startedAt: Date = Date(timeIntervalSince1970: 0)) {
+        current = Self.identity(pid: pid, startedAt: startedAt)
     }
-    func relaunch() {
+    func relaunch(startedAt: Date = Date(timeIntervalSince1970: 0)) {
         let next = (current?.pid ?? 0) + 1
-        current = CodexDesktopAppServer.Identity(pid: next, startSec: 0, startUsec: 0)
+        current = Self.identity(pid: next, startedAt: startedAt)
+    }
+    private static func identity(pid: pid_t, startedAt: Date) -> CodexDesktopAppServer.Identity {
+        let sec = UInt64(max(0, startedAt.timeIntervalSince1970.rounded(.down)))
+        return CodexDesktopAppServer.Identity(pid: pid, startSec: sec, startUsec: 0)
     }
 }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -423,6 +423,31 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-ownerless"]?.failed != true)
     }
 
+    @Test("a missing lock directory does not abandon a live Desktop writer")
+    func missingLockDirectoryKeepsWorking() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-nolockdir.jsonl",
+            lines: [sessionMeta(id: "desktop-nolockdir"), taskStarted(id: "t1")]
+        )
+        let siblingLocks = fixture.root.deletingLastPathComponent()
+            .appendingPathComponent("thread-writer-locks", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: siblingLocks.path))
+
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            isDesktopAppServerAlive: { true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-nolockdir"]?.status == .working)
+
+        for event in await monitor.poll(now: now.addingTimeInterval(60)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-nolockdir"]?.status == .working)
+        #expect(reducer.sessions["desktop-nolockdir"]?.summary != "Abandoned")
+    }
+
     @Test("a thread resumed from an older date directory is discovered")
     func resumedOldThreadDiscovery() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -587,6 +587,40 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-replaced-live"]?.summary != "Abandoned")
     }
 
+    @Test("an overlapping replacement process does not abandon a turn that wrote during the overlap")
+    func overlappingAppServerAppendStaysOwned() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let file = try fixture.write(
+            named: "rollout-overlap.jsonl",
+            lines: [sessionMeta(id: "desktop-overlap"), taskStarted(id: "t1")]
+        )
+        let ownerlessAfter: TimeInterval = 60
+        let server = IdentityFlag(pid: 61)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentities: { server.identities },
+            hasWriterLock: { _ in true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap"]?.status == .working)
+
+        try append(
+            #"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"c1"}}"#,
+            to: file)
+        server.overlap(pid: 62, startedAt: Date())
+        let watcherNow = Date()
+        for event in await monitor.consumeForTesting(file: file, now: watcherNow) { reducer.apply(event) }
+        server.dropOldest()
+
+        let laterScan = watcherNow.addingTimeInterval(ownerlessAfter)
+        for event in await monitor.poll(now: laterScan) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap"]?.status == .working)
+        #expect(reducer.sessions["desktop-overlap"]?.summary != "Abandoned")
+    }
+
     @Test("a watcher append under a replacement server stays owned across the next scan")
     func watcherAppendUnderReplacementStaysOwned() async throws {
         let fixture = try RolloutFixture(now: now)
@@ -1154,13 +1188,23 @@ private final class WriterFlag: @unchecked Sendable {
 }
 
 private final class IdentityFlag: @unchecked Sendable {
-    var current: CodexDesktopAppServer.Identity?
+    var identities: [CodexDesktopAppServer.Identity]
+    var current: CodexDesktopAppServer.Identity? {
+        get { identities.first }
+        set { identities = newValue.map { [$0] } ?? [] }
+    }
     init(pid: pid_t, startedAt: Date = Date(timeIntervalSince1970: 0)) {
-        current = Self.identity(pid: pid, startedAt: startedAt)
+        identities = [Self.identity(pid: pid, startedAt: startedAt)]
     }
     func relaunch(startedAt: Date = Date(timeIntervalSince1970: 0)) {
         let next = (current?.pid ?? 0) + 1
-        current = Self.identity(pid: next, startedAt: startedAt)
+        identities = [Self.identity(pid: next, startedAt: startedAt)]
+    }
+    func overlap(pid: pid_t, startedAt: Date) {
+        identities.append(Self.identity(pid: pid, startedAt: startedAt))
+    }
+    func dropOldest() {
+        if identities.count > 1 { identities.removeFirst() }
     }
     private static func identity(pid: pid_t, startedAt: Date) -> CodexDesktopAppServer.Identity {
         let sec = UInt64(max(0, startedAt.timeIntervalSince1970.rounded(.down)))

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -396,6 +396,33 @@ struct CodexRolloutMonitorTests {
         #expect(events.last?.enrichment?.contextWindow == 1_000)
     }
 
+    @Test("an ownerless Desktop thread leaves working within a minute")
+    func ownerlessThreadLeavesWorking() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-ownerless.jsonl",
+            lines: [sessionMeta(id: "desktop-ownerless"), taskStarted(id: "t1")]
+        )
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            isDesktopAppServerAlive: { false },
+            hasWriterLock: { _ in false }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-ownerless"]?.status == .working)
+
+        for event in await monitor.poll(now: now.addingTimeInterval(59)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-ownerless"]?.status == .working)
+        #expect(reducer.sessions["desktop-ownerless"]?.summary != "Abandoned")
+
+        for event in await monitor.poll(now: now.addingTimeInterval(60)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-ownerless"]?.status == .done)
+        #expect(reducer.sessions["desktop-ownerless"]?.summary == "Abandoned")
+        #expect(reducer.sessions["desktop-ownerless"]?.failed != true)
+    }
+
     @Test("a thread resumed from an older date directory is discovered")
     func resumedOldThreadDiscovery() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -463,6 +463,105 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-phase"]?.failed != true)
     }
 
+    @Test("writer vanishes, ChatGPT relaunches inside the grace, the interrupted turn still retires within a minute")
+    func relaunchInsideGraceStillRetires() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-relaunch.jsonl",
+            lines: [sessionMeta(id: "desktop-relaunch"), taskStarted(id: "t1")]
+        )
+        let discoveryInterval: TimeInterval = 30
+        let ownerlessAfter: TimeInterval = 60
+        let appServer = WriterFlag(isAlive: true)
+        let lock = WriterFlag(isAlive: true)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            discoveryInterval: .seconds(discoveryInterval),
+            ownerlessAfter: ownerlessAfter,
+            isDesktopAppServerAlive: { appServer.isAlive },
+            hasWriterLock: { _ in lock.isAlive }
+        )
+
+        // t=0: last scan that still sees a writer.
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-relaunch"]?.status == .working)
+
+        // ChatGPT quits; the interrupted thread's lock file is leftover.
+        appServer.isAlive = false
+        let firstOwnerless = now.addingTimeInterval(discoveryInterval)
+        for event in await monitor.poll(now: firstOwnerless) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-relaunch"]?.status == .working)
+        #expect(reducer.sessions["desktop-relaunch"]?.summary != "Abandoned")
+
+        // Relaunch inside the grace: new app-server is alive, stale lock remains.
+        // That pair is not fresh thread evidence and must not reset the clock.
+        appServer.isAlive = true
+        let beforeDeadline = now.addingTimeInterval(ownerlessAfter - 1)
+        for event in await monitor.poll(now: beforeDeadline) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-relaunch"]?.status == .working)
+        #expect(reducer.sessions["desktop-relaunch"]?.summary != "Abandoned")
+
+        let deadline = now.addingTimeInterval(ownerlessAfter)
+        for event in await monitor.poll(now: deadline) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-relaunch"]?.status == .done)
+        #expect(reducer.sessions["desktop-relaunch"]?.summary == "Abandoned")
+        #expect(reducer.sessions["desktop-relaunch"]?.failed != true)
+    }
+
+    @Test("a rollout append after an ownerless scan re-arms ownership")
+    func rolloutAppendRearmsOwnership() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let file = try fixture.write(
+            named: "rollout-rearm.jsonl",
+            lines: [sessionMeta(id: "desktop-rearm"), taskStarted(id: "t1")]
+        )
+        let discoveryInterval: TimeInterval = 30
+        let ownerlessAfter: TimeInterval = 60
+        let appServer = WriterFlag(isAlive: true)
+        let lock = WriterFlag(isAlive: true)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            discoveryInterval: .seconds(discoveryInterval),
+            ownerlessAfter: ownerlessAfter,
+            isDesktopAppServerAlive: { appServer.isAlive },
+            hasWriterLock: { _ in lock.isAlive }
+        )
+
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .working)
+
+        appServer.isAlive = false
+        let firstOwnerless = now.addingTimeInterval(discoveryInterval)
+        for event in await monitor.poll(now: firstOwnerless) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .working)
+        #expect(reducer.sessions["desktop-rearm"]?.summary != "Abandoned")
+
+        try append(
+            #"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"c1"}}"#,
+            to: file)
+        appServer.isAlive = true
+        let rearmedAt = firstOwnerless.addingTimeInterval(1)
+        for event in await monitor.poll(now: rearmedAt) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .working)
+        #expect(reducer.sessions["desktop-rearm"]?.activeTool == "exec")
+
+        // Without the append, the original deadline would have retired this turn.
+        let originalDeadline = now.addingTimeInterval(ownerlessAfter)
+        for event in await monitor.poll(now: originalDeadline) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .working)
+        #expect(reducer.sessions["desktop-rearm"]?.summary != "Abandoned")
+
+        for event in await monitor.poll(now: originalDeadline.addingTimeInterval(discoveryInterval)) {
+            reducer.apply(event)
+        }
+        #expect(reducer.sessions["desktop-rearm"]?.status == .working)
+        #expect(reducer.sessions["desktop-rearm"]?.summary != "Abandoned")
+    }
+
     @Test("an owned but silent Desktop rollout stays working")
     func ownedSilentRolloutStaysWorking() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -639,6 +639,32 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-rearm"]?.summary != "Abandoned")
     }
 
+    @Test("a Desktop turn waiting for input is not abandoned when the writer vanishes")
+    func waitingTurnIsNotAbandoned() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-waiting.jsonl",
+            lines: [
+                sessionMeta(id: "desktop-waiting"),
+                taskStarted(id: "t1"),
+                #"{"type":"event_msg","payload":{"type":"exec_approval_request"}}"#,
+            ]
+        )
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            isDesktopAppServerAlive: { false },
+            hasWriterLock: { _ in false }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-waiting"]?.status == .needsResponse)
+
+        for event in await monitor.poll(now: now.addingTimeInterval(60)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-waiting"]?.status == .needsResponse)
+        #expect(reducer.sessions["desktop-waiting"]?.summary != "Abandoned")
+    }
+
     @Test("an owned but silent Desktop rollout stays working")
     func ownedSilentRolloutStaysWorking() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -755,6 +755,34 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-silent"]?.summary != "Abandoned")
     }
 
+    @Test("an unreadable lock directory does not abandon a live Desktop writer")
+    func unreadableLockDirectoryKeepsWorking() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-lockunreadable.jsonl",
+            lines: [sessionMeta(id: "desktop-lockunreadable"), taskStarted(id: "t1")]
+        )
+        let lockDir = fixture.root.deletingLastPathComponent()
+            .appendingPathComponent("thread-writer-locks", isDirectory: true)
+        try FileManager.default.createDirectory(at: lockDir, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: lockDir.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700],
+                                                        ofItemAtPath: lockDir.path) }
+
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            isDesktopAppServerAlive: { true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-lockunreadable"]?.status == .working)
+
+        for event in await monitor.poll(now: now.addingTimeInterval(60)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-lockunreadable"]?.status == .working)
+        #expect(reducer.sessions["desktop-lockunreadable"]?.summary != "Abandoned")
+    }
+
     @Test("a missing lock directory does not abandon a live Desktop writer")
     func missingLockDirectoryKeepsWorking() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -548,6 +548,45 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-replaced"]?.failed != true)
     }
 
+    @Test("a rollout append in the same pass as an app-server replacement stays owned")
+    func appendDuringAppServerReplacementStaysOwned() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let file = try fixture.write(
+            named: "rollout-replaced-live.jsonl",
+            lines: [sessionMeta(id: "desktop-replaced-live"), taskStarted(id: "t1")]
+        )
+        let discoveryInterval: TimeInterval = 30
+        let ownerlessAfter: TimeInterval = 60
+        let server = IdentityFlag(pid: 21)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            discoveryInterval: .seconds(discoveryInterval),
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentity: { server.current },
+            hasWriterLock: { _ in true }
+        )
+
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-replaced-live"]?.status == .working)
+
+        try append(
+            #"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"c1"}}"#,
+            to: file)
+        server.relaunch()
+        let afterReplace = now.addingTimeInterval(discoveryInterval)
+        for event in await monitor.poll(now: afterReplace) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-replaced-live"]?.status == .working)
+        #expect(reducer.sessions["desktop-replaced-live"]?.activeTool == "exec")
+        #expect(reducer.sessions["desktop-replaced-live"]?.summary != "Abandoned")
+
+        let deadline = now.addingTimeInterval(ownerlessAfter)
+        for event in await monitor.poll(now: deadline) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-replaced-live"]?.status == .working)
+        #expect(reducer.sessions["desktop-replaced-live"]?.summary != "Abandoned")
+    }
+
     @Test("a rollout append after an ownerless scan re-arms ownership")
     func rolloutAppendRearmsOwnership() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -660,6 +660,37 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-overlap-boot"]?.summary != "Abandoned")
     }
 
+    @Test("a rollout written before the overlapping replacement is discovered still retires")
+    func rolloutWrittenBeforeOverlapDiscoveryRetires() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let ownerlessAfter: TimeInterval = 60
+        let server = IdentityFlag(pid: 91)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentities: { server.identities },
+            hasWriterLock: { _ in true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+
+        let writtenAt = now.addingTimeInterval(10)
+        let file = try fixture.write(
+            named: "rollout-overlap-stale.jsonl",
+            lines: [sessionMeta(id: "desktop-overlap-stale"), taskStarted(id: "t1")]
+        )
+        try FileManager.default.setAttributes([.modificationDate: writtenAt], ofItemAtPath: file.path)
+        server.overlap(pid: 92, startedAt: now.addingTimeInterval(20))
+        for event in await monitor.poll(now: now.addingTimeInterval(30)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap-stale"]?.status == .working)
+
+        server.dropOldest()
+        for event in await monitor.poll(now: now.addingTimeInterval(90)) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-overlap-stale"]?.status == .done)
+        #expect(reducer.sessions["desktop-overlap-stale"]?.summary == "Abandoned")
+    }
+
     @Test("an overlapping replacement process does not abandon a turn that wrote during the overlap")
     func overlappingAppServerAppendStaysOwned() async throws {
         let fixture = try RolloutFixture(now: now)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -510,6 +510,44 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-relaunch"]?.failed != true)
     }
 
+    @Test("ChatGPT relaunch between scans still retires the interrupted turn within a minute")
+    func appServerReplacementBetweenScansRetires() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-replaced.jsonl",
+            lines: [sessionMeta(id: "desktop-replaced"), taskStarted(id: "t1")]
+        )
+        let discoveryInterval: TimeInterval = 30
+        let ownerlessAfter: TimeInterval = 60
+        let server = IdentityFlag(pid: 11)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            discoveryInterval: .seconds(discoveryInterval),
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentity: { server.current },
+            hasWriterLock: { _ in true }
+        )
+
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-replaced"]?.status == .working)
+
+        // Quit and relaunch entirely between scans: both observations see a live
+        // app-server plus leftover lock. Identity change is the missing edge.
+        server.relaunch()
+        let firstAfterReplace = now.addingTimeInterval(discoveryInterval)
+        for event in await monitor.poll(now: firstAfterReplace) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-replaced"]?.status == .working)
+        #expect(reducer.sessions["desktop-replaced"]?.summary != "Abandoned")
+
+        let deadline = now.addingTimeInterval(ownerlessAfter)
+        for event in await monitor.poll(now: deadline) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-replaced"]?.status == .done)
+        #expect(reducer.sessions["desktop-replaced"]?.summary == "Abandoned")
+        #expect(reducer.sessions["desktop-replaced"]?.failed != true)
+    }
+
     @Test("a rollout append after an ownerless scan re-arms ownership")
     func rolloutAppendRearmsOwnership() async throws {
         let fixture = try RolloutFixture(now: now)
@@ -924,6 +962,17 @@ struct CodexRolloutMonitorTests {
 private final class WriterFlag: @unchecked Sendable {
     var isAlive: Bool
     init(isAlive: Bool) { self.isAlive = isAlive }
+}
+
+private final class IdentityFlag: @unchecked Sendable {
+    var current: CodexDesktopAppServer.Identity?
+    init(pid: pid_t) {
+        current = CodexDesktopAppServer.Identity(pid: pid, startSec: 0, startUsec: 0)
+    }
+    func relaunch() {
+        let next = (current?.pid ?? 0) + 1
+        current = CodexDesktopAppServer.Identity(pid: next, startSec: 0, startUsec: 0)
+    }
 }
 
 private actor EventRecorder {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -423,6 +423,77 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-ownerless"]?.failed != true)
     }
 
+    @Test("worst-case scan phase still abandons within a minute of the writer vanishing")
+    func worstCaseScanPhaseLeavesWorkingWithinAMinute() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-phase.jsonl",
+            lines: [sessionMeta(id: "desktop-phase"), taskStarted(id: "t1")]
+        )
+        let discoveryInterval: TimeInterval = 30
+        let ownerlessAfter: TimeInterval = 60
+        let writer = WriterFlag(isAlive: true)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            discoveryInterval: .seconds(discoveryInterval),
+            ownerlessAfter: ownerlessAfter,
+            isDesktopAppServerAlive: { writer.isAlive },
+            hasWriterLock: { _ in writer.isAlive }
+        )
+
+        // t=0: last scan that still sees a writer. The writer vanishes immediately after.
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-phase"]?.status == .working)
+        writer.isAlive = false
+
+        // Production cadence: first ownerless observation is one interval later.
+        let firstOwnerless = now.addingTimeInterval(discoveryInterval)
+        for event in await monitor.poll(now: firstOwnerless) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-phase"]?.status == .working)
+        #expect(reducer.sessions["desktop-phase"]?.summary != "Abandoned")
+
+        // Bound is ownerlessAfter from the last owned scan, not from first ownerless.
+        // The old clock would still be waiting until firstOwnerless + ownerlessAfter (90s).
+        let deadline = now.addingTimeInterval(ownerlessAfter)
+        for event in await monitor.poll(now: deadline) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-phase"]?.status == .done)
+        #expect(reducer.sessions["desktop-phase"]?.summary == "Abandoned")
+        #expect(reducer.sessions["desktop-phase"]?.failed != true)
+    }
+
+    @Test("an owned but silent Desktop rollout stays working")
+    func ownedSilentRolloutStaysWorking() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            named: "rollout-silent.jsonl",
+            lines: [sessionMeta(id: "desktop-silent"), taskStarted(id: "t1")]
+        )
+        let discoveryInterval: TimeInterval = 30
+        let ownerlessAfter: TimeInterval = 60
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            discoveryInterval: .seconds(discoveryInterval),
+            ownerlessAfter: ownerlessAfter,
+            isDesktopAppServerAlive: { true },
+            hasWriterLock: { _ in true }
+        )
+
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-silent"]?.status == .working)
+
+        for step in 1...3 {
+            for event in await monitor.poll(now: now.addingTimeInterval(discoveryInterval * TimeInterval(step))) {
+                reducer.apply(event)
+            }
+        }
+        #expect(reducer.sessions["desktop-silent"]?.status == .working)
+        #expect(reducer.sessions["desktop-silent"]?.summary != "Abandoned")
+    }
+
     @Test("a missing lock directory does not abandon a live Desktop writer")
     func missingLockDirectoryKeepsWorking() async throws {
         let fixture = try RolloutFixture(now: now)
@@ -748,6 +819,12 @@ struct CodexRolloutMonitorTests {
         #expect(diagnostics.pendingDebounceCount == 0)
         #expect(diagnostics.queuedEventCount == 0)
     }
+}
+
+/// Flip the injected writer probes mid-test without capturing a local `var`.
+private final class WriterFlag: @unchecked Sendable {
+    var isAlive: Bool
+    init(isAlive: Bool) { self.isAlive = isAlive }
 }
 
 private actor EventRecorder {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexRolloutMonitorTests.swift
@@ -587,6 +587,40 @@ struct CodexRolloutMonitorTests {
         #expect(reducer.sessions["desktop-replaced-live"]?.summary != "Abandoned")
     }
 
+    @Test("a watcher append under a replacement server stays owned across the next scan")
+    func watcherAppendUnderReplacementStaysOwned() async throws {
+        let fixture = try RolloutFixture(now: now)
+        defer { fixture.remove() }
+        let file = try fixture.write(
+            named: "rollout-watcher-replace.jsonl",
+            lines: [sessionMeta(id: "desktop-watcher-replace"), taskStarted(id: "t1")]
+        )
+        let ownerlessAfter: TimeInterval = 60
+        let server = IdentityFlag(pid: 51)
+        var reducer = SessionReducer()
+        let monitor = CodexRolloutMonitor(
+            root: fixture.root,
+            ownerlessAfter: ownerlessAfter,
+            desktopAppServerIdentity: { server.current },
+            hasWriterLock: { _ in true }
+        )
+        for event in await monitor.poll(now: now) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-watcher-replace"]?.status == .working)
+
+        try append(
+            #"{"type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"c1"}}"#,
+            to: file)
+        server.relaunch()
+        let watcherNow = Date()
+        for event in await monitor.consumeForTesting(file: file, now: watcherNow) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-watcher-replace"]?.activeTool == "exec")
+
+        let laterScan = watcherNow.addingTimeInterval(ownerlessAfter)
+        for event in await monitor.poll(now: laterScan) { reducer.apply(event) }
+        #expect(reducer.sessions["desktop-watcher-replace"]?.status == .working)
+        #expect(reducer.sessions["desktop-watcher-replace"]?.summary != "Abandoned")
+    }
+
     @Test("a rollout append after an ownerless scan re-arms ownership")
     func rolloutAppendRearmsOwnership() async throws {
         let fixture = try RolloutFixture(now: now)
@@ -757,14 +791,17 @@ struct CodexRolloutMonitorTests {
 
     @Test("an unreadable lock directory does not abandon a live Desktop writer")
     func unreadableLockDirectoryKeepsWorking() async throws {
-        let fixture = try RolloutFixture(now: now)
-        defer { fixture.remove() }
-        _ = try fixture.write(
-            named: "rollout-lockunreadable.jsonl",
-            lines: [sessionMeta(id: "desktop-lockunreadable"), taskStarted(id: "t1")]
-        )
-        let lockDir = fixture.root.deletingLastPathComponent()
-            .appendingPathComponent("thread-writer-locks", isDirectory: true)
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let sessions = home.appendingPathComponent("sessions", isDirectory: true)
+        let day = sessions.appendingPathComponent("2026/09/02", isDirectory: true)
+        try FileManager.default.createDirectory(at: day, withIntermediateDirectories: true)
+        let file = day.appendingPathComponent("rollout-lockunreadable.jsonl")
+        try Data(( [sessionMeta(id: "desktop-lockunreadable"), taskStarted(id: "t1")]
+            .joined(separator: "\n") + "\n").utf8).write(to: file)
+        try FileManager.default.setAttributes([.modificationDate: Date()], ofItemAtPath: file.path)
+        let lockDir = home.appendingPathComponent("thread-writer-locks", isDirectory: true)
         try FileManager.default.createDirectory(at: lockDir, withIntermediateDirectories: true)
         try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: lockDir.path)
         defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700],
@@ -772,7 +809,7 @@ struct CodexRolloutMonitorTests {
 
         var reducer = SessionReducer()
         let monitor = CodexRolloutMonitor(
-            root: fixture.root,
+            root: sessions,
             isDesktopAppServerAlive: { true }
         )
         for event in await monitor.poll(now: now) { reducer.apply(event) }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -128,6 +128,29 @@ struct ObservationHealthDetectorTests {
         #expect(supportedResult.health(agent: .codex, source: .rollout) == .healthy)
     }
 
+    @Test("a rollout older than the recovery window still classifies as temporarily silent after a restart")
+    func staleRolloutAfterRestartIsTemporarilySilent() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try write("model = \"gpt\"\n", to: home.appendingPathComponent(".codex/config.toml"))
+        let rollout = home.appendingPathComponent(".codex/sessions/2023/11/14/rollout-stale.jsonl")
+        try write(
+            #"{"type":"session_meta","payload":{"cli_version":"0.151.0-alpha.7.2"}}"# + "\n" +
+            #"{"type":"event_msg","payload":{"type":"task_started"}}"#,
+            to: rollout)
+        let staleAt = now.addingTimeInterval(-2 * 60 * 60)
+        try FileManager.default.setAttributes([.modificationDate: staleAt], ofItemAtPath: rollout.path)
+        let modifiedAt = try rollout.resourceValues(forKeys: [.contentModificationDateKey])
+            .contentModificationDate
+
+        // No runtime signal: this is an app/daemon restart. Monitor candidates
+        // stay windowed — CodexRolloutMonitorTests.resumedOldThreadDiscovery
+        // already asserts a 3-hour-old rollout is not tailed.
+        let result = detect(home: home)
+        #expect(result.health(agent: .codex, source: .rollout) == .temporarilySilent)
+        #expect(result.diagnostic(agent: .codex, source: .rollout)?.lastObservedAt == modifiedAt)
+    }
+
     @Test("a rollout still being written in an old date directory is healthy")
     func oldDateDirectoryRolloutIsHealthy() throws {
         let home = try tempHome()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -168,6 +168,37 @@ struct ObservationHealthDetectorTests {
         #expect(result.diagnostic(agent: .codex, source: .rollout)?.lastObservedAt != nil)
     }
 
+    @Test("a partial unreadable sessions tree is not classified from the accessible subset")
+    func partialUnreadableSessionsTree() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try write("model = \"gpt\"\n", to: home.appendingPathComponent(".codex/config.toml"))
+        let readable = home.appendingPathComponent(".codex/sessions/2023/11/13/rollout-old.jsonl")
+        try write(
+            #"{"type":"session_meta","payload":{"cli_version":"0.151.0-alpha.7.2"}}"# + "\n" +
+            #"{"type":"event_msg","payload":{"type":"task_started"}}"#,
+            to: readable)
+        let hiddenDir = home.appendingPathComponent(".codex/sessions/2023/11/14", isDirectory: true)
+        let hidden = hiddenDir.appendingPathComponent("rollout-newer.jsonl")
+        try write(
+            #"{"type":"session_meta","payload":{"cli_version":"0.151.0-alpha.7.2"}}"# + "\n" +
+            #"{"type":"event_msg","payload":{"type":"task_started"}}"#,
+            to: hidden)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: hiddenDir.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700],
+                                                        ofItemAtPath: hiddenDir.path) }
+
+        let sessions = home.appendingPathComponent(".codex/sessions", isDirectory: true)
+        let result = detect(home: home)
+        #expect(result.health(agent: .codex, source: .rollout) == .sourceUnreadable)
+        if case .found(let files, incomplete: true) =
+            CodexRolloutDiscovery.candidates(in: sessions, now: now) {
+            #expect(files.map(\.url.lastPathComponent) == ["rollout-old.jsonl"])
+        } else {
+            Issue.record("monitor candidates should still tail the accessible rollout")
+        }
+    }
+
     @Test("an unreadable rollout directory is not treated as an empty source")
     func unreadableRolloutDirectory() throws {
         let home = try tempHome()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -128,6 +128,23 @@ struct ObservationHealthDetectorTests {
         #expect(supportedResult.health(agent: .codex, source: .rollout) == .healthy)
     }
 
+    @Test("a rollout still being written in an old date directory is healthy")
+    func oldDateDirectoryRolloutIsHealthy() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try write("model = \"gpt\"\n", to: home.appendingPathComponent(".codex/config.toml"))
+        // `now` is 2023-11-14. The old today/yesterday walk cannot see October.
+        let old = home.appendingPathComponent(".codex/sessions/2023/10/01/rollout-resumed.jsonl")
+        try write(
+            #"{"type":"session_meta","payload":{"cli_version":"0.151.0-alpha.7.2"}}"# + "\n" +
+            #"{"type":"event_msg","payload":{"type":"task_started"}}"#,
+            to: old)
+
+        let result = detect(home: home)
+        #expect(result.health(agent: .codex, source: .rollout) == .healthy)
+        #expect(result.diagnostic(agent: .codex, source: .rollout)?.lastObservedAt != nil)
+    }
+
     @Test("an unreadable rollout directory is not treated as an empty source")
     func unreadableRolloutDirectory() throws {
         let home = try tempHome()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -124,6 +124,11 @@ struct SessionReducerTests {
         ordinary.apply(ev(.stop, message: "Abandoned", at: 1))
         #expect(ordinary.sessions["s1"]?.hasUnreadCompletion == true)
         #expect(ordinary.sessions["s1"]?.probeRetired != true)
+
+        r.apply(ev(.preToolUse, tool: "Bash", at: 121))
+        #expect(r.sessions["s1"]?.probeRetired != true)
+        r.apply(ev(.stop, at: 122))
+        #expect(r.sessions["s1"]?.hasUnreadCompletion == true)
     }
 
     @Test("a failure-looking Stop message marks failed even without a tool error")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -129,6 +129,13 @@ struct SessionReducerTests {
         #expect(r.sessions["s1"]?.probeRetired != true)
         r.apply(ev(.stop, at: 122))
         #expect(r.sessions["s1"]?.hasUnreadCompletion == true)
+
+        var genuine = SessionReducer()
+        genuine.apply(ev(.userPromptSubmit, at: 0))
+        genuine.apply(ev(.stop, message: "Abandoned", probeRetirement: true, at: 60))
+        genuine.apply(ev(.stop, message: "Done", at: 61))
+        #expect(genuine.sessions["s1"]?.probeRetired != true)
+        #expect(genuine.sessions["s1"]?.hasUnreadCompletion == true)
     }
 
     @Test("a failure-looking Stop message marks failed even without a tool error")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -100,6 +100,18 @@ struct SessionReducerTests {
         #expect(r.sessions["s1"]?.presentationState == .thinking)
     }
 
+    @Test("probe abandonment is done, not a successful unread completion")
+    func abandonedStopIsNotUnreadCompletion() {
+        var r = SessionReducer()
+        r.apply(ev(.userPromptSubmit, at: 0))
+        r.apply(ev(.stop, message: "Abandoned", at: 60))
+        #expect(r.sessions["s1"]?.status == .done)
+        #expect(r.sessions["s1"]?.summary == "Abandoned")
+        #expect(r.sessions["s1"]?.failed != true)
+        #expect(r.sessions["s1"]?.hasUnreadCompletion == false)
+        #expect(r.sessions["s1"]?.presentationState != .completeUnread)
+    }
+
     @Test("a failure-looking Stop message marks failed even without a tool error")
     func failureStopMessage() {
         var r = SessionReducer()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -110,6 +110,12 @@ struct SessionReducerTests {
         #expect(r.sessions["s1"]?.failed != true)
         #expect(r.sessions["s1"]?.hasUnreadCompletion == false)
         #expect(r.sessions["s1"]?.presentationState != .completeUnread)
+
+        r.apply(ev(.userPromptSubmit, at: 61))
+        r.apply(ev(.postToolUse, tool: "Bash", toolError: true, at: 62))
+        r.apply(ev(.stop, message: "Abandoned", at: 120))
+        #expect(r.sessions["s1"]?.failed != true)
+        #expect(r.sessions["s1"]?.hasUnreadCompletion == false)
     }
 
     @Test("a failure-looking Stop message marks failed even without a tool error")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -16,12 +16,14 @@ struct SessionReducerTests {
         message: String? = nil,
         model: String? = nil,
         toolError: Bool = false,
+        probeRetirement: Bool = false,
         at: TimeInterval = 0
     ) -> HookEvent {
         HookEvent(kind: kind, sessionID: sid, agent: .claudeCode,
                   cwd: cwd, toolName: tool, message: message,
                   model: model,
-                  toolError: toolError, timestamp: t0.addingTimeInterval(at))
+                  toolError: toolError, timestamp: t0.addingTimeInterval(at),
+                  probeRetirement: probeRetirement)
     }
 
     @Test("preToolUse sets the active tool; postToolUse and a new turn clear it")
@@ -104,7 +106,7 @@ struct SessionReducerTests {
     func abandonedStopIsNotUnreadCompletion() {
         var r = SessionReducer()
         r.apply(ev(.userPromptSubmit, at: 0))
-        r.apply(ev(.stop, message: "Abandoned", at: 60))
+        r.apply(ev(.stop, message: "Abandoned", probeRetirement: true, at: 60))
         #expect(r.sessions["s1"]?.status == .done)
         #expect(r.sessions["s1"]?.summary == "Abandoned")
         #expect(r.sessions["s1"]?.failed != true)
@@ -113,9 +115,15 @@ struct SessionReducerTests {
 
         r.apply(ev(.userPromptSubmit, at: 61))
         r.apply(ev(.postToolUse, tool: "Bash", toolError: true, at: 62))
-        r.apply(ev(.stop, message: "Abandoned", at: 120))
+        r.apply(ev(.stop, message: "Abandoned", probeRetirement: true, at: 120))
         #expect(r.sessions["s1"]?.failed != true)
         #expect(r.sessions["s1"]?.hasUnreadCompletion == false)
+
+        var ordinary = SessionReducer()
+        ordinary.apply(ev(.userPromptSubmit, at: 0))
+        ordinary.apply(ev(.stop, message: "Abandoned", at: 1))
+        #expect(ordinary.sessions["s1"]?.hasUnreadCompletion == true)
+        #expect(ordinary.sessions["s1"]?.probeRetired != true)
     }
 
     @Test("a failure-looking Stop message marks failed even without a tool error")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
@@ -134,7 +134,7 @@ struct SessionStoreTests {
             kind: .stop, sessionID: "s", agent: .codex,
             cwd: "/x/p", message: "Abandoned",
             observationSource: .rollout, timestamp: retiredAt,
-            desktopThreadID: "s"),
+            desktopThreadID: "s", probeRetirement: true),
             recordsEvidence: false)
 
         let after = await store.snapshot(now: retiredAt)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
@@ -113,4 +113,49 @@ struct SessionStoreTests {
         #expect(await store.acknowledgeCompletion(sessionID: "s"))
         #expect(await store.snapshot(now: t0.addingTimeInterval(3)).sessions.first?.presentationState == .idle)
     }
+
+    @Test("a probe retirement does not refresh rollout observation evidence")
+    func retirementDoesNotRecordRolloutEvidence() async {
+        // Wall-clock T0 so source diagnostics stay inside the 10-minute healthy window.
+        let observedAt = Date()
+        let store = SessionStore()
+        await store.ingest(HookEvent(
+            kind: .userPromptSubmit, sessionID: "s", agent: .codex,
+            cwd: "/x/p", observationSource: .rollout, timestamp: observedAt,
+            desktopThreadID: "s"))
+        let before = await store.snapshot(now: observedAt)
+        #expect(before.sessions.first?.status == .working)
+        #expect(before.sessions.first?.observations?.first { $0.source == .rollout }?.lastObservedAt == observedAt)
+        #expect(before.observationDiagnostics?.health(agent: .codex, source: .rollout) == .healthy)
+        #expect(before.observationDiagnostics?.lastObserved(agent: .codex, source: .rollout) == observedAt)
+
+        let retiredAt = observedAt.addingTimeInterval(30)
+        await store.ingest(HookEvent(
+            kind: .stop, sessionID: "s", agent: .codex,
+            cwd: "/x/p", message: "Abandoned",
+            observationSource: .rollout, timestamp: retiredAt,
+            desktopThreadID: "s"),
+            recordsEvidence: false)
+
+        let after = await store.snapshot(now: retiredAt)
+        #expect(after.sessions.first?.status == .done)
+        #expect(after.sessions.first?.summary == "Abandoned")
+        #expect(after.sessions.first?.desktopThreadID == "s")
+        #expect(after.sessions.first?.failed != true)
+        #expect(after.sessions.first?.observations?.first { $0.source == .rollout }?.lastObservedAt == observedAt)
+        #expect(after.observationDiagnostics?.health(agent: .codex, source: .rollout) == .healthy)
+        #expect(after.observationDiagnostics?.lastObserved(agent: .codex, source: .rollout) == observedAt)
+    }
+}
+
+private extension Array where Element == AgentObservationDiagnostic {
+    func health(agent: AgentKind, source: ObservationSource) -> ObservationHealth? {
+        first(where: { $0.agent == agent })?.sources
+            .first(where: { $0.source == source })?.health
+    }
+
+    func lastObserved(agent: AgentKind, source: ObservationSource) -> Date? {
+        first(where: { $0.agent == agent })?.sources
+            .first(where: { $0.source == source })?.lastObservedAt
+    }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
@@ -142,6 +142,7 @@ struct SessionStoreTests {
         #expect(after.sessions.first?.summary == "Abandoned")
         #expect(after.sessions.first?.desktopThreadID == "s")
         #expect(after.sessions.first?.failed != true)
+        #expect(after.sessions.first?.hasUnreadCompletion == false)
         #expect(after.sessions.first?.observations?.first { $0.source == .rollout }?.lastObservedAt == observedAt)
         #expect(after.observationDiagnostics?.health(agent: .codex, source: .rollout) == .healthy)
         #expect(after.observationDiagnostics?.lastObserved(agent: .codex, source: .rollout) == observedAt)


### PR DESCRIPTION
## Summary
- Diagnose Codex rollout health from the same recursive `sessions` discovery the monitor already uses, so a resumed old-date file is `healthy` instead of `eventsMissing`.
- Let an already-working Desktop thread leave `working` within a minute when its ChatGPT.app writer is gone (`summary = "Abandoned"`). Lock files linger and their mtime does not follow writes, so a lock is only a negative signal.
- Writer-lock path is the sibling of the injected `sessions` root (`CODEX_HOME` / fixtures), not a hardcoded `~/.codex`. A missing lock directory is not treated as “no locks”.
- Ownerless grace is measured from the last scan that still saw a writer, so the worst-case discovery phase still retires within 60s.
- Once a thread has been observed ownerless, a relaunched ChatGPT.app plus a leftover writer lock does not reset that clock. Only a rollout append (`cursor.consume`) re-arms ownership.
- Probe retirement still applies `stop` → `done` with summary `Abandoned`, but it does not record a source-level healthy signal or refresh the session's rollout observation.

## Known boundary
If the **daemon itself** restarts, bootstrap of an already-active turn that still sees a live app-server plus a leftover lock treats that thread as owned. That case is left for H2 observation; this PR does not track process start time or pid.

## Test plan
- [x] `cd VibeBuddyKit && swift test` — 218 tests / 26 suites
- [x] `cd VibeBuddyMac && swift test` — 476 tests / 44 suites (baseline at PR #15: 466 / 44)
- [x] macOS app Debug build (`CODE_SIGNING_ALLOWED=NO`)
- [ ] Settings panel: a resumed old-date rollout shows healthy (ticket 06; live 2000+ tree not timed)
- [ ] Real Desktop quit/crash mid-turn leaves working within a minute (ticket 01 / 02)
- [ ] Real ChatGPT relaunch inside the 60s grace still retires the interrupted turn (H2)

Do not merge from this PR — M session owns integration.