### PR TITLE
docs: correct implementation facts after #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Source-agnostic from day one. **Claude Code and Codex** are tested end-to-end; a
 The Mac shows a QR encoding `host:port` + a bearer token. The phone scans it once — no manual IP entry. (The same QR can carry a Tailscale `100.x` address later, with no code change.)
 
 ### 🖥️ Native Mac menu-bar app
-A `MenuBarExtra` glance with live counts, a macOS notch glance, **jump-to-terminal** (open the right session with one click), launch-at-login, and a Keychain-stored token. ⏎ / ⌘F dashboard shortcuts included. Sparkle update plumbing is in source; it is not live on the public v1.0 build.
+A `MenuBarExtra` glance with live counts, a macOS notch glance, **jump-to-terminal** (open the right session with one click), launch-at-login, and a LAN bearer token persisted in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`. ⏎ / ⌘F dashboard shortcuts included. Sparkle update plumbing is in source; it is not live on the public v1.0 build.
 
 ### 🔒 Local-first & private by design
 vibebuddy talks **directly** between your Mac and your phone over your own network. Session data **never** touches a vibebuddy server — there is no vibebuddy cloud, no account, no analytics, no tracking. Daemon routes are bearer-token gated. (The optional voice companion sends microphone audio and selected session context only to the provider *you* chose, with *your* key, when you turn it on.)
@@ -124,7 +124,7 @@ The hard part — *detecting* session state — is solved by **hooks** that each
 |------|------|
 | `VibeBuddyKit/` | Shared Codable wire model (SwiftPM) |
 | `VibeBuddyMac/` | macOS core lib + `vibebuddyd` headless CLI (SwiftPM) |
-| `VibeBuddyMacApp/` | macOS menu-bar app (xcodegen) — Keychain token, launch-at-login, Sparkle |
+| `VibeBuddyMacApp/` | macOS menu-bar app (xcodegen) — owner-only LAN-token file, launch-at-login, Sparkle |
 | `VibeBuddyApp/` | iOS app (xcodegen) |
 | `docs/planning/` | overview, PRD, architecture, roadmap, prior-art |
 
@@ -133,14 +133,14 @@ The hard part — *detecting* session state — is solved by **hooks** that each
 cd VibeBuddyMacApp && xcodegen generate
 open VibeBuddyMacApp.xcodeproj   # build & run (⌘R)
 ```
-A menu-bar-only app: live counts, a "Pair a phone" QR, and launch-at-login; the LAN token lives in the Keychain. (`vibebuddyd` in `VibeBuddyMac/` is the headless equivalent: `swift run vibebuddyd`.)
+A menu-bar-only app: live counts, a "Pair a phone" QR, and launch-at-login; the Mac daemon's `TokenStore` keeps the LAN token in the owner-only file `~/Library/Application Support/vibebuddy/token`. (`vibebuddyd` in `VibeBuddyMac/` is the headless equivalent: `swift run vibebuddyd`.)
 
 **iOS app:**
 ```bash
 cd VibeBuddyApp && xcodegen generate
 open VibeBuddyApp.xcodeproj   # run on a Simulator/device
 ```
-Pair by scanning the QR, or enter host/port/token manually. (Simulator: use `127.0.0.1` and the token from `~/Library/Application Support/vibebuddy/token`.)
+Pair by scanning the QR, or enter host/port/token manually. On iOS, `ConnectionStore` persists the pairing payload in `UserDefaults`. (Simulator: use `127.0.0.1` and the token from `~/Library/Application Support/vibebuddy/token`.)
 
 **Hooks (feed real agent sessions):**
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@
 Mac 显示一个编码了 `host:port` + bearer token 的二维码。手机扫一次即可——无需手动输 IP。（同一个二维码以后可以承载 Tailscale `100.x` 地址，无需改代码。）
 
 ### 🖥️ 原生 Mac 菜单栏应用
-`MenuBarExtra` 实时计数概览、macOS 刘海概览、**跳转到终端**（一键打开对应会话）、开机自启，以及 Keychain 存储的 token。还有 ⏎ / ⌘F 仪表盘快捷键。源码里已接 Sparkle，公开的 v1.0 构建尚未启用自动更新。
+`MenuBarExtra` 实时计数概览、macOS 刘海概览、**跳转到终端**（一键打开对应会话）、开机自启，以及持久化在仅所有者可读写（`0600`）文件 `~/Library/Application Support/vibebuddy/token` 中的局域网 bearer token。还有 ⏎ / ⌘F 仪表盘快捷键。源码里已接 Sparkle，公开的 v1.0 构建尚未启用自动更新。
 
 ### 🔒 本地优先，隐私至上
 vibebuddy 在你的 Mac 与手机之间**直接**通过你自己的网络通信。会话数据**绝不**经过 vibebuddy 服务器——没有 vibebuddy 云、没有账号、没有埋点、没有追踪。守护进程路由由 bearer token 把关。（可选语音伙伴只会在你开启后，把麦克风音频和所选会话上下文发往*你选择*的服务商，并使用*你自己*的 key。）
@@ -124,7 +124,7 @@ Claude Code / Codex / Qwen / … ──hooks──▶ vibebuddy（macOS 菜单�
 |------|------|
 | `VibeBuddyKit/` | 共享 Codable 线缆模型（SwiftPM） |
 | `VibeBuddyMac/` | macOS 核心库 + `vibebuddyd` 无头 CLI（SwiftPM） |
-| `VibeBuddyMacApp/` | macOS 菜单栏应用（xcodegen）—— Keychain token、开机自启、Sparkle |
+| `VibeBuddyMacApp/` | macOS 菜单栏应用（xcodegen）—— 仅所有者可读写的局域网 token 文件、开机自启、Sparkle |
 | `VibeBuddyApp/` | iOS 应用（xcodegen） |
 | `docs/planning/` | 概览、PRD、架构、路线图、先行研究 |
 
@@ -133,14 +133,14 @@ Claude Code / Codex / Qwen / … ──hooks──▶ vibebuddy（macOS 菜单�
 cd VibeBuddyMacApp && xcodegen generate
 open VibeBuddyMacApp.xcodeproj   # 构建并运行（⌘R）
 ```
-一个纯菜单栏应用：实时计数、"配对手机"二维码、开机自启；局域网 token 存在 Keychain 里。（`VibeBuddyMac/` 里的 `vibebuddyd` 是无头等价物：`swift run vibebuddyd`。）
+一个纯菜单栏应用：实时计数、"配对手机"二维码、开机自启；Mac 守护进程的 `TokenStore` 把局域网 token 保存在仅所有者可读写的文件 `~/Library/Application Support/vibebuddy/token` 中。（`VibeBuddyMac/` 里的 `vibebuddyd` 是无头等价物：`swift run vibebuddyd`。）
 
 **iOS 应用：**
 ```bash
 cd VibeBuddyApp && xcodegen generate
 open VibeBuddyApp.xcodeproj   # 在模拟器/真机上运行
 ```
-扫码配对，或手动输入 host/port/token。（模拟器：用 `127.0.0.1` 和 `~/Library/Application Support/vibebuddy/token` 里的 token。）
+扫码配对，或手动输入 host/port/token。在 iOS 上，`ConnectionStore` 把配对 payload 持久化到 `UserDefaults`。（模拟器：用 `127.0.0.1` 和 `~/Library/Application Support/vibebuddy/token` 里的 token。）
 
 **Hooks（接入真实 agent 会话）：**
 ```bash

--- a/docs/planning/architecture.md
+++ b/docs/planning/architecture.md
@@ -15,15 +15,15 @@ Mac
       • Reducer           → derive per-session status (needsResponse/working/done)
       • TranscriptReader  → tail JSONL for model, tokens, last assistant text
       • Broadcaster       → push ServerEvent to WS clients
-      • GET /snapshot, GET /ws   ← bound to 0.0.0.0:PORT (LAN), bearer-token gated
+      • GET /snapshot, WebSocket /ws ← bound to 0.0.0.0:PORT (LAN), bearer-token gated
       • GET /health              ← unauthenticated liveness probe
       │
       │  LAN WebSocket + REST, bearer token  (later: Tailscale 100.x via same channel)
       ▼
 iPhone
   VibeBuddyApp  (SwiftUI, depends on VibeBuddyKit)
-      • Pairing      → scan QR → {host, port, token} → Keychain
-      • Connection store (reconnect, snapshot-on-reconnect)
+      • Pairing      → scan QR → {host, port, token, macName?} → ConnectionStore / UserDefaults
+      • DashboardStore + WebSocket client (automatic /ws reconnect; server-pushed initial snapshot)
       • Dashboard (3 sections) + remote approve / answer
       • local notifications + APNs; Widget / Live Activity
       • Watch companion (iPhone relays; Watch has no Mac token)
@@ -95,7 +95,8 @@ public enum ServerEvent: Codable, Sendable {
 public struct PairingPayload: Codable, Sendable {
     public var host: String          // LAN IP today, Tailscale 100.x later
     public var port: Int
-    public var token: String         // bearer token, stored in Keychain on the phone
+    public var token: String         // bearer token, stored with this payload in UserDefaults
+    public var macName: String?
 }
 ```
 
@@ -105,7 +106,7 @@ We register these Claude Code hooks and reduce them. Claude's status hooks are f
 
 | Hook event | Effect on session |
 |---|---|
-| `SessionStart` | upsert session, `status = working`, set project/branch/cwd |
+| `SessionStart` | upsert session, `status = done`, set project/branch/cwd; remain idle until `UserPromptSubmit` |
 | `UserPromptSubmit` | `status = working`, `statusSince = now` |
 | `PreToolUse` | stay `working`; record active tool name for the "working" detail |
 | `PostToolUse` | stay `working`; clear active tool |
@@ -118,11 +119,11 @@ On every event the daemon also refreshes derived metadata via **TranscriptReader
 
 ## Connection & Pairing
 
-1. `VibeBuddyMac` generates a random `token` on first run (kept in the Mac Keychain) and binds the server to `0.0.0.0:PORT`.
-2. The menu bar's **"Show pairing QR"** renders a QR encoding `PairingPayload { host, port, token }` (host = current LAN IP; later a Tailscale `100.x` IP).
-3. `VibeBuddyApp` scans the QR, stores the payload in the **iOS Keychain**, then connects.
-4. Every `GET /snapshot` and `GET /ws` requires the bearer token (`Authorization: Bearer <token>`); requests without it get `401`. `GET /health` is open (liveness only). `POST /hook`, `/approval`, and `/terminal` also require the same token (header or `?token=`, **ADR-0009**).
-5. On reconnect (phone woke, WiFi changed) the app re-fetches `GET /snapshot` to resync, then resumes the `/ws` stream.
+1. `VibeBuddyMac` generates a random `token` on first run. `TokenStore` persists it in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`, and the server binds to `0.0.0.0:PORT`.
+2. The menu bar's **"Show pairing QR"** renders a QR encoding `PairingPayload { host, port, token, macName? }` (host = current LAN IP; later a Tailscale `100.x` IP).
+3. `VibeBuddyApp` scans the QR, and `ConnectionStore` encodes the full payload into **iOS `UserDefaults`** before connecting.
+4. `GET /snapshot` and the WebSocket `/ws` upgrade require the bearer token in `Authorization: Bearer <token>`; without it, `/snapshot` returns `401` and `/ws` refuses the upgrade. `GET /health` is open (liveness only). `POST /hook`, `/approval`, and `/terminal` also require the same token (header or `?token=`, **ADR-0009**).
+5. On initial connection and reconnect (phone woke, WiFi changed), the app opens `/ws` directly. After the WebSocket is established, the server immediately pushes the current snapshot and then subsequent updates; the current iOS client does not pre-fetch `GET /snapshot`.
 
 ## Wire Protocol
 
@@ -131,8 +132,8 @@ On every event the daemon also refreshes derived metadata via **TranscriptReader
 | Endpoint | Auth | Purpose |
 |---|---|---|
 | `GET /health` | none | liveness probe for the connection screen |
-| `GET /snapshot` | bearer token | full `Snapshot` JSON — initial load and after reconnect |
-| `GET /ws` | bearer token | WebSocket stream of `ServerEvent` frames |
+| `GET /snapshot` | bearer token | full `Snapshot` JSON for explicit REST callers; not used by the current iOS reconnect path |
+| `GET /ws` | bearer token | WebSocket stream; current `Snapshot` immediately after upgrade, then subsequent `ServerEvent` frames |
 
 **Hooks → daemon (bearer token; query token allowed per ADR-0009):**
 
@@ -150,11 +151,11 @@ The forwarder reads `VIBEBUDDY_TOKEN` or the token file selected by `VIBEBUDDY_T
 ## Key Architectural Decisions
 
 1. **Single shared package (VibeBuddyKit).** Models + `Codable` live once; the two apps can't drift on the wire format. *Trade-off*: both Xcode apps take a local-package dependency (fine in a monorepo).
-2. **Mac side is a SwiftUI `MenuBarExtra` app (R1)**, not a headless CLI. Gives a Mac-side glance and a home for launch-at-login, port config, and the pairing QR; matches `eul` / open-vibe-island. The hook-intake + reducer + WebSocket server are embedded behind a `Server` protocol.
-3. **QR pairing + bearer token (R2).** The phone scans a QR instead of typing an IP; the token gives light LAN auth and is reused unchanged when the host becomes a Tailscale IP. Tokens live in Keychain on both sides.
+2. **Mac side is a SwiftUI `MenuBarExtra` app (R1)**, not a headless CLI. Gives a Mac-side glance and a home for launch-at-login, port config, and the pairing QR; matches `eul` / open-vibe-island. The hook-intake, reducer, and WebSocket server are embedded in the Mac product.
+3. **QR pairing + bearer token (R2).** The phone scans a QR instead of typing an IP; the token gives light LAN auth and is reused unchanged when the host becomes a Tailscale IP. The Mac stores it in an owner-only file; iOS stores the full pairing payload in `UserDefaults`.
 4. **Status delivery is bounded and fail-open; the daemon is not read-only.** Claude status hooks run asynchronously and stay off the agent's critical path. Codex and Grok currently invoke status hooks synchronously, but the forwarder caps local HTTP delivery at one second for Codex and three seconds for Grok, so a missing or wedged daemon can delay them only briefly. Remote approval is an opt-in blocking gate. Hook routes share the install bearer token (**ADR-0009**).
 5. **Source-agnostic sessions.** `agent: AgentKind` on every session; Claude Code and Codex are adapters normalizing their payloads into one `AgentSession`. Codex is additive.
-6. **Server library (Phase B decision).** Lean candidates: **Hummingbird 2** (small, async/await, first-class WS) or raw **Network.framework** `NWListener` (zero deps). Isolated behind the `Server` protocol so it's swappable.
+6. **Server library.** The current server is implemented directly with **Hummingbird 2** and HummingbirdWebSocket. There is no `NWListener` backend or `Server` protocol layer in the current implementation.
 7. **Transport is config, not code.** `host:port` + token are data (delivered by QR), so LAN→Tailscale is a value swap.
 
 ## Testing Seams (for TDD / to-spec)


### PR DESCRIPTION
## Summary

This is the post-verification documentation correction for PR #21. It fixes five implementation facts without changing the public v1.0, real-device acceptance, or closed-app APNs boundaries.

1. Token storage: the Mac `TokenStore` persists the LAN bearer token in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`; iOS `ConnectionStore` persists the full `PairingPayload` in `UserDefaults`. Evidence: `VibeBuddyMac/Sources/VibeBuddyMacCore/Token.swift:11-39`, `VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PairingTests.swift:17-36`, `VibeBuddyApp/Sources/ConnectionStore.swift:4-41`.
2. Session reduction: `SessionStart` creates or resumes an idle `done` session; `UserPromptSubmit` moves it to `working`. Evidence: `VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift:41-52`, `VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift:171-182`.
3. Pairing and authentication: the QR encodes `PairingPayload` with host, port, token, and optional Mac name; the client stores that payload and uses the token as a bearer header. Evidence: `VibeBuddyKit/Sources/VibeBuddyKit/Models.swift:472-485`, `VibeBuddyMac/Sources/VibeBuddyMacCore/Pairing.swift:6-17`, `VibeBuddyApp/Sources/SnapshotStream.swift:17-23`, `VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift:100-105,176-189`.
4. Reconnect flow: `DashboardStore` retries the WebSocket client, which opens `/ws` directly; `SessionStore.subscribe()` immediately yields the current snapshot after upgrade. The existing `GET /snapshot` endpoint is not the current iOS reconnect path. Evidence: `VibeBuddyApp/Sources/DashboardStore.swift:126-151`, `VibeBuddyApp/Sources/SnapshotStream.swift:11-40`, `VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift:347-365`, `VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift:100-121`.
5. Server implementation: the Mac package depends on Hummingbird 2 and HummingbirdWebSocket, and `VibeBuddyServer` uses them directly. There is no implemented `NWListener` backend or `Server` protocol layer. Evidence: `VibeBuddyMac/Package.swift:11-24`, `VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift:1-5,96-165`.

## Validation

- Diff from `f8f0a12ba352533073909674835e56d930ecc1ba` contains only `README.md`, `README.zh-CN.md`, and `docs/planning/architecture.md`.
- `git diff --check` passes.
- All five repository-relative links in each README resolve.
- English and Chinese README token-storage semantics match.
- No Swift or Xcode build was run for this docs-only correction.

H2 remains frozen and awaits M4. This PR does not start M4, H2, H3, or H1.