### PR TITLE
feat(mac): layer the menu bar session list — pinned, grouped by agent, capped

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/MenuSessionList.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/MenuSessionList.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Layout of the menu bar popover's session list.
+///
+/// The popover's job is "do I need to do anything?", so it is laid out in three
+/// layers instead of one flat column that grows with every session:
+///
+/// 1. **Pinned** — sessions that need the user (`error`, `requiresInput`). They
+///    belong to no group and are never hidden.
+/// 2. **Groups** — everything else, grouped by agent. A collapsed group hides
+///    only its finished/idle rows; a session that is still working stays
+///    visible, the way a collapsed Slack section still shows its unread
+///    channels. Group headers are pointless with a single agent, so they are
+///    dropped (and collapsing is ignored) in that case.
+/// 3. The Mac view caps the whole list's height and scrolls inside it.
+///
+/// Input order is preserved: the store already sorts most-urgent then
+/// most-recent, and each group inherits that order. Groups themselves sort by
+/// their most urgent row, then by recency.
+public struct MenuSessionList: Equatable, Sendable {
+    public struct Group: Equatable, Sendable, Identifiable {
+        public let agent: AgentKind
+        /// Every non-pinned session for this agent, in snapshot order.
+        public let sessions: [AgentSession]
+        public let isCollapsed: Bool
+
+        public var id: AgentKind { agent }
+        public var summary: TaskPresentationSummary { TaskPresentationSummary(sessions: sessions) }
+
+        /// Rows the popover renders: all of them when expanded, only the ones
+        /// still working when collapsed.
+        public var visibleSessions: [AgentSession] {
+            isCollapsed ? sessions.filter { $0.presentationState == .thinking } : sessions
+        }
+    }
+
+    public let pinned: [AgentSession]
+    public let groups: [Group]
+
+    /// Headers (and therefore collapsing) only make sense with more than one agent.
+    public var showsGroupHeaders: Bool { groups.count > 1 }
+    public var isEmpty: Bool { pinned.isEmpty && groups.isEmpty }
+
+    public init(_ sessions: [AgentSession], collapsedAgents: Set<AgentKind>) {
+        pinned = sessions.filter { Self.isPinned($0) }
+        let rest = sessions.filter { !Self.isPinned($0) }
+        let byAgent = Dictionary(grouping: rest, by: \.agent)
+        let multiple = byAgent.count > 1
+        groups = byAgent
+            .map { agent, sessions in
+                Group(agent: agent, sessions: sessions,
+                      isCollapsed: multiple && collapsedAgents.contains(agent))
+            }
+            .sorted { a, b in
+                // Each group's first row is its most urgent + most recent one.
+                guard let x = a.sessions.first, let y = b.sessions.first else { return false }
+                if x.presentationState.attentionRank != y.presentationState.attentionRank {
+                    return x.presentationState.attentionRank < y.presentationState.attentionRank
+                }
+                return x.updatedAt > y.updatedAt
+            }
+    }
+
+    private static func isPinned(_ session: AgentSession) -> Bool {
+        switch session.presentationState {
+        case .error, .requiresInput: return true
+        case .thinking, .completeUnread, .idle, .unassigned: return false
+        }
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/MenuSessionListTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/MenuSessionListTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import Foundation
+@testable import VibeBuddyKit
+
+@Suite("MenuSessionList")
+struct MenuSessionListTests {
+
+    private func session(_ id: String, _ agent: AgentKind, _ status: SessionStatus,
+                         unread: Bool = false, age: TimeInterval = 0) -> AgentSession {
+        let t = Date(timeIntervalSince1970: 1_000_000 - age)
+        return AgentSession(id: id, agent: agent, project: id, status: status,
+                            waitKind: status == .needsResponse ? .permission : nil,
+                            hasUnreadCompletion: unread, statusSince: t, updatedAt: t)
+    }
+
+    @Test("sessions that need the user are pinned above every group")
+    func pinned() {
+        let list = MenuSessionList([
+            session("approve", .claudeCode, .needsResponse),
+            session("cx-work", .codex, .working),
+            session("cc-done", .claudeCode, .done, unread: true),
+        ], collapsedAgents: [])
+        #expect(list.pinned.map(\.id) == ["approve"])
+        #expect(list.groups.map(\.agent) == [.codex, .claudeCode])
+        #expect(list.groups.flatMap(\.sessions).map(\.id) == ["cx-work", "cc-done"])
+    }
+
+    @Test("groups sort by their most urgent row, then recency")
+    func groupOrder() {
+        let list = MenuSessionList([
+            session("cc-work", .claudeCode, .working, age: 60),
+            session("cx-work", .codex, .working, age: 10),
+            session("cc-done", .claudeCode, .done, unread: true),
+        ], collapsedAgents: [])
+        #expect(list.groups.map(\.agent) == [.codex, .claudeCode])
+    }
+
+    @Test("a collapsed group keeps its working rows and hides finished ones")
+    func collapsedKeepsWorking() {
+        let list = MenuSessionList([
+            session("cx-work", .codex, .working),
+            session("cx-done", .codex, .done, unread: true),
+            session("cx-idle", .codex, .done),
+            session("cc-done", .claudeCode, .done, unread: true),
+        ], collapsedAgents: [.codex])
+        let codex = list.groups.first { $0.agent == .codex }!
+        #expect(codex.isCollapsed)
+        #expect(codex.visibleSessions.map(\.id) == ["cx-work"])
+        #expect(codex.summary.completeUnread == 1 && codex.summary.idle == 1 && codex.summary.thinking == 1)
+        let claude = list.groups.first { $0.agent == .claudeCode }!
+        #expect(!claude.isCollapsed)
+        #expect(claude.visibleSessions.map(\.id) == ["cc-done"])
+    }
+
+    @Test("a single agent shows no headers and ignores collapsing")
+    func singleAgent() {
+        let list = MenuSessionList([
+            session("a", .codex, .working),
+            session("b", .codex, .done, unread: true),
+        ], collapsedAgents: [.codex])
+        #expect(!list.showsGroupHeaders)
+        #expect(list.groups.count == 1)
+        #expect(!list.groups[0].isCollapsed)
+        #expect(list.groups[0].visibleSessions.map(\.id) == ["a", "b"])
+    }
+}

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -49,6 +49,9 @@ final class MenuBarModel: ObservableObject {
     @Published var toggleGlanceHotkey: Hotkey = .toggleGlanceDefault
     /// Idle-cleanup window in hours; 0 means never. Default 2h.
     @Published var idleTimeoutHours: Double = 2
+    /// Agent groups the user folded in the menu bar list (persisted). A folded
+    /// group still shows its working rows — see `MenuSessionList`.
+    @Published private(set) var collapsedMenuAgents: Set<AgentKind> = []
     let port: Int
     private let token: String
     private let store: SessionStore
@@ -84,6 +87,7 @@ final class MenuBarModel: ObservableObject {
     private var pollTask: Task<Void, Never>?
     private var glance: GlanceWindow?
     private static let pairedPhoneInfoKey = "pairedPhoneInfo"
+    private static let collapsedMenuAgentsKey = "menuCollapsedAgents"
     private static let legacyPairedPhoneKey = "pairedPhone"
 
     init(runtimeEnabled: Bool = true) {
@@ -105,6 +109,8 @@ final class MenuBarModel: ObservableObject {
         // Snap to one of the 3 presets so the menu Picker selection always matches.
         glanceScale = [0.8, 1.0, 1.2].min(by: { abs($0 - base) < abs($1 - base) }) ?? 1.0
         showGlance = UserDefaults.standard.bool(forKey: "showGlance", default: true)
+        collapsedMenuAgents = Set((UserDefaults.standard.stringArray(forKey: Self.collapsedMenuAgentsKey) ?? [])
+            .compactMap(AgentKind.init(rawValue:)))
         openDashboardHotkey = Hotkey.loadOpenDashboard()
         toggleGlanceHotkey = Hotkey.loadToggleGlance()
         usage = AccountUsageCoordinator(store: store, notifier: notifier)
@@ -524,6 +530,19 @@ final class MenuBarModel: ObservableObject {
         pairedPhone = nil
         UserDefaults.standard.removeObject(forKey: Self.pairedPhoneInfoKey)
         UserDefaults.standard.removeObject(forKey: Self.legacyPairedPhoneKey)
+    }
+
+    var menuSessionList: MenuSessionList {
+        MenuSessionList(sessions, collapsedAgents: collapsedMenuAgents)
+    }
+
+    func toggleMenuGroup(_ agent: AgentKind) {
+        if collapsedMenuAgents.contains(agent) {
+            collapsedMenuAgents.remove(agent)
+        } else {
+            collapsedMenuAgents.insert(agent)
+        }
+        UserDefaults.standard.set(collapsedMenuAgents.map(\.rawValue).sorted(), forKey: Self.collapsedMenuAgentsKey)
     }
 
     func setShowGlance(_ on: Bool) {

--- a/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
+++ b/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
@@ -233,8 +233,14 @@ struct MenuBarLabel: View {
     }
 }
 
+private struct SessionListHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = max(value, nextValue()) }
+}
+
 struct MenuContent: View {
     @ObservedObject var model: MenuBarModel
+    @State private var listContentHeight: CGFloat = 0
     @Environment(\.openWindow) private var openWindow
     @Environment(\.openSettings) private var openSettings
 
@@ -325,9 +331,7 @@ struct MenuContent: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading).padding(.vertical, 2)
             } else {
-                VStack(spacing: 9) {
-                    ForEach(model.sessions) { row($0) }
-                }
+                sessionList
             }
 
             Divider()
@@ -384,6 +388,96 @@ struct MenuContent: View {
                          : AnyShapeStyle(.secondary))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(value) \(state.label)")
+    }
+
+    /// Height cap for the session list — about eight compact rows. A short list
+    /// takes its natural height; a long one scrolls inside the cap so the
+    /// buttons above and the footer below never move off screen.
+    private static let listMaxHeight: CGFloat = 320
+
+    /// A ScrollView inside a MenuBarExtra window collapses to zero height
+    /// unless it is given one explicitly, so the rows report their natural
+    /// height and the scroller is sized to that, capped.
+    private var sessionList: some View {
+        ScrollView(.vertical) {
+            sessionRows
+                .background(GeometryReader { geo in
+                    Color.clear.preference(key: SessionListHeightKey.self, value: geo.size.height)
+                })
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .onPreferenceChange(SessionListHeightKey.self) { listContentHeight = $0 }
+        .frame(height: min(max(listContentHeight, 1), Self.listMaxHeight))
+    }
+
+    /// Three layers (see `MenuSessionList`): sessions that need the user stay
+    /// pinned on top in the full two-line row; everything else is grouped by
+    /// agent in compact one-line rows, and a folded group hides only its
+    /// finished rows.
+    private var sessionRows: some View {
+        let list = model.menuSessionList
+        return VStack(alignment: .leading, spacing: 9) {
+            ForEach(list.pinned) { row($0) }
+            ForEach(list.groups) { group in
+                if list.showsGroupHeaders { groupHeader(group) }
+                ForEach(group.visibleSessions) { compactRow($0) }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func groupHeader(_ group: MenuSessionList.Group) -> some View {
+        Button {
+            model.toggleMenuGroup(group.agent)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(group.isCollapsed ? 0 : 90))
+                    .frame(width: 10)
+                Text(group.agent.displayName).font(.caption.weight(.semibold))
+                Spacer(minLength: 4)
+                HStack(spacing: 7) {
+                    ForEach([TaskPresentationState.thinking, .completeUnread, .idle], id: \.self) { state in
+                        let count = group.summary.count(for: state)
+                        if count > 0 {
+                            HStack(spacing: 3) {
+                                TaskStatusIndicator(state, size: 7)
+                                Text("\(count)").monospacedDigit()
+                            }
+                            .accessibilityLabel("\(count) \(state.label)")
+                        }
+                    }
+                }
+                .font(.caption2.weight(.medium)).foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 7).padding(.vertical, 4)
+            .background(.quaternary.opacity(0.6), in: RoundedRectangle(cornerRadius: 6))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(group.isCollapsed ? "Show finished sessions" : "Hide finished sessions")
+        .accessibilityLabel("\(group.agent.displayName), \(group.sessions.count) sessions")
+        .accessibilityValue(group.isCollapsed ? "collapsed" : "expanded")
+    }
+
+    /// One-line row for sessions that don't need the user: the dot carries the
+    /// state, the trailing text says what the agent is doing and since when.
+    private func compactRow(_ session: AgentSession) -> some View {
+        HStack(spacing: 8) {
+            TaskStatusIndicator(session.presentationState, size: 8)
+            Text(session.project)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1).truncationMode(.middle)
+            Spacer(minLength: 6)
+            HStack(spacing: 4) {
+                Text(ToolActivity.label(for: session))
+                Text("·").foregroundStyle(.tertiary)
+                Text(session.updatedAt, style: .relative).monospacedDigit()
+            }
+            .font(.caption).foregroundStyle(.secondary).lineLimit(1).fixedSize()
+        }
     }
 
     private func row(_ session: AgentSession) -> some View {


### PR DESCRIPTION
## Why
With many sessions the menu bar popover grew to the full screen height: a flat `VStack` with no height cap, two-line rows, and Ready sessions lingering for the 2 h idle timeout.

## What
- **Kit** `MenuSessionList` (pure, tested): sessions that need the user (`error` / `requiresInput`) are pinned on top; everything else is grouped by agent, groups ordered by their most urgent row then recency. A collapsed group hides only finished/idle rows — working rows stay visible (Slack-sidebar rule). With a single agent there are no headers and collapsing is ignored.
- **MenuBarModel**: `collapsedMenuAgents` persisted in UserDefaults (`menuCollapsedAgents`, by `AgentKind.rawValue`), `toggleMenuGroup`.
- **MenuContent**: list scrolls inside a 320 pt cap so the buttons above and the footer below never move. Pinned rows keep the existing two-line style; grouped rows are compact one-liners; group headers carry per-state count dots and toggle collapse.

Implementation note: `ViewThatFits` + `frame(maxHeight:)` collapses a `ScrollView` to zero height inside a `MenuBarExtra` window, so the rows report their height through a preference and the scroller gets an explicit `frame(height:)`.

## Verification
- `swift test` in VibeBuddyKit: 223 tests pass (4 new in `MenuSessionListTests`).
- Debug build launched with `VIBEBUDDY_DEMO=1`: 8 demo sessions render as 3 pinned rows + Grok / Codex / Claude Code groups; with the demo set temporarily tripled to 24 the list scrolls inside the cap and the footer stays fixed.
- Not exercised on device: clicking a group header (the popover exposes no AX window); covered by the Kit tests.