### PR TITLE
fix(apns): one registry record per phone, keyed on a stable device id

### DIFF
--- a/VibeBuddyApp/Sources/PushRegistration.swift
+++ b/VibeBuddyApp/Sources/PushRegistration.swift
@@ -47,6 +47,9 @@ final class PushRegistration {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try? JSONEncoder().encode(DeviceRegistrationPayload(
             token: token,
+            // Keychain-held, so a reinstall (new token) still reads as this phone
+            // and replaces its own record on the Mac instead of adding one.
+            deviceID: PushDeviceIdentity.current(),
             name: UIDevice.current.name,
             model: UIDevice.current.model,
             systemVersion: "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -37,6 +37,29 @@ public enum KeychainStore {
     }
 }
 
+/// The phone's stable push identity: one UUID, minted on first use and kept in
+/// the Keychain, which outlives a reinstall and a device restore. Those are the
+/// events that hand the app a new APNs token, and without an identity that
+/// survives them the Mac's registry sees each new token as a new phone and keeps
+/// the old one — with the switches it uploaded last time. See
+/// `DeviceRegistrationPayload.deviceID`.
+public enum PushDeviceIdentity {
+    public static let keychainKey = "pushDeviceID"
+
+    /// Reads the identity, minting and storing one when none exists. The
+    /// storage is injectable so the rule can be tested without a Keychain.
+    public static func current(
+        read: (String) -> String? = KeychainStore.get,
+        write: (String?, String) -> Void = KeychainStore.set,
+        mint: () -> String = { UUID().uuidString }
+    ) -> String {
+        if let existing = read(keychainKey), !existing.isEmpty { return existing }
+        let fresh = mint()
+        write(fresh, keychainKey)
+        return fresh
+    }
+}
+
 /// The language the voice companion converses in — drives speech recognition,
 /// the model's reply language, and the spoken voice. Independent of the app's UI
 /// language (which is English).

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -620,6 +620,12 @@ public struct PairingPayload: Codable, Sendable, Equatable {
 /// can arrive in either order.
 public struct DeviceRegistrationPayload: Codable, Sendable, Equatable {
     public var token: String?
+    /// The phone's own stable identity, minted once and kept in its Keychain so
+    /// it survives a reinstall or restore — the events that rotate `token`. The
+    /// Mac keys its registry on this, so one phone is one record however many
+    /// tokens it has been through. Optional so older payloads decode unchanged;
+    /// a payload without it is keyed on its token alone.
+    public var deviceID: String?
     public var name: String?
     public var model: String?
     public var systemVersion: String?
@@ -631,11 +637,12 @@ public struct DeviceRegistrationPayload: Codable, Sendable, Equatable {
     /// decode unchanged; the Mac treats a missing value as the default set.
     public var categories: NotificationCategoryPrefs?
 
-    public init(token: String? = nil, name: String? = nil,
+    public init(token: String? = nil, deviceID: String? = nil, name: String? = nil,
                 model: String? = nil, systemVersion: String? = nil,
                 playSound: Bool? = nil, quietMode: Bool? = nil,
                 categories: NotificationCategoryPrefs? = nil) {
         self.token = token
+        self.deviceID = deviceID
         self.name = name
         self.model = model
         self.systemVersion = systemVersion

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/WireCodingTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/WireCodingTests.swift
@@ -81,6 +81,29 @@ struct WireCodingTests {
         let legacy = try JSONDecoder().decode(DeviceRegistrationPayload.self,
                                               from: Data(#"{"token":"t","playSound":true}"#.utf8))
         #expect(legacy.categories == nil)
+        #expect(legacy.deviceID == nil)
+        // The stable identity rides along and round-trips.
+        var identified = p
+        identified.deviceID = "3E1D-hermes"
+        #expect(try roundTrip(identified).deviceID == "3E1D-hermes")
+    }
+
+    @Test("PushDeviceIdentity mints once and then reads back the same value")
+    func pushDeviceIdentityIsStable() {
+        var stored: [String: String] = [:]
+        var minted = 0
+        let mint = { minted += 1; return "id-\(minted)" }
+        let first = PushDeviceIdentity.current(
+            read: { stored[$0] }, write: { stored[$1] = $0 }, mint: mint)
+        let second = PushDeviceIdentity.current(
+            read: { stored[$0] }, write: { stored[$1] = $0 }, mint: mint)
+        #expect(first == "id-1")
+        #expect(second == first)
+        #expect(minted == 1)
+        // A blank stored value counts as none — it must not become the identity.
+        stored[PushDeviceIdentity.keychainKey] = ""
+        #expect(PushDeviceIdentity.current(
+            read: { stored[$0] }, write: { stored[$1] = $0 }, mint: mint) == "id-2")
     }
 
     // 5. Wire-format stability — rawValues are the documented strings

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/DeviceRegistry.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/DeviceRegistry.swift
@@ -94,22 +94,36 @@ struct DeviceRegistry {
     /// Upsert a device, merging in only the preference fields this payload
     /// carries — a phone that reconnects before its APNs callback fires keeps
     /// the switches it uploaded last time.
+    ///
+    /// One phone is one record. The phone's `deviceID` names it; a reinstalled
+    /// or restored phone comes back with a new token under the same id and
+    /// *replaces* its old record. Keying on the token alone left the old one
+    /// standing, and Apple keeps delivering to a superseded token for a while,
+    /// so a category the user had since switched off was still pushed through
+    /// the stale record. A payload without an id (an older phone build, a raw
+    /// token POST) is keyed on its token, and a record without an id is adopted
+    /// by the first identified payload that carries the same token.
     mutating func upsert(_ payload: DeviceRegistrationPayload, now: Date) {
         guard let token = payload.token, !token.isEmpty else { return }
-        let existing = entries.first { $0.device.token == token }
+        let id = payload.deviceID.flatMap { $0.isEmpty ? nil : $0 }
+        let existing = id.flatMap { id in entries.first { $0.device.deviceID == id } }
+            ?? entries.first { $0.device.token == token }
         var merged = existing?.device ?? DeviceRegistrationPayload(token: token)
         merged.token = token
+        if let id { merged.deviceID = id }
         if let v = payload.name { merged.name = v }
         if let v = payload.model { merged.model = v }
         if let v = payload.systemVersion { merged.systemVersion = v }
         if let v = payload.playSound { merged.playSound = v }
         if let v = payload.quietMode { merged.quietMode = v }
         if let v = payload.categories { merged.categories = v }
-        entries.removeAll { $0.device.token == token }
+        entries.removeAll { $0.device.token == token || (id != nil && $0.device.deviceID == id) }
         // Re-registering does not re-prove the token: a phone that reconnects
-        // keeps whatever standing it had with Apple.
+        // keeps whatever standing it had with Apple. A *new* token starts from
+        // nothing, whoever the phone is — Apple has not accepted it yet.
+        let standing = existing?.device.token == token ? existing?.lastAcceptedAt : nil
         entries.append(DeviceRegistryEntry(device: merged, registeredAt: now,
-                                           lastAcceptedAt: existing?.lastAcceptedAt))
+                                           lastAcceptedAt: standing))
         entries = Self.pruned(entries, capacity: capacity)
         persistBestEffort()
     }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/DeviceRegistryTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/DeviceRegistryTests.swift
@@ -56,6 +56,77 @@ struct DeviceRegistryTests {
         #expect(await tokens.devices().count == 1)
     }
 
+    // MARK: One phone, one record
+
+    /// The 02:01 case: the user switched a category off, but the same phone's
+    /// older token was still on file with the switch on, and Apple still
+    /// delivered to it.
+    @Test func reinstalledPhoneReplacesItsOldTokenInsteadOfSittingBesideIt() async throws {
+        let url = tempURL()
+        let tokens = DeviceTokens(url: url)
+        var on = NotificationCategoryPrefs.default
+        on.set(.agentDone, enabled: true)
+        await tokens.register(DeviceRegistrationPayload(
+            token: "old", deviceID: "hermes", name: "Hermes", categories: on))
+
+        var off = NotificationCategoryPrefs.default
+        off.set(.agentDone, enabled: false)
+        await tokens.register(DeviceRegistrationPayload(
+            token: "new", deviceID: "hermes", name: "Hermes", categories: off))
+
+        let devices = await tokens.devices()
+        #expect(devices.count == 1)
+        #expect(devices.first?.token == "new")
+        #expect(devices.first?.categories?.isEnabled(.agentDone) == false)
+        #expect(await DeviceTokens(url: url).all() == ["new"])   // the old token is gone from disk too
+    }
+
+    @Test func newTokenStartsWithoutTheOldTokensStanding() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        await tokens.register(DeviceRegistrationPayload(token: "old", deviceID: "hermes"))
+        await tokens.applySendResult(sent(200), token: "old")
+
+        await tokens.register(DeviceRegistrationPayload(token: "new", deviceID: "hermes"))
+        // Apple has never accepted "new": a 400 on it means junk, not a config error.
+        #expect(await tokens.applySendResult(sent(400), token: "new"))
+        #expect(await tokens.all().isEmpty)
+    }
+
+    @Test func recordWithoutAnIDIsAdoptedByTheSameToken() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        var prefs = NotificationCategoryPrefs.default
+        prefs.set(.agentDone, enabled: false)
+        // Written by the previous phone build, or by the raw-token POST.
+        await tokens.register(DeviceRegistrationPayload(token: "abc", categories: prefs))
+        await tokens.applySendResult(sent(200), token: "abc")
+
+        await tokens.register(DeviceRegistrationPayload(token: "abc", deviceID: "hermes", name: "Hermes"))
+        let devices = await tokens.devices()
+        #expect(devices.count == 1)
+        #expect(devices.first?.deviceID == "hermes")
+        #expect(devices.first?.categories?.isEnabled(.agentDone) == false)
+        // Same token, so its standing with Apple carries over.
+        #expect(await tokens.applySendResult(sent(400), token: "abc") == false)
+    }
+
+    @Test func twoPhonesStayTwoRecords() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        await tokens.register(DeviceRegistrationPayload(token: "a", deviceID: "hermes"))
+        await tokens.register(DeviceRegistrationPayload(token: "b", deviceID: "second-phone"))
+        await tokens.register(DeviceRegistrationPayload(token: "a2", deviceID: "hermes"))
+        #expect(Set(await tokens.all()) == ["a2", "b"])
+        #expect(await tokens.devices().count == 2)
+    }
+
+    @Test func partialReportUnderTheSameIDKeepsPrefs() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        await tokens.register(DeviceRegistrationPayload(
+            token: "old", deviceID: "hermes", playSound: false))
+        // Token rotated; this report carries no switches.
+        await tokens.register(DeviceRegistrationPayload(token: "new", deviceID: "hermes"))
+        #expect(await tokens.devices().first?.playSound == false)
+    }
+
     @Test func tokenlessPayloadIsNotRegistered() async throws {
         let tokens = DeviceTokens(url: tempURL())
         await tokens.register(DeviceRegistrationPayload(name: "Hermes"))


### PR DESCRIPTION
Stacked on #48 (ticket 11); ticket `.scratch/notification-categories/issues/14-one-record-per-phone.md`.

## What was wrong
The registry #48 persists is keyed on the APNs token, and a phone's token rotates on reinstall, restore and some OS updates. Each rotation left the previous record standing with the switches the phone had uploaded *then*, and Apple keeps delivering to a superseded token for a while. That is the 02:01 "switched off, still received" case from #48's acceptance: the stale record, not the live one, was pushed to. Nothing in the payload identified the phone, so the Mac could not merge.

## What changed
- **The phone names itself.** `DeviceRegistrationPayload.deviceID` is a UUID minted once and kept in the Keychain (`PushDeviceIdentity`, beside `KeychainStore` in the Kit), because the Keychain survives exactly the events that rotate the token. `identifierForVendor` would reset on a full removal, which is the reinstall case.
- **Id wins over token.** `DeviceRegistry.upsert` finds the phone by id first, then by token, removes every record sharing either, merges the preference fields onto what it found, and writes one record. A payload without an id (older phone build, raw-token POST) still keys on its token; an id-less record is adopted by the first identified payload with the same token, so existing files migrate on the phone's next connection with no schema change.
- **A rotated token starts with no APNs standing.** `lastAcceptedAt` carries over only when the token is unchanged, so #48's junk rule (400 on a never-accepted token evicts) applies to the new token instead of being shielded by the old one's history.
- 410 / 400 handling is unchanged and token-keyed; with one record per phone it now removes the phone's only record.

## Validation
- Kit 253 tests pass (payload round-trip and legacy decode, identity mints once and rejects a blank stored value).
- MacCore 629 tests pass (`DeviceRegistryTests` +5: reinstalled phone replaces its old token *and* its old switches, new token has no standing, id-less record adopted by the same token keeping its prefs and standing, two phones stay two records, partial report under the same id keeps prefs).
- Mac app and iOS app build; iOS `VibeBuddyAppTests` pass on iPhone 17 Pro.

## Not verified here
Real-device acceptance is in the ticket: reinstall the iPhone app and confirm `device-registry.json` keeps one record with the same `deviceID` and a new `token`; switch `agent_done` off and finish a session with the old token still known to Apple.

## Merge order
#48 first; GitHub retargets this PR to `main` when it does. #47 and #48 share push sites; this branch does not touch them.