### PR TITLE
Release iPhone and Apple Watch 1.1 (4)

### DIFF
--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -46,8 +46,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app
-        MARKETING_VERSION: "1.0"
-        CURRENT_PROJECT_VERSION: "3"
+        MARKETING_VERSION: "1.1"
+        CURRENT_PROJECT_VERSION: "4"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -79,8 +79,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.widget
-        MARKETING_VERSION: "1.0"
-        CURRENT_PROJECT_VERSION: "3"
+        MARKETING_VERSION: "1.1"
+        CURRENT_PROJECT_VERSION: "4"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -106,8 +106,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
-        MARKETING_VERSION: "1.0"
-        CURRENT_PROJECT_VERSION: "3"
+        MARKETING_VERSION: "1.1"
+        CURRENT_PROJECT_VERSION: "4"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2

--- a/docs/app-store-paste-sheet.md
+++ b/docs/app-store-paste-sheet.md
@@ -1,9 +1,12 @@
-# App Store Connect — paste sheet (iOS 1.0)
+# App Store Connect — paste sheet (iOS 1.1)
+
+For this routine update, use the existing app (Apple ID `6777469338`) and select
+version **1.1**, build **4**. Do not create another app. The release-specific
+English and Simplified Chinese notes below are required. Older initial-submission
+wording in `app-store-listing.md` is not the source of truth for this update.
 
 Every field you have to fill in on the web, in the order App Store Connect asks for
-it. Copy the fenced blocks verbatim. Source of truth for the wording is
-[`app-store-listing.md`](app-store-listing.md); this file is the same text arranged
-for typing-free submission. Character limits are Apple's and are already respected.
+it. Preserve the existing live account settings unless a change is explicitly authorized.
 
 Legend: **🧑 you only** (login, payment, uploads) · **⚙️ decision** (pick one, then be
 consistent) · everything else is copy-paste.
@@ -20,21 +23,11 @@ consistent) · everything else is copy-paste.
 
 ---
 
-## 1. New App
+## 1. Existing App — Version 1.1
 
-App Store Connect ▸ Apps ▸ **+** ▸ New App.
-
-| Field | Value |
-|---|---|
-| Platform | iOS |
-| Name | `VibeBuddy: Agent Monitor` |
-| Primary language | English (U.S.) |
-| Bundle ID | `com.vibebuddy.app` |
-| SKU | `vibebuddy-ios-001` |
-| User Access | Full Access |
-
-> The plain name "vibebuddy" was already taken on the store (checked 2026-06-06).
-> The bundle id, the repo and the Mac app stay `vibebuddy`; only the store name differs.
+Open the existing **VibeBuddy: Agent Monitor** app and create iOS version **1.1**.
+Bundle ID: `com.vibebuddy.app`. Primary language: English (U.S.); also supply
+Simplified Chinese release metadata and screenshots.
 
 ---
 
@@ -60,157 +53,103 @@ Watch your AI coding agents
 | Field | Value |
 |---|---|
 | Price | Free |
-| Availability | **United States** only |
-
-> **Why not "all countries and regions".** Offering the app in the China mainland
-> storefront requires an ICP filing number, and App Store Connect blocks the
-> submission without one. Decision of 2026-09-03: US store only, so there is no
-> filing obligation and none of what it drags along — no MIIT name matching, so the
-> name above keeps its subtitle and stays free to change later.
-> `docs/icp-app-filing-checklist.md` is marked not-applicable and holds the detail
-> should that ever change.
->
-> If you meant "anywhere except China" rather than literally the US, select all
-> countries and regions and clear **China mainland** — same filing outcome, far
-> wider reach. It is one checkbox either way, and changeable after release.
+| Availability | Preserve the existing 147 available regions; China mainland and the 27 EU regions remain unavailable (verified 2026-09-05) |
 
 ---
 
 ## 4. App Privacy
 
-**Privacy Policy URL** — the text is ready in [`privacy-policy.md`](privacy-policy.md);
-it needs a public home first. Publish it to the same GitHub Pages site as the Mac
-appcast (`gh-pages` branch of `semantic-craft/iOS-vibebuddy`) and use:
+**Privacy Policy URL** (existing public policy):
 
 ```
-https://semantic-craft.github.io/iOS-vibebuddy/privacy-policy.html
+https://github.com/semantic-craft/iOS-vibebuddy/blob/main/docs/privacy-policy.md
 ```
 
-Data collection answers — "Do you or your third-party partners collect data from
-this app?" → **Yes** (the push token counts), then:
-
-| Data type | Collected | Linked to user | Used for tracking | Purpose |
-|---|---|---|---|---|
-| Identifiers ▸ Device ID (APNs token) | Yes | No | No | App Functionality |
-| Audio Data ⚙️ | see below | No | No | App Functionality |
-| Everything else | No | — | — | — |
-
-⚙️ **Audio Data — decide once, then keep it consistent.** The voice companion streams
-microphone audio straight from the device to the provider *the user* configures with
-*their own* API key; vibebuddy runs no server and never receives or stores it
-(ADR-0002). Under Apple's definition, data your app does not access is not
-"collected", so declaring nothing is defensible. **Recommended: declare it anyway** —
-Audio Data ▸ App Functionality ▸ Not linked to you ▸ Not used for tracking — because
-audio does leave the device and the conservative answer ages better under review.
-
-Declare **no** third-party SDK: there is none. No analytics, no advertising, no
-tracking, no location.
+Preserve the existing privacy declarations for this update: Device ID, Other User
+Content, and Audio Data, each for App Functionality and linked to identity.
+The policy now describes the paired iPhone-to-Watch relay and local Watch snapshot
+cache. Do not replace the live declarations with the older initial-submission
+recommendations in the listing document.
 
 ---
 
-## 5. Version Information (1.0)
+## 5. Version Information (1.1)
 
-**Promotional text** (≤170 chars — this is 147, editable after release without review):
+The complete English and Simplified Chinese descriptions are saved in App Store
+Connect. They describe iPhone/Watch task monitoring, supported approvals, weekly
+usage and freshness, the paired-iPhone requirement, and optional voice with the
+user's provider key. Preserve these saved descriptions; do not paste the older
+1.0 description from `app-store-listing.md` over them.
 
-```
-Keep an eye on your Claude Code and Codex sessions from your phone. Get notified when one needs you, review the exact command, and approve or deny.
-```
+Support URL: `https://github.com/semantic-craft/iOS-vibebuddy`.
+Mac Companion download: `https://github.com/semantic-craft/iOS-vibebuddy/releases/latest`.
+Copyright: `2026 Xianwei Zhang`.
 
-**Description**:
-
-```
-vibebuddy is the phone companion for the vibebuddy Mac app. It shows the live status of your AI coding agents (Claude Code, Codex) running on your Mac, and lets you respond without walking back to your desk.
-
-• Live dashboard — see every session grouped by Needs Response / Working / Done, with project, branch, model, and context-window usage.
-• Status buddy — an at-a-glance mood indicator for everything that's running.
-• Remote approvals — when an agent asks to run a command or edit a file, review the full command or diff on your phone and approve or deny.
-• Notifications & Live Activity — get a banner the moment a session needs you; track counts on the lock screen and Dynamic Island.
-• Voice companion (optional) — talk to your agents in real time and approve or answer by voice, using your own AI-provider key. Off by default with an in-app disclosure before first use.
-
-vibebuddy connects directly to your own Mac over your local network (paired by scanning a QR code) — your session data never goes through our servers. The Mac app is free and open source.
-
-Requires the free vibebuddy Mac app running on your Mac, on the same network.
-
-Tip: tap "查看演示 / View Demo" on the connect screen to explore the interface with sample data — no Mac required.
-```
-
-**Keywords** (≤100 chars — this is 85, comma-separated, no spaces after commas):
+**What's New in This Version — English (U.S.)**:
 
 ```
-claude code,codex,ai agent,terminal,dashboard,approve,coding,developer,remote,monitor
+Meet the Apple Watch companion: check your AI coding tasks from your wrist and respond to supported approval requests.
+
+• Sync the latest task state from iPhone to Apple Watch.
+• View Codex and Claude weekly usage and data freshness on Apple Watch.
+• Improved task status detection, connection feedback, and recovery after interruptions.
+• The updated Mac Companion fixes Codex Desktop detection, log reading, and restarting after quitting.
+
+Apple Watch features require a paired iPhone. To connect to your Mac, install the latest Mac Companion:
+https://github.com/semantic-craft/iOS-vibebuddy/releases/latest
 ```
 
-**Support URL**:
+**What's New in This Version — Simplified Chinese**:
 
 ```
-https://github.com/semantic-craft/iOS-vibebuddy
-```
+新增 Apple Watch 伴侣，让你在手腕上查看 AI 编程任务状态，并处理支持的审批请求。
 
-**Marketing URL** (optional):
+• 将 iPhone 上的最新任务状态同步到 Apple Watch。
+• 在 Apple Watch 上查看 Codex 与 Claude 的周用量和数据更新时间。
+• 改进任务状态识别、连接状态提示及中断后的状态恢复。
+• 配套 Mac Companion 已更新，修复 Codex Desktop 识别、日志读取和退出后重新启动的问题。
 
-```
-https://github.com/semantic-craft/iOS-vibebuddy
-```
-
-**Copyright**:
-
-```
-2026 Xianwei Zhang
-```
-
-**What's New in This Version** — omit for 1.0 (the field only appears from 1.1 on).
-If asked anyway:
-
-```
-First release.
+Apple Watch 功能需要配对的 iPhone。连接自己的 Mac 时，请安装最新版 Mac Companion：
+https://github.com/semantic-craft/iOS-vibebuddy/releases/latest
 ```
 
 ---
 
-## 6. Screenshots — 🧑 upload
+## 6. Screenshots
 
-Apple requires one set at the largest iPhone size; the rest are scaled automatically.
+The 1.1 version has real Release-simulator screenshots for each localization:
+one iPhone dashboard (1320 × 2868, 6.9-inch slot), and two Apple Watch screenshots
+(416 × 496, dashboard and weekly usage). Smaller iPhone sizes inherit the 6.9-inch
+images. Do not restore the stale 1.0 screenshots or attach the old demo video.
 
-| Size | File |
-|---|---|
-| 6.9" (iPhone 16 Pro Max) | `docs/app-store-screenshots/6.9/01-dashboard.png` |
-| 6.5" | `docs/app-store-screenshots/6.5/01-dashboard.png` |
-| extras | `docs/app-store-screenshots/pro-max-demo-dashboard-resolved.png`, `…-approval-question.png` |
-
-> Only one screenshot per size is committed. Apple accepts a single screenshot, but a
-> listing with 3–5 converts better — the two "extras" above are already the right
-> device size and can go in as shots 2 and 3.
+The capture evidence is local to the release worktree under
+`.scratch/app-store-update/screenshots/{en-US,zh-Hans}/`; these are not tracked
+repository assets. The screenshots already saved in App Store Connect are the
+submission copies.
 
 ---
 
 ## 7. App Review Information
 
-| Field | Value |
-|---|---|
-| Sign-in required | **No** |
-| Contact | 🧑 your name, phone, email |
+No app account or sign-in is required. Use the account holder's existing review
+contact details without committing their phone number or email to the repository.
 
-**Notes** — this is the field that decides a companion app's fate; paste all of it:
+Review notes saved in App Store Connect explain:
 
-```
-vibebuddy is the iOS companion to the vibebuddy macOS app (a free, open-source menu-bar tool that monitors local AI coding-agent sessions such as Claude Code and Codex). Normal use pairs the phone to a Mac on the same Wi-Fi by scanning a QR code.
+1. Launch iPhone and tap **See the demo (no Mac needed)** / **查看演示（无需 Mac）**.
+2. Inspect sample tasks and resolve a sample approval locally; no command runs on a Mac.
+3. Keep iPhone open in demo mode, then launch the app on its paired Apple Watch.
+   The Watch receives the sample state from iPhone. It has no separate demo button.
+4. For live use, install the latest Mac Companion, pair iPhone by QR on the same
+   local network, and keep iPhone reachable and connected for Watch approvals.
+   Some requests require review on iPhone and are labeled accordingly.
+5. Camera permission supports QR pairing; Local Network permission supports the
+   iPhone-to-Mac connection. Voice is optional, off by default, and requires a
+   provider choice, the user's API key, disclosure acceptance, microphone permission,
+   and an explicit start. Audio and selected context go directly to that provider.
 
-Because the review device has no paired Mac, the app includes a built-in Demo mode so you can fully evaluate it without any setup:
-
-1. Launch the app.
-2. On the connect screen, tap "查看演示(无需 Mac)" / "View Demo" (below the manual-entry link).
-3. The dashboard loads with sample sessions. You can see the status buddy, the per-session context-window bars, and a sample approval card (an "Edit" diff) — tap 批准 / Approve or 拒绝 / Deny to see it resolve.
-4. Tap 退出演示 / Exit Demo (top right) to return.
-
-Camera permission is only for scanning the pairing QR; Local Network permission is only for the direct phone-to-Mac connection. Apart from the optional voice feature below, no data leaves the user's own devices; there is no backend account.
-
-Voice companion (optional). Tapping the pet can start a real-time voice conversation with the agent companion. It is entirely optional and off by default. It only starts after the user selects a provider (Qwen/DashScope, OpenAI, or Gemini/Google), enters their own provider API key in Settings, accepts the in-app disclosure, grants iOS microphone permission, and taps again to start. When started, the app sends microphone audio plus selected coding-session context (project names, agent type, status, and optional summaries) directly from the device to the selected provider over an encrypted connection using the user's own key. It does not pass through any vibebuddy server. The dashboard, notifications, and approvals are fully usable without voice, so the app can be evaluated end-to-end without setting up a provider key.
-
-Demo credentials: none required. Demo mode needs no login, and voice needs no key to review.
-```
-
-**Attachment** — upload `docs/app-store-screenshots/pro-max-demo-reviewer-flow.mp4`.
-A reviewer who can see the flow is far less likely to reach for Guideline 4.2.
+The paired-simulator demo relay was verified after restarting the simulator pair.
+This does not claim acceptance of every real-device approval or voice workflow.
 
 ---
 
@@ -219,8 +158,9 @@ A reviewer who can see the flow is far less likely to reach for Guideline 4.2.
 1. `tools/archive-ios.sh` → an Apple Distribution–signed `.ipa`.
 2. Upload it: Xcode ▸ Organizer ▸ Distribute App, or `xcrun altool --upload-app`.
    The script prints both.
-3. Wait for processing, then pick the build under **TestFlight** (internal testing
-   needs no review) before submitting for App Store review.
+3. Wait for build **1.1 (4)** to finish processing, then select build **4** in
+   the iOS **1.1** App Store version. TestFlight processing alone does not submit
+   an App Store review. Verify both localizations and submit the version for review.
 
 **Export Compliance** — answered automatically. `ITSAppUsesNonExemptEncryption` is
 already `false` in the Info.plist because the app uses only standard HTTPS, so App
@@ -228,17 +168,8 @@ Store Connect stops asking per upload.
 
 ---
 
-## 9. Known rejection risk
+## 9. Submission status
 
-The realistic one is **Guideline 4.2 / 4.2.3** — minimum functionality, or a
-companion app the reviewer cannot exercise because the external software is missing.
-Three mitigations are already in place; keep all three:
-
-1. **Demo mode** — the reviewer sees the whole interface with no Mac. Step-by-step in §7.
-2. **The demo video** attached in §7.
-3. **Standalone value** stated in the description: remote approvals, the live
-   dashboard, Live Activity, context-window monitoring.
-
-If it is rejected anyway, reply in Resolution Center pointing at the Demo-mode steps
-rather than resubmitting — a reviewer who missed the demo entry point is the most
-common cause.
+Saving metadata, processing the build, adding the version for review, submitting
+it, Apple approval, and public availability are distinct steps. Report each only
+when its App Store Connect status confirms it.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,12 +1,12 @@
 # vibebuddy — Privacy Policy
 
-_Last updated: 2026-06-06_
+_Last updated: 2026-09-05_
 
 vibebuddy ("the app") is a companion to the vibebuddy Mac application. We designed it to keep your data on your own devices.
 
 ## What the app accesses
 
-- **Local network:** the app connects directly to the vibebuddy Mac app running on your own Mac, over your local network, to display session status and send your approve/deny decisions. This data is exchanged only between your iPhone and your Mac.
+- **Local network:** the app connects directly to the vibebuddy Mac app running on your own Mac, over your local network, to display session status and send your approve/deny decisions. This connection is between your iPhone and your Mac. If you use the Apple Watch companion, the paired iPhone relays task status, supported approval requests, and usage information to the Watch through Apple WatchConnectivity. Supported Watch actions are relayed back through the iPhone; the Watch does not connect directly to your Mac or receive its pairing token.
 - **Camera:** used solely to scan the pairing QR code shown by the Mac app. No images are stored or transmitted.
 - **Push notifications:** if you enable notifications, Apple issues a device token that the app sends to your Mac app so it can notify you when a session needs attention. The token is used only for this purpose.
 - **Microphone & voice (optional):** the voice companion is **off by default**. It only starts after you choose a provider — OpenAI, Google (Gemini), or Alibaba (DashScope / Qwen) — enter your own provider API key, accept the in-app disclosure, grant microphone permission, and tap again to start a voice conversation. When you use it, your microphone audio and selected session context (project names, agent type, status, and optional summaries) are streamed over an encrypted connection **directly to the provider you choose**, authenticated with **your own key**, which is stored only in your device Keychain. That data is processed by the chosen provider under **their** privacy policy and your account with them; it does **not** pass through any vibebuddy server. The app is fully usable without ever enabling voice.
@@ -20,7 +20,7 @@ vibebuddy ("the app") is a companion to the vibebuddy Mac application. We design
 
 ## Data retention
 
-Pairing details (your Mac's address and access token) are stored locally on your device and removed when you disconnect.
+Pairing details (your Mac's address and access token) are stored locally on your iPhone and removed when you disconnect. The Apple Watch companion stores its last received task snapshot locally so it can show the last known state after restarting, together with freshness and connection information. This snapshot is replaced as new state arrives and is not sent to a vibebuddy server.
 
 ## Contact
 


### PR DESCRIPTION
Update the existing iPhone app and its embedded Widget and Apple Watch companion to 1.1 (4). App Store Connect currently distributes 1.0 (3) and lists no later upload, so the new build advances all three bundles together while preserving the separate Mac v1.1 release.

Validation: independent configuration review PASS; Release archive and App Store Connect export succeeded; all three exported bundle versions are 1.1 (4), Distribution-signed, and pass codesign --verify --strict. The export gate also verified production APNs and get-task-allow=false. Apple upload, processing and review remain separate delivery steps.
