### PR TITLE
fix(watch): satisfy WCSessionDelegate on Swift 6.3

### DIFF
--- a/VibeBuddyApp/Watch/WatchStateStore.swift
+++ b/VibeBuddyApp/Watch/WatchStateStore.swift
@@ -173,4 +173,10 @@ extension WatchStateStore: WCSessionDelegate {
         let reachable = session.isReachable
         Task { @MainActor [weak self] in self?.linkChanged(reachable: reachable) }
     }
+
+    // Both are iOS-only (`__WATCHOS_UNAVAILABLE` in the SDK) and never fire on
+    // the Watch, but Swift 6.3 insists on witnesses for them all the same.
+    nonisolated func sessionDidBecomeInactive(_ session: WCSession) {}
+
+    nonisolated func sessionDidDeactivate(_ session: WCSession) {}
 }


### PR DESCRIPTION
## Summary
- Xcode 26.6 / Swift 6.3.3 now requires witnesses for `sessionDidBecomeInactive(_:)` and `sessionDidDeactivate(_:)` on `WCSessionDelegate`, even though the watchOS SDK marks both `__WATCHOS_UNAVAILABLE`. The watchOS target stopped compiling, which broke the iOS simulator build of the app scheme.
- Adds two `nonisolated` empty stubs to `WatchStateStore`, matching how `WatchConnectivityTransport` on the iOS side already declares them. No `@preconcurrency` on the conformance; the existing delegate methods already pass strict checking.

## Verification
- `xcodebuild -project VibeBuddyApp/VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` → BUILD SUCCEEDED
- `swift test` in VibeBuddyKit → 219 tests in 26 suites passed