### PR TITLE
docs(planning): roadmap status after the notification sessions landed

### DIFF
--- a/docs/planning/roadmap-2026-09.json
+++ b/docs/planning/roadmap-2026-09.json
@@ -1,7 +1,7 @@
 {
- "generatedAt": "2026-09-06T04:45+08:00",
- "main": "fc8f016",
- "howToUse": "status 是快照，以仓库事实为准：agent 节点 done = PR 已合并（描述第一行为节点 id）或票 Status done；可派 = deps 全 done 且自身非 done/in-progress 且 owner A；WP-S 串行 S-1→S-4→S-3→S-2；并发上限 4；优先级 S > A > M > 其余 1.2 > 1.3。票的 Status 只用仓库规定的标签（needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix）与 done；工作流状态（in-progress / pr-open / changes-requested）只存在于本文件的 status 字段，由总控回写；executor / pr 同理。",
+ "generatedAt": "2026-09-06T05:00+08:00",
+ "main": "ed37ad3",
+ "howToUse": "status 是快照，以仓库事实为准：agent 节点 done = PR 已合并（描述第一行为节点 id）或票 Status done；可派 = deps 全 done 且自身非 done/in-progress 且 owner A；并发上限 4；优先级 S > A > M > 其余 1.2 > 1.3。票的 Status 只用仓库规定的标签（needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix）与 done；工作流状态（in-progress / pr-open / changes-requested）只存在于本文件的 status 字段，由总控回写；executor / pr 同理。S-2 已由两个 worktree（claude/notification-dedup-strategy-008bff、codex/notification-dedup）在做，不要再派。",
  "vision": {
   "Q1": "面向 App Store 公众，你是第一用户",
   "Q3": "不发起？已修订：允许派新活与复杂回复，不做远程终端",
@@ -99,10 +99,10 @@
   },
   {
    "session": "Find why many completions never push to the phone",
-   "state": "运行中，已开 PR #47（CONFLICTING）",
-   "output": "PushFanout / skipped 结果码；票 12-never-a-silent-push",
-   "whenDone": "它自己合 main（含 #46），#48 合并后再合一次；吞并票 07；协调会话合并",
-   "nodes": "S-3"
+   "state": "已合并 #47（会话与协调会话各修一版评审，合成一份）",
+   "output": "PushFanout / skipped 结果码；票 12-never-a-silent-push；票 07 并入",
+   "whenDone": "无",
+   "nodes": "—"
   },
   {
    "session": "通知不一致问题",
@@ -113,10 +113,10 @@
   },
   {
    "session": "Persist the Mac's phone push registry across restarts",
-   "state": "PR #48 已开（协调会话代为合 main 两次）",
-   "output": "DeviceRegistry 落盘、410/400 规则、13 个测试",
-   "whenDone": "评审后合并；与 A-12 密钥方案相邻",
-   "nodes": "S-4"
+   "state": "已合并 #48（评审两条已修：只对 BadDeviceToken 驱逐；忘记手机会阻止其重新注册）",
+   "output": "DeviceRegistry 落盘、410/400 规则",
+   "whenDone": "无",
+   "nodes": "—"
   },
   {
    "session": "Claude Code API 集成方案（#42）",
@@ -270,7 +270,7 @@
    "owner": "A",
    "status": "done",
    "executor": null,
-   "pr": null,
+   "pr": 46,
    "deps": [],
    "ticket": "worktree q3-mobile-scope-decision-f38b01 · 分支 claude/notification-inconsistency-ca700d（未提交）",
    "vision": [
@@ -290,11 +290,11 @@
   {
    "id": "S-4",
    "lane": "S",
-   "title": "PR #48 待评审合并：推送注册表持久化（DeviceRegistry）",
+   "title": "已合并 #48：推送注册表持久化（DeviceRegistry）",
    "version": "1.2",
    "owner": "A",
-   "status": "in-progress",
-   "executor": "claude-session",
+   "status": "done",
+   "executor": null,
    "pr": 48,
    "deps": [
     "S-1"
@@ -312,16 +312,16 @@
     "verify": "MacCore 535+、Kit、iOS 测试；两端构建。",
     "skills": "resolving-merge-conflicts、code-review"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-4 PR #48 待评审合并：推送注册表持久化（DeviceRegistry）。\n票 / 位置：.scratch/notification-categories/issues/11-persist-the-apns-device-registry.md · worktree musing-mcclintock-9e9a5f（未提交，真机已验证）\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接；Q8 关闭 App 后送达：不做中继，手段待 ADR）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：会话「Persist the Mac's phone push registry」的成果进 main：设备 token 注册表落盘、410 删除、400 只删从未被苹果接受过的编号。\n  范围：合 main（S-1 之后）、测试、提交、PR、评审、合并；票与 CONTEXT.md 的改动一并进。\n  不做：不改 APNs 密钥来源（A-11/A-12）。\n  验收：PR 合并；Mac 重启后不用打开手机就能推送；DeviceRegistryTests 13 个通过。\n  验证：MacCore 535+、Kit、iOS 测试；两端构建。\n  建议技能：resolving-merge-conflicts、code-review（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n在 worktree .claude/worktrees/musing-mcclintock-9e9a5f 继续。改动已由会话在真机（Hermes）验证过：DeviceRegistry.swift + 测试、APNs.swift、VibeBuddyServer.swift、VibeBuddyDaemon.swift、MenuBarModel.swift、SettingsView.swift、手机 PushRegistration / DashboardStore、CONTEXT.md。等 S-1 合并后 git merge origin/main，解冲突（MenuBarModel.push 与 VibeBuddyServer 的推送路径现在按 DeliveryMatrix 走，注册表只替换设备来源），跑测试与构建，提交、PR、处理评审、合并。\n\n分支与工作区：从 origin/main 新建分支 claude/s-4-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-4）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-4 已合并 #48：推送注册表持久化（DeviceRegistry）。\n票 / 位置：.scratch/notification-categories/issues/11-persist-the-apns-device-registry.md · worktree musing-mcclintock-9e9a5f（未提交，真机已验证）\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接；Q8 关闭 App 后送达：不做中继，手段待 ADR）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：会话「Persist the Mac's phone push registry」的成果进 main：设备 token 注册表落盘、410 删除、400 只删从未被苹果接受过的编号。\n  范围：合 main（S-1 之后）、测试、提交、PR、评审、合并；票与 CONTEXT.md 的改动一并进。\n  不做：不改 APNs 密钥来源（A-11/A-12）。\n  验收：PR 合并；Mac 重启后不用打开手机就能推送；DeviceRegistryTests 13 个通过。\n  验证：MacCore 535+、Kit、iOS 测试；两端构建。\n  建议技能：resolving-merge-conflicts、code-review（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n在 worktree .claude/worktrees/musing-mcclintock-9e9a5f 继续。改动已由会话在真机（Hermes）验证过：DeviceRegistry.swift + 测试、APNs.swift、VibeBuddyServer.swift、VibeBuddyDaemon.swift、MenuBarModel.swift、SettingsView.swift、手机 PushRegistration / DashboardStore、CONTEXT.md。等 S-1 合并后 git merge origin/main，解冲突（MenuBarModel.push 与 VibeBuddyServer 的推送路径现在按 DeliveryMatrix 走，注册表只替换设备来源），跑测试与构建，提交、PR、处理评审、合并。\n\n分支与工作区：从 origin/main 新建分支 claude/s-4-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-4）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "S-3",
    "lane": "S",
-   "title": "PR #47 待合 main 与评审：完成通知没推到手机（PushFanout / skipped）",
+   "title": "已合并 #47：完成通知没推到手机（PushFanout / skipped，含票 07）",
    "version": "1.2",
    "owner": "A",
-   "status": "in-progress",
-   "executor": "claude-session",
+   "status": "done",
+   "executor": null,
    "pr": 47,
    "deps": [
     "S-4"
@@ -339,16 +339,16 @@
     "verify": "Kit / MacCore 测试含新增的 CueAudience、PushFanout 用例；两端构建。",
     "skills": "diagnosing-bugs、tdd、code-review"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-3 PR #47 待合 main 与评审：完成通知没推到手机（PushFanout / skipped）。\n票 / 位置：.scratch/notification-categories/issues/12-one-cue-evaluation-and-no-silent-push.md · worktree nostalgic-ramanujan-26a52d（会话进行中）· 吞并票 07\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接；Q26 被过滤提醒记 filtered）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：一次策略评估、多个受众过滤（CueAudience），推送扇出可测（PushFanout），没推的原因记进投递日志（skipped：apnsNotConfigured / noRegisteredDevice / quietMode / categoryOff）。\n  范围：与 main 上已有的 DeliveryMatrix、observe() 返回未过滤列表、每设备开关对齐；把分类通知票 07 的 filtered 需求合成同一套结果码。\n  不做：不重做关注度矩阵；不改 APNs 密钥。\n  验收：PR 合并；投递日志里每个被吞掉的提醒都有原因；Mac 关掉的类别不影响手机；票 07 标 done（由本节点完成）。\n  验证：Kit / MacCore 测试含新增的 CueAudience、PushFanout 用例；两端构建。\n  建议技能：diagnosing-bugs、tdd、code-review（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n这是正在跑的会话「Find why many completions never push to the phone」的收尾。它的分支基于旧 main，而 main 今天已并入：#44 的 SessionAttention + DeliveryMatrix（SoundAlert 带 delivery 等级）、NotificationCoordinator.observe 返回未经 Mac 类别过滤的列表、MenuBarModel.push 按每台手机的开关与 Quiet 列推送、守护进程推送也走矩阵。收尾要求：1）等 S-4 合并后 git merge origin/main；2）CueAudience 的 quietMode 语义改为「按 muted 列」而不是「只留审批」，categoryOff 与 DeliveryMatrix 分别负责要不要 / 多响，不重复过滤；3）NotificationDeliveryOutcome 只加一个新值：用 skipped 还是 filtered 二选一（推荐 skipped，failureReason 记原因 category / attention / quiet / focusedTerminal / apnsNotConfigured / noRegisteredDevice），并把 .scratch/notification-categories/issues/07 的 DoD 一并勾掉；4）Mac 设置页投递视图显示这些行；5）测试、构建、PR、评审、合并。\n\n分支与工作区：从 origin/main 新建分支 claude/s-3-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-3）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-3 已合并 #47：完成通知没推到手机（PushFanout / skipped，含票 07）。\n票 / 位置：.scratch/notification-categories/issues/12-one-cue-evaluation-and-no-silent-push.md · worktree nostalgic-ramanujan-26a52d（会话进行中）· 吞并票 07\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接；Q26 被过滤提醒记 filtered）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：一次策略评估、多个受众过滤（CueAudience），推送扇出可测（PushFanout），没推的原因记进投递日志（skipped：apnsNotConfigured / noRegisteredDevice / quietMode / categoryOff）。\n  范围：与 main 上已有的 DeliveryMatrix、observe() 返回未过滤列表、每设备开关对齐；把分类通知票 07 的 filtered 需求合成同一套结果码。\n  不做：不重做关注度矩阵；不改 APNs 密钥。\n  验收：PR 合并；投递日志里每个被吞掉的提醒都有原因；Mac 关掉的类别不影响手机；票 07 标 done（由本节点完成）。\n  验证：Kit / MacCore 测试含新增的 CueAudience、PushFanout 用例；两端构建。\n  建议技能：diagnosing-bugs、tdd、code-review（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n这是正在跑的会话「Find why many completions never push to the phone」的收尾。它的分支基于旧 main，而 main 今天已并入：#44 的 SessionAttention + DeliveryMatrix（SoundAlert 带 delivery 等级）、NotificationCoordinator.observe 返回未经 Mac 类别过滤的列表、MenuBarModel.push 按每台手机的开关与 Quiet 列推送、守护进程推送也走矩阵。收尾要求：1）等 S-4 合并后 git merge origin/main；2）CueAudience 的 quietMode 语义改为「按 muted 列」而不是「只留审批」，categoryOff 与 DeliveryMatrix 分别负责要不要 / 多响，不重复过滤；3）NotificationDeliveryOutcome 只加一个新值：用 skipped 还是 filtered 二选一（推荐 skipped，failureReason 记原因 category / attention / quiet / focusedTerminal / apnsNotConfigured / noRegisteredDevice），并把 .scratch/notification-categories/issues/07 的 DoD 一并勾掉；4）Mac 设置页投递视图显示这些行；5）测试、构建、PR、评审、合并。\n\n分支与工作区：从 origin/main 新建分支 claude/s-3-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-3）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "S-2",
    "lane": "S",
-   "title": "本地通知 × APNs 去重决策与实现",
+   "title": "进行中（两个 worktree）：本地通知 × APNs 去重决策与实现",
    "version": "1.2",
    "owner": "A",
-   "status": "blocked",
-   "executor": null,
+   "status": "in-progress",
+   "executor": "claude+codex worktrees",
    "pr": null,
    "deps": [
     "S-3"
@@ -365,7 +365,7 @@
     "verify": "两项真机实测先做：iOS 后台 WebSocket 存活时间、本地 add 撞同 id 远程通知的行为；然后三套测试与构建。",
     "skills": "grill-with-docs（先定方案）、diagnosing-bugs、tdd"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-2 本地通知 × APNs 去重决策与实现。\n票 / 位置：.scratch/notification-categories/issues/13-local-apns-dedupe.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：同一次权限请求不再在手机上出现两条（本地通知 + APNs 推送），且任何场景都不比现在少收到。\n  范围：三个候选（Mac 按在线状态跳过 / 手机撤回同 id 远程通知 / 后台完全交给 APNs）选一或组合，写依据，实现，真机验收。\n  不做：不减少任何一种场景的提醒；不引入新的不稳定因素。\n  验收：前台、刚退后台 10 秒内、退后台 5 分钟后各触发一次审批：每种恰好一条横幅、一次声音、点击打开会话；关闭 APNs 时行为不变少；Watch 不重复。\n  验证：两项真机实测先做：iOS 后台 WebSocket 存活时间、本地 add 撞同 id 远程通知的行为；然后三套测试与构建。\n  建议技能：grill-with-docs（先定方案）、diagnosing-bugs、tdd（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n票 .scratch/notification-categories/issues/13-local-apns-dedupe.md 已写好（现象、现有机制、三个候选方案、决策要求、验收）。硬约束：不能让任何场景比现在更少收到提醒。方案 1（Mac 按手机在线状态跳过推送）需要把 /ws 连接与设备 token 关联并加静默超时兜底；方案 2（手机 post 本地通知前撤回同 identifier 的远程通知）零 Mac 改动但只覆盖一种到达顺序；方案 3（后台完全交给 APNs）依赖 APNs 可达。两项真机实测（后台 ws 存活时间、本地 add 撞同 id 远程通知）由用户在 Hermes 上完成后再定；决策记进 docs/planning 或 ADR，PR 描述写排除依据。\n\n分支与工作区：从 origin/main 新建分支 claude/s-2-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-2）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-2 进行中（两个 worktree）：本地通知 × APNs 去重决策与实现。\n票 / 位置：.scratch/notification-categories/issues/13-local-apns-dedupe.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：同一次权限请求不再在手机上出现两条（本地通知 + APNs 推送），且任何场景都不比现在少收到。\n  范围：三个候选（Mac 按在线状态跳过 / 手机撤回同 id 远程通知 / 后台完全交给 APNs）选一或组合，写依据，实现，真机验收。\n  不做：不减少任何一种场景的提醒；不引入新的不稳定因素。\n  验收：前台、刚退后台 10 秒内、退后台 5 分钟后各触发一次审批：每种恰好一条横幅、一次声音、点击打开会话；关闭 APNs 时行为不变少；Watch 不重复。\n  验证：两项真机实测先做：iOS 后台 WebSocket 存活时间、本地 add 撞同 id 远程通知的行为；然后三套测试与构建。\n  建议技能：grill-with-docs（先定方案）、diagnosing-bugs、tdd（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n票 .scratch/notification-categories/issues/13-local-apns-dedupe.md 已写好（现象、现有机制、三个候选方案、决策要求、验收）。硬约束：不能让任何场景比现在更少收到提醒。方案 1（Mac 按手机在线状态跳过推送）需要把 /ws 连接与设备 token 关联并加静默超时兜底；方案 2（手机 post 本地通知前撤回同 identifier 的远程通知）零 Mac 改动但只覆盖一种到达顺序；方案 3（后台完全交给 APNs）依赖 APNs 可达。两项真机实测（后台 ws 存活时间、本地 add 撞同 id 远程通知）由用户在 Hermes 上完成后再定；决策记进 docs/planning 或 ADR，PR 描述写排除依据。\n\n分支与工作区：从 origin/main 新建分支 claude/s-2-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-2）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "S-5",


### PR DESCRIPTION
ROADMAP

## Summary
- S-1 (#46), S-4 (#48), S-3 (#47) marked done; S-2 marked in progress (two worktrees already exist: claude/notification-dedup-strategy-008bff and codex/notification-dedup, so the coordinator must not dispatch a third).
- Session inventory rows updated; header now main ed37ad3.
- Prompts unchanged except the how-to-use note.

## Validation
- Docs only; JSON regenerated from the roadmap page data.