### PR TITLE
feat(codex): answer Codex CLI PermissionRequest approvals from the phone

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
@@ -35,13 +35,14 @@ public struct ApprovalDetails: Equatable, Sendable {
     }
 }
 
-/// The fields the `/approval` route needs out of a blocking PreToolUse payload,
+/// The fields the `/approval` route needs out of a blocking hook payload,
 /// decoded per agent. Claude Code (and every Claude-shape CLI) sends snake_case
-/// `tool_name` / `tool_input` / `session_id`; Grok Build sends camelCase
-/// `toolName` / `toolInput` / `sessionId` and adds a `permissionMode`.
+/// `tool_name` / `tool_input` / `session_id` on `PreToolUse`; the Codex CLI
+/// sends the same snake_case shape on `PermissionRequest`; Grok Build sends
+/// camelCase `toolName` / `toolInput` / `sessionId` and adds a `permissionMode`.
 ///
-/// Grok's tool vocabulary is normalized here, at the boundary, so the matcher,
-/// the allow-store and `ApprovalDetails` all stay agent-agnostic.
+/// Grok's and Codex's tool vocabularies are normalized here, at the boundary,
+/// so the matcher, the allow-store and `ApprovalDetails` all stay agent-agnostic.
 public enum ApprovalPayload {
     public struct Call {
         public let tool: String
@@ -57,6 +58,17 @@ public enum ApprovalPayload {
     }
 
     public static func decode(_ obj: [String: Any], agent: AgentKind) -> Call {
+        if agent == .codex {
+            // Codex only fires `PermissionRequest` when it would prompt, and a
+            // hook `allow` is final there — so no `permissionMode` rides along
+            // (the UI would otherwise hedge the way it must for Grok).
+            let raw = obj["tool_name"] as? String ?? ""
+            let input = obj["tool_input"] as? [String: Any] ?? [:]
+            return Call(tool: CodexToolVocabulary.canonicalTool(raw),
+                        input: CodexToolVocabulary.canonicalInput(tool: raw, input),
+                        sessionID: obj["session_id"] as? String ?? "",
+                        permissionMode: nil)
+        }
         guard agent == .grok else {
             return Call(tool: obj["tool_name"] as? String ?? "",
                         input: obj["tool_input"] as? [String: Any] ?? [:],

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexToolVocabulary.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexToolVocabulary.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Translates the Codex CLI's `PermissionRequest` tool vocabulary into the
+/// canonical (Claude Code) names and input keys that `PermissionMatcher`,
+/// `AllowRule` and `ApprovalDetails` already speak.
+///
+/// Codex's hook payload is Claude-shaped (`tool_name` / `tool_input` /
+/// `session_id`) and already says `Bash` for shell commands and `mcp__…` for
+/// MCP tools, so the only translation is `apply_patch`: Codex's own matcher
+/// aliases it to `Edit` and `Write`, and its `tool_input.command` carries the
+/// whole patch rather than a `file_path`.
+public enum CodexToolVocabulary {
+
+    /// Canonical tool name. Unknown names pass through unchanged: the matcher's
+    /// conservative default arm then forces `.ask`, which is the safe direction.
+    public static func canonicalTool(_ raw: String) -> String {
+        raw == "apply_patch" ? "Edit" : raw
+    }
+
+    /// Canonical input keys. For `apply_patch`, a patch that touches exactly one
+    /// file gains a `file_path` so `Edit(<path>)` rules match it and "Always
+    /// allow" can persist one; a multi-file patch stays path-less, which keeps
+    /// the matcher at `.ask` and persists no rule (over-asking is safe).
+    /// Original keys are kept — this only *adds* the canonical spelling.
+    public static func canonicalInput(tool raw: String, _ input: [String: Any]) -> [String: Any] {
+        guard raw == "apply_patch", input["file_path"] == nil,
+              let patch = input["command"] as? String else { return input }
+        let paths = patchedFiles(patch)
+        guard paths.count == 1, let only = paths.first else { return input }
+        var out = input
+        out["file_path"] = only
+        return out
+    }
+
+    /// The distinct file paths named by `*** Add File:` / `*** Update File:` /
+    /// `*** Delete File:` headers in an `apply_patch` envelope. `*** Move to:`
+    /// is a property of the preceding Update, not a separate file.
+    static func patchedFiles(_ patch: String) -> [String] {
+        var seen: [String] = []
+        for line in patch.split(separator: "\n", omittingEmptySubsequences: true) {
+            for header in ["*** Add File: ", "*** Update File: ", "*** Delete File: "]
+            where line.hasPrefix(header) {
+                let path = line.dropFirst(header.count).trimmingCharacters(in: .whitespaces)
+                if !path.isEmpty, !seen.contains(path) { seen.append(path) }
+            }
+        }
+        return seen
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexToolVocabulary.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexToolVocabulary.swift
@@ -32,13 +32,14 @@ public enum CodexToolVocabulary {
         return out
     }
 
-    /// The distinct file paths named by `*** Add File:` / `*** Update File:` /
-    /// `*** Delete File:` headers in an `apply_patch` envelope. `*** Move to:`
-    /// is a property of the preceding Update, not a separate file.
+    /// The distinct file paths an `apply_patch` envelope touches: the `*** Add
+    /// File:` / `*** Update File:` / `*** Delete File:` headers, plus every
+    /// `*** Move to:` destination — a rename writes the destination too, so a
+    /// cross-scope move must not pass as a single-file edit of its source.
     static func patchedFiles(_ patch: String) -> [String] {
         var seen: [String] = []
         for line in patch.split(separator: "\n", omittingEmptySubsequences: true) {
-            for header in ["*** Add File: ", "*** Update File: ", "*** Delete File: "]
+            for header in ["*** Add File: ", "*** Update File: ", "*** Delete File: ", "*** Move to: "]
             where line.hasPrefix(header) {
                 let path = line.dropFirst(header.count).trimmingCharacters(in: .whitespaces)
                 if !path.isEmpty, !seen.contains(path) { seen.append(path) }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -86,6 +86,11 @@ public actor SessionStore {
         needsResponseHandler = handler
     }
 
+    /// True when a session with this id is currently tracked.
+    public func hasSession(_ id: String) -> Bool {
+        reducer.sessions[id] != nil
+    }
+
     /// Parse a raw hook payload, apply it, enrich from the transcript, and push
     /// the new snapshot to every subscriber. Returns false if it wasn't a hook.
     @discardableResult

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -297,10 +297,15 @@ public struct VibeBuddyServer: Sendable {
             let input = call.input
             let sessionID = call.sessionID
             let r = rules(agent)
-            // The blocking hook is also this agent's lifecycle signal — ingesting
-            // it moves a Claude/Grok session to `working` (PreToolUse) and a Codex
-            // session to `needsResponse` (PermissionRequest) in the dashboard.
-            await store.ingest(data, agent: agent, receivedAt: Date())
+            // Claude and Grok gate every PreToolUse, so the blocking hook doubles
+            // as the tool signal — ingesting it moves the session to `working`.
+            // The Codex CLI gates only PermissionRequest, a *wait* signal: ingesting
+            // it would mark the session `needsResponse` and push a "needs you"
+            // alert even when a rule decides at once, so Codex is ingested only
+            // when the wait is real (the `.ask` arm) and the session is unknown.
+            if agent != .codex {
+                await store.ingest(data, agent: agent, receivedAt: Date())
+            }
             // Native deny always wins, over every vibebuddy overlay (ADR 0010).
             if PermissionMatcher.decide(tool: tool, input: input, allow: [], deny: r.deny) == .deny {
                 return Self.permissionResponse("deny", agent: agent)
@@ -319,6 +324,11 @@ public struct VibeBuddyServer: Sendable {
             case .allow: return Self.permissionResponse("allow", agent: agent)
             case .deny:  return Self.permissionResponse("deny", agent: agent)
             case .ask:
+                if agent == .codex, !(await store.hasSession(sessionID)) {
+                    // Only the gate is trusted (no status forwarders yet): open the
+                    // session from this payload so the card has a row to land on.
+                    await store.ingest(data, agent: agent, receivedAt: Date())
+                }
                 let id = makeID()
                 let d = ApprovalDetails.from(tool: tool, input: input)
                 // Record what an "always allow" / "allow this session" would act

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -273,11 +273,13 @@ public struct VibeBuddyServer: Sendable {
         }
 
         // Blocking approval intake — bearer-token gated (the approval hook reads
-        // the token file and sends it). Parse the PreToolUse hook payload, run the
-        // permission matcher, and either decide immediately (allow/deny) or hold
-        // until the phone responds via `/decision` or the timeout fires.
-        // `?agent=<source>` selects the envelope shape to decode and the decision
-        // contract to answer in; no parameter means Claude Code, as before.
+        // the token file and sends it). Parse the hook payload (Claude/Grok gate
+        // every PreToolUse; the Codex CLI gates only its PermissionRequest, which
+        // fires when Codex would prompt), run the permission matcher, and either
+        // decide immediately (allow/deny) or hold until the phone responds via
+        // `/decision` or the timeout fires. `?agent=<source>` selects the envelope
+        // shape to decode and the decision contract to answer in; no parameter
+        // means Claude Code, as before.
         let registry = self.approvalRegistry
         let rules = self.rules
         let allowStore = self.allowStore
@@ -295,8 +297,9 @@ public struct VibeBuddyServer: Sendable {
             let input = call.input
             let sessionID = call.sessionID
             let r = rules(agent)
-            // The blocking hook is also this agent's PreToolUse signal — ingesting
-            // it is what moves the session to `working` in the dashboard.
+            // The blocking hook is also this agent's lifecycle signal — ingesting
+            // it moves a Claude/Grok session to `working` (PreToolUse) and a Codex
+            // session to `needsResponse` (PermissionRequest) in the dashboard.
             await store.ingest(data, agent: agent, receivedAt: Date())
             // Native deny always wins, over every vibebuddy overlay (ADR 0010).
             if PermissionMatcher.decide(tool: tool, input: input, allow: [], deny: r.deny) == .deny {
@@ -452,6 +455,14 @@ public struct VibeBuddyServer: Sendable {
             json = decision == "deny"
                 ? #"{"decision":"deny","reason":"vibebuddy"}"#
                 : #"{"decision":"\#(decision)"}"#
+        } else if agent == .codex {
+            // Codex answers approvals through its `PermissionRequest` hook:
+            // `decision.behavior` is `allow`/`deny`, and a deny may carry a
+            // message the model sees. Any other field fails closed on Codex's
+            // side, so send nothing beyond the contract.
+            json = decision == "deny"
+                ? #"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"Denied from vibebuddy"}}}"#
+                : #"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#
         } else {
             json = #"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"\#(decision)","permissionDecisionReason":"vibebuddy"}}"#
         }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -287,17 +287,28 @@ struct ApprovalRoutesTests {
     // would prompt), answered in Codex's own contract: hookSpecificOutput with
     // `decision.behavior` allow/deny. An `allow` is final on Codex's side.
 
-    @Test("an allow-listed codex request answers allow in the PermissionRequest contract")
+    @Test("an allow-listed codex request answers allow at once and raises no wait")
     func codexAllowImmediate() async throws {
-        try await server(allow: ["Bash(ls:*)"]).buildApplication().test(.router) { client in
+        let store = SessionStore()
+        try await server(allow: ["Bash(ls:*)"], store: store).buildApplication().test(.router) { client in
             let text = try await approve(client, body: codexRequest("ls -la"), agent: "codex")
             #expect(text == codexAllow)
+            // A decided request is not a wait: nothing is marked needsResponse
+            // (and so no "needs you" push fires) for an immediate outcome.
+            #expect(await store.snapshot(now: Date()).sessions.first { $0.id == "cs" } == nil)
         }
     }
 
-    @Test("the blocking codex hook is also its PermissionRequest signal — the session waits with a card")
-    func codexIngestsTheEvent() async throws {
+    /// A Codex session the status forwarders have already opened (working).
+    private func seedCodexSession(_ store: SessionStore) async {
+        let prompt = #"{"hook_event_name":"UserPromptSubmit","session_id":"cs","cwd":"/x/p","prompt":"go"}"#
+        await store.ingest(Data(prompt.utf8), agent: .codex, receivedAt: Date())
+    }
+
+    @Test("a held codex request puts the card on the known session, and a phone deny returns it to working")
+    func codexHoldOnKnownSession() async throws {
         let store = SessionStore()
+        await seedCodexSession(store)
         let srv = server(store: store)   // empty allow → .ask
         try await srv.buildApplication().test(.router) { client in
             async let held = approve(client, body: codexRequest("rm -rf build"), agent: "codex")
@@ -317,6 +328,26 @@ struct ApprovalRoutesTests {
             #expect(try await held == codexDeny)
             let after = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "cs" })
             #expect(after.pendingApproval == nil)
+            #expect(after.status == .working)   // denied is not stuck waiting
+        }
+    }
+
+    @Test("a held codex request on an unknown session opens it from the payload so the card has a row")
+    func codexHoldOnUnknownSessionOpensIt() async throws {
+        let store = SessionStore()
+        let srv = server(store: store)
+        try await srv.buildApplication().test(.router) { client in
+            async let held = approve(client, body: codexRequest("rm -rf build"), agent: "codex")
+            try await waitForPendingApproval(store, session: "cs")
+            let session = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "cs" })
+            #expect(session.status == .needsResponse)
+            #expect(session.pendingApproval?.command == "rm -rf build")
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"allow"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await held == codexAllow)
         }
     }
 
@@ -328,11 +359,36 @@ struct ApprovalRoutesTests {
         }
     }
 
-    @Test("a native deny rule short-circuits a codex request without holding")
+    @Test("a native deny rule short-circuits a codex request without holding or a wait")
     func codexNativeDeny() async throws {
-        try await server(deny: ["Bash(rm:*)"]).buildApplication().test(.router) { client in
+        let store = SessionStore()
+        await seedCodexSession(store)
+        try await server(deny: ["Bash(rm:*)"], store: store).buildApplication().test(.router) { client in
             let text = try await approve(client, body: codexRequest("rm -rf build"), agent: "codex")
             #expect(text == codexDeny)
+            let session = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "cs" })
+            #expect(session.status == .working)      // still the working session it was
+            #expect(session.pendingApproval == nil)
+        }
+    }
+
+    @Test("a rename out of an allowed scope holds — the destination counts as touched")
+    func codexRenameAcrossScopesHolds() async throws {
+        let patch = "*** Begin Patch\n*** Update File: /x/p/allowed/a.swift\n*** Move to: /x/p/denied/b.swift\n@@\n-a\n+b\n*** End Patch"
+        let store = SessionStore()
+        let srv = server(allow: ["Edit(/x/p/allowed/**)"], store: store)
+        try await srv.buildApplication().test(.router) { client in
+            async let held = approve(client, body: codexRequest(patch, tool: "apply_patch"), agent: "codex")
+            try await waitForPendingApproval(store, session: "cs")
+            let pending = await store.snapshot(now: Date()).sessions.first { $0.id == "cs" }?.pendingApproval
+            #expect(pending?.tool == "Edit")
+            #expect(pending?.filePath == nil)
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"deny"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await held == codexDeny)
         }
     }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -12,6 +12,21 @@ private func bash(_ cmd: String) -> String {
     #"{"hook_event_name":"PreToolUse","session_id":"s","cwd":"/x/p","tool_name":"Bash","tool_input":{"command":"\#(cmd)"}}"#
 }
 
+/// A Codex CLI PermissionRequest payload: Claude-shaped keys, fired only when
+/// Codex would prompt. `tool_input.command` carries the shell command (Bash)
+/// or the whole patch (apply_patch).
+private func codexRequest(_ command: String, tool: String = "Bash",
+                          mode: String = "default") -> String {
+    let escaped = command.replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\n", with: "\\n")
+    return #"{"hook_event_name":"PermissionRequest","session_id":"cs","cwd":"/x/p","model":"gpt","#
+        + #""permission_mode":"\#(mode)","turn_id":"t1","transcript_path":null,"#
+        + #""tool_name":"\#(tool)","tool_input":{"command":"\#(escaped)"}}"#
+}
+
+private let codexAllow = #"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#
+private let codexDeny = #"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"Denied from vibebuddy"}}}"#
+
 /// A Grok Build PreToolUse envelope: camelCase keys, snake_case event value.
 private func grokBash(_ cmd: String, tool: String = "run_terminal_command",
                       mode: String = "bypassPermissions") -> String {
@@ -266,6 +281,117 @@ struct ApprovalRoutesTests {
         }
     }
 
+    // MARK: - Codex CLI (?agent=codex)
+    //
+    // Claude-shaped envelope on PermissionRequest (Codex fires it only when it
+    // would prompt), answered in Codex's own contract: hookSpecificOutput with
+    // `decision.behavior` allow/deny. An `allow` is final on Codex's side.
+
+    @Test("an allow-listed codex request answers allow in the PermissionRequest contract")
+    func codexAllowImmediate() async throws {
+        try await server(allow: ["Bash(ls:*)"]).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: codexRequest("ls -la"), agent: "codex")
+            #expect(text == codexAllow)
+        }
+    }
+
+    @Test("the blocking codex hook is also its PermissionRequest signal — the session waits with a card")
+    func codexIngestsTheEvent() async throws {
+        let store = SessionStore()
+        let srv = server(store: store)   // empty allow → .ask
+        try await srv.buildApplication().test(.router) { client in
+            async let held = approve(client, body: codexRequest("rm -rf build"), agent: "codex")
+            try await waitForPendingApproval(store, session: "cs")
+            let session = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "cs" })
+            #expect(session.agent == .codex)
+            #expect(session.status == .needsResponse)
+            #expect(session.pendingApproval?.tool == "Bash")
+            #expect(session.pendingApproval?.command == "rm -rf build")
+            // Codex's allow is final, so no hedging mode rides on the card.
+            #expect(session.pendingApproval?.permissionMode == nil)
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"deny"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await held == codexDeny)
+            let after = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "cs" })
+            #expect(after.pendingApproval == nil)
+        }
+    }
+
+    @Test("no decision on a codex request times out to an empty body — Codex then prompts itself")
+    func codexTimesOutEmpty() async throws {
+        try await server(approvalTimeout: .milliseconds(200)).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: codexRequest("rm -rf build"), agent: "codex")
+            #expect(text.isEmpty)
+        }
+    }
+
+    @Test("a native deny rule short-circuits a codex request without holding")
+    func codexNativeDeny() async throws {
+        try await server(deny: ["Bash(rm:*)"]).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: codexRequest("rm -rf build"), agent: "codex")
+            #expect(text == codexDeny)
+        }
+    }
+
+    @Test("apply_patch on one file is an Edit the user's path rules can allow")
+    func codexApplyPatchSingleFile() async throws {
+        let patch = "*** Begin Patch\n*** Update File: /x/p/src/app.swift\n@@\n-a\n+b\n*** End Patch"
+        try await server(allow: ["Edit(/x/p/src/**)"]).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: codexRequest(patch, tool: "apply_patch"), agent: "codex")
+            #expect(text == codexAllow)
+        }
+    }
+
+    @Test("apply_patch across files holds as an Edit card and alwaysAllow persists no rule")
+    func codexApplyPatchMultiFileHolds() async throws {
+        let patch = "*** Begin Patch\n*** Update File: /x/p/a.swift\n@@\n-a\n+b\n*** Add File: /x/p/b.swift\n+c\n*** End Patch"
+        let store = SessionStore()
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vbapproval-\(UUID().uuidString).json")
+        let allowStore = VibeBuddyAllowStore(url: storeURL)
+        let srv = VibeBuddyServer(store: store, token: "t0k", host: "0.0.0.0", port: 9876,
+                                  approvalRegistry: ApprovalRegistry(),
+                                  rules: { _ in PermissionRules(allow: ["Edit(/x/p/src/**)"], deny: []) },
+                                  allowStore: allowStore, approvalTimeout: .seconds(5),
+                                  approvalID: { "s" })
+        try await srv.buildApplication().test(.router) { client in
+            async let held = approve(client, body: codexRequest(patch, tool: "apply_patch"), agent: "codex")
+            try await waitForPendingApproval(store, session: "cs")
+            let pending = await store.snapshot(now: Date()).sessions.first { $0.id == "cs" }?.pendingApproval
+            #expect(pending?.tool == "Edit")
+            #expect(pending?.filePath == nil)
+            #expect(pending?.command == patch)
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"alwaysAllow"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await held == codexAllow)
+            // A path-less Edit yields no rule: the next multi-file patch asks again.
+            #expect(await allowStore.all().isEmpty)
+        }
+    }
+
+    @Test("alwaysAllow from a codex approval matches the next identical codex command")
+    func codexAlwaysAllowPersists() async throws {
+        let store = SessionStore()
+        try await server(store: store).buildApplication().test(.router) { client in
+            async let first = approve(client, body: codexRequest("git status"), agent: "codex")
+            try await waitForPendingApproval(store, session: "cs")
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"alwaysAllow"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await first == codexAllow)
+            let again = try await approve(client, body: codexRequest("git status"), agent: "codex")
+            #expect(again == codexAllow)
+        }
+    }
+
     // MARK: - end-to-end through hooks/approval-hook.sh
 
     @Test("hooks/approval-hook.sh grok posts, and prints the daemon's JSON verbatim")
@@ -284,6 +410,11 @@ struct ApprovalRoutesTests {
         let claude = try await runApprovalHook(source: nil, port: port, token: "t0k",
                                                stdin: bash("ls -la"))
         #expect(claude.contains("\"permissionDecision\":\"allow\""))
+
+        // `codex` answers in the PermissionRequest contract, byte for byte.
+        let codex = try await runApprovalHook(source: "codex", port: port, token: "t0k",
+                                              stdin: codexRequest("ls -la"))
+        #expect(codex == codexAllow)
 
         // A wrong token is a 401 → nothing on stdout → the agent fails open.
         let unauthorized = try await runApprovalHook(source: "grok", port: port, token: "wrong",

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexToolVocabularyTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexToolVocabularyTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import VibeBuddyMacCore
+
+@Suite("CodexToolVocabulary — Codex PermissionRequest tool names/keys → the canonical vocabulary")
+struct CodexToolVocabularyTests {
+
+    @Test("Bash and MCP names already are canonical and pass through")
+    func passthrough() {
+        #expect(CodexToolVocabulary.canonicalTool("Bash") == "Bash")
+        #expect(CodexToolVocabulary.canonicalTool("mcp__fs__read") == "mcp__fs__read")
+        #expect(CodexToolVocabulary.canonicalTool("something_new") == "something_new")
+    }
+
+    @Test("apply_patch is the Edit alias Codex's own matcher uses")
+    func applyPatch() {
+        #expect(CodexToolVocabulary.canonicalTool("apply_patch") == "Edit")
+    }
+
+    @Test("a single-file patch gains a file_path so Edit(<path>) rules can match it")
+    func singleFilePatchGetsPath() {
+        let patch = "*** Begin Patch\n*** Update File: src/app.swift\n@@\n-a\n+b\n*** End Patch"
+        let input = CodexToolVocabulary.canonicalInput(tool: "apply_patch", ["command": patch])
+        #expect(input["file_path"] as? String == "src/app.swift")
+        #expect(input["command"] as? String == patch)   // original key kept
+    }
+
+    @Test("a multi-file patch stays path-less, so the matcher keeps asking")
+    func multiFilePatchStaysPathless() {
+        let patch = "*** Begin Patch\n*** Add File: a.txt\n+x\n*** Delete File: b.txt\n*** End Patch"
+        let input = CodexToolVocabulary.canonicalInput(tool: "apply_patch", ["command": patch])
+        #expect(input["file_path"] == nil)
+        #expect(CodexToolVocabulary.patchedFiles(patch) == ["a.txt", "b.txt"])
+    }
+
+    @Test("a move counts as one file, and other tools' inputs are untouched")
+    func moveAndOtherTools() {
+        let patch = "*** Begin Patch\n*** Update File: old.txt\n*** Move to: new.txt\n@@\n-a\n+b\n*** End Patch"
+        #expect(CodexToolVocabulary.patchedFiles(patch) == ["old.txt"])
+        let bash = CodexToolVocabulary.canonicalInput(tool: "Bash", ["command": "ls"])
+        #expect(bash["file_path"] == nil)
+        #expect(bash["command"] as? String == "ls")
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexToolVocabularyTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CodexToolVocabularyTests.swift
@@ -33,10 +33,15 @@ struct CodexToolVocabularyTests {
         #expect(CodexToolVocabulary.patchedFiles(patch) == ["a.txt", "b.txt"])
     }
 
-    @Test("a move counts as one file, and other tools' inputs are untouched")
-    func moveAndOtherTools() {
+    @Test("a rename touches its destination too, so it stays path-less")
+    func moveTouchesDestination() {
         let patch = "*** Begin Patch\n*** Update File: old.txt\n*** Move to: new.txt\n@@\n-a\n+b\n*** End Patch"
-        #expect(CodexToolVocabulary.patchedFiles(patch) == ["old.txt"])
+        #expect(CodexToolVocabulary.patchedFiles(patch) == ["old.txt", "new.txt"])
+        #expect(CodexToolVocabulary.canonicalInput(tool: "apply_patch", ["command": patch])["file_path"] == nil)
+    }
+
+    @Test("other tools' inputs are untouched")
+    func otherTools() {
         let bash = CodexToolVocabulary.canonicalInput(tool: "Bash", ["command": "ls"])
         #expect(bash["file_path"] == nil)
         #expect(bash["command"] as? String == "ls")

--- a/docs/multi-cli-hook-setup.md
+++ b/docs/multi-cli-hook-setup.md
@@ -30,7 +30,7 @@ The CLI pipes its event JSON on stdin. VibeBuddy reads `hook_event_name`,
 | CLI | source | config | hook style | status |
 |-----|--------|--------|-----------|--------|
 | Claude Code | `claude` | `~/.claude/settings.json` | JSON `hooks` array | ✅ tested |
-| Codex | `codex` | `~/.codex/hooks.json` (`notify` untouched) | JSON `hooks` array | ✅ tested |
+| Codex CLI | `codex` | `~/.codex/hooks.json` (`notify` untouched) | JSON `hooks` array; `--approval` gates `PermissionRequest` | ✅ tested |
 | OpenCode | `opencode` | `~/.config/opencode/` plugin | Claude-compatible hooks | ⚠️ template |
 | Qwen Code | `qwen` | `~/.qwen/` | Claude-compatible hooks | ⚠️ template |
 | Kimi | `kimi` | `~/.kimi/config.toml` | TOML hooks | ⚠️ template |
@@ -62,9 +62,34 @@ workspace.
 ```
 
 Other hook-compatible CLIs (OpenCode, Qwen) follow the same shape with
-`agent=<their source>`. Kimi/Codex use their TOML hook tables; Antigravity uses
+`agent=<their source>`. Kimi uses its TOML hook table; Antigravity uses
 a Gemini plugin that shells out to the same curl. Copilot has no hook surface
 yet — it appears once a future watcher observes it.
+
+### Codex CLI (`~/.codex/hooks.json`)
+
+```bash
+python3 hooks/install-codex-hooks.py --install     # status hooks (12 events) + terminal capture
+python3 hooks/install-codex-hooks.py --approval    # + the blocking phone-approval gate
+python3 hooks/install-codex-hooks.py --uninstall   # revert
+```
+
+Codex reads a Claude-compatible `hooks` object and pipes Claude-shaped JSON to
+each command, so the forwarder is the same script with `codex` as its argument.
+Re-trust the entries via `/hooks` in a fresh session after any change.
+
+#### Remote approval (`--approval`)
+
+Codex honours a hook `allow` only on `PermissionRequest` — its `PreToolUse`
+accepts `deny` alone — and it fires `PermissionRequest` only when it would prompt
+(shell escalation, a patch outside the sandbox, managed network). `--approval`
+therefore replaces just that group with a blocking `hooks/approval-hook.sh codex`
+(`timeout: 30`) posting to `/approval?agent=codex`; the daemon replies
+`{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"|"deny"}}}`,
+and a phone decision is final. Silence (no phone answer in 25s) falls back to
+Codex's own prompt. `apply_patch` is decided as `Edit`, with a `file_path` from
+the patch when it names one file. **Codex Desktop never runs `hooks.json`**, so
+this covers the CLI only.
 
 ### Grok Build (`~/.grok/hooks/vibebuddy.json`)
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -22,7 +22,7 @@ Computer Use or another notifier keeps working. The per-CLI installers below
 remain available if you want to wire one CLI at a time.
 
 `--approval` installs the blocking phone-approval gate for the CLIs that have one
-(Claude and Grok); every other detected CLI gets a plain `--install`.
+(Claude, the Codex CLI, and Grok); every other detected CLI gets a plain `--install`.
 
 Claude-shape CLIs (Claude, Qwen, Kimi) need no daemon decoder; Codex / Grok /
 Antigravity are decoded per-source inside the daemon. (Note: Antigravity `agy`
@@ -71,6 +71,36 @@ python3 hooks/install-codex-hooks.py --install
 Codex requires explicit trust after `hooks.json` changes. Start a fresh Codex
 session, run `/hooks`, review the VibeBuddy entries, and trust them. The installer
 does not read or forge Codex's trust state.
+
+### Remote approval (`--approval`, Codex CLI only)
+
+```bash
+python3 hooks/install-codex-hooks.py --approval
+```
+
+Codex fires `PermissionRequest` only when it would prompt you — a shell
+escalation, a patch outside the sandbox, managed network access — and it honours
+a hook's `decision.behavior` there (`PreToolUse` accepts only `deny`). So
+`--approval` replaces the fire-and-forget `PermissionRequest` group with a
+blocking `hooks/approval-hook.sh codex` (`timeout: 30`) that posts to
+`/approval?agent=codex`, and leaves the `PreToolUse` status forwarder in place.
+The daemon answers in Codex's own contract:
+
+```json
+{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}
+```
+
+A phone `allow` is final; a `deny` carries a message the model sees. No decision
+within 25s prints nothing and Codex shows its own prompt as usual. `Bash` and
+`mcp__…` names are already the canonical vocabulary; `apply_patch` is decided as
+`Edit`, with a `file_path` derived from the patch when it touches exactly one file
+(so `Edit(<path>)` rules and "Always allow" apply) and path-less otherwise (always
+asks, persists no rule). A plain `--install` afterwards keeps the gate. Re-trust
+via `/hooks` after installing, as after any `hooks.json` change.
+
+**Codex Desktop is not covered**: it never runs `hooks.json`, and its approval
+prompts are not written to the rollout, so a Desktop wait stays invisible to the
+phone (see below).
 
 ### Codex Desktop
 
@@ -168,10 +198,14 @@ is listening.
 ```bash
 python3 hooks/install-claude-hooks.py --approval   # add the blocking PreToolUse approval hook
 python3 hooks/install-claude-hooks.py --uninstall  # removes it too
+python3 hooks/install-codex-hooks.py --approval    # Codex CLI: the gate on PermissionRequest
 ```
 Commands not in your `permissions.allow` are sent to the phone to approve/deny.
-On timeout/unreachable, Claude proceeds with its normal behaviour. Useful only if
-your Mac actually prompts (prompting mode); auto-mode users gain nothing.
+On timeout/unreachable, the agent proceeds with its normal behaviour. For Claude
+the gate sits on every `PreToolUse`, so it asks about every tool call the daemon
+cannot match to a rule — including calls Claude's own auto mode would have let
+through; "Allow session" on the phone is the relief valve. For the Codex CLI it
+sits on `PermissionRequest`, which only fires when Codex would prompt anyway.
 
 ## Terminal capture (jump-back)
 

--- a/hooks/install-agent-hooks.py
+++ b/hooks/install-agent-hooks.py
@@ -10,7 +10,7 @@ rather than duplicated.
   --dry-run    list detected CLIs and what each would do
   --install    install vibebuddy hooks into every detected CLI
   --approval   install, and add the blocking phone-approval gate where the CLI
-               supports one (Claude, Grok); every other CLI gets --install
+               supports one (Claude, Codex CLI, Grok); every other CLI gets --install
   --uninstall  remove vibebuddy hooks from every detected CLI
 
 Idempotent: every per-CLI installer is idempotent, so a re-run is a no-op.
@@ -35,9 +35,10 @@ CLIS = [
 ]
 
 
-# CLIs whose installer understands `--approval` (a blocking PreToolUse gate that
-# asks the phone). Everything else is installed status-only.
-APPROVAL_CAPABLE = {"claude", "grok"}
+# CLIs whose installer understands `--approval` (a blocking gate that asks the
+# phone: PreToolUse for Claude and Grok, PermissionRequest for the Codex CLI).
+# Everything else is installed status-only.
+APPROVAL_CAPABLE = {"claude", "codex", "grok"}
 
 
 def present(path):

--- a/hooks/install-codex-hooks.py
+++ b/hooks/install-codex-hooks.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Install/uninstall VibeBuddy lifecycle hooks in ~/.codex/hooks.json.
 
+    --dry-run    preview (default)
+    --install    status hooks (plus terminal capture); keeps an existing approval gate
+    --approval   --install, with the blocking phone-approval gate on PermissionRequest
+    --uninstall  remove every VibeBuddy entry
+
 The Codex ``notify`` command is deliberately untouched: it may already belong
 to Codex Computer Use or another notifier. Lifecycle progress belongs in
 ``hooks.json``, where multiple consumers can coexist.
@@ -16,6 +21,14 @@ HOOKS = os.path.expanduser("~/.codex/hooks.json")
 BACKUP = os.path.expanduser("~/.codex/hooks.json.vibebuddy-backup")
 FORWARDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vibebuddy-forward.sh")
 COMMAND = f'"{FORWARDER}" codex'
+# Remote approval (--approval): Codex fires PermissionRequest only when it would
+# prompt, and honours the hook's `decision.behavior` there — so the blocking gate
+# replaces the fire-and-forget PermissionRequest group and nothing else. The
+# daemon answers within 25s; 30s leaves the hook's own curl cap (30s) room.
+APPROVAL_HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "approval-hook.sh")
+APPROVAL_COMMAND = f'"{APPROVAL_HOOK}" codex'
+APPROVAL_EVENT = "PermissionRequest"
+APPROVAL_TIMEOUT = 30
 EVENTS = [
     "SessionStart",
     "UserPromptSubmit",
@@ -75,6 +88,17 @@ def is_forwarder(hook):
             and argv[1] == "codex")
 
 
+def is_approval(hook):
+    if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
+        return False
+    try:
+        argv = shlex.split(hook["command"])
+    except ValueError:
+        return False
+    return (len(argv) == 2 and os.path.basename(argv[0]) == "approval-hook.sh"
+            and argv[1] == "codex")
+
+
 def is_capture(hook):
     if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
         return False
@@ -86,7 +110,14 @@ def is_capture(hook):
 
 
 def is_vibebuddy(hook):
-    return is_forwarder(hook) or is_capture(hook)
+    return is_forwarder(hook) or is_capture(hook) or is_approval(hook)
+
+
+def has_approval(root):
+    hooks = root.get("hooks") if isinstance(root.get("hooks"), dict) else {}
+    return any(is_approval(hook)
+               for group in hooks.get(APPROVAL_EVENT, []) if isinstance(group, dict)
+               for hook in group.get("hooks", []))
 
 
 def without_vibebuddy(groups):
@@ -100,18 +131,28 @@ def without_vibebuddy(groups):
     return cleaned
 
 
-def install(root):
+def install(root, approval=False):
+    # A plain re-install (the Mac app's Repair button) must not silently drop a
+    # gate the user opted into, so an existing gate is carried forward.
+    approval = approval or has_approval(root)
     hooks = root.get("hooks") if isinstance(root.get("hooks"), dict) else {}
     for event in list(hooks):
         hooks[event] = without_vibebuddy(hooks[event])
         if not hooks[event]:
             del hooks[event]
     for event in EVENTS:
-        command = {
-            "type": "command",
-            "command": COMMAND,
-            "timeout": 3,
-        }
+        if approval and event == APPROVAL_EVENT:
+            command = {
+                "type": "command",
+                "command": APPROVAL_COMMAND,
+                "timeout": APPROVAL_TIMEOUT,
+            }
+        else:
+            command = {
+                "type": "command",
+                "command": COMMAND,
+                "timeout": 3,
+            }
         # Released Codex builds currently skip command hooks carrying
         # `async: true`; SessionEnd is synchronous by design as well. Keep all
         # handlers synchronous and bounded, while the forwarder caps its local
@@ -167,7 +208,7 @@ def write(data):
 
 def main():
     mode = sys.argv[1] if len(sys.argv) > 1 else "--dry-run"
-    if mode not in {"--dry-run", "--install", "--uninstall"}:
+    if mode not in {"--dry-run", "--install", "--uninstall", "--approval"}:
         print("unknown mode:", mode)
         sys.exit(2)
     try:
@@ -177,7 +218,10 @@ def main():
         sys.exit(1)
 
     before = encoded(root)
-    updated = uninstall(root) if mode == "--uninstall" else install(root)
+    if mode == "--uninstall":
+        updated = uninstall(root)
+    else:
+        updated = install(root, approval=(mode == "--approval"))
     after = encoded(updated)
     changed = before != after
 
@@ -191,7 +235,9 @@ def main():
         write(after)
         action = "removed" if mode == "--uninstall" else "installed"
         print(f"{action} VibeBuddy Codex lifecycle hooks; preserved all other hooks and notify")
-        if mode == "--install":
+        if mode == "--approval":
+            print("installed the blocking phone-approval gate on PermissionRequest")
+        if mode in {"--install", "--approval"}:
             print("next: start a fresh Codex session, run /hooks, and trust the VibeBuddy entries")
 
 

--- a/hooks/test_install_agent_hooks.py
+++ b/hooks/test_install_agent_hooks.py
@@ -248,6 +248,32 @@ def main():
         if "Stop" not in grok_hooks:
             fails.append("--approval dropped the grok status hooks")
 
+        # codex: the gate sits on PermissionRequest (the only event whose hook
+        # decision Codex honours for an allow); PreToolUse keeps its status
+        # forwarder so the session still goes `working` once the tool runs.
+        codex_hooks = json.loads(open(os.path.join(home, ".codex/hooks.json")).read())["hooks"]
+        codex_gate = [hook for group in codex_hooks.get("PermissionRequest", [])
+                      for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in hook.get("command", "") for hook in codex_gate):
+            fails.append("--approval did not add the codex approval gate on PermissionRequest")
+        if any("vibebuddy-forward.sh" in hook.get("command", "") for hook in codex_gate):
+            fails.append("--approval left the fire-and-forget codex PermissionRequest group")
+        if not all(hook.get("timeout") == 30 for hook in codex_gate
+                   if "approval-hook.sh" in hook.get("command", "")):
+            fails.append("codex approval gate must allow 30s for the phone round trip")
+        if not any(hook.get("command", "").endswith('" codex') for hook in codex_gate):
+            fails.append("codex approval gate must pass the codex source argument")
+        codex_pre_tool = [hook.get("command", "") for group in codex_hooks.get("PreToolUse", [])
+                          for hook in group.get("hooks", [])]
+        if not any('vibebuddy-forward.sh" codex' in command for command in codex_pre_tool):
+            fails.append("--approval dropped the codex PreToolUse status forwarder")
+        if any("approval-hook.sh" in command for command in codex_pre_tool):
+            fails.append("codex approval gate must not sit on PreToolUse (Codex rejects allow there)")
+        if USER_CODEX_HOOK not in [hook.get("command", "")
+                                   for group in codex_hooks.get("SessionStart", [])
+                                   for hook in group.get("hooks", [])]:
+            fails.append("--approval dropped the user's codex lifecycle hook")
+
         # A plain re-install (the Mac app's Repair button) rewrites the grok file
         # wholesale; it must not silently drop the gate the user opted into.
         rr = run("--install", home)
@@ -266,6 +292,13 @@ def main():
                            for hook in group.get("hooks", [])]
         if not any("approval-hook.sh" in hook.get("command", "") for hook in claude_pre_tool):
             fails.append("plain --install dropped the existing claude approval gate")
+        codex_hooks = json.loads(open(os.path.join(home, ".codex/hooks.json")).read())["hooks"]
+        codex_gate = [hook.get("command", "") for group in codex_hooks.get("PermissionRequest", [])
+                      for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in command for command in codex_gate):
+            fails.append("plain --install dropped the existing codex approval gate")
+        if any("vibebuddy-forward.sh" in command for command in codex_gate):
+            fails.append("re-install after --approval re-added the codex PermissionRequest forwarder")
 
         # Grok imports ~/.claude/settings.json hooks and resolves a quoted,
         # argument-less command as a literal path, so the Claude capture hook
@@ -305,6 +338,8 @@ def main():
                                     for group in groups for hook in group.get("hooks", [])]
         if any("vibebuddy-forward.sh" in command for command in remaining_codex_commands):
             fails.append("uninstall left vibebuddy codex lifecycle hooks")
+        if any("approval-hook.sh" in command for command in remaining_codex_commands):
+            fails.append("uninstall left the codex approval gate")
         if USER_CODEX_HOOK not in remaining_codex_commands:
             fails.append("uninstall removed the user's codex lifecycle hook")
         if "vibebuddy-forward.sh" in kimi or "vibebuddy:" in kimi:


### PR DESCRIPTION
## Why

Phone approval only existed for Claude Code and Grok. The Codex CLI (0.152.1) accepts a hook `allow` only on its `PermissionRequest` event (`PreToolUse` takes `deny` alone) and fires that event only when it would prompt, and the daemon answered every `/approval` in the Claude or Grok contract. So there was no Codex config to install; this adds the product support.

## Changes

- **Daemon** `/approval?agent=codex`: decodes the Claude-shaped `PermissionRequest` payload, normalises `apply_patch` → `Edit` via a new `CodexToolVocabulary` (a single-file patch gains `file_path` so `Edit(<path>)` rules and Always-allow apply; multi-file patches stay path-less and always ask), and replies in Codex's contract: `{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"|"deny"}}}` (deny carries a message). No `permissionMode` rides on the card because a Codex allow is final. Silence still returns an empty body, so Codex falls back to its own prompt.
- **Installer** `hooks/install-codex-hooks.py --approval`: swaps only the `PermissionRequest` forwarder for the blocking `approval-hook.sh codex` gate (`timeout: 30`), keeps the `PreToolUse` status forwarder, and a plain `--install` carries an existing gate forward (mirrors the Grok installer). `install-agent-hooks.py --approval` now covers codex. `--uninstall` removes the gate.
- **Docs**: `hooks/README.md` and `docs/multi-cli-hook-setup.md` describe the Codex CLI gate and state that Codex Desktop never runs `hooks.json`.

## Validation

- `VibeBuddyMac`: 506 tests / 45 suites pass (was 494/44). New: `CodexToolVocabularyTests` (5) and 7 Codex cases in `ApprovalRoutesTests` — immediate allow contract, hold → phone deny with card fields, timeout → empty body, native deny short-circuit, single-file `apply_patch` allowed by an `Edit(**)` rule, multi-file patch holds and persists no rule, Always-allow persists and matches the next Codex call. The end-to-end test runs the real `hooks/approval-hook.sh codex` against a live server and checks the reply byte for byte.
- `python3 hooks/test_install_agent_hooks.py` passes with the new Codex assertions (gate on `PermissionRequest` only, PreToolUse forwarder retained, re-install keeps the gate, uninstall clean, user hooks preserved).
- Contract source: Codex hooks docs (learn.chatgpt.com/docs/hooks) and the JSON schemas embedded in the codex 0.152.1 binary (`permission-request.command.input/output`).

## Not verified here

- A real interactive Codex TUI round trip (approve/deny from the phone). `codex exec` refuses approvals, so this needs a TUI session after the Mac is redeployed from this branch and the hook is trusted via `/hooks`.
- The currently installed public v1.1 daemon does not speak this contract; do not run `install-codex-hooks.py --approval` against it.
- Codex Desktop remains uncovered by design.