### PR TITLE
feat(claude): gate phone approvals on PermissionRequest, not every PreToolUse

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
@@ -36,18 +36,31 @@ public struct ApprovalDetails: Equatable, Sendable {
 }
 
 /// The fields the `/approval` route needs out of a blocking hook payload,
-/// decoded per agent. Claude Code (and every Claude-shape CLI) sends snake_case
-/// `tool_name` / `tool_input` / `session_id` on `PreToolUse`; the Codex CLI
-/// sends the same snake_case shape on `PermissionRequest`; Grok Build sends
+/// decoded per agent. Claude Code (and every Claude-shape CLI) and the Codex CLI
+/// send snake_case `tool_name` / `tool_input` / `session_id`; Grok Build sends
 /// camelCase `toolName` / `toolInput` / `sessionId` and adds a `permissionMode`.
+///
+/// Which *event* carried the payload decides both the reply contract and what
+/// the request means: a `PermissionRequest` fires only when the agent would
+/// prompt (a real wait, answered with `decision.behavior`), while a `PreToolUse`
+/// gate fires for every tool call (answered with `permissionDecision`).
 ///
 /// Grok's and Codex's tool vocabularies are normalized here, at the boundary,
 /// so the matcher, the allow-store and `ApprovalDetails` all stay agent-agnostic.
 public enum ApprovalPayload {
+    /// The hook event a gate payload arrived on.
+    public enum Event: Equatable, Sendable {
+        /// Every tool call, before the agent's own permission check.
+        case preToolUse
+        /// Only the calls the agent would stop and ask about.
+        case permissionRequest
+    }
+
     public struct Call {
         public let tool: String
         public let input: [String: Any]
         public let sessionID: String
+        public let event: Event
         /// Grok only: `default | auto | plan | bypassPermissions` at the time of
         /// the call. Outside `bypassPermissions` an `allow` from the phone only
         /// means "the hook didn't block it" — Grok still raises its own local
@@ -58,29 +71,30 @@ public enum ApprovalPayload {
     }
 
     public static func decode(_ obj: [String: Any], agent: AgentKind) -> Call {
-        if agent == .codex {
-            // Codex only fires `PermissionRequest` when it would prompt, and a
-            // hook `allow` is final there — so no `permissionMode` rides along
-            // (the UI would otherwise hedge the way it must for Grok).
-            let raw = obj["tool_name"] as? String ?? ""
-            let input = obj["tool_input"] as? [String: Any] ?? [:]
-            return Call(tool: CodexToolVocabulary.canonicalTool(raw),
-                        input: CodexToolVocabulary.canonicalInput(tool: raw, input),
-                        sessionID: obj["session_id"] as? String ?? "",
-                        permissionMode: nil)
-        }
         guard agent == .grok else {
-            return Call(tool: obj["tool_name"] as? String ?? "",
-                        input: obj["tool_input"] as? [String: Any] ?? [:],
+            // Claude-shape envelope. A `PermissionRequest` allow is final on
+            // both Claude Code and Codex, so no `permissionMode` rides along
+            // (the UI would otherwise hedge the way it must for Grok).
+            let event: Event = obj["hook_event_name"] as? String == "PermissionRequest"
+                ? .permissionRequest : .preToolUse
+            let raw = obj["tool_name"] as? String ?? ""
+            var input = obj["tool_input"] as? [String: Any] ?? [:]
+            var tool = raw
+            if agent == .codex {
+                tool = CodexToolVocabulary.canonicalTool(raw)
+                input = CodexToolVocabulary.canonicalInput(tool: raw, input)
+            }
+            return Call(tool: tool, input: input,
                         sessionID: obj["session_id"] as? String ?? "",
-                        permissionMode: nil)
+                        event: event, permissionMode: nil)
         }
+        // Grok has no PermissionRequest hook; its gate is PreToolUse only.
         let normalized = GrokToolVocabulary.normalize(
             tool: obj["toolName"] as? String ?? "",
             input: obj["toolInput"] as? [String: Any] ?? [:])
         let mode = (obj["permissionMode"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         return Call(tool: normalized.tool, input: normalized.input,
                     sessionID: obj["sessionId"] as? String ?? "",
-                    permissionMode: mode)
+                    event: .preToolUse, permissionMode: mode)
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -93,13 +93,18 @@ public actor SessionStore {
 
     /// Parse a raw hook payload, apply it, enrich from the transcript, and push
     /// the new snapshot to every subscriber. Returns false if it wasn't a hook.
+    /// `announcesWait: false` applies the event without firing the
+    /// needs-response handler — for a wait the caller is about to announce
+    /// itself (a `PermissionRequest` gate that opens an unknown session right
+    /// before `beginApproval`), so one request never produces two pushes.
     @discardableResult
-    public func ingest(_ data: Data, agent: AgentKind = .claudeCode, receivedAt: Date) -> Bool {
+    public func ingest(_ data: Data, agent: AgentKind = .claudeCode, receivedAt: Date,
+                       announcesWait: Bool = true) -> Bool {
         // Source-aware decode: the `?agent=` value tags Claude-shaped lifecycle
         // hooks directly and selects a translator only for different envelopes.
         switch HookDecoder.decode(data, agent: agent, receivedAt: receivedAt) {
         case let .event(event):
-            ingest(event, observationSource: .hook)
+            ingest(event, observationSource: .hook, announcesWait: announcesWait)
             return true
         case .ignored:
             // Understood, but carries no progress (grok fires several such events
@@ -130,7 +135,8 @@ public actor SessionStore {
     private func ingest(
         _ event: HookEvent,
         observationSource: ObservationSource,
-        recordsEvidence: Bool = true
+        recordsEvidence: Bool = true,
+        announcesWait: Bool = true
     ) {
         let wasWaiting = reducer.sessions[event.sessionID]?.status == .needsResponse
         if let path = event.transcriptPath { transcriptPaths[event.sessionID] = path }
@@ -175,7 +181,7 @@ public actor SessionStore {
             at: event.timestamp
         )
         broadcast()
-        if !wasWaiting, let session = reducer.sessions[event.sessionID],
+        if announcesWait, !wasWaiting, let session = reducer.sessions[event.sessionID],
            session.status == .needsResponse, let handler = needsResponseHandler {
             Task { await handler(session) }
         }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -326,8 +326,9 @@ public struct VibeBuddyServer: Sendable {
             case .ask:
                 if call.event == .permissionRequest, !(await store.hasSession(sessionID)) {
                     // Only the gate is installed (no status forwarders yet): open
-                    // the session from this payload so the card has a row to land on.
-                    await store.ingest(data, agent: agent, receivedAt: Date())
+                    // the session from this payload so the card has a row to land
+                    // on. `beginApproval` below announces the wait — once.
+                    await store.ingest(data, agent: agent, receivedAt: Date(), announcesWait: false)
                 }
                 let id = makeID()
                 let d = ApprovalDetails.from(tool: tool, input: input)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -273,13 +273,13 @@ public struct VibeBuddyServer: Sendable {
         }
 
         // Blocking approval intake — bearer-token gated (the approval hook reads
-        // the token file and sends it). Parse the hook payload (Claude/Grok gate
-        // every PreToolUse; the Codex CLI gates only its PermissionRequest, which
-        // fires when Codex would prompt), run the permission matcher, and either
-        // decide immediately (allow/deny) or hold until the phone responds via
-        // `/decision` or the timeout fires. `?agent=<source>` selects the envelope
-        // shape to decode and the decision contract to answer in; no parameter
-        // means Claude Code, as before.
+        // the token file and sends it). Parse the gate payload, run the
+        // permission matcher, and either decide immediately (allow/deny) or hold
+        // until the phone responds via `/decision` or the timeout fires.
+        // `?agent=<source>` selects the envelope shape to decode; the event the
+        // payload arrived on (`PermissionRequest` — only when the agent would
+        // prompt — or a `PreToolUse` gate on every call) selects the decision
+        // contract to answer in. No parameter means Claude Code, as before.
         let registry = self.approvalRegistry
         let rules = self.rules
         let allowStore = self.allowStore
@@ -297,18 +297,18 @@ public struct VibeBuddyServer: Sendable {
             let input = call.input
             let sessionID = call.sessionID
             let r = rules(agent)
-            // Claude and Grok gate every PreToolUse, so the blocking hook doubles
-            // as the tool signal — ingesting it moves the session to `working`.
-            // The Codex CLI gates only PermissionRequest, a *wait* signal: ingesting
-            // it would mark the session `needsResponse` and push a "needs you"
-            // alert even when a rule decides at once, so Codex is ingested only
-            // when the wait is real (the `.ask` arm) and the session is unknown.
-            if agent != .codex {
+            // A PreToolUse gate doubles as the tool signal — ingesting it moves
+            // the session to `working`. A PermissionRequest is a *wait* signal:
+            // ingesting it would mark the session `needsResponse` and push a
+            // "needs you" alert even when a rule decides at once, so it is
+            // ingested only when the wait is real (the `.ask` arm) and the
+            // session is not yet known.
+            if call.event == .preToolUse {
                 await store.ingest(data, agent: agent, receivedAt: Date())
             }
             // Native deny always wins, over every vibebuddy overlay (ADR 0010).
             if PermissionMatcher.decide(tool: tool, input: input, allow: [], deny: r.deny) == .deny {
-                return Self.permissionResponse("deny", agent: agent)
+                return Self.permissionResponse("deny", agent: agent, event: call.event)
             }
             // vibebuddy overlay: a session-wide allow, or an exact always-allow rule the
             // user set — both bypass the matcher's pattern heuristics since the user
@@ -317,16 +317,16 @@ public struct VibeBuddyServer: Sendable {
             let storeRules = await allowStore.all()   // [String] is Sendable; match locally
             let storeAllowed = storeRules.contains { AllowRule.matchesExactly($0, tool: tool, input: input) }
             if sessionAllowed || storeAllowed {
-                return Self.permissionResponse("allow", agent: agent)
+                return Self.permissionResponse("allow", agent: agent, event: call.event)
             }
             // Otherwise the native allow/ask matching (composition-guarded).
             switch PermissionMatcher.decide(tool: tool, input: input, allow: r.allow, deny: r.deny) {
-            case .allow: return Self.permissionResponse("allow", agent: agent)
-            case .deny:  return Self.permissionResponse("deny", agent: agent)
+            case .allow: return Self.permissionResponse("allow", agent: agent, event: call.event)
+            case .deny:  return Self.permissionResponse("deny", agent: agent, event: call.event)
             case .ask:
-                if agent == .codex, !(await store.hasSession(sessionID)) {
-                    // Only the gate is trusted (no status forwarders yet): open the
-                    // session from this payload so the card has a row to land on.
+                if call.event == .permissionRequest, !(await store.hasSession(sessionID)) {
+                    // Only the gate is installed (no status forwarders yet): open
+                    // the session from this payload so the card has a row to land on.
                     await store.ingest(data, agent: agent, receivedAt: Date())
                 }
                 let id = makeID()
@@ -345,8 +345,8 @@ public struct VibeBuddyServer: Sendable {
                 let outcome = await registry.wait(id: id, timeout: timeout)
                 await store.endApproval(sessionID: sessionID, at: Date())
                 switch outcome {
-                case .allow: return Self.permissionResponse("allow", agent: agent)
-                case .deny:  return Self.permissionResponse("deny", agent: agent)
+                case .allow: return Self.permissionResponse("allow", agent: agent, event: call.event)
+                case .deny:  return Self.permissionResponse("deny", agent: agent, event: call.event)
                 case .pass:  return Response(status: .ok)
                 }
             }
@@ -459,15 +459,16 @@ public struct VibeBuddyServer: Sendable {
     /// `{"decision":…,"reason":…}` — that is what we emit for it, so the wire is
     /// unambiguous when read from a Grok transcript. Either way a timeout still
     /// answers with an empty 200 body, which both CLIs read as "no opinion".
-    static func permissionResponse(_ decision: String, agent: AgentKind = .claudeCode) -> Response {
+    static func permissionResponse(_ decision: String, agent: AgentKind = .claudeCode,
+                                   event: ApprovalPayload.Event = .preToolUse) -> Response {
         let json: String
         if agent == .grok {
             json = decision == "deny"
                 ? #"{"decision":"deny","reason":"vibebuddy"}"#
                 : #"{"decision":"\#(decision)"}"#
-        } else if agent == .codex {
-            // Codex answers approvals through its `PermissionRequest` hook:
-            // `decision.behavior` is `allow`/`deny`, and a deny may carry a
+        } else if event == .permissionRequest {
+            // Claude Code and Codex answer a `PermissionRequest` hook the same
+            // way: `decision.behavior` is `allow`/`deny`, and a deny may carry a
             // message the model sees. Any other field fails closed on Codex's
             // side, so send nothing beyond the contract.
             json = decision == "deny"

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -12,6 +12,13 @@ private func bash(_ cmd: String) -> String {
     #"{"hook_event_name":"PreToolUse","session_id":"s","cwd":"/x/p","tool_name":"Bash","tool_input":{"command":"\#(cmd)"}}"#
 }
 
+/// A Claude Code PermissionRequest payload: fired only when Claude would stop
+/// and ask (a prompt in default mode, an uncertain classifier in auto mode).
+private func claudeRequest(_ cmd: String, tool: String = "Bash") -> String {
+    #"{"hook_event_name":"PermissionRequest","session_id":"ps","cwd":"/x/p","permission_mode":"default","#
+        + #""tool_use_id":"toolu_1","tool_name":"\#(tool)","tool_input":{"command":"\#(cmd)"}}"#
+}
+
 /// A Codex CLI PermissionRequest payload: Claude-shaped keys, fired only when
 /// Codex would prompt. `tool_input.command` carries the shell command (Bash)
 /// or the whole patch (apply_patch).
@@ -281,6 +288,67 @@ struct ApprovalRoutesTests {
         }
     }
 
+    // MARK: - Claude Code PermissionRequest (the gate `--approval` installs)
+    //
+    // Same envelope as Claude's PreToolUse, but it only fires when Claude would
+    // prompt, and it is answered with `decision.behavior` — the very contract
+    // Codex adopted. A PreToolUse payload keeps the `permissionDecision` reply.
+
+    @Test("an allow-listed claude PermissionRequest answers allow in the decision contract, with no wait")
+    func claudePermissionRequestAllowImmediate() async throws {
+        let store = SessionStore()
+        try await server(allow: ["Bash(ls:*)"], store: store).buildApplication().test(.router) { client in
+            let text = try await approve(client, body: claudeRequest("ls -la"))
+            #expect(text == codexAllow)
+            #expect(await store.snapshot(now: Date()).sessions.first { $0.id == "ps" } == nil)
+        }
+    }
+
+    @Test("a held claude PermissionRequest shows the card on the known session; a phone deny answers deny + message")
+    func claudePermissionRequestHoldThenDeny() async throws {
+        let store = SessionStore()
+        let prompt = #"{"hook_event_name":"UserPromptSubmit","session_id":"ps","cwd":"/x/p","prompt":"go"}"#
+        await store.ingest(Data(prompt.utf8), receivedAt: Date())
+        let srv = server(store: store)   // empty allow → .ask
+        try await srv.buildApplication().test(.router) { client in
+            async let held = approve(client, body: claudeRequest("rm -rf build"))
+            try await waitForPendingApproval(store, session: "ps")
+            let session = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "ps" })
+            #expect(session.agent == .claudeCode)
+            #expect(session.status == .needsResponse)
+            #expect(session.pendingApproval?.command == "rm -rf build")
+            #expect(session.pendingApproval?.permissionMode == nil)
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"deny"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await held == codexDeny)
+            let after = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "ps" })
+            #expect(after.pendingApproval == nil)
+            #expect(after.status == .working)
+        }
+    }
+
+    @Test("alwaysAllow from a claude PermissionRequest also auto-allows the same call on a PreToolUse gate")
+    func claudePermissionRequestAlwaysAllowSharesRules() async throws {
+        let store = SessionStore()
+        try await server(store: store).buildApplication().test(.router) { client in
+            async let first = approve(client, body: claudeRequest("git status"))
+            try await waitForPendingApproval(store, session: "ps")
+            try await client.execute(uri: "/decision", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: #"{"approvalId":"s","decision":"alwaysAllow"}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            #expect(try await first == codexAllow)
+            // The persisted rule is event-agnostic: a legacy PreToolUse gate
+            // reads it too, in its own contract.
+            let legacy = try await approve(client, body: bash("git status"))
+            #expect(legacy.contains("\"permissionDecision\":\"allow\""))
+        }
+    }
+
     // MARK: - Codex CLI (?agent=codex)
     //
     // Claude-shaped envelope on PermissionRequest (Codex fires it only when it
@@ -471,6 +539,11 @@ struct ApprovalRoutesTests {
         let codex = try await runApprovalHook(source: "codex", port: port, token: "t0k",
                                               stdin: codexRequest("ls -la"))
         #expect(codex == codexAllow)
+
+        // So does Claude's PermissionRequest gate (no source argument).
+        let request = try await runApprovalHook(source: nil, port: port, token: "t0k",
+                                                stdin: claudeRequest("ls -la"))
+        #expect(request == codexAllow)
 
         // A wrong token is a 401 → nothing on stdout → the agent fails open.
         let unauthorized = try await runApprovalHook(source: "grok", port: port, token: "wrong",

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -400,9 +400,18 @@ struct ApprovalRoutesTests {
         }
     }
 
-    @Test("a held codex request on an unknown session opens it from the payload so the card has a row")
+    /// Counts needs-response announcements (the APNs push path) and remembers
+    /// whether each carried the approval card.
+    private actor WaitAnnouncements {
+        var cards: [Bool] = []
+        func record(_ session: AgentSession) { cards.append(session.pendingApproval != nil) }
+    }
+
+    @Test("a held request on an unknown session opens it from the payload and announces the wait once, with the card")
     func codexHoldOnUnknownSessionOpensIt() async throws {
         let store = SessionStore()
+        let announced = WaitAnnouncements()
+        await store.setNeedsResponseHandler { session in await announced.record(session) }
         let srv = server(store: store)
         try await srv.buildApplication().test(.router) { client in
             async let held = approve(client, body: codexRequest("rm -rf build"), agent: "codex")
@@ -410,6 +419,10 @@ struct ApprovalRoutesTests {
             let session = try #require(await store.snapshot(now: Date()).sessions.first { $0.id == "cs" })
             #expect(session.status == .needsResponse)
             #expect(session.pendingApproval?.command == "rm -rf build")
+            // One push, and it is the approval push — not a generic "needs you"
+            // from opening the session followed by a second one for the card.
+            try await Task.sleep(for: .milliseconds(50))
+            #expect(await announced.cards == [true])
             try await client.execute(uri: "/decision", method: .post,
                 headers: [.authorization: "Bearer t0k"],
                 body: ByteBuffer(string: #"{"approvalId":"s","decision":"allow"}"#)) { res in

--- a/docs/multi-cli-hook-setup.md
+++ b/docs/multi-cli-hook-setup.md
@@ -29,7 +29,7 @@ The CLI pipes its event JSON on stdin. VibeBuddy reads `hook_event_name`,
 
 | CLI | source | config | hook style | status |
 |-----|--------|--------|-----------|--------|
-| Claude Code | `claude` | `~/.claude/settings.json` | JSON `hooks` array | ✅ tested |
+| Claude Code | `claude` | `~/.claude/settings.json` | JSON `hooks` array; `--approval` gates `PermissionRequest` | ✅ tested |
 | Codex CLI | `codex` | `~/.codex/hooks.json` (`notify` untouched) | JSON `hooks` array; `--approval` gates `PermissionRequest` | ✅ tested |
 | OpenCode | `opencode` | `~/.config/opencode/` plugin | Claude-compatible hooks | ⚠️ template |
 | Qwen Code | `qwen` | `~/.qwen/` | Claude-compatible hooks | ⚠️ template |
@@ -65,6 +65,19 @@ Other hook-compatible CLIs (OpenCode, Qwen) follow the same shape with
 `agent=<their source>`. Kimi uses its TOML hook table; Antigravity uses
 a Gemini plugin that shells out to the same curl. Copilot has no hook surface
 yet — it appears once a future watcher observes it.
+
+#### Remote approval (`--approval`)
+
+`install-claude-hooks.py --approval` replaces the asynchronous `PermissionRequest`
+status group with a blocking `hooks/approval-hook.sh` (`timeout: 30`, matcher
+`*`). Claude fires `PermissionRequest` only when it would stop and ask — a prompt
+in default mode, an uncertain classifier in auto mode — and honours the hook's
+`hookSpecificOutput.decision.behavior` (`allow` / `deny` + `message`); Claude Code
+2.1.261 validates exactly that shape. Every other tool call never reaches the
+phone. Silence (no phone answer in 25s) leaves Claude's own prompt in place;
+`bypassPermissions` fires the event but ignores the answer. The `PreToolUse`
+status forwarder stays asynchronous. An older gate on `PreToolUse` (every call
+held) is migrated by `--install`.
 
 ### Codex CLI (`~/.codex/hooks.json`)
 

--- a/docs/planning/architecture.md
+++ b/docs/planning/architecture.md
@@ -102,7 +102,7 @@ public struct PairingPayload: Codable, Sendable {
 
 ## State Machine (hook event → status)
 
-We register these Claude Code hooks and reduce them. Claude's status hooks are fail-open and asynchronous, so they stay off the agent's critical path. Remote approval is a separate, opt-in blocking `PreToolUse` gate — not the default path, and not a read-only daemon.
+We register these Claude Code hooks and reduce them. Claude's status hooks are fail-open and asynchronous, so they stay off the agent's critical path. Remote approval is a separate, opt-in blocking `PermissionRequest` gate — it fires only when Claude would prompt, answers in that event's `decision.behavior` contract, and is not the default path (nor a read-only daemon).
 
 | Hook event | Effect on session |
 |---|---|

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -196,16 +196,25 @@ is listening.
 ## Remote approval (opt-in)
 
 ```bash
-python3 hooks/install-claude-hooks.py --approval   # add the blocking PreToolUse approval hook
+python3 hooks/install-claude-hooks.py --approval   # the blocking gate on PermissionRequest
 python3 hooks/install-claude-hooks.py --uninstall  # removes it too
-python3 hooks/install-codex-hooks.py --approval    # Codex CLI: the gate on PermissionRequest
+python3 hooks/install-codex-hooks.py --approval    # Codex CLI: same gate, same event
 ```
-Commands not in your `permissions.allow` are sent to the phone to approve/deny.
-On timeout/unreachable, the agent proceeds with its normal behaviour. For Claude
-the gate sits on every `PreToolUse`, so it asks about every tool call the daemon
-cannot match to a rule — including calls Claude's own auto mode would have let
-through; "Allow session" on the phone is the relief valve. For the Codex CLI it
-sits on `PermissionRequest`, which only fires when Codex would prompt anyway.
+Both gates sit on `PermissionRequest`, which fires only when the agent would stop
+and ask — for Claude that is a permission prompt in default mode, or an uncertain
+classifier in auto mode; tool calls the agent runs on its own never reach the
+phone. The gate is a synchronous `hooks/approval-hook.sh` (`timeout: 30`) that
+posts to `/approval`; the daemon first tries your `permissions.allow` / `deny`
+rules and vibebuddy's own always-allow store, and only otherwise shows the card.
+It answers `{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":
+{"behavior":"allow"|"deny"}}}`; a phone decision is final, and no decision within
+25s prints nothing, so the agent falls back to its own prompt. `bypassPermissions`
+still fires the event but ignores the answer.
+
+An older install put Claude's gate on `PreToolUse` — every tool call, held for
+the phone. `--install` and `--approval` both migrate such a gate to
+`PermissionRequest`; the daemon still answers a `PreToolUse` payload in that
+event's `permissionDecision` contract (Grok's gate lives there by necessity).
 
 ## Terminal capture (jump-back)
 

--- a/hooks/install-agent-hooks.py
+++ b/hooks/install-agent-hooks.py
@@ -36,7 +36,7 @@ CLIS = [
 
 
 # CLIs whose installer understands `--approval` (a blocking gate that asks the
-# phone: PreToolUse for Claude and Grok, PermissionRequest for the Codex CLI).
+# phone: PermissionRequest for Claude and the Codex CLI, PreToolUse for Grok).
 # Everything else is installed status-only.
 APPROVAL_CAPABLE = {"claude", "codex", "grok"}
 

--- a/hooks/install-claude-hooks.py
+++ b/hooks/install-claude-hooks.py
@@ -27,6 +27,13 @@ FORWARDER_MARKER = "vibebuddy-forward.sh"
 APPROVAL_HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "approval-hook.sh")
 APPROVAL_COMMAND = f'"{APPROVAL_HOOK}"'
 APPROVAL_MARKER = "approval-hook.sh"
+# Remote approval (--approval) gates PermissionRequest: Claude fires it only when
+# it would stop and ask (a prompt in default mode, an uncertain classifier in
+# auto mode), and honours the hook's `decision.behavior` there. Gating every
+# PreToolUse instead — the original design, from before this event existed —
+# held every tool call for the phone; an old gate found there is migrated.
+APPROVAL_EVENT = "PermissionRequest"
+APPROVAL_TIMEOUT = 30   # the daemon answers within 25s; the hook's curl caps at 30s
 CAPTURE_HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "capture-terminal.sh")
 CAPTURE_MARKER = "capture-terminal.sh"
 TOOL_EVENTS = {"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionDenied"}
@@ -101,15 +108,31 @@ def install(data):
     return added
 
 
+def has_approval(data):
+    hooks = data.get("hooks", {}) if isinstance(data.get("hooks", {}), dict) else {}
+    return any(has_marker(g, APPROVAL_MARKER) for arr in hooks.values() for g in arr)
+
+
 def install_approval(data):
     hooks = data.setdefault("hooks", {})
-    arr = hooks.setdefault("PreToolUse", [])
-    # Drop the fire-and-forget vibebuddy /hook group for PreToolUse; the blocking
-    # approval hook subsumes the working-status update via /approval.
+    # Retire the legacy PreToolUse gate; install() has already restored the
+    # asynchronous status forwarder there.
+    for ev in list(hooks):
+        if ev != APPROVAL_EVENT:
+            hooks[ev] = [g for g in hooks[ev] if not has_marker(g, APPROVAL_MARKER)]
+            if not hooks[ev]:
+                del hooks[ev]
+    arr = hooks.setdefault(APPROVAL_EVENT, [])
+    # The blocking gate replaces the fire-and-forget status group on this one
+    # event; the daemon still learns of the wait from the gate itself.
     arr[:] = [g for g in arr if not has_status_marker(g)]
-    if not any(has_marker(g, APPROVAL_MARKER) for g in arr):
-        arr.append({"matcher": "*", "hooks": [{"type": "command", "command": APPROVAL_COMMAND}]})
-    return ["PreToolUse(approval)"]
+    expected = {"matcher": "*", "hooks": [{"type": "command", "command": APPROVAL_COMMAND,
+                                            "timeout": APPROVAL_TIMEOUT}]}
+    owned = [g for g in arr if has_marker(g, APPROVAL_MARKER)]
+    if owned != [expected]:
+        arr[:] = [g for g in arr if not has_marker(g, APPROVAL_MARKER)]
+        arr.append(expected)
+    return [f"{APPROVAL_EVENT}(approval)"]
 
 
 def uninstall(data):
@@ -169,6 +192,10 @@ def main():
         return
 
     added = install(data)
+    if has_approval(data):
+        # A plain re-install (the Mac app's Repair button) keeps — and, for an
+        # old PreToolUse gate, migrates — the approval gate the user opted into.
+        added += install_approval(data)
     if mode == "--dry-run":
         print("would add vibebuddy hooks for:", added or "(already installed)")
         print("status events:", ", ".join(EVENTS))

--- a/hooks/test_install_agent_hooks.py
+++ b/hooks/test_install_agent_hooks.py
@@ -108,6 +108,33 @@ def check_grok_home(fails):
             fails.append("uninstall left vibebuddy.json under $GROK_HOME")
 
 
+def check_claude_legacy_gate_migration(fails):
+    """A pre-PermissionRequest install left the gate on PreToolUse, holding every
+    tool call; a plain --install must move it to PermissionRequest."""
+    installer = os.path.join(HOOKS, "install-claude-hooks.py")
+    with tempfile.TemporaryDirectory() as home:
+        env = {**os.environ, "HOME": home}
+        settings = os.path.join(home, ".claude/settings.json")
+        os.makedirs(os.path.dirname(settings), exist_ok=True)
+        gate = os.path.join(HOOKS, "approval-hook.sh")
+        open(settings, "w").write(json.dumps({"hooks": {"PreToolUse": [
+            {"matcher": "*", "hooks": [{"type": "command", "command": f'"{gate}"'}]}]}}))
+        r = subprocess.run([sys.executable, installer, "--install"], env=env,
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            fails.append(f"claude legacy-gate --install exited {r.returncode}: {r.stderr}")
+            return
+        hooks = json.loads(open(settings).read())["hooks"]
+        pre_tool = [h.get("command", "") for g in hooks.get("PreToolUse", []) for h in g.get("hooks", [])]
+        gate_now = [h.get("command", "") for g in hooks.get("PermissionRequest", []) for h in g.get("hooks", [])]
+        if any("approval-hook.sh" in c for c in pre_tool):
+            fails.append("plain --install left the legacy claude gate on PreToolUse")
+        if not any("vibebuddy-forward.sh" in c for c in pre_tool):
+            fails.append("legacy-gate migration did not restore the PreToolUse status forwarder")
+        if not any("approval-hook.sh" in c for c in gate_now):
+            fails.append("legacy-gate migration did not move the claude gate to PermissionRequest")
+
+
 def snapshot(home):
     out = {}
     for rel in MANAGED:
@@ -239,12 +266,23 @@ def main():
             fails.append("grok approval gate must allow 30s for the phone round trip")
         if not any(hook.get("command", "").endswith('" grok') for hook in pre_tool):
             fails.append("grok approval gate must pass the grok source argument")
-        claude_pre_tool = [hook for group in json.loads(
-                               open(os.path.join(home, ".claude/settings.json")).read()
-                           ).get("hooks", {}).get("PreToolUse", [])
+        claude_hooks = json.loads(open(os.path.join(home, ".claude/settings.json")).read()).get("hooks", {})
+        claude_gate = [hook for group in claude_hooks.get("PermissionRequest", [])
+                       for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in hook.get("command", "") for hook in claude_gate):
+            fails.append("--approval did not add the claude approval gate on PermissionRequest")
+        if any("vibebuddy-forward.sh" in hook.get("command", "") for hook in claude_gate):
+            fails.append("--approval left the async claude PermissionRequest status group")
+        if not all(hook.get("timeout") == 30 for hook in claude_gate
+                   if "approval-hook.sh" in hook.get("command", "")):
+            fails.append("claude approval gate must allow 30s for the phone round trip")
+        claude_pre_tool = [hook for group in claude_hooks.get("PreToolUse", [])
                            for hook in group.get("hooks", [])]
-        if not any("approval-hook.sh" in hook.get("command", "") for hook in claude_pre_tool):
-            fails.append("--approval did not add the claude approval gate")
+        if any("approval-hook.sh" in hook.get("command", "") for hook in claude_pre_tool):
+            fails.append("claude approval gate must not sit on PreToolUse (it would hold every call)")
+        if not any("vibebuddy-forward.sh" in hook.get("command", "") and hook.get("async") is True
+                   for hook in claude_pre_tool):
+            fails.append("--approval dropped the async claude PreToolUse status forwarder")
         if "Stop" not in grok_hooks:
             fails.append("--approval dropped the grok status hooks")
 
@@ -286,12 +324,13 @@ def main():
             fails.append("plain --install dropped the existing grok approval gate")
         if "Stop" not in grok_hooks:
             fails.append("re-install after --approval dropped the grok status hooks")
-        claude_pre_tool = [hook for group in json.loads(
-                               open(os.path.join(home, ".claude/settings.json")).read()
-                           ).get("hooks", {}).get("PreToolUse", [])
-                           for hook in group.get("hooks", [])]
-        if not any("approval-hook.sh" in hook.get("command", "") for hook in claude_pre_tool):
+        claude_hooks = json.loads(open(os.path.join(home, ".claude/settings.json")).read()).get("hooks", {})
+        claude_gate = [hook.get("command", "") for group in claude_hooks.get("PermissionRequest", [])
+                       for hook in group.get("hooks", [])]
+        if not any("approval-hook.sh" in command for command in claude_gate):
             fails.append("plain --install dropped the existing claude approval gate")
+        if any("vibebuddy-forward.sh" in command for command in claude_gate):
+            fails.append("re-install after --approval re-added the claude PermissionRequest forwarder")
         codex_hooks = json.loads(open(os.path.join(home, ".codex/hooks.json")).read())["hooks"]
         codex_gate = [hook.get("command", "") for group in codex_hooks.get("PermissionRequest", [])
                       for hook in group.get("hooks", [])]
@@ -352,6 +391,7 @@ def main():
             fails.append("uninstall left opencode plugin")
 
     check_grok_home(fails)
+    check_claude_legacy_gate_migration(fails)
 
     if fails:
         print("FAIL:")


### PR DESCRIPTION
## Why

`install-claude-hooks.py --approval` put the blocking gate on `PreToolUse`, so every tool call the daemon could not match to a `permissions.allow` rule was held for the phone for up to 25s — including the calls Claude's own auto mode runs silently. With an empty allow list that is every call in every session. Claude Code fires `PermissionRequest` only when it would stop and ask (a prompt in default mode, an uncertain classifier in auto mode) and honours the hook's `decision.behavior` there — the same contract Codex adopted in #26 — so the gate belongs on that event.

## Changes

- **Daemon**: `ApprovalPayload.Call` now carries the `event` the payload arrived on. The reply contract and the wait semantics key on it instead of on the agent: a `PermissionRequest` (Claude or Codex) is answered with `hookSpecificOutput.decision.behavior` and is ingested only when the request must hold and the session is unknown; a `PreToolUse` payload keeps the `permissionDecision` contract and the ingest-first behaviour (Grok's gate lives there by necessity). The Codex-specific branches from #26 collapse into this.
- **Installer**: `--approval` writes the gate on `PermissionRequest` (matcher `*`, `timeout: 30`) and keeps the async `PreToolUse` status forwarder; `--install` and `--approval` both migrate a legacy `PreToolUse` gate. `--uninstall` unchanged.
- **Docs**: hooks README, multi-CLI setup, architecture note.

## Validation

- `VibeBuddyMac`: 512 tests / 45 suites pass. New: Claude `PermissionRequest` allow at once with no wait, hold → card → phone deny → back to `working`, always-allow rule shared with a `PreToolUse` payload, and the end-to-end run of the real `hooks/approval-hook.sh` with a `PermissionRequest` payload (byte-for-byte contract). All existing `PreToolUse` and Grok cases unchanged.
- `python3 hooks/test_install_agent_hooks.py` passes, including a new legacy-gate migration check.
- Contract source: the `PermissionRequest` output schema embedded in Claude Code 2.1.261 (`decision: {behavior:"allow", updatedInput?, updatedPermissions?} | {behavior:"deny", message?, interrupt?}`), identical to Codex 0.152.1's.

## Not verified here

A live round trip with a real `claude` session (a `PermissionRequest` reaching the phone, decision honoured). Planned right after merge + Mac redeploy.