### PR TITLE
fix: stabilize Codex rollout health and Mac graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Source-agnostic from day one. **Claude Code and Codex** are tested end-to-end; a
 The Mac shows a QR encoding `host:port` + a bearer token. The phone scans it once — no manual IP entry. (The same QR can carry a Tailscale `100.x` address later, with no code change.)
 
 ### 🖥️ Native Mac menu-bar app
-A `MenuBarExtra` glance with live counts, a macOS notch glance, **jump-to-terminal** (open the right session with one click), launch-at-login, and a LAN bearer token persisted in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`. ⏎ / ⌘F dashboard shortcuts included. Sparkle update plumbing is in source; it is not live on the public v1.0 build.
+A `MenuBarExtra` glance with live counts, a macOS notch glance, **jump-to-terminal** (open the right session with one click), launch-at-login, and a LAN bearer token persisted in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`. ⏎ / ⌘F dashboard shortcuts included. v1.1 uses a signed Sparkle update feed; original v1.0 users need a one-time manual installation.
 
 ### 🔒 Local-first & private by design
 vibebuddy talks **directly** between your Mac and your phone over your own network. Session data **never** touches a vibebuddy server — there is no vibebuddy cloud, no account, no analytics, no tracking. Daemon routes are bearer-token gated. (The optional voice companion sends microphone audio and selected session context only to the provider *you* chose, with *your* key, when you turn it on.)
@@ -86,13 +86,11 @@ Full English and Simplified-Chinese UI on both apps. Plus a **Demo mode** that l
 ## ⬇️ Download
 
 ### macOS app
-**[Download vibebuddy-mac-v1.0.dmg →](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)** · Apple Silicon · macOS 14+
+**[Download the latest Mac Companion →](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)** · Apple Silicon · macOS 14+
 
-> **First launch (unsigned build).** This early build isn't notarized yet, so Gatekeeper will warn the first time. Open the `.dmg`, drag **vibebuddy** to **Applications**, then either **right-click → Open → Open**, or run once:
-> ```bash
-> xattr -dr com.apple.quarantine /Applications/vibebuddy.app
-> ```
-> The current public build is unsigned. A signed + notarized (double-click-to-open, zero-warning) build is not in this release.
+The v1.1 DMG is Developer ID signed and notarized. Open it and drag **VibeBuddyMacApp** to **Applications**. No quarantine-removal command is needed.
+
+**Updating from v1.0:** install v1.1 manually once. The original v1.0 shipped with an invalid update URL, so it cannot discover this release automatically. v1.1 uses the published Sparkle feed for future releases. The installed source build and the GitHub release are separate: use the latest release asset for the supported download.
 
 ### iPhone app
 Build it from source for now — see [Build & run](#️-build--run). Install on your own iPhone; there is no public iPhone download.
@@ -169,7 +167,7 @@ vibebuddy stands on the shoulders of two clever projects that first proved you c
 
 ## 📍 Status
 
-The public Mac release is **[v1.0](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.0)**. v1 core implements the 3-bucket dashboard, QR pairing, notifications, remote approvals, Live Activity / Dynamic Island, the voice companion, and multi-CLI hooks (Claude Code + Codex tested). The iPhone app is installed from Xcode on a personal device, but real-device acceptance is still partial: Widget / Live Activity visuals, always-allow / allow-session approval flows, voice actions, iOS voice parity, the OpenAI path, and the Watch companion remain pending human verification. See the [`real-device acceptance checklist`](docs/roadmap-checklist-2026-06-06.md) and [`roadmap`](docs/planning/roadmap.md).
+The Mac v1.1 source includes Codex Desktop 0.153.3 monitoring, bounded UTF-8 rollout handling, graceful daemon shutdown, observation diagnostics and Watch companion support. Mac, iPhone and Apple Watch have been installed locally; real phone approvals, recovery and phone-to-Watch state relay were verified. Full wrist approval, notification perception, voice and accessibility acceptance remain user follow-ups. App Store availability is separate from the Mac GitHub release. See the [latest Mac release](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) and [roadmap](docs/planning/roadmap.md).
 
 ## 📄 License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@
 Mac 显示一个编码了 `host:port` + bearer token 的二维码。手机扫一次即可——无需手动输 IP。（同一个二维码以后可以承载 Tailscale `100.x` 地址，无需改代码。）
 
 ### 🖥️ 原生 Mac 菜单栏应用
-`MenuBarExtra` 实时计数概览、macOS 刘海概览、**跳转到终端**（一键打开对应会话）、开机自启，以及持久化在仅所有者可读写（`0600`）文件 `~/Library/Application Support/vibebuddy/token` 中的局域网 bearer token。还有 ⏎ / ⌘F 仪表盘快捷键。源码里已接 Sparkle，公开的 v1.0 构建尚未启用自动更新。
+`MenuBarExtra` 实时计数概览、macOS 刘海概览、**跳转到终端**（一键打开对应会话）、开机自启，以及持久化在仅所有者可读写（`0600`）文件 `~/Library/Application Support/vibebuddy/token` 中的局域网 bearer token。还有 ⏎ / ⌘F 仪表盘快捷键。v1.1 使用带签名的 Sparkle 更新源；原 v1.0 用户需要先手动安装一次新版。
 
 ### 🔒 本地优先，隐私至上
 vibebuddy 在你的 Mac 与手机之间**直接**通过你自己的网络通信。会话数据**绝不**经过 vibebuddy 服务器——没有 vibebuddy 云、没有账号、没有埋点、没有追踪。守护进程路由由 bearer token 把关。（可选语音伙伴只会在你开启后，把麦克风音频和所选会话上下文发往*你选择*的服务商，并使用*你自己*的 key。）
@@ -86,13 +86,11 @@ vibebuddy 在你的 Mac 与手机之间**直接**通过你自己的网络通信�
 ## ⬇️ 下载
 
 ### macOS 应用
-**[下载 vibebuddy-mac-v1.0.dmg →](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)** · Apple Silicon · macOS 14+
+**[下载最新版 Mac Companion →](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)** · Apple Silicon · macOS 14+
 
-> **首次打开（未签名版）。** 这个早期版本尚未公证，首次打开会被 macOS Gatekeeper 拦截。打开 `.dmg`，把 **vibebuddy** 拖进**应用程序**，然后**右键 → 打开 → 打开**，或在终端执行一次：
-> ```bash
-> xattr -dr com.apple.quarantine /Applications/vibebuddy.app
-> ```
-> 当前公开构建尚未签名。正式签名 + 公证版（双击即开、零警告）不在这个公开版本里。
+v1.1 DMG 已使用 Developer ID 签名并完成公证。打开后把 **VibeBuddyMacApp** 拖入**应用程序**，无需执行移除隔离属性的命令。
+
+**从 v1.0 更新：**请手动安装一次 v1.1。原 v1.0 内置更新地址无效，不能自动发现本次更新；v1.1 使用正式 Sparkle 更新源接收后续版本。源码构建和 GitHub 发布包是不同交付物，需要直接安装时请使用上方最新版 Release 资产。
 
 ### iPhone 应用
 目前请从源码构建——见 [构建与运行](#️-构建与运行)。装到你自己的 iPhone 上即可；没有公开的 iPhone 下载。
@@ -169,7 +167,7 @@ vibebuddy 站在两个聪明项目的肩膀上——它们最早证明了可以�
 
 ## 📍 状态
 
-当前公开的 Mac 版本是 **[v1.0](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.0)**。v1 核心已实现三栏仪表盘、扫码配对、通知、远程批准、实时活动 / 灵动岛、语音伴侣，以及多 CLI hooks（Claude Code + Codex 已测试）。iPhone 应用已通过 Xcode 安装到个人设备，但真机验收仍不完整：Widget / 实时活动目视效果、总是允许 / 本次会话允许的批准流程、语音操作、iOS 语音能力对齐、OpenAI 路径，以及 Watch 伴侣应用仍待人工验证。见 [`真机验收清单`](docs/roadmap-checklist-2026-06-06.md)和[`路线图`](docs/planning/roadmap.md)。
+Mac v1.1 源码已包含 Codex Desktop 0.153.3 观测、UTF-8 截断处理、守护进程正常退出、观测诊断和 Watch 伴侣支持。Mac、iPhone、Apple Watch 已在本地安装，真实手机审批、恢复及手机到手表的状态传递已验证。完整腕上审批、通知感知、语音与可访问性体验仍留待实际使用确认。App Store 上架与 Mac GitHub 发布分别推进。见[最新 Mac Release](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)和[路线图](docs/planning/roadmap.md)。
 
 ## 📄 许可
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
@@ -379,6 +379,8 @@ public enum ObservationHealthDetector {
         guard components.count >= 2, let minor = Int(components[1]) else { return false }
         // Pre-1.0 minor versions may change the rollout schema. Keep this an
         // explicit allowlist so a future semver is not mistaken for evidence.
-        return major == 0 && minor == 151
+        // H2-R real Desktop replay verified 0.153.3 turn/tool/model/token shapes.
+        // Admit only that observed release, not every unverified 0.153 patch.
+        return (major == 0 && minor == 151) || version == "0.153.3"
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
@@ -338,12 +338,18 @@ public enum ObservationHealthDetector {
         fileManager fm: FileManager
     ) -> RolloutInspection {
         let limit = 1 << 20
-        guard let data = readData(at: url, upToCount: limit, fileManager: fm),
-              let text = String(data: data, encoding: .utf8) else { return .unsupported }
+        guard var data = readData(at: url, upToCount: limit, fileManager: fm) else { return .unsupported }
         let fileSize = ((try? fm.attributesOfItem(atPath: url.path))?[.size] as? NSNumber)?.intValue
         let truncated = (fileSize ?? data.count) > data.count
-        var lines = text.split(separator: "\n", omittingEmptySubsequences: true)
-        if truncated, data.last != 0x0A, !lines.isEmpty { lines.removeLast() }
+        // The byte limit can split a UTF-8 character as well as a JSON record.
+        // Drop the incomplete record before strict decoding, so a valid stream
+        // is not rejected merely because its 1 MiB boundary falls inside text.
+        if truncated, data.last != 0x0A {
+            guard let newline = data.lastIndex(of: 0x0A) else { return .unsupported }
+            data = data.prefix(through: newline)
+        }
+        guard let text = String(data: data, encoding: .utf8) else { return .unsupported }
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
 
         var version: String?
         var hasSupportedEvent = false

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -128,6 +128,44 @@ struct ObservationHealthDetectorTests {
         #expect(supportedResult.health(agent: .codex, source: .rollout) == .healthy)
     }
 
+    // Minimized from the H2-R Desktop rollout on 2026-09-05 (0.153.3).
+    // IDs, paths, model and tool content are synthetic; no user text is retained.
+    @Test("observed Desktop 0.153.3 progress is compatible even with runtime coverage")
+    func desktop1533Compatibility() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let rollout = home.appendingPathComponent(".codex/sessions/rollout-h2.jsonl")
+        let meta = #"{"type":"session_meta","payload":{"id":"h2","cwd":"/test","originator":"Codex Desktop","source":"vscode","cli_version":"0.153.3"}}"#
+        try write(meta, to: rollout)
+        #expect(detect(home: home).health(agent: .codex, source: .rollout) == .eventsMissing)
+
+        let lines = [meta,
+            #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            #"{"type":"turn_context","payload":{"model":"test-model"}}"#,
+            #"{"type":"response_item","payload":{"type":"custom_tool_call","call_id":"c1","name":"exec","input":""}}"#,
+            #"{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"c1","output":""}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}"#,
+        ]
+        var parser = CodexRolloutParser()
+        let events = lines.flatMap { parser.parseEvents(Data($0.utf8), receivedAt: now) }
+        #expect(events.map(\.kind) == [.userPromptSubmit, .sessionMetadataChanged,
+                                      .preToolUse, .postToolUse, .stop])
+        #expect(!parser.turnActive)
+        try write(lines.joined(separator: "\n"), to: rollout)
+        let signal = ObservationRuntimeSignal(agent: .codex, source: .rollout,
+            lastObservedAt: now, observedCoverage: [.lifecycle, .turn, .tool])
+        let result = detect(home: home, signals: [signal])
+        #expect(result.health(agent: .codex, source: .rollout) == .healthy)
+        #expect(result.diagnostic(agent: .codex, source: .rollout)?.observedCoverage
+            == signal.observedCoverage)
+        #expect(detect(home: home).health(agent: .codex, source: .rollout) == .healthy)
+
+        try write(lines.joined(separator: "\n").replacingOccurrences(of: "0.153.3", with: "0.153.4"),
+                  to: rollout)
+        #expect(detect(home: home, signals: [signal])
+            .health(agent: .codex, source: .rollout) == .unknownVersion)
+    }
+
     @Test("a rollout older than the recovery window still classifies as temporarily silent after a restart")
     func staleRolloutAfterRestartIsTemporarilySilent() throws {
         let home = try tempHome()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -166,6 +166,28 @@ struct ObservationHealthDetectorTests {
             .health(agent: .codex, source: .rollout) == .unknownVersion)
     }
 
+    @Test("bounded rollout inspection discards a partial line before decoding UTF-8")
+    func boundedRolloutUTF8() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let rollout = home.appendingPathComponent(".codex/sessions/rollout-boundary.jsonl")
+        let prefix = #"{"type":"session_meta","payload":{"cli_version":"0.153.3"}}"# + "\n"
+            + #"{"type":"event_msg","payload":{"type":"task_started"}}"# + "\n"
+        let messageStart = #"{"type":"response_item","payload":{"type":"message","text":""#
+        // Like the real H2 rollouts, the 1 MiB read ends inside a valid character
+        // in an incomplete record. Earlier complete records remain usable.
+        let padding = String(repeating: "a", count: (1 << 20) - prefix.utf8.count
+            - messageStart.utf8.count - 1)
+        try write(prefix + messageStart + padding + "中" + #""}}"# + "\n", to: rollout)
+        #expect(detect(home: home).health(agent: .codex, source: .rollout) == .healthy)
+
+        // Corrupt bytes in a complete record must still fail strict decoding.
+        var corrupt = Data(prefix.utf8)
+        corrupt.append(contentsOf: [0xFF, 0x0A])
+        try corrupt.write(to: rollout)
+        #expect(detect(home: home).health(agent: .codex, source: .rollout) == .unknownVersion)
+    }
+
     @Test("a rollout older than the recovery window still classifies as temporarily silent after a restart")
     func staleRolloutAfterRestartIsTemporarilySilent() throws {
         let home = try tempHome()

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -191,7 +191,13 @@ final class MenuBarModel: ObservableObject {
                                          Task { @MainActor in self?.recordPairedDevice(device) }
                                      })
         Task.detached(priority: .utility) {
-            do { try await server.runService() }
+            do {
+                try await server.runService()
+                // Hummingbird consumes SIGTERM/SIGINT and returns after shutting
+                // down the server and joining its rollout monitor. Finish the
+                // app lifetime too, so a later open can start a healthy instance.
+                await MainActor.run { NSApplication.shared.terminate(nil) }
+            }
             catch { FileHandle.standardError.write(Data("server error: \(error)\n".utf8)) }
         }
     }

--- a/docs/release-notes-1.1.md
+++ b/docs/release-notes-1.1.md
@@ -48,3 +48,17 @@ once its signed appcast is published.
 - Consistent status wording across the Mac app, the iPhone app, and Codex Micro.
 
 **Requires macOS 14 or later. Apple Silicon.**
+
+### Reliability fixes
+
+- Recognizes verified Codex Desktop 0.153.3 rollout files.
+- Avoids a false unknown-version warning when the bounded rollout read splits a UTF-8 character.
+- Exits the Mac app after graceful daemon shutdown, allowing an ordinary reopen to restore the service.
+
+### iPhone and Apple Watch companion
+
+The source includes the paired Watch companion and phone-to-Watch session-state relay. The Mac download is the companion server; iPhone and Watch App Store updates are distributed separately. Full wrist interaction and notification experience remain real-use follow-ups.
+
+### Updating from v1.0
+
+Install this DMG manually once. The original v1.0 update URL was invalid and cannot discover v1.1. This release uses the official signed feed for future updates; the one-time manual installation is not an automatic v1.0-to-v1.1 upgrade test.


### PR DESCRIPTION
## Changes

Fix two failures reproduced during installed Mac/iPhone acceptance:

- Recognize verified Codex Desktop 0.153.3 rollouts. Trim incomplete JSONL bytes before strict UTF-8 decoding so the 1 MiB read boundary cannot misclassify a valid rollout as an unknown version. Complete-record corruption and unsupported versions remain rejected.
- Terminate the Mac app after the embedded server finishes graceful shutdown. Previously SIGTERM closed the listener but left the AppKit process alive, preventing an ordinary reopen from restoring service.

README download instructions and release notes now point to the latest Mac Companion and explain the one-time manual update required from v1.0.

## Validation

- Mac suite: 494 tests across 44 suites; independent reviews of both fixes approved.
- Regression reproduced against real large rollout files; healthy source state verified after the cache interval and installed-app restart.
- Installed Release app exited approximately 0.1 seconds after SIGTERM; ordinary reopen restored health and real snapshot data.
- Latest Mac, companion iPhone and physical Watch installed; physical Watch received non-demo live state from its paired iPhone.

Full wrist interaction, notification perception and other user-only acceptance remain provisional by user instruction. This PR does not claim complete H3 acceptance, public release or Sparkle upgrade validation.
