### PR TITLE
fix(mac): truncate compact menu rows at the tail

### DIFF
--- a/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
+++ b/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
@@ -444,7 +444,7 @@ struct MenuContent: View {
             TaskStatusIndicator(session.presentationState, size: 8)
             Text(session.project)
                 .font(.system(size: 13, weight: .semibold))
-                .lineLimit(1).truncationMode(.middle)
+                .lineLimit(1).truncationMode(.tail)
             Spacer(minLength: 6)
             HStack(spacing: 4) {
                 Text(ToolActivity.label(for: session))


### PR DESCRIPTION
Follow-up to #32. Compact rows in the menu bar list cut long project names in the middle (`pet-icon-d…ign-40d777`), which kept the hash suffix but lost the readable prefix. Switch to tail truncation so the start of the name always shows.

Verified: Debug build compiles; one-line change in `MenuContent.compactRow`.