### PR TITLE
feat: classify Mac notifications by session attention and cue

### DIFF
--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -463,9 +463,9 @@ final class DashboardStore: ObservableObject {
             quietMode: SoundPrefs.effectiveQuiet()))
         for alert in alerts {
             notifier.notify(alert)
-            Haptics.play(for: alert.sound)   // a tasteful tap to go with the cue
+            if alert.delivery.interrupts { Haptics.play(for: alert.sound) }   // a tasteful tap to go with the cue
         }
-        if !alerts.isEmpty { cuePulse += 1 }   // let the buddy react
+        if alerts.contains(where: \.delivery.interrupts) { cuePulse += 1 }   // let the buddy react
         // Answered on the Mac, or gone entirely: the banner it left on the phone
         // and on the wrist is describing something nobody is blocked on.
         notifications.record(alerts)

--- a/VibeBuddyApp/Sources/Notifier.swift
+++ b/VibeBuddyApp/Sources/Notifier.swift
@@ -31,7 +31,7 @@ struct LocalNotifier: AttentionNotifier {
         // The identifier the Mac's push uses as its collapse id: whichever
         // channel gets there first, iOS keeps one notification, and the Watch
         // mirrors one.
-        post(title: title, body: body, sound: alert.sound,
+        post(title: title, body: body, sound: alert.sound, delivery: alert.delivery,
              id: alert.notificationID, sessionID: alert.sessionID)
     }
 
@@ -50,13 +50,16 @@ struct LocalNotifier: AttentionNotifier {
     }
 
     private func post(title: String, body: String, sound: NotificationSound,
+                      delivery: DeliveryLevel = .bannerSound,
                       id: String, sessionID: String? = nil) {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
-        content.sound = Self.soundOn
+        content.sound = delivery.makesSound && Self.soundOn
             ? UNNotificationSound(named: UNNotificationSoundName(rawValue: sound.fileName))
             : nil
+        // A list-only cue is filed in Notification Center without a banner.
+        if delivery == .list { content.interruptionLevel = .passive }
         // Everything said about one session groups and opens as that session,
         // on the phone and on the wrist alike.
         if let sessionID {

--- a/VibeBuddyKit/Sources/VibeBuddyKit/DeliveryMatrix.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/DeliveryMatrix.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// How loudly one cue reaches you. Ordered from silent to loud so a context
+/// can only ever *cap* a level (`min`), never raise it.
+public enum DeliveryLevel: Int, Sendable, Comparable, CaseIterable {
+    /// Not posted anywhere.
+    case drop = 0
+    /// Added to Notification Center without a banner or a sound.
+    case list
+    /// A banner, no sound.
+    case banner
+    /// A banner with the cue's sound.
+    case bannerSound
+
+    public static func < (lhs: DeliveryLevel, rhs: DeliveryLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    public var makesSound: Bool { self == .bannerSound }
+
+    /// Whether this level is worth pulling you away from something else: a
+    /// banner on the Mac, a push to the phone. `list` and `drop` are not.
+    public var interrupts: Bool { self >= .banner }
+}
+
+/// The one table that says how a cue reaches you given the session's attention
+/// level. Shared by the Mac's local notifications, the Mac's push to the phone,
+/// and the phone's own local notifications, so all three agree.
+///
+/// | cue            | followed     | normal       | muted   |
+/// |----------------|--------------|--------------|---------|
+/// | needsApproval  | banner+sound | banner+sound | banner  |
+/// | agentStuck     | banner+sound | banner       | list    |
+/// | needsAnswer    | banner+sound | list         | list    |
+/// | agentDone      | banner       | list         | drop    |
+/// | longWaitNudge  | banner       | list         | drop    |
+///
+/// Quiet mode is the `muted` column for every session. `pairSuccess` is not a
+/// session cue and is always loud.
+public enum DeliveryMatrix {
+    public static func level(for sound: NotificationSound, attention: SessionAttention) -> DeliveryLevel {
+        switch (sound, attention) {
+        case (.needsApproval, .followed), (.needsApproval, .normal): return .bannerSound
+        case (.needsApproval, .muted): return .banner
+        case (.agentStuck, .followed): return .bannerSound
+        case (.agentStuck, .normal): return .banner
+        case (.agentStuck, .muted): return .list
+        case (.needsAnswer, .followed): return .bannerSound
+        case (.needsAnswer, .normal), (.needsAnswer, .muted): return .list
+        case (.agentDone, .followed), (.longWaitNudge, .followed): return .banner
+        case (.agentDone, .normal), (.longWaitNudge, .normal): return .list
+        case (.agentDone, .muted), (.longWaitNudge, .muted): return .drop
+        case (.pairSuccess, _): return .bannerSound
+        }
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -377,9 +377,13 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     /// snapshots decode as a normal completion. Distinct from a real stop
     /// whose last message happened to be "Abandoned".
     public var probeRetired: Bool?
-    /// The attention level the daemon settled on for this session. Absent means
-    /// `normal`; only the daemon writes it (via `/attention`), clients read it.
+    /// The attention level in effect for this session: the user's own choice
+    /// when there is one, else what the daemon inferred from recent
+    /// interaction. Absent means `normal`. Only the daemon writes it.
     public var attention: SessionAttention?
+    /// The level the user set by hand (via `/attention`), if any. Absent means
+    /// the level is automatic — the UI shows this so a choice can be undone.
+    public var attentionOverride: SessionAttention?
     public var statusSince: Date
     public var updatedAt: Date
 
@@ -408,6 +412,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         childTopologyDegraded: Bool? = nil,
         probeRetired: Bool? = nil,
         attention: SessionAttention? = nil,
+        attentionOverride: SessionAttention? = nil,
         statusSince: Date,
         updatedAt: Date
     ) {
@@ -435,6 +440,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.childTopologyDegraded = childTopologyDegraded
         self.probeRetired = probeRetired
         self.attention = attention
+        self.attentionOverride = attentionOverride
         self.statusSince = statusSince
         self.updatedAt = updatedAt
     }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -36,6 +36,17 @@ public enum WaitKind: String, Codable, Sendable {
     case question        // asked something / idle waiting for input
 }
 
+/// How much of your attention a session has earned. Decides, together with
+/// the cue, whether a notification interrupts you, sits in the list, or is
+/// never posted (see `DeliveryMatrix`). The daemon owns the value: a manual
+/// choice from the Mac or the phone overrides whatever the automatic signals
+/// would have said, and the choice lives exactly as long as the session.
+public enum SessionAttention: String, Codable, Sendable, CaseIterable {
+    case followed   // you are driving this one — everything interrupts
+    case normal     // the default — only what blocks or breaks interrupts
+    case muted      // you chose to stop hearing from it — approvals only, silently
+}
+
 /// A tool use awaiting the user's approval from the phone. Present only while a
 /// session is blocked on a remote approve/deny.
 public struct PendingApproval: Codable, Sendable, Equatable {
@@ -366,6 +377,9 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     /// snapshots decode as a normal completion. Distinct from a real stop
     /// whose last message happened to be "Abandoned".
     public var probeRetired: Bool?
+    /// The attention level the daemon settled on for this session. Absent means
+    /// `normal`; only the daemon writes it (via `/attention`), clients read it.
+    public var attention: SessionAttention?
     public var statusSince: Date
     public var updatedAt: Date
 
@@ -393,6 +407,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         childAgents: [ChildAgent]? = nil,
         childTopologyDegraded: Bool? = nil,
         probeRetired: Bool? = nil,
+        attention: SessionAttention? = nil,
         statusSince: Date,
         updatedAt: Date
     ) {
@@ -419,6 +434,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.childAgents = childAgents
         self.childTopologyDegraded = childTopologyDegraded
         self.probeRetired = probeRetired
+        self.attention = attention
         self.statusSince = statusSince
         self.updatedAt = updatedAt
     }
@@ -435,6 +451,9 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
 
     /// Whether to treat this session as failed/stuck (Optional `failed` is "no").
     public var isStuck: Bool { failed == true }
+
+    /// The attention level to apply: an unset value is `normal`.
+    public var effectiveAttention: SessionAttention { attention ?? .normal }
 
     public var runningChildAgents: [ChildAgent] {
         (childAgents ?? []).filter { $0.status == .running }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/NotificationSound.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/NotificationSound.swift
@@ -14,10 +14,6 @@ public enum NotificationSound: String, Sendable, CaseIterable, Equatable {
     /// The bundled CAF resource name (`needs_approval.caf`, …).
     public var fileName: String { "\(rawValue).caf" }
 
-    /// In Quiet / Focus mode only the security-decision cue survives; everything
-    /// else falls silent (the visual surfaces — banner, Live Activity — remain).
-    public var survivesQuietMode: Bool { self == .needsApproval }
-
     /// Whether this cue describes a session that is *still waiting*. Only these
     /// stop being true when the session moves on, so only these are withdrawn;
     /// a completion is history and stays until the user clears it.

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
@@ -1,14 +1,21 @@
 import Foundation
 
-/// A decision to play one cue for one session at a state boundary.
+/// A decision to say one thing about one session at a state boundary, and how
+/// loudly to say it.
 public struct SoundAlert: Equatable, Sendable {
     public let session: AgentSession
     public let sound: NotificationSound
+    /// How this cue reaches you, already reduced through `DeliveryMatrix`,
+    /// Quiet mode and the focused-terminal cap. Never `.drop`: a dropped cue is
+    /// not emitted at all.
+    public let delivery: DeliveryLevel
     public var sessionID: String { session.id }
 
-    public init(session: AgentSession, sound: NotificationSound) {
+    public init(session: AgentSession, sound: NotificationSound,
+                delivery: DeliveryLevel = .bannerSound) {
         self.session = session
         self.sound = sound
+        self.delivery = delivery
     }
 }
 
@@ -37,11 +44,11 @@ public struct SoundPolicyInput: Sendable {
     /// True when the user is actively looking at the app (front window / active
     /// scene). Completion stays silent when it's already on screen.
     public var appActive: Bool
-    /// Quiet / Focus mode: only approvals ring.
+    /// Quiet / Focus mode: every session is treated as `muted`.
     public var quietMode: Bool
     /// IDs of sessions whose own terminal window is currently frontmost — the user
-    /// is already looking at them, so their completion stays silent, the same way
-    /// `appActive` silences completion when VibeBuddy itself is frontmost. The Mac
+    /// is already looking at them, and the native prompt is right there, so
+    /// nothing about them interrupts: every cue is capped to the list. The Mac
     /// fills this from the frontmost terminal app; iOS leaves it empty.
     public var focusedSessionIDs: Set<String>
 
@@ -55,16 +62,19 @@ public struct SoundPolicyInput: Sendable {
     }
 }
 
-/// Turns the live snapshot stream into a stream of sound cues, applying every
-/// rule in one tested place:
+/// Turns the live snapshot stream into a stream of cues, applying every rule in
+/// one tested place:
 ///   - only state *boundaries* ring; starting work and plain refreshes stay silent;
 ///   - a waiting cue fires once per fresh wait and debounces re-entries;
 ///   - completion rings only when the task actually ran (> `doneMinRuntime`) and
 ///     you're not already watching the app;
 ///   - a failed / aborted ending rings the duller `agentStuck` instead;
 ///   - one gentle `longWaitNudge` after a wait drags past the threshold;
-///   - Quiet / Focus mode keeps only approvals.
-/// Shared by the Mac menu bar and the iOS app so both behave identically.
+///   - then `DeliveryMatrix` decides how loud each cue is from the session's
+///     attention level, Quiet mode reads every session as `muted`, a focused
+///     terminal caps its session to the list, and a `drop` is never emitted.
+/// Shared by the Mac menu bar, the Mac's push to the phone, and the iOS app so
+/// all three behave identically.
 public final class SoundPolicy {
     private let config: SoundPolicyConfig
     private var seenFirstSnapshot = false
@@ -88,29 +98,33 @@ public final class SoundPolicy {
 
         var alerts: [SoundAlert] = []
         for session in input.sessions {
-            if let alert = boundaryAlert(prev: previous[session.id], now: session, input: input) {
-                alerts.append(alert)
-            }
+            guard let sound = boundarySound(prev: previous[session.id], now: session, input: input)
+            else { continue }
+            let attention: SessionAttention = input.quietMode ? .muted : session.effectiveAttention
+            var level = DeliveryMatrix.level(for: sound, attention: attention)
+            if input.focusedSessionIDs.contains(session.id) { level = min(level, .list) }
+            guard level != .drop else { continue }
+            alerts.append(SoundAlert(session: session, sound: sound, delivery: level))
         }
-        return input.quietMode ? alerts.filter { $0.sound.survivesQuietMode } : alerts
+        return alerts
     }
 
-    /// The cue earned by `session` given its prior state, before Quiet filtering.
-    private func boundaryAlert(prev: AgentSession?, now session: AgentSession,
-                               input: SoundPolicyInput) -> SoundAlert? {
+    /// The cue earned by `session` given its prior state, before the matrix.
+    private func boundarySound(prev: AgentSession?, now session: AgentSession,
+                               input: SoundPolicyInput) -> NotificationSound? {
         switch session.status {
-        case .needsResponse: return waitingAlert(prev: prev, now: session, input: input)
-        case .done:          return completionAlert(prev: prev, now: session, input: input)
+        case .needsResponse: return waitingSound(prev: prev, now: session, input: input)
+        case .done:          return completionSound(prev: prev, now: session, input: input)
         case .working:       return nil   // starting work is process noise — never rings
         }
     }
 
-    private func waitingAlert(prev: AgentSession?, now session: AgentSession,
-                              input: SoundPolicyInput) -> SoundAlert? {
+    private func waitingSound(prev: AgentSession?, now session: AgentSession,
+                              input: SoundPolicyInput) -> NotificationSound? {
         let enteringWait = prev?.status != .needsResponse
         guard enteringWait else {
             // Same wait, still unanswered: one gentle nudge once it drags on.
-            return longWaitAlert(now: session, input: input)
+            return longWaitSound(now: session, input: input)
         }
         // Fresh wait: ring once, debounced against this session's last waiting cue.
         if let last = lastWaitingSoundAt[session.id],
@@ -118,32 +132,30 @@ public final class SoundPolicy {
             return nil
         }
         lastWaitingSoundAt[session.id] = input.now
-        let sound: NotificationSound = session.waitKind == .permission ? .needsApproval : .needsAnswer
-        return SoundAlert(session: session, sound: sound)
+        return session.waitKind == .permission ? .needsApproval : .needsAnswer
     }
 
-    private func longWaitAlert(now session: AgentSession, input: SoundPolicyInput) -> SoundAlert? {
+    private func longWaitSound(now session: AgentSession, input: SoundPolicyInput) -> NotificationSound? {
         guard input.now.timeIntervalSince(session.statusSince) >= config.longWaitThreshold,
               nudgedWaitSince[session.id] != session.statusSince else { return nil }
         nudgedWaitSince[session.id] = session.statusSince
-        return SoundAlert(session: session, sound: .longWaitNudge)
+        return .longWaitNudge
     }
 
-    private func completionAlert(prev: AgentSession?, now session: AgentSession,
-                                 input: SoundPolicyInput) -> SoundAlert? {
+    private func completionSound(prev: AgentSession?, now session: AgentSession,
+                                 input: SoundPolicyInput) -> NotificationSound? {
         // Only a real transition into done that we watched, and only when you're
-        // not already looking at the result — either VibeBuddy is frontmost
-        // (`appActive`) or this session's own terminal window is (`focusedSessionIDs`).
-        let watching = input.appActive || input.focusedSessionIDs.contains(session.id)
-        guard let prev, prev.status != .done, !watching else { return nil }
+        // not already looking at the result in VibeBuddy itself (`appActive`).
+        // A focused terminal is handled by the list cap in `evaluate`.
+        guard let prev, prev.status != .done, !input.appActive else { return nil }
         if session.probeRetired == true { return nil }
 
         // Real signal first (a tool/turn error reported by the hook), then the
         // prose heuristic as a fallback. Either way failures ring regardless of runtime.
         if session.isStuck || FailureHeuristic.looksFailed(session.summary) {
-            return SoundAlert(session: session, sound: .agentStuck)
+            return .agentStuck
         }
         guard input.now.timeIntervalSince(prev.statusSince) >= config.doneMinRuntime else { return nil }
-        return SoundAlert(session: session, sound: .agentDone)
+        return .agentDone
     }
 }

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
@@ -12,9 +12,11 @@ struct SoundPolicyTests {
                          wait: WaitKind? = nil,
                          since: TimeInterval = 0,
                          summary: String? = nil,
-                         probeRetired: Bool? = nil) -> AgentSession {
+                         probeRetired: Bool? = nil,
+                         attention: SessionAttention? = nil) -> AgentSession {
         AgentSession(id: id, agent: .claudeCode, project: id, status: status,
                      waitKind: wait, summary: summary, probeRetired: probeRetired,
+                     attention: attention,
                      statusSince: Date(timeIntervalSince1970: since),
                      updatedAt: Date(timeIntervalSince1970: since))
     }
@@ -34,12 +36,30 @@ struct SoundPolicyTests {
         #expect(NotificationSound.agentDone.fileName == "agent_done.caf")
     }
 
-    @Test("only approvals survive Quiet/Focus mode")
-    func quietSurvivors() {
-        #expect(NotificationSound.needsApproval.survivesQuietMode)
-        for s in NotificationSound.allCases where s != .needsApproval {
-            #expect(!s.survivesQuietMode)
+    // MARK: DeliveryMatrix — the one table
+
+    @Test("the matrix matches the spec table row by row")
+    func matrixTable() {
+        typealias Row = (NotificationSound, DeliveryLevel, DeliveryLevel, DeliveryLevel)
+        let rows: [Row] = [
+            (.needsApproval, .bannerSound, .bannerSound, .banner),
+            (.agentStuck,    .bannerSound, .banner,      .list),
+            (.needsAnswer,   .bannerSound, .list,        .list),
+            (.agentDone,     .banner,      .list,        .drop),
+            (.longWaitNudge, .banner,      .list,        .drop),
+        ]
+        for (sound, followed, normal, muted) in rows {
+            #expect(DeliveryMatrix.level(for: sound, attention: .followed) == followed, "\(sound) followed")
+            #expect(DeliveryMatrix.level(for: sound, attention: .normal) == normal, "\(sound) normal")
+            #expect(DeliveryMatrix.level(for: sound, attention: .muted) == muted, "\(sound) muted")
         }
+    }
+
+    @Test("delivery levels order silent → loud, and only banners interrupt")
+    func deliveryOrdering() {
+        #expect(DeliveryLevel.drop < .list && .list < .banner && .banner < .bannerSound)
+        #expect(!DeliveryLevel.list.interrupts && DeliveryLevel.banner.interrupts)
+        #expect(DeliveryLevel.bannerSound.makesSound && !DeliveryLevel.banner.makesSound)
     }
 
     // MARK: First snapshot — no backlog noise
@@ -59,6 +79,7 @@ struct SoundPolicyTests {
         _ = p.evaluate(input([session("a", .working)], now: 0))
         let alerts = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1)], now: 1))
         #expect(alerts.map(\.sound) == [.needsAnswer])
+        #expect(alerts.map(\.delivery) == [.list])   // normal attention: a question waits in the list
     }
 
     @Test("a fresh permission transition rings needs_approval")
@@ -67,6 +88,46 @@ struct SoundPolicyTests {
         _ = p.evaluate(input([session("a", .working)], now: 0))
         let alerts = p.evaluate(input([session("a", .needsResponse, wait: .permission, since: 1)], now: 1))
         #expect(alerts.map(\.sound) == [.needsApproval])
+        #expect(alerts.map(\.delivery) == [.bannerSound])
+    }
+
+    // MARK: attention — the matrix applied per session
+
+    @Test("a followed session's question rings out loud")
+    func followedQuestionLoud() {
+        let p = SoundPolicy()
+        _ = p.evaluate(input([session("a", .working)], now: 0))
+        let alerts = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1,
+                                               attention: .followed)], now: 1))
+        #expect(alerts.map(\.delivery) == [.bannerSound])
+    }
+
+    @Test("a muted session's approval still shows, silently")
+    func mutedApprovalSilentBanner() {
+        let p = SoundPolicy()
+        _ = p.evaluate(input([session("a", .working)], now: 0))
+        let alerts = p.evaluate(input([session("a", .needsResponse, wait: .permission, since: 1,
+                                               attention: .muted)], now: 1))
+        #expect(alerts.map(\.delivery) == [.banner])
+    }
+
+    @Test("a muted session's completion is dropped — not even in the list")
+    func mutedDoneDropped() {
+        let p = SoundPolicy()
+        _ = p.evaluate(input([session("a", .working, since: 0)], now: 0))
+        let alerts = p.evaluate(input([session("a", .done, since: 40, attention: .muted)],
+                                      now: 40, appActive: false))
+        #expect(alerts.isEmpty)
+    }
+
+    @Test("a normal session's completion goes to the list, a followed one banners")
+    func doneByAttention() {
+        let p = SoundPolicy()
+        _ = p.evaluate(input([session("a", .working, since: 0), session("b", .working, since: 0)], now: 0))
+        let alerts = p.evaluate(input([session("a", .done, since: 40),
+                                       session("b", .done, since: 40, attention: .followed)],
+                                      now: 40, appActive: false))
+        #expect(alerts.map { "\($0.sessionID):\($0.delivery)" } == ["a:list", "b:banner"])
     }
 
     @Test("a session that keeps waiting does not re-ring")
@@ -128,13 +189,15 @@ struct SoundPolicyTests {
         #expect(alerts.isEmpty)
     }
 
-    @Test("done is silent when its own terminal is frontmost — you're already looking at it")
-    func doneFocusedTerminalSilent() {
+    @Test("a focused terminal caps its own session to the list — even a followed approval")
+    func focusedTerminalCapsToList() {
         let p = SoundPolicy()
-        _ = p.evaluate(input([session("a", .working, since: 0)], now: 0))
-        let alerts = p.evaluate(input([session("a", .done, since: 40)], now: 40,
-                                      appActive: false, focused: ["a"]))
-        #expect(alerts.isEmpty)
+        _ = p.evaluate(input([session("a", .working, since: 0), session("b", .working, since: 0)], now: 0))
+        let alerts = p.evaluate(input([session("a", .done, since: 40, attention: .followed),
+                                       session("b", .needsResponse, wait: .permission, since: 40,
+                                               attention: .followed)],
+                                      now: 40, appActive: false, focused: ["a", "b"]))
+        #expect(alerts.map { "\($0.sound.rawValue):\($0.delivery)" } == ["agent_done:list", "needs_approval:list"])
     }
 
     @Test("done still rings for a session whose terminal is NOT the focused one")
@@ -203,28 +266,30 @@ struct SoundPolicyTests {
         #expect(alerts.isEmpty)
     }
 
-    // MARK: Quiet / Focus mode — only approvals survive
+    // MARK: Quiet / Focus mode — every session reads as muted
 
-    @Test("Quiet mode silences a question ping")
-    func quietSilencesQuestion() {
+    @Test("Quiet mode sends a question to the list, even for a followed session")
+    func quietQuestionToList() {
         let p = SoundPolicy()
         _ = p.evaluate(input([session("a", .working)], now: 0))
-        let alerts = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1)],
+        let alerts = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1,
+                                               attention: .followed)],
                                       now: 1, quiet: true))
-        #expect(alerts.isEmpty)
+        #expect(alerts.map(\.delivery) == [.list])
     }
 
-    @Test("Quiet mode still lets an approval through")
-    func quietKeepsApproval() {
+    @Test("Quiet mode still shows an approval, without its sound")
+    func quietKeepsApprovalSilently() {
         let p = SoundPolicy()
         _ = p.evaluate(input([session("a", .working)], now: 0))
         let alerts = p.evaluate(input([session("a", .needsResponse, wait: .permission, since: 1)],
                                       now: 1, quiet: true))
         #expect(alerts.map(\.sound) == [.needsApproval])
+        #expect(alerts.map(\.delivery) == [.banner])
     }
 
-    @Test("Quiet mode silences completion")
-    func quietSilencesDone() {
+    @Test("Quiet mode drops completion")
+    func quietDropsDone() {
         let p = SoundPolicy()
         _ = p.evaluate(input([session("a", .working, since: 0)], now: 0))
         let alerts = p.evaluate(input([session("a", .done, since: 40)], now: 40,
@@ -241,6 +306,7 @@ struct SoundPolicyTests {
         _ = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1)], now: 1))  // initial ping
         let nudge = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1)], now: 200))
         #expect(nudge.map(\.sound) == [.longWaitNudge])
+        #expect(nudge.map(\.delivery) == [.list])   // normal attention: a nudge never interrupts
     }
 
     @Test("the long-wait nudge fires only once per wait")
@@ -253,8 +319,8 @@ struct SoundPolicyTests {
         #expect(again.isEmpty)
     }
 
-    @Test("Quiet mode silences the long-wait nudge")
-    func quietSilencesLongWait() {
+    @Test("Quiet mode drops the long-wait nudge")
+    func quietDropsLongWait() {
         let p = SoundPolicy()
         _ = p.evaluate(input([session("a", .working)], now: 0))
         _ = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1)], now: 1))

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalDetails.swift
@@ -47,8 +47,12 @@ public enum ApprovalPayload {
         public let tool: String
         public let input: [String: Any]
         public let sessionID: String
-        /// Grok only: `default | auto | plan | bypassPermissions` at the time of
-        /// the call. Outside `bypassPermissions` an `allow` from the phone only
+        /// The agent's permission mode at the time of the call. Claude Code
+        /// sends `permission_mode` (`default | plan | acceptEdits | auto |
+        /// dontAsk | bypassPermissions`); Grok sends `permissionMode`
+        /// (`default | auto | plan | bypassPermissions`). Drives
+        /// `ApprovalShortCircuit`: a `bypassPermissions` call is never held.
+        /// For Grok outside `bypassPermissions` an `allow` from the phone only
         /// means "the hook didn't block it" — Grok still raises its own local
         /// prompt, which no remote client can answer. A `deny` is authoritative
         /// in every mode, so the phone approval still runs; the mode rides along
@@ -61,14 +65,18 @@ public enum ApprovalPayload {
             return Call(tool: obj["tool_name"] as? String ?? "",
                         input: obj["tool_input"] as? [String: Any] ?? [:],
                         sessionID: obj["session_id"] as? String ?? "",
-                        permissionMode: nil)
+                        permissionMode: nonEmpty(obj["permission_mode"]))
         }
         let normalized = GrokToolVocabulary.normalize(
             tool: obj["toolName"] as? String ?? "",
             input: obj["toolInput"] as? [String: Any] ?? [:])
-        let mode = (obj["permissionMode"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let mode = nonEmpty(obj["permissionMode"])
         return Call(tool: normalized.tool, input: normalized.input,
                     sessionID: obj["sessionId"] as? String ?? "",
                     permissionMode: mode)
+    }
+
+    private static func nonEmpty(_ value: Any?) -> String? {
+        (value as? String).flatMap { $0.isEmpty ? nil : $0 }
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalShortCircuit.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ApprovalShortCircuit.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The calls the phone should never be asked about, decided purely from the
+/// tool name and the agent's permission mode at the time of the call.
+///
+/// The blocking approval hook runs on every PreToolUse regardless of mode, so
+/// without this gate a `bypassPermissions` session — one the user explicitly
+/// told not to prompt — still raised a phone card and a Mac banner for every
+/// tool call. Read-only tools are the same story in every mode: nothing to
+/// approve, nothing worth interrupting for.
+///
+/// Native deny rules are checked before this and still win (ADR 0010); this
+/// only decides silent-allow vs ask, never deny.
+public enum ApprovalShortCircuit {
+    /// Tools that only observe. Never worth a card in any mode. MCP tools
+    /// (`mcp__*`) are deliberately absent: their effects are unknowable here.
+    public static let readOnlyTools: Set<String> = [
+        "Read", "Glob", "Grep", "LS", "WebFetch", "WebSearch",
+        "ToolSearch", "TodoWrite", "NotebookRead", "AskUserQuestion",
+    ]
+
+    /// Tools `acceptEdits` mode already auto-approves locally.
+    public static let editTools: Set<String> = [
+        "Edit", "Write", "MultiEdit", "NotebookEdit",
+    ]
+
+    /// Whether this call is allowed without asking the phone.
+    ///
+    /// - `bypassPermissions`: everything.
+    /// - `acceptEdits`: read-only tools plus the edit tools.
+    /// - `default`, `plan`, `auto`, `dontAsk`, or an absent mode: read-only
+    ///   tools only. `auto` and `dontAsk` are grouped with `default` on purpose
+    ///   — over-asking is safe, under-asking is not.
+    public static func autoAllows(tool: String, permissionMode: String?) -> Bool {
+        switch permissionMode {
+        case "bypassPermissions":
+            return true
+        case "acceptEdits":
+            return readOnlyTools.contains(tool) || editTools.contains(tool)
+        default:
+            return readOnlyTools.contains(tool)
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AttentionOverrides.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AttentionOverrides.swift
@@ -1,0 +1,58 @@
+import Foundation
+import VibeBuddyKit
+
+/// The attention levels the user set by hand, keyed by session id. Owned by
+/// `SessionStore`, persisted beside the lifecycle journal so a daemon restart
+/// keeps a muted session muted, and pruned whenever a session goes away —
+/// a choice about a session lives exactly as long as the session.
+public struct AttentionOverrides: Sendable, Equatable {
+    public private(set) var levels: [String: SessionAttention]
+    private let url: URL?
+
+    public static func defaultURL() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+        return base.appendingPathComponent("vibebuddy/attention.json")
+    }
+
+    /// `url: nil` keeps the overrides in memory only (tests, throwaway daemons).
+    public init(url: URL?) {
+        self.url = url
+        self.levels = url.map(Self.read) ?? [:]
+    }
+
+    public subscript(sessionID: String) -> SessionAttention? { levels[sessionID] }
+
+    /// Set, or with `nil` clear, the user's choice for one session.
+    public mutating func set(_ level: SessionAttention?, for sessionID: String) {
+        guard levels[sessionID] != level else { return }
+        levels[sessionID] = level
+        write()
+    }
+
+    /// Forget every session not in `live`.
+    public mutating func prune(keeping live: Set<String>) {
+        let stale = levels.keys.filter { !live.contains($0) }
+        guard !stale.isEmpty else { return }
+        for id in stale { levels[id] = nil }
+        write()
+    }
+
+    private static func read(_ url: URL) -> [String: SessionAttention] {
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let raw = obj["sessions"] as? [String: String] else { return [:] }
+        return raw.compactMapValues(SessionAttention.init(rawValue:))
+    }
+
+    private func write() {
+        guard let url else { return }
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let raw = levels.mapValues(\.rawValue)
+        if let data = try? JSONSerialization.data(
+            withJSONObject: ["sessions": raw], options: [.prettyPrinted, .sortedKeys]) {
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AttentionOverrides.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AttentionOverrides.swift
@@ -56,3 +56,17 @@ public struct AttentionOverrides: Sendable, Equatable {
         }
     }
 }
+
+/// The level a session gets when the user has not chosen one: `followed`
+/// while they were recently *driving* it — typed a prompt, jumped to it,
+/// answered its approval or question — and `normal` otherwise. Never
+/// `muted`: silence is only ever a choice.
+public enum AutoAttention {
+    /// How long one interaction keeps a session followed.
+    public static let window: TimeInterval = 10 * 60
+
+    public static func level(lastInteractionAt: Date?, now: Date) -> SessionAttention {
+        guard let lastInteractionAt, now.timeIntervalSince(lastInteractionAt) < window else { return .normal }
+        return .followed
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/NotificationCoordinator.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/NotificationCoordinator.swift
@@ -8,10 +8,11 @@ public protocol AttentionNotifier {
 }
 
 /// Feeds each snapshot through the shared `SoundPolicy` and forwards the cues it
-/// earns to `notifier`. All the *when to ring* logic lives in `SoundPolicy`
-/// (unit-tested in VibeBuddyKit); this type only supplies the ambient context
-/// (clock, app-active, Quiet mode), fans the decisions out, and records delivery
-/// *after* those existing rules.
+/// earns to `notifier`. All the *when to ring* and *how loud* logic lives in
+/// `SoundPolicy` (unit-tested in VibeBuddyKit); this type only supplies the
+/// ambient context (clock, app-active, Quiet mode, focused terminals), fans the
+/// decisions out, records delivery, and hands the same cues back so the push to
+/// the phone is built from one decision rather than a second policy.
 public final class NotificationCoordinator: @unchecked Sendable {
     private let notifier: AttentionNotifier
     private let policy: SoundPolicy
@@ -27,13 +28,15 @@ public final class NotificationCoordinator: @unchecked Sendable {
         self.delivery = delivery
     }
 
+    @discardableResult
     public func observe(_ sessions: [AgentSession], now: Date = Date(),
                         appActive: Bool, quietMode: Bool,
-                        focusedSessionIDs: Set<String> = []) async {
+                        focusedSessionIDs: Set<String> = []) async -> [SoundAlert] {
         let input = SoundPolicyInput(sessions: sessions, now: now,
                                      appActive: appActive, quietMode: quietMode,
                                      focusedSessionIDs: focusedSessionIDs)
-        for alert in policy.evaluate(input) {
+        let alerts = policy.evaluate(input)
+        for alert in alerts {
             let attempt = await notifier.notify(alert)
             guard attempt.shouldRecord else { continue }
             await delivery?.record(NotificationDeliveryRecord(
@@ -45,5 +48,6 @@ public final class NotificationCoordinator: @unchecked Sendable {
                 timestamp: now
             ))
         }
+        return alerts
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/NotificationCoordinator.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/NotificationCoordinator.swift
@@ -5,6 +5,10 @@ import VibeBuddyKit
 /// implementation posts a local notification with the cue's sound; tests use a spy.
 public protocol AttentionNotifier {
     func notify(_ alert: SoundAlert) async -> LocalNotificationAttempt
+    /// Take back notifications whose session is no longer waiting: a banner or
+    /// a list entry for an answered approval describes something nobody is
+    /// blocked on any more. Identifiers are `SoundAlert.notificationID`.
+    func withdraw(_ identifiers: [String]) async
 }
 
 /// Feeds each snapshot through the shared `SoundPolicy` and forwards the cues it
@@ -17,6 +21,9 @@ public final class NotificationCoordinator: @unchecked Sendable {
     private let notifier: AttentionNotifier
     private let policy: SoundPolicy
     private let delivery: (any NotificationDeliveryRecording)?
+    /// What was posted for each waiting session, so it can be withdrawn the
+    /// moment the session stops waiting. Completions are never tracked.
+    private var ledger = WaitingNotificationLedger()
 
     public init(
         notifier: AttentionNotifier,
@@ -36,6 +43,11 @@ public final class NotificationCoordinator: @unchecked Sendable {
                                      appActive: appActive, quietMode: quietMode,
                                      focusedSessionIDs: focusedSessionIDs)
         let alerts = policy.evaluate(input)
+        // Withdraw before posting: a session that left one wait and entered
+        // another in the same snapshot keeps only the new cue.
+        let stale = ledger.withdrawals(for: sessions)
+        if !stale.isEmpty { await notifier.withdraw(stale) }
+        ledger.record(alerts)
         for alert in alerts {
             let attempt = await notifier.notify(alert)
             guard attempt.shouldRecord else { continue }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -29,11 +29,14 @@ public actor SessionStore {
     private var runtimeSignals: [AgentKind: [ObservationSource: ObservationRuntimeSignal]] = [:]
     private var diagnosticCache: (at: Date, value: [AgentObservationDiagnostic])?
     private var lifecycleJournal: LifecycleJournal?
+    /// The user's hand-set attention levels, layered onto every snapshot.
+    private var attention: AttentionOverrides
 
     public init(
         staleAfter: TimeInterval = 2 * 60 * 60,
         diagnosticsHome: URL? = nil,
         journalURL: URL? = nil,
+        attentionURL: URL? = nil,
         grokHome: URL? = nil,
         now: Date = Date()
     ) {
@@ -45,6 +48,20 @@ public actor SessionStore {
             self.lifecycleJournal = journal
             reducer.restore(journal.restorableSessions(now: now, meaningfulFor: staleAfter))
         }
+        var attention = AttentionOverrides(url: attentionURL)
+        attention.prune(keeping: Set(reducer.sessions.keys))
+        self.attention = attention
+    }
+
+    /// Set (or with `nil` clear) the user's attention choice for a live session.
+    /// Returns false when no such session exists — there is nothing to attach
+    /// the choice to, and it would never be pruned.
+    @discardableResult
+    public func setAttention(sessionID: String, _ level: SessionAttention?) -> Bool {
+        guard reducer.sessions[sessionID] != nil else { return false }
+        attention.set(level, for: sessionID)
+        broadcast()
+        return true
     }
 
     /// Change the idle-cleanup window at runtime (from Settings).
@@ -67,6 +84,7 @@ public actor SessionStore {
             transcriptPaths[id] = nil
             grokDirectories[id] = nil
         }
+        attention.prune(keeping: Set(reducer.sessions.keys))
         for id in removed {
             guard let session = before[id] else { continue }
             appendJournal(
@@ -142,6 +160,7 @@ public actor SessionStore {
             transcriptPaths[event.sessionID] = nil
             pendingTerminalRefs[event.sessionID] = nil
             grokDirectories[event.sessionID] = nil
+            attention.set(nil, for: event.sessionID)
         } else {
             // Grok keeps a session's facts in a directory of files rather than
             // one transcript, so it enriches from that directory instead.
@@ -315,6 +334,11 @@ public actor SessionStore {
     private func currentSnapshot(now: Date) -> Snapshot {
         var snapshot = reducer.snapshot(now: now, observationDiagnostics: diagnostics(now: now))
         snapshot.providerQuota = providerQuota.isEmpty ? nil : providerQuota
+        snapshot.sessions = snapshot.sessions.map { session in
+            var session = session
+            session.attention = attention[session.id]
+            return session
+        }
         return snapshot
     }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -31,6 +31,9 @@ public actor SessionStore {
     private var lifecycleJournal: LifecycleJournal?
     /// The user's hand-set attention levels, layered onto every snapshot.
     private var attention: AttentionOverrides
+    /// When the user last drove each session (prompt, jump, decision, answer);
+    /// what `AutoAttention` reads when there is no hand-set level.
+    private var lastInteractionAt: [String: Date] = [:]
 
     public init(
         staleAfter: TimeInterval = 2 * 60 * 60,
@@ -64,6 +67,15 @@ public actor SessionStore {
         return true
     }
 
+    /// The user just acted on this session — typed a prompt, jumped to it,
+    /// decided its approval, answered its question. Keeps it `followed` for
+    /// `AutoAttention.window` unless a hand-set level says otherwise.
+    public func recordInteraction(sessionID: String, at: Date = Date()) {
+        guard reducer.sessions[sessionID] != nil else { return }
+        lastInteractionAt[sessionID] = at
+        broadcast()
+    }
+
     /// Change the idle-cleanup window at runtime (from Settings).
     public func setStaleAfter(_ interval: TimeInterval) { staleAfter = interval }
 
@@ -83,6 +95,7 @@ public actor SessionStore {
         for id in removed {
             transcriptPaths[id] = nil
             grokDirectories[id] = nil
+            lastInteractionAt[id] = nil
         }
         attention.prune(keeping: Set(reducer.sessions.keys))
         for id in removed {
@@ -148,6 +161,8 @@ public actor SessionStore {
         let wasWaiting = reducer.sessions[event.sessionID]?.status == .needsResponse
         if let path = event.transcriptPath { transcriptPaths[event.sessionID] = path }
         reducer.apply(event, observationSource: observationSource, recordsEvidence: recordsEvidence)
+        // A prompt is the user driving the session in person.
+        if event.kind == .userPromptSubmit { lastInteractionAt[event.sessionID] = event.timestamp }
         if let enrichment = event.enrichment {
             reducer.enrich(sessionID: event.sessionID, with: enrichment)
         }
@@ -160,6 +175,7 @@ public actor SessionStore {
             transcriptPaths[event.sessionID] = nil
             pendingTerminalRefs[event.sessionID] = nil
             grokDirectories[event.sessionID] = nil
+            lastInteractionAt[event.sessionID] = nil
             attention.set(nil, for: event.sessionID)
         } else {
             // Grok keeps a session's facts in a directory of files rather than
@@ -336,7 +352,9 @@ public actor SessionStore {
         snapshot.providerQuota = providerQuota.isEmpty ? nil : providerQuota
         snapshot.sessions = snapshot.sessions.map { session in
             var session = session
+            session.attentionOverride = attention[session.id]
             session.attention = attention[session.id]
+                ?? AutoAttention.level(lastInteractionAt: lastInteractionAt[session.id], now: now)
             return session
         }
         return snapshot

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -353,24 +353,21 @@ public struct VibeBuddyServer: Sendable {
             else { throw HTTPError(.badRequest) }
             // "allow"/"deny" resolve this one prompt; "alwaysAllow" also persists a rule;
             // "allowSession" also allows the rest of this session (ADR 0010). Unknown → deny.
+            let ctx = await approvalContext.take(id: id)
             switch decision {
             case "alwaysAllow":
-                if let ctx = await approvalContext.take(id: id), let rule = ctx.rule {
-                    await allowStore.add(rule)
-                }
+                if let rule = ctx?.rule { await allowStore.add(rule) }
                 await registry.resolve(id: id, with: .allow)
             case "allowSession":
-                if let ctx = await approvalContext.take(id: id) {
-                    await sessionAllow.add(ctx.sessionID)
-                }
+                if let ctx { await sessionAllow.add(ctx.sessionID) }
                 await registry.resolve(id: id, with: .allow)
             case "allow":
-                _ = await approvalContext.take(id: id)
                 await registry.resolve(id: id, with: .allow)
             default:
-                _ = await approvalContext.take(id: id)
                 await registry.resolve(id: id, with: .deny)
             }
+            // Deciding is driving: the session stays followed for a while.
+            if let ctx { await store.recordInteraction(sessionID: ctx.sessionID) }
             return .ok
         }
 
@@ -428,6 +425,7 @@ public struct VibeBuddyServer: Sendable {
             // Jumping is an explicit return to the task, even if this terminal
             // type cannot ultimately be focused.
             await store.acknowledgeCompletion(sessionID: sid)
+            await store.recordInteraction(sessionID: sid)
             // Report what actually happened so the phone can give honest feedback.
             // The jumper answers after it has run, so `focused` means the exact
             // pane/tab really came forward — not merely that a command existed.
@@ -458,6 +456,7 @@ public struct VibeBuddyServer: Sendable {
             if let ref = await store.terminalRef(for: sid) {
                 onAnswer(ref, answer)
                 await store.endQuestion(sessionID: sid, at: Date())
+                await store.recordInteraction(sessionID: sid)
             }
             return .ok
         }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -374,6 +374,27 @@ public struct VibeBuddyServer: Sendable {
             return .ok
         }
 
+        // The user's attention choice for one session — bearer-token gated (the
+        // phone and the Mac UI both send this). `attention: null` returns the
+        // session to the automatic default.
+        authed.post("attention") { request, _ -> HTTPResponse.Status in
+            let buffer = try await request.body.collect(upTo: 4096)
+            guard let o = try? JSONSerialization.jsonObject(with: Data(buffer: buffer)) as? [String: Any],
+                  let sid = o["sessionId"] as? String else { throw HTTPError(.badRequest) }
+            let level: SessionAttention?
+            switch o["attention"] {
+            case nil, is NSNull:
+                level = nil
+            case let raw as String:
+                guard let parsed = SessionAttention(rawValue: raw) else { throw HTTPError(.badRequest) }
+                level = parsed
+            default:
+                throw HTTPError(.badRequest)
+            }
+            guard await store.setAttention(sessionID: sid, level) else { throw HTTPError(.notFound) }
+            return .ok
+        }
+
         let onJump = self.onJump
         let onJumpToDesktopThread = self.onJumpToDesktopThread
         // Terminal-ref capture — bearer-token gated (the capture hook reads the

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -302,6 +302,11 @@ public struct VibeBuddyServer: Sendable {
             if PermissionMatcher.decide(tool: tool, input: input, allow: [], deny: r.deny) == .deny {
                 return Self.permissionResponse("deny", agent: agent)
             }
+            // Nothing to decide: a bypass-mode call, or a tool that only reads.
+            // Answered here so it never becomes a pending card or a banner.
+            if ApprovalShortCircuit.autoAllows(tool: tool, permissionMode: call.permissionMode) {
+                return Self.permissionResponse("allow", agent: agent)
+            }
             // vibebuddy overlay: a session-wide allow, or an exact always-allow rule the
             // user set — both bypass the matcher's pattern heuristics since the user
             // explicitly approved this precise tool use.

--- a/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
+++ b/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
@@ -31,7 +31,8 @@ struct VibeBuddyDaemon {
         let server = VibeBuddyServer(
             store: SessionStore(
                 diagnosticsHome: FileManager.default.homeDirectoryForCurrentUser,
-                journalURL: journalURL
+                journalURL: journalURL,
+                attentionURL: AttentionOverrides.defaultURL()
             ),
             token: token, port: port, pusher: pusher,
             codexRolloutMonitor: CodexRolloutMonitor())

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalRoutesTests.swift
@@ -12,6 +12,13 @@ private func bash(_ cmd: String) -> String {
     #"{"hook_event_name":"PreToolUse","session_id":"s","cwd":"/x/p","tool_name":"Bash","tool_input":{"command":"\#(cmd)"}}"#
 }
 
+/// A Claude PreToolUse approval payload for any tool, carrying a permission mode.
+private func claude(tool: String, input: String = #"{"command":"rm -rf build"}"#,
+                    mode: String?) -> String {
+    let modeField = mode.map { #","permission_mode":"\#($0)""# } ?? ""
+    return #"{"hook_event_name":"PreToolUse","session_id":"s","cwd":"/x/p"\#(modeField),"tool_name":"\#(tool)","tool_input":\#(input)}"#
+}
+
 /// A Grok Build PreToolUse envelope: camelCase keys, snake_case event value.
 private func grokBash(_ cmd: String, tool: String = "run_terminal_command",
                       mode: String = "bypassPermissions") -> String {
@@ -176,6 +183,86 @@ struct ApprovalRoutesTests {
         }
     }
 
+    // MARK: permission-mode / read-only short circuit (notification-filtering/01)
+
+    private func expectImmediateAllow(_ srv: VibeBuddyServer, store: SessionStore,
+                                      body: String) async throws {
+        try await srv.buildApplication().test(.router) { client in
+            try await client.execute(uri: "/approval", method: .post,
+                headers: [.authorization: "Bearer t0k"], body: ByteBuffer(string: body)) { res in
+                #expect(res.status == .ok)
+                #expect(String(buffer: res.body).contains("\"permissionDecision\":\"allow\""))
+            }
+        }
+        let session = await store.snapshot(now: Date()).sessions.first { $0.id == "s" }
+        #expect(session?.pendingApproval == nil)
+        #expect(session?.status == .working)   // the hook is still the PreToolUse signal
+    }
+
+    @Test("a bypassPermissions Bash call allows at once, holds nothing, still goes working")
+    func bypassModeShortCircuits() async throws {
+        let store = SessionStore()
+        try await expectImmediateAllow(server(store: store), store: store,
+                                       body: claude(tool: "Bash", mode: "bypassPermissions"))
+    }
+
+    @Test("a default-mode Read allows at once without a card")
+    func defaultModeReadShortCircuits() async throws {
+        let store = SessionStore()
+        try await expectImmediateAllow(server(store: store), store: store,
+            body: claude(tool: "Read", input: #"{"file_path":"/x/p/a.swift"}"#, mode: "default"))
+    }
+
+    @Test("an acceptEdits Edit allows at once without a card")
+    func acceptEditsEditShortCircuits() async throws {
+        let store = SessionStore()
+        try await expectImmediateAllow(server(store: store), store: store,
+            body: claude(tool: "Edit", input: #"{"file_path":"/x/p/a.swift","old_string":"a","new_string":"b"}"#,
+                         mode: "acceptEdits"))
+    }
+
+    @Test("a default-mode Edit still holds for the phone")
+    func defaultModeEditHolds() async throws {
+        let store = SessionStore()
+        let srv = server(store: store, approvalTimeout: .milliseconds(300))
+        try await srv.buildApplication().test(.router) { client in
+            async let held = client.execute(uri: "/approval", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: claude(tool: "Edit",
+                    input: #"{"file_path":"/x/p/a.swift","old_string":"a","new_string":"b"}"#,
+                    mode: "default"))) { res -> String in String(buffer: res.body) }
+            try await waitForPendingApproval(store, session: "s")
+            #expect(try await held.isEmpty)   // timed out → fail-open, empty body
+        }
+    }
+
+    @Test("a default-mode MCP tool still holds — MCP is never read-only")
+    func defaultModeMCPHolds() async throws {
+        let store = SessionStore()
+        let srv = server(store: store, approvalTimeout: .milliseconds(300))
+        try await srv.buildApplication().test(.router) { client in
+            async let held = client.execute(uri: "/approval", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: claude(tool: "mcp__filesystem__read_file",
+                    input: #"{"path":"/x/p/a.swift"}"#, mode: "default"))) { res -> String in
+                String(buffer: res.body)
+            }
+            try await waitForPendingApproval(store, session: "s")
+            #expect(try await held.isEmpty)
+        }
+    }
+
+    @Test("a native deny rule beats bypassPermissions")
+    func denyBeatsBypass() async throws {
+        try await server(deny: ["Bash(rm:*)"]).buildApplication().test(.router) { client in
+            try await client.execute(uri: "/approval", method: .post,
+                headers: [.authorization: "Bearer t0k"],
+                body: ByteBuffer(string: claude(tool: "Bash", mode: "bypassPermissions"))) { res in
+                #expect(String(buffer: res.body).contains("\"permissionDecision\":\"deny\""))
+            }
+        }
+    }
+
     @Test("an allow-listed grok call answers in grok's decision contract")
     func grokAllowImmediate() async throws {
         try await server(allow: ["Bash(ls:*)"]).buildApplication().test(.router) { client in
@@ -222,7 +309,8 @@ struct ApprovalRoutesTests {
     @Test("no decision on a grok call times out to an empty body (fail-open)")
     func grokTimesOutEmpty() async throws {
         try await server(approvalTimeout: .milliseconds(200)).buildApplication().test(.router) { client in
-            let text = try await approve(client, body: grokBash("rm -rf build"), agent: "grok")
+            // `default` mode: a bypass-mode call would short-circuit to allow instead of holding.
+            let text = try await approve(client, body: grokBash("rm -rf build", mode: "default"), agent: "grok")
             #expect(text.isEmpty)
         }
     }
@@ -249,7 +337,7 @@ struct ApprovalRoutesTests {
     func grokAlwaysAllowPersists() async throws {
         let store = SessionStore()
         try await server(store: store).buildApplication().test(.router) { client in
-            async let first = approve(client, body: grokBash("git status"), agent: "grok")
+            async let first = approve(client, body: grokBash("git status", mode: "default"), agent: "grok")
             try await waitForPendingApproval(store, session: "gs")
             try await client.execute(uri: "/decision", method: .post,
                 headers: [.authorization: "Bearer t0k"],
@@ -260,7 +348,7 @@ struct ApprovalRoutesTests {
 
             // Same command again — and under grok's older tool spelling, which
             // canonicalizes to the same `Bash(git status)` rule.
-            let again = try await approve(client, body: grokBash("git status", tool: "run_terminal_cmd"),
+            let again = try await approve(client, body: grokBash("git status", tool: "run_terminal_cmd", mode: "default"),
                                           agent: "grok")
             #expect(again == #"{"decision":"allow"}"#)
         }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalShortCircuitTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ApprovalShortCircuitTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import VibeBuddyMacCore
+
+@Suite("ApprovalShortCircuit — silent-allow boundary")
+struct ApprovalShortCircuitTests {
+    private func allows(_ tool: String, _ mode: String?) -> Bool {
+        ApprovalShortCircuit.autoAllows(tool: tool, permissionMode: mode)
+    }
+
+    @Test("bypassPermissions allows everything, MCP tools included")
+    func bypassAllowsAll() {
+        #expect(allows("Bash", "bypassPermissions"))
+        #expect(allows("Edit", "bypassPermissions"))
+        #expect(allows("mcp__github__create_issue", "bypassPermissions"))
+    }
+
+    @Test("read-only tools are allowed in every mode, including no mode at all")
+    func readOnlyEverywhere() {
+        for mode in ["default", "plan", "acceptEdits", "auto", "dontAsk", nil] {
+            #expect(allows("Read", mode), "Read in \(mode ?? "nil")")
+            #expect(allows("Grep", mode), "Grep in \(mode ?? "nil")")
+            #expect(allows("WebFetch", mode), "WebFetch in \(mode ?? "nil")")
+        }
+    }
+
+    @Test("acceptEdits also allows the edit tools, but not Bash")
+    func acceptEditsAllowsEdits() {
+        #expect(allows("Edit", "acceptEdits"))
+        #expect(allows("Write", "acceptEdits"))
+        #expect(allows("NotebookEdit", "acceptEdits"))
+        #expect(!allows("Bash", "acceptEdits"))
+    }
+
+    @Test("default, plan, auto, dontAsk and nil still hold Bash and edits")
+    func conservativeModesHold() {
+        for mode in ["default", "plan", "auto", "dontAsk", nil] {
+            #expect(!allows("Bash", mode), "Bash in \(mode ?? "nil")")
+            #expect(!allows("Edit", mode), "Edit in \(mode ?? "nil")")
+        }
+    }
+
+    @Test("MCP tools are never read-only")
+    func mcpNeverReadOnly() {
+        #expect(!allows("mcp__filesystem__read_file", "default"))
+        #expect(!allows("mcp__filesystem__read_file", "acceptEdits"))
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AttentionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AttentionTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+import NIOCore
+import Hummingbird
+import HummingbirdTesting
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+private func hook(_ event: String, session: String) -> Data {
+    Data(#"{"hook_event_name":"\#(event)","session_id":"\#(session)","cwd":"/x/p"}"#.utf8)
+}
+
+@Suite("Attention — the user's choice per session, owned by the daemon")
+struct AttentionTests {
+    /// A private directory per file: the journal chmods its parent to 0700,
+    /// which the shared temp root refuses, and a refused persist is silent.
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("vbattention-\(UUID().uuidString)")
+            .appendingPathComponent("state.json")
+    }
+
+    @Test("a set level shows on the session in every snapshot; nil clears it")
+    func setAndClear() async {
+        let store = SessionStore()
+        await store.ingest(hook("SessionStart", session: "a"), receivedAt: Date())
+        #expect(await store.setAttention(sessionID: "a", .muted))
+        #expect(await store.snapshot(now: Date()).sessions.first?.attention == .muted)
+        #expect(await store.setAttention(sessionID: "a", nil))
+        #expect(await store.snapshot(now: Date()).sessions.first?.attention == nil)
+    }
+
+    @Test("an unknown session takes no level")
+    func unknownSessionRefused() async {
+        let store = SessionStore()
+        #expect(await store.setAttention(sessionID: "ghost", .followed) == false)
+    }
+
+    @Test("a level dies with its session")
+    func prunedWithSession() async {
+        let url = tempURL()
+        let store = SessionStore(attentionURL: url)
+        await store.ingest(hook("SessionStart", session: "a"), receivedAt: Date())
+        await store.setAttention(sessionID: "a", .followed)
+        await store.ingest(hook("SessionEnd", session: "a"), receivedAt: Date())
+        let text = String(decoding: (try? Data(contentsOf: url)) ?? Data(), as: UTF8.self)
+        #expect(!text.contains("followed"))
+    }
+
+    @Test("a level survives a restart when the journal restores the session")
+    func persistsAcrossRestart() async throws {
+        let attentionURL = tempURL()
+        let journalURL = tempURL()
+        let t0 = Date()
+        let first = SessionStore(journalURL: journalURL, attentionURL: attentionURL, now: t0)
+        await first.ingest(hook("SessionStart", session: "a"), receivedAt: t0)
+        await first.ingest(hook("UserPromptSubmit", session: "a"), receivedAt: t0)
+        await first.setAttention(sessionID: "a", .muted)
+
+        let second = SessionStore(journalURL: journalURL, attentionURL: attentionURL,
+                                  now: t0.addingTimeInterval(5))
+        let restored = await second.snapshot(now: t0.addingTimeInterval(5)).sessions
+        #expect(restored.first(where: { $0.id == "a" })?.attention == .muted)
+    }
+
+    @Test("POST /attention sets, clears, and refuses what it cannot parse")
+    func route() async throws {
+        let store = SessionStore()
+        await store.ingest(hook("SessionStart", session: "a"), receivedAt: Date())
+        let srv = VibeBuddyServer(store: store, token: "t0k", port: 9876)
+        try await srv.buildApplication().test(.router) { client in
+            func post(_ body: String) async throws -> HTTPResponse.Status {
+                try await client.execute(uri: "/attention", method: .post,
+                                         headers: [.authorization: "Bearer t0k"],
+                                         body: ByteBuffer(string: body)) { $0.status }
+            }
+            #expect(try await post(#"{"sessionId":"a","attention":"followed"}"#) == .ok)
+            #expect(await store.snapshot(now: Date()).sessions.first?.attention == .followed)
+            #expect(try await post(#"{"sessionId":"a","attention":null}"#) == .ok)
+            #expect(await store.snapshot(now: Date()).sessions.first?.attention == nil)
+            #expect(try await post(#"{"sessionId":"a","attention":"loud"}"#) == .badRequest)
+            #expect(try await post(#"{"sessionId":"ghost","attention":"muted"}"#) == .notFound)
+            try await client.execute(uri: "/attention", method: .post,
+                                     body: ByteBuffer(string: #"{"sessionId":"a","attention":"muted"}"#)) { res in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AttentionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AttentionTests.swift
@@ -27,7 +27,8 @@ struct AttentionTests {
         #expect(await store.setAttention(sessionID: "a", .muted))
         #expect(await store.snapshot(now: Date()).sessions.first?.attention == .muted)
         #expect(await store.setAttention(sessionID: "a", nil))
-        #expect(await store.snapshot(now: Date()).sessions.first?.attention == nil)
+        let cleared = await store.snapshot(now: Date()).sessions.first
+        #expect(cleared?.attentionOverride == nil && cleared?.attention == .normal)
     }
 
     @Test("an unknown session takes no level")
@@ -63,6 +64,56 @@ struct AttentionTests {
         #expect(restored.first(where: { $0.id == "a" })?.attention == .muted)
     }
 
+    // MARK: automatic level — followed while you drive it
+
+    @Test("a prompt makes a session followed for ten minutes, then normal again")
+    func promptFollowsThenLapses() async {
+        let t0 = Date()
+        let store = SessionStore()
+        await store.ingest(hook("SessionStart", session: "a"), receivedAt: t0)
+        #expect(await store.snapshot(now: t0).sessions.first?.attention == .normal)
+        await store.ingest(hook("UserPromptSubmit", session: "a"), receivedAt: t0)
+        #expect(await store.snapshot(now: t0.addingTimeInterval(599)).sessions.first?.attention == .followed)
+        #expect(await store.snapshot(now: t0.addingTimeInterval(601)).sessions.first?.attention == .normal)
+        #expect(await store.snapshot(now: t0).sessions.first?.attentionOverride == nil)
+    }
+
+    @Test("a hand-set level wins over the automatic one, both ways")
+    func overrideWins() async {
+        let t0 = Date()
+        let store = SessionStore()
+        await store.ingest(hook("UserPromptSubmit", session: "a"), receivedAt: t0)
+        await store.setAttention(sessionID: "a", .muted)
+        let muted = await store.snapshot(now: t0).sessions.first
+        #expect(muted?.attention == .muted && muted?.attentionOverride == .muted)
+        await store.setAttention(sessionID: "a", nil)
+        await store.ingest(hook("Stop", session: "a"), receivedAt: t0.addingTimeInterval(700))
+        await store.setAttention(sessionID: "a", .followed)
+        #expect(await store.snapshot(now: t0.addingTimeInterval(700)).sessions.first?.attention == .followed)
+    }
+
+    @Test("jump, decision and answer each count as driving the session")
+    func routesRecordInteraction() async throws {
+        let t0 = Date()
+        let store = SessionStore()
+        await store.ingest(hook("SessionStart", session: "a"), receivedAt: t0)
+        let srv = VibeBuddyServer(store: store, token: "t0k", port: 9876,
+                                  onJump: { _ in .focused }, onAnswer: { _, _ in })
+        await store.setTerminalRef(sessionID: "a", TerminalRef(termProgram: "ghostty", tty: "ttys001"))
+        try await srv.buildApplication().test(.router) { client in
+            for (uri, body) in [("/jump", #"{"sessionId":"a"}"#),
+                                ("/answer", #"{"sessionId":"a","answer":"yes"}"#)] {
+                await store.recordInteraction(sessionID: "a", at: t0.addingTimeInterval(-3600))
+                try await client.execute(uri: uri, method: .post,
+                                         headers: [.authorization: "Bearer t0k"],
+                                         body: ByteBuffer(string: body)) { res in
+                    #expect(res.status == .ok, "\(uri)")
+                }
+                #expect(await store.snapshot(now: Date()).sessions.first?.attention == .followed, "\(uri)")
+            }
+        }
+    }
+
     @Test("POST /attention sets, clears, and refuses what it cannot parse")
     func route() async throws {
         let store = SessionStore()
@@ -77,7 +128,7 @@ struct AttentionTests {
             #expect(try await post(#"{"sessionId":"a","attention":"followed"}"#) == .ok)
             #expect(await store.snapshot(now: Date()).sessions.first?.attention == .followed)
             #expect(try await post(#"{"sessionId":"a","attention":null}"#) == .ok)
-            #expect(await store.snapshot(now: Date()).sessions.first?.attention == nil)
+            #expect(await store.snapshot(now: Date()).sessions.first?.attentionOverride == nil)
             #expect(try await post(#"{"sessionId":"a","attention":"loud"}"#) == .badRequest)
             #expect(try await post(#"{"sessionId":"ghost","attention":"muted"}"#) == .notFound)
             try await client.execute(uri: "/attention", method: .post,

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/NotificationCoordinatorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/NotificationCoordinatorTests.swift
@@ -15,10 +15,12 @@ struct NotificationCoordinatorTests {
     final class SpyNotifier: AttentionNotifier {
         var result: LocalNotificationAttempt = .scheduled()
         private(set) var played: [(id: String, sound: NotificationSound)] = []
+        private(set) var withdrawn: [[String]] = []
         func notify(_ alert: SoundAlert) async -> LocalNotificationAttempt {
             played.append((alert.sessionID, alert.sound))
             return result
         }
+        func withdraw(_ identifiers: [String]) async { withdrawn.append(identifiers) }
     }
 
     private func session(_ id: String, _ status: SessionStatus, wait: WaitKind? = nil,
@@ -41,6 +43,26 @@ struct NotificationCoordinatorTests {
         #expect(Set(spy.played.map { "\($0.id):\($0.sound.rawValue)" }) == [
             "claude:needs_approval", "codex:agent_done",
         ])
+    }
+
+    @Test("a waiting cue is withdrawn once its session stops waiting; a completion stays")
+    func withdrawsResolvedWaits() async {
+        let spy = SpyNotifier()
+        let c = NotificationCoordinator(notifier: spy)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        await c.observe([session("q", .working, since: t0), session("d", .working, since: t0)],
+                        now: t0, appActive: false, quietMode: false)
+        await c.observe([session("q", .needsResponse, wait: .question, since: t0),
+                         session("d", .done, since: t0)],
+                        now: t0.addingTimeInterval(60), appActive: false, quietMode: false)
+        #expect(spy.withdrawn.isEmpty)
+        // Answered on the terminal: q is working again, d is still just done.
+        await c.observe([session("q", .working, since: t0), session("d", .done, since: t0)],
+                        now: t0.addingTimeInterval(61), appActive: false, quietMode: false)
+        #expect(spy.withdrawn == [[NotificationIdentity.id(sessionID: "q", sound: .needsAnswer)]])
+        // Gone entirely: nothing left to withdraw for q, and d was never tracked.
+        await c.observe([], now: t0.addingTimeInterval(62), appActive: false, quietMode: false)
+        #expect(spy.withdrawn.count == 1)
     }
 
     @Test("forwards a fresh question transition as needs_answer")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/NotificationCoordinatorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/NotificationCoordinatorTests.swift
@@ -70,15 +70,29 @@ struct NotificationCoordinatorTests {
         #expect(spy.played.isEmpty)
     }
 
-    @Test("Quiet mode forwards approvals but not questions")
-    func quietModeKeepsApprovalsOnly() async {
+    @Test("Quiet mode reads every session as muted: a silent approval banner, a listed question")
+    func quietModeMutesEverything() async {
         let spy = SpyNotifier()
         let c = NotificationCoordinator(notifier: spy)
         await c.observe([session("a", .working), session("b", .working)], appActive: false, quietMode: true)
-        await c.observe([session("a", .needsResponse, wait: .question),
-                         session("b", .needsResponse, wait: .permission)], appActive: false, quietMode: true)
-        #expect(spy.played.map(\.sound) == [.needsApproval])
-        #expect(spy.played.map(\.id) == ["b"])
+        let alerts = await c.observe([session("a", .needsResponse, wait: .question),
+                                      session("b", .needsResponse, wait: .permission)],
+                                     appActive: false, quietMode: true)
+        #expect(alerts.map { "\($0.sessionID):\($0.sound.rawValue):\($0.delivery)" } == [
+            "a:needs_answer:list", "b:needs_approval:banner",
+        ])
+        #expect(spy.played.map(\.id) == ["a", "b"])
+    }
+
+    @Test("the cues handed back are the ones the notifier was given, so push and local agree")
+    func returnsWhatItForwarded() async {
+        let spy = SpyNotifier()
+        let c = NotificationCoordinator(notifier: spy)
+        await c.observe([session("a", .working)], appActive: false, quietMode: false)
+        let alerts = await c.observe([session("a", .needsResponse, wait: .permission)],
+                                     appActive: false, quietMode: false)
+        #expect(alerts.map(\.delivery) == [.bannerSound])
+        #expect(alerts.map(\.sessionID) == spy.played.map(\.id))
     }
 
     @Test("Quiet, foreground, and anti-duplication still skip sends and records")
@@ -96,15 +110,17 @@ struct NotificationCoordinatorTests {
                          session("r", .needsResponse, wait: .permission, since: t0)],
                         now: t0.addingTimeInterval(60), appActive: true, quietMode: true)
 
-        #expect(spy.played.map { "\($0.id):\($0.sound.rawValue)" } == ["r:needs_approval"])
+        // Quiet: the question is listed, the approval banners silently, and the
+        // completion is dropped (VibeBuddy is frontmost anyway).
+        #expect(spy.played.map { "\($0.id):\($0.sound.rawValue)" } == ["q:needs_answer", "r:needs_approval"])
         #expect(delivery.records.map { "\($0.sessionID ?? ""):\($0.sound ?? ""):\($0.outcome.rawValue)" } == [
-            "r:needs_approval:scheduled",
+            "q:needs_answer:scheduled", "r:needs_approval:scheduled",
         ])
 
         await c.observe([session("r", .needsResponse, wait: .permission, since: t0)],
                         now: t0.addingTimeInterval(61), appActive: true, quietMode: true)
-        #expect(spy.played.count == 1)
-        #expect(delivery.records.count == 1)
+        #expect(spy.played.count == 2)
+        #expect(delivery.records.count == 2)
         #expect(!delivery.records.contains(where: { $0.outcome.rawValue == "delivered" }))
     }
 

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -37,6 +37,9 @@ struct DashboardView: View {
                                showInclude: companionEnabled,
                                onToggleInclude: { model.toggleBuddy(s.id) })
                     .tag(s.id)
+                    .contextMenu {
+                        AttentionPicker(session: s, model: model, style: .menu)
+                    }
             }
             .searchable(text: $query, prompt: "Search sessions")
             .searchFocusedCompat($searchFocused)
@@ -283,6 +286,12 @@ private struct SessionRowView: View {
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(Color(taskStatus: TaskPresentationState.error.colorToken))
                 }
+                if let glyph = session.effectiveAttention.rowGlyph {
+                    Image(systemName: glyph)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .help(session.effectiveAttention.title)
+                }
                 if showInclude {
                     Spacer(minLength: 8)
                     Button(action: onToggleInclude) {
@@ -413,6 +422,14 @@ private struct DetailView: View {
                 Button { showTranscript = true } label: {
                     Label("Recent output", systemImage: "text.alignleft")
                 }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Notifications").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    AttentionPicker(session: session, model: model, style: .segmented)
+                    Text(session.attentionOverride == nil
+                         ? "Automatic: \(session.effectiveAttention.title.lowercased()) — followed while you're driving it, normal otherwise."
+                         : session.effectiveAttention.explanation)
+                        .font(.caption2).foregroundStyle(.tertiary)
+                }
                 if let m = session.model {
                     Label(m, systemImage: "cpu").font(.caption).foregroundStyle(.secondary)
                 }
@@ -483,6 +500,73 @@ private struct TranscriptSheet: View {
                 }
                 .padding()
             }
+        }
+    }
+}
+
+/// The one control for how much a session may interrupt you, in two shapes:
+/// a segmented picker in the detail pane and radio items in a row's context
+/// menu. `nil` is "automatic" — the daemon's own reading of recent interaction.
+private struct AttentionPicker: View {
+    enum Style { case segmented, menu }
+    let session: AgentSession
+    @ObservedObject var model: MenuBarModel
+    let style: Style
+
+    private var selection: Binding<SessionAttention?> {
+        Binding(get: { session.attentionOverride },
+                set: { model.setAttention(session.id, $0) })
+    }
+
+    var body: some View {
+        switch style {
+        case .segmented: picker.pickerStyle(.segmented)
+        case .menu: picker.pickerStyle(.inline)
+        }
+    }
+
+    private var picker: some View {
+        Picker("Notifications", selection: selection) {
+            Text(style == .menu
+                 ? "Automatic (\(autoLevel.title.lowercased()))"
+                 : "Auto").tag(SessionAttention?.none)
+            ForEach(SessionAttention.allCases, id: \.self) { level in
+                Label(level.title, systemImage: level.symbol).tag(SessionAttention?.some(level))
+            }
+        }
+        .labelsHidden()
+    }
+
+    /// What automatic would give right now: the effective level while no
+    /// override is set, else the daemon's `attention` still reflects the
+    /// override, so fall back to `normal` as the honest default.
+    private var autoLevel: SessionAttention {
+        session.attentionOverride == nil ? session.effectiveAttention : .normal
+    }
+}
+
+extension SessionAttention {
+    var title: String {
+        switch self {
+        case .followed: "Followed"
+        case .normal: "Normal"
+        case .muted: "Muted"
+        }
+    }
+    var symbol: String {
+        switch self {
+        case .followed: "bell.badge"
+        case .normal: "bell"
+        case .muted: "bell.slash"
+        }
+    }
+    /// A glyph on the row only when the session is not at the default.
+    var rowGlyph: String? { self == .normal ? nil : symbol }
+    var explanation: String {
+        switch self {
+        case .followed: "Everything about this session interrupts you."
+        case .normal: "Only approvals and failures interrupt; the rest waits in Notification Center."
+        case .muted: "Approvals show silently; nothing else interrupts."
         }
     }
 }

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -68,7 +68,6 @@ final class MenuBarModel: ObservableObject {
     // a backgrounded phone, so the phone hears the full pack (not just needs-you).
     private let pusher: APNsPusher?
     private let deviceTokens = DeviceTokens()
-    private let phonePolicy = SoundPolicy()
     private let budgetMonitor = BudgetMonitor()
     /// Account usage is intentionally separate from `sessions`; refresh errors
     /// never enter SessionStore or the progress notification pipeline.
@@ -95,7 +94,8 @@ final class MenuBarModel: ObservableObject {
             diagnosticsHome: FileManager.default.homeDirectoryForCurrentUser,
             journalURL: ProcessInfo.processInfo.environment["VIBEBUDDY_JOURNAL_PATH"].map {
                 URL(fileURLWithPath: $0)
-            } ?? LifecycleJournalLocation.defaultURL()
+            } ?? LifecycleJournalLocation.defaultURL(),
+            attentionURL: AttentionOverrides.defaultURL()
         )
         // File-based store (owner-only): no Keychain ACL, so an ad-hoc rebuild
         // never re-prompts. Shared with vibebuddyd's default store.
@@ -177,8 +177,8 @@ final class MenuBarModel: ObservableObject {
     }
 
     private func startServer() {
-        // pusher: nil — push is driven from startPolling via `phonePolicy` so the
-        // phone gets the whole pack; the server only collects device tokens/prefs.
+        // pusher: nil — push is driven from startPolling off the same cues the
+        // Mac notifies on; the server only collects device tokens/prefs.
         let server = VibeBuddyServer(store: store, token: token, port: port,
                                      pusher: nil, deviceTokens: deviceTokens,
                                      activityTokens: activityTokens,
@@ -225,13 +225,13 @@ final class MenuBarModel: ObservableObject {
                 let frontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
                 let focused = ForegroundTerminal.focusedSessionIDs(
                     among: snapshot.sessions, frontmostBundleID: frontmost)
-                await self.notificationCoordinator.observe(
+                let alerts = await self.notificationCoordinator.observe(
                     snapshot.sessions,
                     appActive: NSApp.isActive,                 // user looking at VibeBuddy?
-                    quietMode: Self.effectiveQuiet(),          // Focus mode (manual or nightly) → approvals only
+                    quietMode: Self.effectiveQuiet(),          // Focus mode (manual or nightly) → every session muted
                     focusedSessionIDs: focused)                // …or looking at the session's own terminal
                 await self.refreshNotificationDeliveryHealth()
-                await self.pushToPhones(snapshot.sessions)
+                await self.pushToPhones(alerts)
                 await self.pushActivityUpdates(snapshot.sessions)
                 await self.checkBudget(snapshot.sessions)
                 try? await Task.sleep(for: .seconds(2))
@@ -296,21 +296,25 @@ final class MenuBarModel: ObservableObject {
         }
     }
 
-    /// Push the full sound pack to paired phones, each device respecting its own
-    /// prefs. `appActive: false` = the phone's backgrounded view; when the phone
-    /// is actually foreground it suppresses the remote push (see willPresent).
-    private func pushToPhones(_ sessions: [AgentSession]) async {
-        guard let pusher else { return }
-        let alerts = phonePolicy.evaluate(SoundPolicyInput(
-            sessions: sessions, now: Date(), appActive: false, quietMode: false))
-        guard !alerts.isEmpty else { return }
+    /// Push the cues the Mac just decided on to paired phones. Only a cue loud
+    /// enough to interrupt here is worth pulling you back from elsewhere; a
+    /// list-only cue stays on the Mac. Each device then applies its own prefs:
+    /// its Quiet mode reads the cue through the `muted` column, never louder
+    /// than the Mac decided, and mute drops the sound. When the phone is in the
+    /// foreground it suppresses the remote push itself (see willPresent).
+    private func pushToPhones(_ alerts: [SoundAlert]) async {
+        guard let pusher, !alerts.isEmpty else { return }
         let devices = await deviceTokens.devices()
-        for alert in alerts {
+        for alert in alerts where alert.delivery.interrupts {
             let (title, body) = Self.pushCopy(for: alert)
             for device in devices {
                 guard let deviceToken = device.token else { continue }
-                if device.quietMode == true && !alert.sound.survivesQuietMode { continue }  // night: approvals only
-                let sound = device.playSound != false ? alert.sound.fileName : ""           // mute → silent banner
+                var level = alert.delivery
+                if device.quietMode == true {
+                    level = min(level, DeliveryMatrix.level(for: alert.sound, attention: .muted))
+                }
+                guard level.interrupts else { continue }
+                let sound = level.makesSound && device.playSound != false ? alert.sound.fileName : ""
                 await pusher.send(title: title, body: body, to: deviceToken, sound: sound,
                                   sessionID: alert.sessionID, soundCategory: alert.sound.rawValue)
             }

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -359,24 +359,20 @@ final class MenuBarModel: ObservableObject {
     /// so "always allow" / "allow this session" behave identically to the phone.
     func decide(_ approvalId: String, _ choice: ApprovalDecision) {
         Task {
+            let ctx = await approvalContext.take(id: approvalId)
             switch choice {
             case .alwaysAllow:
-                if let ctx = await approvalContext.take(id: approvalId), let rule = ctx.rule {
-                    await allowStore.add(rule)
-                }
+                if let rule = ctx?.rule { await allowStore.add(rule) }
                 await approvalRegistry.resolve(id: approvalId, with: .allow)
             case .allowSession:
-                if let ctx = await approvalContext.take(id: approvalId) {
-                    await sessionAllow.add(ctx.sessionID)
-                }
+                if let ctx { await sessionAllow.add(ctx.sessionID) }
                 await approvalRegistry.resolve(id: approvalId, with: .allow)
             case .allow:
-                _ = await approvalContext.take(id: approvalId)
                 await approvalRegistry.resolve(id: approvalId, with: .allow)
             case .deny:
-                _ = await approvalContext.take(id: approvalId)
                 await approvalRegistry.resolve(id: approvalId, with: .deny)
             }
+            if let ctx { await store.recordInteraction(sessionID: ctx.sessionID) }
         }
     }
 
@@ -394,6 +390,7 @@ final class MenuBarModel: ObservableObject {
     /// ("no terminal recorded"), not a dead control — that silence was the bug.
     func jump(_ session: AgentSession) {
         acknowledge(session.id)
+        Task { [store] in await store.recordInteraction(sessionID: session.id) }
         if let ref = session.terminalRef {
             Task { [weak self] in
                 let outcome = await TerminalJumper.jump(ref)
@@ -435,6 +432,18 @@ final class MenuBarModel: ObservableObject {
         Task { [store] in await store.acknowledgeCompletion(sessionID: sessionID) }
     }
 
+    /// Set, or with `nil` return to automatic, how much this session may
+    /// interrupt you. The daemon owns the value; demo mode mirrors it locally.
+    func setAttention(_ sessionID: String, _ level: SessionAttention?) {
+        if ProcessInfo.processInfo.environment["VIBEBUDDY_DEMO"] == "1" {
+            guard let index = sessions.firstIndex(where: { $0.id == sessionID }) else { return }
+            sessions[index].attentionOverride = level
+            sessions[index].attention = level ?? .normal
+            return
+        }
+        Task { [store] in await store.setAttention(sessionID: sessionID, level) }
+    }
+
     /// Include/exclude a session from the buddy's context (ephemeral). Takes effect
     /// on the next call — a live call keeps the snapshot it started with.
     func toggleBuddy(_ id: String) {
@@ -459,7 +468,9 @@ final class MenuBarModel: ObservableObject {
             decide(ap.id, approve: false); return "Denied \(s.project)."
         case .answer(let project, let text):
             guard let s = match(project), let ref = s.terminalRef else { return "No matching session, or it has no terminal." }
-            TerminalInjector.inject(text, into: ref); return "Replied to \(s.project)."
+            TerminalInjector.inject(text, into: ref)
+            Task { [store] in await store.recordInteraction(sessionID: s.id) }
+            return "Replied to \(s.project)."
         case .none:
             return ""
         }

--- a/VibeBuddyMacApp/Sources/UserNotificationsNotifier.swift
+++ b/VibeBuddyMacApp/Sources/UserNotificationsNotifier.swift
@@ -29,13 +29,20 @@ final class UserNotificationsNotifier: NSObject, AttentionNotifier, UNUserNotifi
             return .failed(reason: classified.failureReason ?? "permissionDenied")
         }
         do {
+            // The same identifier the phone uses, so the ledger can name it.
             try await post(title: title, body: body, sound: alert.sound, delivery: alert.delivery,
-                           id: "\(alert.sessionID)-\(alert.sound.rawValue)")
+                           id: alert.notificationID)
             return .scheduled()
         } catch {
             return .failed(reason: LocalNotificationDelivery.classify(
                 authorized: true, scheduleError: error).failureReason ?? "scheduleFailed")
         }
+    }
+
+    func withdraw(_ identifiers: [String]) async {
+        guard !identifiers.isEmpty else { return }
+        center.removeDeliveredNotifications(withIdentifiers: identifiers)
+        center.removePendingNotificationRequests(withIdentifiers: identifiers)
     }
 
     /// A phone just paired — the one chrome cue that isn't tied to a session.

--- a/VibeBuddyMacApp/Sources/UserNotificationsNotifier.swift
+++ b/VibeBuddyMacApp/Sources/UserNotificationsNotifier.swift
@@ -3,9 +3,10 @@ import UserNotifications
 import VibeBuddyKit
 import VibeBuddyMacCore
 
-/// Posts a macOS banner with the sound pack's cue. A thin wrapper over
-/// `UNUserNotificationCenter`; *which* cue and *when* are decided by
-/// `SoundPolicy` (unit-tested), so this type stays pure system I/O.
+/// Posts a macOS notification with the sound pack's cue. A thin wrapper over
+/// `UNUserNotificationCenter`; *which* cue, *when* and *how loud* are decided
+/// by `SoundPolicy` (unit-tested), so this type stays pure system I/O: it maps
+/// the alert's `DeliveryLevel` onto sound / banner / list-only presentation.
 final class UserNotificationsNotifier: NSObject, AttentionNotifier, UNUserNotificationCenterDelegate {
     private let center = UNUserNotificationCenter.current()
 
@@ -20,7 +21,7 @@ final class UserNotificationsNotifier: NSObject, AttentionNotifier, UNUserNotifi
     }
 
     func notify(_ alert: SoundAlert) async -> LocalNotificationAttempt {
-        guard Self.flag("notifyOnNeedsResponse") else { return .skipped }
+        guard Self.flag("notifyOnNeedsResponse"), alert.delivery != .drop else { return .skipped }
         let authorized = await isAuthorized()
         let (title, body) = Self.copy(for: alert)
         let classified = LocalNotificationDelivery.classify(authorized: authorized, scheduleError: nil)
@@ -28,7 +29,7 @@ final class UserNotificationsNotifier: NSObject, AttentionNotifier, UNUserNotifi
             return .failed(reason: classified.failureReason ?? "permissionDenied")
         }
         do {
-            try await post(title: title, body: body, sound: alert.sound,
+            try await post(title: title, body: body, sound: alert.sound, delivery: alert.delivery,
                            id: "\(alert.sessionID)-\(alert.sound.rawValue)")
             return .scheduled()
         } catch {
@@ -91,22 +92,42 @@ final class UserNotificationsNotifier: NSObject, AttentionNotifier, UNUserNotifi
         }
     }
 
-    private func post(title: String, body: String, sound: NotificationSound, id: String) async throws {
+    private static let deliveryKey = "delivery"
+
+    private func post(title: String, body: String, sound: NotificationSound,
+                      delivery: DeliveryLevel, id: String) async throws {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
-        content.sound = Self.flag("playNotificationSound")
+        content.sound = delivery.makesSound && Self.flag("playNotificationSound")
             ? UNNotificationSound(named: UNNotificationSoundName(rawValue: sound.fileName))
             : nil
+        // Carried to `willPresent`, which is where an accessory app actually
+        // decides what the system shows.
+        content.userInfo = [Self.deliveryKey: delivery.rawValue]
+        if delivery == .list { content.interruptionLevel = .passive }
         try await center.add(UNNotificationRequest(identifier: id, content: content, trigger: nil))
     }
 
-    /// Show the banner even though the menu-bar app runs as an accessory.
+    /// Present according to the cue's delivery level, even though the menu-bar
+    /// app runs as an accessory: a list-only cue lands in Notification Center
+    /// without a banner; everything else banners *and* stays in the list, so
+    /// what was said can still be found later. Chrome cues (pairing, budget,
+    /// usage) carry no level and are shown in full.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        Self.flag("playNotificationSound") ? [.banner, .sound] : [.banner]
+        let raw = notification.request.content.userInfo[Self.deliveryKey] as? Int
+        let level = raw.flatMap(DeliveryLevel.init(rawValue:)) ?? .bannerSound
+        switch level {
+        case .drop, .list:
+            return [.list]
+        case .banner:
+            return [.banner, .list]
+        case .bannerSound:
+            return Self.flag("playNotificationSound") ? [.banner, .list, .sound] : [.banner, .list]
+        }
     }
 
     /// A Bool default that treats an absent key as `true` (on by default).

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -170,8 +170,14 @@ python3 hooks/install-claude-hooks.py --approval   # add the blocking PreToolUse
 python3 hooks/install-claude-hooks.py --uninstall  # removes it too
 ```
 Commands not in your `permissions.allow` are sent to the phone to approve/deny.
-On timeout/unreachable, Claude proceeds with its normal behaviour. Useful only if
-your Mac actually prompts (prompting mode); auto-mode users gain nothing.
+On timeout/unreachable, Claude proceeds with its normal behaviour.
+
+The daemon answers some calls itself, so they never reach the phone or raise a
+Mac banner: every call from a `bypassPermissions` session; read-only tools
+(Read, Glob, Grep, LS, WebFetch, WebSearch, ToolSearch, TodoWrite, NotebookRead,
+AskUserQuestion) in any mode; and the edit tools (Edit, Write, MultiEdit,
+NotebookEdit) in `acceptEdits`. MCP tools are never treated as read-only. A
+native `permissions.deny` rule still wins over all of this.
 
 ## Terminal capture (jump-back)
 


### PR DESCRIPTION
## Why

Since the global approval hook went in, every Claude tool call from a `bypassPermissions` session raised a phone card and a Mac banner, and with ~5 sessions open the banners drowned out the ones that mattered. This PR adds one classification layer under the existing switches so only what needs handling interrupts.

Decisions were settled in three grilling rounds and recorded in `.scratch/notification-filtering/PRD.md` (local tracker).

## What

Four independently mergeable layers, one commit each:

1. **daemon: approval short-circuit** — `/approval` answers itself for `bypassPermissions` calls, read-only tools in any mode, and edit tools in `acceptEdits`; MCP tools are never read-only; native deny still wins. The Claude payload now decodes `permission_mode`.
2. **attention level + delivery matrix** — `SessionAttention` (followed / normal / muted) on the session, `DeliveryMatrix` reducing every cue to banner+sound / banner / list-only / drop. Quiet mode is the muted column; a focused terminal caps its session to the list. Mac local notification, Mac→phone push and the phone's local notification consume the same `SoundAlert`, so a list-only cue never pushes. `POST /attention` sets or clears the user's choice; persisted per session id and pruned with the session.
3. **automatic attention + Mac control** — followed for 10 minutes after a prompt, jump, decision or answer; never auto-muted. Context menu radio group and detail-pane segmented picker with an Automatic choice.
4. **Notification Center withdrawal** — the Mac keeps the shared `WaitingNotificationLedger` and removes approval / question / nudge entries once the session stops waiting; completions stay.

## Behaviour changes worth knowing

- Banners now also stay in Notification Center (previously banner-only), which layer 4 relies on.
- Push follows the Mac's decision: when VibeBuddy is frontmost, a completion no longer pushes to the phone.
- `auto` / `dontAsk` permission modes are treated like `default` (only read-only tools short-circuit); not discussed in grilling.
- `NotificationSound.survivesQuietMode` is removed.

## Verification

- VibeBuddyKit 224 and VibeBuddyMacCore 515 tests pass; new suites for the short circuit, the matrix, attention state/routes, coordinator withdrawal.
- Real daemon: bypass / Read / acceptEdits-Edit calls allow in ~40 ms with no pending card; default-mode MCP call still holds; `/attention` set / clear / 400 / 404 / SessionEnd cleanup.
- Redeployed to /Applications via `tools/redeploy-mac.sh` and re-checked against the live daemon (this session's own bypass calls allow immediately; attention values as expected).
- Mac app and iOS simulator builds pass. Not checked by hand: the Mac context menu / segmented picker, and the withdrawal in Notification Center.
