### PR TITLE
fix(daemon): shared TokenStore fallback and drop stray Sparkle pin

### DIFF
--- a/VibeBuddyMac/Package.resolved
+++ b/VibeBuddyMac/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1c6a9c29110e433fd1d705c24ff2c98093008922a909a138d45aa2dc9fd019d3",
+  "originHash" : "4a79b9879f40f1a130103a70c351c8c15aa94c8fe19291378d834f80f338ed45",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -35,15 +35,6 @@
       "state" : {
         "revision" : "89c66b8d6655209268c44f619afcf771d8d83ec9",
         "version" : "2.7.0"
-      }
-    },
-    {
-      "identity" : "sparkle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle",
-      "state" : {
-        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
-        "version" : "2.9.6"
       }
     },
     {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -475,7 +475,7 @@ struct BearerAuth: Sendable {
     func authorizes(_ request: Request) -> Bool {
         // An empty configured token must never authorize anything (an empty
         // `Authorization: Bearer ` header or `?token=` would otherwise match it).
-        // Fail closed rather than `precondition`: vibebuddyd 优先环境变量，否则 TokenStore；空 env 仍 401.
+        // Fail closed rather than `precondition`: empty VIBEBUDDY_TOKEN still 401s.
         guard !token.isEmpty else { return false }
         if request.headers[.authorization] == "Bearer \(token)" { return true }
         if allowsQueryToken, request.uri.queryParameters["token"].map(String.init) == token { return true }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -475,9 +475,7 @@ struct BearerAuth: Sendable {
     func authorizes(_ request: Request) -> Bool {
         // An empty configured token must never authorize anything (an empty
         // `Authorization: Bearer ` header or `?token=` would otherwise match it).
-        // Fail closed rather than `precondition`: the menu-bar app's TokenStore
-        // always yields a non-empty token, but `vibebuddyd` takes VIBEBUDDY_TOKEN
-        // from the environment and an empty value must 401, not kill the process.
+        // Fail closed rather than `precondition`: vibebuddyd 优先环境变量，否则 TokenStore；空 env 仍 401.
         guard !token.isEmpty else { return false }
         if request.headers[.authorization] == "Bearer \(token)" { return true }
         if allowsQueryToken, request.uri.queryParameters["token"].map(String.init) == token { return true }

--- a/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
+++ b/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
@@ -2,13 +2,22 @@ import Foundation
 import VibeBuddyMacCore
 
 /// Headless entry point for Phase B (the menu-bar app wraps this in Phase C).
-/// Config via env: VIBEBUDDY_PORT (default 9876), VIBEBUDDY_TOKEN (default "devtoken").
+/// Config via env: VIBEBUDDY_PORT (default 9876), VIBEBUDDY_TOKEN (env wins,
+/// including empty; otherwise TokenStore.defaultStore()).
 @main
 struct VibeBuddyDaemon {
     static func main() async throws {
         let env = ProcessInfo.processInfo.environment
         let port = env["VIBEBUDDY_PORT"].flatMap(Int.init) ?? 9876
-        let token = env["VIBEBUDDY_TOKEN"] ?? "devtoken"
+        let token: String
+        let tokenSource: String
+        if let envToken = env["VIBEBUDDY_TOKEN"] {
+            token = envToken  // including empty: BearerAuth fail-closed, no store fallback
+            tokenSource = "env"
+        } else {
+            token = (try? TokenStore.defaultStore().loadOrCreate()) ?? Token.generate()
+            tokenSource = "TokenStore"
+        }
         let journalURL = env["VIBEBUDDY_JOURNAL_PATH"].map {
             URL(fileURLWithPath: $0)
         } ?? LifecycleJournalLocation.defaultURL()
@@ -27,7 +36,7 @@ struct VibeBuddyDaemon {
             token: token, port: port, pusher: pusher,
             codexRolloutMonitor: CodexRolloutMonitor())
         FileHandle.standardError.write(Data(
-            "vibebuddyd: listening on 0.0.0.0:\(port) (apns: \(pusher != nil ? "on" : "off"))\n".utf8))
+            "vibebuddyd: listening on 0.0.0.0:\(port) (apns: \(pusher != nil ? "on" : "off"), token: \(tokenSource))\n".utf8))
         try await server.runService()
     }
 }

--- a/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
+++ b/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
@@ -15,7 +15,7 @@ struct VibeBuddyDaemon {
             token = envToken  // including empty: BearerAuth fail-closed, no store fallback
             tokenSource = "env"
         } else {
-            token = (try? TokenStore.defaultStore().loadOrCreate()) ?? Token.generate()
+            token = try TokenStore.defaultStore().loadOrCreate()
             tokenSource = "TokenStore"
         }
         let journalURL = env["VIBEBUDDY_JOURNAL_PATH"].map {


### PR DESCRIPTION
## Summary
- `vibebuddyd` no longer falls back to the literal `devtoken`. `VIBEBUDDY_TOKEN` still wins when set (including empty → BearerAuth fail-closed); when unset it reads the same `TokenStore.defaultStore()` file the menu-bar app uses.
- `VibeBuddyMac/Package.resolved` now matches `Package.swift`: Sparkle pin removed. Sparkle stays a Mac App-only dependency.

## Test plan
- [x] `cd VibeBuddyKit && swift test` — 218 Swift Testing + 27 XCTest
- [x] `cd VibeBuddyMac && swift test` — 468 tests / 44 suites; second run did not rewrite `originHash`
- [x] `xcodegen generate` + `xcodebuild` MacApp Debug macOS `CODE_SIGNING_ALLOWED=NO` — succeeds
- [x] MacApp build **does** write Sparkle back into `VibeBuddyMac/Package.resolved`; committed file stays Sparkle-free; restore with `git checkout --`

Do not merge this PR — M merges first.


Made with [Cursor](https://cursor.com)