### PR TITLE
docs(planning): roadmap v3 — first wave PRs, S-6, W-1..3, merge order

### DIFF
--- a/docs/planning/roadmap-2026-09.json
+++ b/docs/planning/roadmap-2026-09.json
@@ -1,5 +1,5 @@
 {
- "generatedAt": "2026-09-06T19:30+08:00",
+ "generatedAt": "2026-09-06T05:02+08:00",
  "main": "7b41256",
  "howToUse": "status 是快照，以仓库事实为准：agent 节点 done = PR 已合并（描述第一行为节点 id）或票 Status done；pr-open = 有开放 PR（pr 字段）；可派 = deps 全 done 且自身非 done/in-progress/pr-open 且 owner A；并发上限 4；优先级 S > A > M > 其余 1.2 > 1.3。票的 Status 只用仓库规定的标签与 done；工作流状态只写本文件。合并顺序提醒：#57 → #56 → #55（三者都改 Kit 通知类型与 Mac Settings / MenuBarModel，每合一个让下一个合 main）；#53 与 #54 都建了 docs/adr/0012-*，后合者改 0013；S-2 以 #54 为准，codex/notification-dedup 弃用。",
  "vision": {

--- a/docs/planning/roadmap-2026-09.json
+++ b/docs/planning/roadmap-2026-09.json
@@ -1,7 +1,7 @@
 {
- "generatedAt": "2026-09-06T05:00+08:00",
- "main": "ed37ad3",
- "howToUse": "status 是快照，以仓库事实为准：agent 节点 done = PR 已合并（描述第一行为节点 id）或票 Status done；可派 = deps 全 done 且自身非 done/in-progress 且 owner A；并发上限 4；优先级 S > A > M > 其余 1.2 > 1.3。票的 Status 只用仓库规定的标签（needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix）与 done；工作流状态（in-progress / pr-open / changes-requested）只存在于本文件的 status 字段，由总控回写；executor / pr 同理。S-2 已由两个 worktree（claude/notification-dedup-strategy-008bff、codex/notification-dedup）在做，不要再派。",
+ "generatedAt": "2026-09-06T19:30+08:00",
+ "main": "7b41256",
+ "howToUse": "status 是快照，以仓库事实为准：agent 节点 done = PR 已合并（描述第一行为节点 id）或票 Status done；pr-open = 有开放 PR（pr 字段）；可派 = deps 全 done 且自身非 done/in-progress/pr-open 且 owner A；并发上限 4；优先级 S > A > M > 其余 1.2 > 1.3。票的 Status 只用仓库规定的标签与 done；工作流状态只写本文件。合并顺序提醒：#57 → #56 → #55（三者都改 Kit 通知类型与 Mac Settings / MenuBarModel，每合一个让下一个合 main）；#53 与 #54 都建了 docs/adr/0012-*，后合者改 0013；S-2 以 #54 为准，codex/notification-dedup 弃用。",
  "vision": {
   "Q1": "面向 App Store 公众，你是第一用户",
   "Q3": "不发起？已修订：允许派新活与复杂回复，不做远程终端",
@@ -189,6 +189,55 @@
    "nodes": "—"
   },
   {
+   "session": "协调会话（coord-log）",
+   "state": "运行中",
+   "output": "第一波已派：A-05 #56、A-06 #57、A-08 #55、A-11 #53；S-2 #54；候补 M-02 → M-04 → M-05 → F/W → B-3 → D-1 → D-2",
+   "whenDone": "第一波合并后派候补",
+   "nodes": "COORD"
+  },
+  {
+   "session": "A-05 / A-06 / A-08 / A-11 执行会话",
+   "state": "PR 开着",
+   "output": "#56 #57 #55 #53，各自测试通过",
+   "whenDone": "审查合并（顺序 #57 → #56 → #55；#53 的 ADR 与 #54 撞号）",
+   "nodes": "A-05 A-06 A-08 A-11"
+  },
+  {
+   "session": "去重 S-2（Claude）",
+   "state": "PR #54 开着",
+   "output": "手机回执 /notified + Mac 暂缓推送 ≤3 s；ADR-0012（撞号）",
+   "whenDone": "审查合并；需你两项真机实测确认",
+   "nodes": "S-2"
+  },
+  {
+   "session": "去重 S-2（Codex worktree）",
+   "state": "进行中，改 vision 文档",
+   "output": "codex/notification-dedup，无 PR",
+   "whenDone": "弃用，以 #54 为准；不要合并它对 vision 的改动",
+   "nodes": "—"
+  },
+  {
+   "session": "手表表盘组件规格会话",
+   "state": "规格与原型完成",
+   "output": "watch-complication PRD + PROTOTYPE.html + 三张票与 handoff",
+   "whenDone": "W-1 → W-2 → W-3 可派",
+   "nodes": "W-1 W-2 W-3"
+  },
+  {
+   "session": "AGENTS 规则审阅会话",
+   "state": "PR #52 开着",
+   "output": "AGENTS.md 交付边界与验证策略",
+   "whenDone": "评审后合并（一条可移植性意见）",
+   "nodes": "—"
+  },
+  {
+   "session": "push-registration-defects（#50）",
+   "state": "已关闭",
+   "output": "票 14：一台手机一条记录（设备 id），代码完成",
+   "whenDone": "重提为 S-6",
+   "nodes": "S-6"
+  },
+  {
    "session": "Codex 配置指南集成",
    "state": "空闲，无代码",
    "output": "票 observability-v2/09（ready-for-agent）、desktop-monitoring/12（deferred）",
@@ -344,16 +393,16 @@
   {
    "id": "S-2",
    "lane": "S",
-   "title": "进行中（两个 worktree）：本地通知 × APNs 去重决策与实现",
+   "title": "PR #54 待评审合并：一次提醒只弹一条（手机回执 /notified）",
    "version": "1.2",
    "owner": "A",
-   "status": "in-progress",
-   "executor": "claude+codex worktrees",
-   "pr": null,
+   "status": "pr-open",
+   "executor": "claude-executor (#54); codex worktree superseded",
+   "pr": 54,
    "deps": [
     "S-3"
    ],
-   "ticket": ".scratch/notification-categories/issues/13-local-apns-dedupe.md",
+   "ticket": ".scratch/notification-categories/issues/13-local-apns-dedupe.md · PR #54（Claude）· codex/notification-dedup 另一份，弃用",
    "vision": [
     "Q4"
    ],
@@ -365,7 +414,34 @@
     "verify": "两项真机实测先做：iOS 后台 WebSocket 存活时间、本地 add 撞同 id 远程通知的行为；然后三套测试与构建。",
     "skills": "grill-with-docs（先定方案）、diagnosing-bugs、tdd"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-2 进行中（两个 worktree）：本地通知 × APNs 去重决策与实现。\n票 / 位置：.scratch/notification-categories/issues/13-local-apns-dedupe.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：同一次权限请求不再在手机上出现两条（本地通知 + APNs 推送），且任何场景都不比现在少收到。\n  范围：三个候选（Mac 按在线状态跳过 / 手机撤回同 id 远程通知 / 后台完全交给 APNs）选一或组合，写依据，实现，真机验收。\n  不做：不减少任何一种场景的提醒；不引入新的不稳定因素。\n  验收：前台、刚退后台 10 秒内、退后台 5 分钟后各触发一次审批：每种恰好一条横幅、一次声音、点击打开会话；关闭 APNs 时行为不变少；Watch 不重复。\n  验证：两项真机实测先做：iOS 后台 WebSocket 存活时间、本地 add 撞同 id 远程通知的行为；然后三套测试与构建。\n  建议技能：grill-with-docs（先定方案）、diagnosing-bugs、tdd（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n票 .scratch/notification-categories/issues/13-local-apns-dedupe.md 已写好（现象、现有机制、三个候选方案、决策要求、验收）。硬约束：不能让任何场景比现在更少收到提醒。方案 1（Mac 按手机在线状态跳过推送）需要把 /ws 连接与设备 token 关联并加静默超时兜底；方案 2（手机 post 本地通知前撤回同 identifier 的远程通知）零 Mac 改动但只覆盖一种到达顺序；方案 3（后台完全交给 APNs）依赖 APNs 可达。两项真机实测（后台 ws 存活时间、本地 add 撞同 id 远程通知）由用户在 Hermes 上完成后再定；决策记进 docs/planning 或 ADR，PR 描述写排除依据。\n\n分支与工作区：从 origin/main 新建分支 claude/s-2-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-2）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-2 PR #54 待评审合并：一次提醒只弹一条（手机回执 /notified）。\n票 / 位置：.scratch/notification-categories/issues/13-local-apns-dedupe.md · PR #54（Claude）· codex/notification-dedup 另一份，弃用\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：同一次权限请求不再在手机上出现两条（本地通知 + APNs 推送），且任何场景都不比现在少收到。\n  范围：三个候选（Mac 按在线状态跳过 / 手机撤回同 id 远程通知 / 后台完全交给 APNs）选一或组合，写依据，实现，真机验收。\n  不做：不减少任何一种场景的提醒；不引入新的不稳定因素。\n  验收：前台、刚退后台 10 秒内、退后台 5 分钟后各触发一次审批：每种恰好一条横幅、一次声音、点击打开会话；关闭 APNs 时行为不变少；Watch 不重复。\n  验证：两项真机实测先做：iOS 后台 WebSocket 存活时间、本地 add 撞同 id 远程通知的行为；然后三套测试与构建。\n  建议技能：grill-with-docs（先定方案）、diagnosing-bugs、tdd（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n票 .scratch/notification-categories/issues/13-local-apns-dedupe.md 已写好（现象、现有机制、三个候选方案、决策要求、验收）。硬约束：不能让任何场景比现在更少收到提醒。方案 1（Mac 按手机在线状态跳过推送）需要把 /ws 连接与设备 token 关联并加静默超时兜底；方案 2（手机 post 本地通知前撤回同 identifier 的远程通知）零 Mac 改动但只覆盖一种到达顺序；方案 3（后台完全交给 APNs）依赖 APNs 可达。两项真机实测（后台 ws 存活时间、本地 add 撞同 id 远程通知）由用户在 Hermes 上完成后再定；决策记进 docs/planning 或 ADR，PR 描述写排除依据。\n\n分支与工作区：从 origin/main 新建分支 claude/s-2-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-2）写在 PR 描述第一行，方便协调会话对账。"
+  },
+  {
+   "id": "S-6",
+   "lane": "S",
+   "title": "注册表一台手机一条记录（设备 id；#50 关闭需重提）",
+   "version": "1.2",
+   "owner": "A",
+   "status": "ready",
+   "executor": null,
+   "pr": null,
+   "deps": [
+    "S-4"
+   ],
+   "ticket": ".scratch/notification-categories/issues/14-one-record-per-phone.md（code complete）· 原 PR #50 已关闭",
+   "vision": [
+    "Q4",
+    "Q8"
+   ],
+   "spec": {
+    "goal": "手机的 APNs token 会轮换；注册表按 token 记录会留下带旧开关的僵尸记录并被推送。手机上报稳定的 deviceID，注册表按它合并。",
+    "scope": "DeviceRegistrationPayload.deviceID；DeviceRegistry 按设备合并、token 轮换时替换；手机端生成并持久化 id。",
+    "non": "不改密钥来源。",
+    "accept": "票 14 的验收：同一手机换 token 后只有一条记录，旧 token 不再被推；测试覆盖。",
+    "verify": "MacCore / Kit / iOS 测试；两端构建。",
+    "skills": "tdd、implement"
+   },
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：S-6 注册表一台手机一条记录（设备 id；#50 关闭需重提）。\n票 / 位置：.scratch/notification-categories/issues/14-one-record-per-phone.md（code complete）· 原 PR #50 已关闭\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 一周零漏接；Q8 关闭 App 后送达：不做中继，手段待 ADR）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：手机的 APNs token 会轮换；注册表按 token 记录会留下带旧开关的僵尸记录并被推送。手机上报稳定的 deviceID，注册表按它合并。\n  范围：DeviceRegistrationPayload.deviceID；DeviceRegistry 按设备合并、token 轮换时替换；手机端生成并持久化 id。\n  不做：不改密钥来源。\n  验收：票 14 的验收：同一手机换 token 后只有一条记录，旧 token 不再被推；测试覆盖。\n  验证：MacCore / Kit / iOS 测试；两端构建。\n  建议技能：tdd、implement（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n票 14 的代码已在 PR #50 分支（claude/push-registration-defects-dda1f9）上写完但 PR 被关闭（叠在 #48 上，#48 已合）。从 origin/main 新开分支，把 #50 的提交 cherry-pick 或重做：手机生成稳定 deviceID 并随 DeviceRegistrationPayload 上报；DeviceRegistry 按 deviceID 合并，token 轮换时替换旧 token 并沿用开关与 lastAcceptedAt；无 deviceID 的旧手机仍按 token。跑测试与两端构建，开 PR（描述第一行 S-6）。\n\n分支与工作区：从 origin/main 新建分支 claude/s-6-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（S-6）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "S-5",
@@ -374,7 +450,7 @@
    "version": "1.3",
    "owner": "A",
    "status": "in-progress",
-   "executor": "claude-session",
+   "executor": "claude-design-session",
    "pr": null,
    "deps": [],
    "ticket": "会话「Mac版设计界面风格」· 设计画布 78619df8",
@@ -395,12 +471,12 @@
   {
    "id": "A-05",
    "lane": "A",
-   "title": "Time Sensitive + 可操作横幅",
+   "title": "PR #56 待评审合并：Time Sensitive + 可操作横幅",
    "version": "1.2",
    "owner": "A",
-   "status": "ready",
-   "executor": null,
-   "pr": null,
+   "status": "pr-open",
+   "executor": "claude-executor",
+   "pr": 56,
    "deps": [],
    "ticket": ".scratch/notification-categories/issues/05-time-sensitive-and-actionable-banners.md",
    "vision": [
@@ -416,17 +492,17 @@
     "verify": "Kit / MacCore 测试；iOS 与 Mac 构建。",
     "skills": "implement、tdd、code-review"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-05 Time Sensitive + 可操作横幅。\n票 / 位置：.scratch/notification-categories/issues/05-time-sensitive-and-actionable-banners.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q18 横幅 Approve / Deny，提问文本作答；Q23 审批与提问 Time Sensitive；Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：审批横幅 Approve（需解锁）/ Deny，提问横幅文本作答；审批与提问 Time Sensitive；Mac 横幅同样；APNs 带 category。\n  范围：Kit 类别 id、iOS UNNotificationCategory 与 didReceive、Mac 类别与 action、APNs payload、entitlement、Demo 样本。\n  不做：Always allow 不上横幅；Watch 不写代码（镜像自动继承）。\n  验收：票 05 全部勾选；Demo 模式横幅带按钮；payload 测试覆盖 category 与 interruption-level。\n  验证：Kit / MacCore 测试；iOS 与 Mac 构建。\n  建议技能：implement、tdd、code-review（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n实现票 05。Kit：共享通知类别 id（approval、question）与 action id；SoundAlert 暴露 isTimeSensitive（bannerSound × approval/question × 非 muted）。iPhone：启动注册 UNNotificationCategory，approval = Approve（.authenticationRequired）+ Deny（.destructive），question = UNTextInputNotificationAction；Notifier.post 设 categoryIdentifier、interruptionLevel、userInfo（sessionId、approval id）；AppDelegate.didReceive 处理三个 action，经 DecisionClient.decide / .answer，404/409 时改为打开会话。Mac：同样注册类别，action 走进程内 decide / answer。APNs：payload 加 category、interruption-level、approval id，补测试。xcodegen 加 time-sensitive entitlement 并记入 docs/app-store-submission-checklist.md。Demo 样本横幅带按钮。\n\n分支与工作区：从 origin/main 新建分支 claude/a-05-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-05）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-05 PR #56 待评审合并：Time Sensitive + 可操作横幅。\n票 / 位置：.scratch/notification-categories/issues/05-time-sensitive-and-actionable-banners.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q18 横幅 Approve / Deny，提问文本作答；Q23 审批与提问 Time Sensitive；Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：审批横幅 Approve（需解锁）/ Deny，提问横幅文本作答；审批与提问 Time Sensitive；Mac 横幅同样；APNs 带 category。\n  范围：Kit 类别 id、iOS UNNotificationCategory 与 didReceive、Mac 类别与 action、APNs payload、entitlement、Demo 样本。\n  不做：Always allow 不上横幅；Watch 不写代码（镜像自动继承）。\n  验收：票 05 全部勾选；Demo 模式横幅带按钮；payload 测试覆盖 category 与 interruption-level。\n  验证：Kit / MacCore 测试；iOS 与 Mac 构建。\n  建议技能：implement、tdd、code-review（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n实现票 05。Kit：共享通知类别 id（approval、question）与 action id；SoundAlert 暴露 isTimeSensitive（bannerSound × approval/question × 非 muted）。iPhone：启动注册 UNNotificationCategory，approval = Approve（.authenticationRequired）+ Deny（.destructive），question = UNTextInputNotificationAction；Notifier.post 设 categoryIdentifier、interruptionLevel、userInfo（sessionId、approval id）；AppDelegate.didReceive 处理三个 action，经 DecisionClient.decide / .answer，404/409 时改为打开会话。Mac：同样注册类别，action 走进程内 decide / answer。APNs：payload 加 category、interruption-level、approval id，补测试。xcodegen 加 time-sensitive entitlement 并记入 docs/app-store-submission-checklist.md。Demo 样本横幅带按钮。\n\n分支与工作区：从 origin/main 新建分支 claude/a-05-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-05）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "A-06",
    "lane": "A",
-   "title": "quota 第七类",
+   "title": "PR #57 待评审合并：quota 第七类",
    "version": "1.2",
    "owner": "A",
-   "status": "ready",
-   "executor": null,
-   "pr": null,
+   "status": "pr-open",
+   "executor": "claude-executor",
+   "pr": 57,
    "deps": [],
    "ticket": ".scratch/notification-categories/issues/06-quota-category.md",
    "vision": [
@@ -440,17 +516,17 @@
     "verify": "Kit / MacCore 测试；两端构建。",
     "skills": "implement、tdd"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-06 quota 第七类。\n票 / 位置：.scratch/notification-categories/issues/06-quota-category.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q24 quota 第七类）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：配额 / 预算通知成为可开关的第七类：Mac 默认开，手机默认关。\n  范围：NotificationCategoryPrefs 加 quota；Mac notifyBudget / notifyUsage 走开关与日志；手机开关与推送。\n  不做：不改关注度矩阵（quota 与关注度无关）。\n  验收：旧存档缺键按默认解码；Mac 与手机开关生效；测试覆盖。\n  验证：Kit / MacCore 测试；两端构建。\n  建议技能：implement、tdd（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n实现票 06。NotificationCategoryPrefs 增加 quota（若不想加音频文件，用与 NotificationSound 并列的类别枚举，但 displayOrder 与 isEnabled 语义一致）；默认 Mac 开、手机关；旧存档缺键按默认解码。Mac 的 notifyBudget / notifyUsage 走类别开关与 delivery log，不再借 longWaitNudge 音效。手机 Settings 显示开关；开时 Mac 按上传的 categories 推 quota 通知。\n\n分支与工作区：从 origin/main 新建分支 claude/a-06-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-06）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-06 PR #57 待评审合并：quota 第七类。\n票 / 位置：.scratch/notification-categories/issues/06-quota-category.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q24 quota 第七类）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：配额 / 预算通知成为可开关的第七类：Mac 默认开，手机默认关。\n  范围：NotificationCategoryPrefs 加 quota；Mac notifyBudget / notifyUsage 走开关与日志；手机开关与推送。\n  不做：不改关注度矩阵（quota 与关注度无关）。\n  验收：旧存档缺键按默认解码；Mac 与手机开关生效；测试覆盖。\n  验证：Kit / MacCore 测试；两端构建。\n  建议技能：implement、tdd（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n实现票 06。NotificationCategoryPrefs 增加 quota（若不想加音频文件，用与 NotificationSound 并列的类别枚举，但 displayOrder 与 isEnabled 语义一致）；默认 Mac 开、手机关；旧存档缺键按默认解码。Mac 的 notifyBudget / notifyUsage 走类别开关与 delivery log，不再借 longWaitNudge 音效。手机 Settings 显示开关；开时 Mac 按上传的 categories 推 quota 通知。\n\n分支与工作区：从 origin/main 新建分支 claude/a-06-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-06）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "A-08",
    "lane": "A",
-   "title": "漏接计数",
+   "title": "PR #55 待评审合并：漏接计数",
    "version": "1.2",
    "owner": "A",
-   "status": "ready",
-   "executor": null,
-   "pr": null,
+   "status": "pr-open",
+   "executor": "claude-executor",
+   "pr": 55,
    "deps": [],
    "ticket": ".scratch/notification-categories/issues/08-missed-counter.md",
    "vision": [
@@ -465,19 +541,19 @@
     "verify": "MacCore 测试；Mac 构建。",
     "skills": "tdd、implement"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-08 漏接计数。\n票 / 位置：.scratch/notification-categories/issues/08-missed-counter.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q13 漏接计数做进 App；Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：任一 needsResponse 超过 5 分钟无任何一端确认即计一次漏接；Mac 设置页显示本周数。这是 1.2 能否发布的判据。\n  范围：MacCore MissedLedger（journal 旁，0600，8 周）；所有确认路径取消计时；GET /missed；Mac 设置页显示。\n  不做：手机端显示不做；不改 snapshot。\n  验收：每条确认路径取消计时有测试；一次等待只记一条；muted 会话也算；零显示为 0。\n  验证：MacCore 测试；Mac 构建。\n  建议技能：tdd、implement（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n实现票 08。MissedLedger 与 LifecycleJournal 同目录：会话进入 needsResponse 时按 (sessionId, statusSince) 起 5 分钟计时；期间没有 acknowledge / decision / answer / jump（含 Mac 进程内路径）则写一条 missed（waitKind、agentKind）；muted 也算。GET /missed?week= 返回计数；Mac Settings → Notifications 显示本周数与按 agent 分布。\n\n分支与工作区：从 origin/main 新建分支 claude/a-08-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-08）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-08 PR #55 待评审合并：漏接计数。\n票 / 位置：.scratch/notification-categories/issues/08-missed-counter.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q13 漏接计数做进 App；Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：任一 needsResponse 超过 5 分钟无任何一端确认即计一次漏接；Mac 设置页显示本周数。这是 1.2 能否发布的判据。\n  范围：MacCore MissedLedger（journal 旁，0600，8 周）；所有确认路径取消计时；GET /missed；Mac 设置页显示。\n  不做：手机端显示不做；不改 snapshot。\n  验收：每条确认路径取消计时有测试；一次等待只记一条；muted 会话也算；零显示为 0。\n  验证：MacCore 测试；Mac 构建。\n  建议技能：tdd、implement（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n实现票 08。MissedLedger 与 LifecycleJournal 同目录：会话进入 needsResponse 时按 (sessionId, statusSince) 起 5 分钟计时；期间没有 acknowledge / decision / answer / jump（含 Mac 进程内路径）则写一条 missed（waitKind、agentKind）；muted 也算。GET /missed?week= 返回计数；Mac Settings → Notifications 显示本周数与按 agent 分布。\n\n分支与工作区：从 origin/main 新建分支 claude/a-08-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-08）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "A-11",
    "lane": "A",
-   "title": "APNs 密钥方案 ADR（三条路比较）",
+   "title": "PR #53 待评审合并：APNs 密钥方案 ADR",
    "version": "1.2",
    "owner": "A",
-   "status": "ready",
-   "executor": null,
-   "pr": null,
+   "status": "pr-open",
+   "executor": "claude-executor",
+   "pr": 53,
    "deps": [],
-   "ticket": "docs/adr/0012-apns-key-delivery.md（待写）",
+   "ticket": "docs/adr/0012-apns-key-delivery.md（#53；与 #54 的 0012 撞号，后合者改 0013）",
    "vision": [
     "Q8",
     "Q4"
@@ -490,7 +566,7 @@
     "verify": "—",
     "skills": "research（查 Apple 文档与同类开源做法）、writing-for-agents"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-11 APNs 密钥方案 ADR（三条路比较）。\n票 / 位置：docs/adr/0012-apns-key-delivery.md（待写）\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q8 关闭 App 后送达：不做中继，手段待 ADR；Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：给用户一份能拍板的 ADR：内置 .p8（含轮换、只向配对登记 token 发送）、每用户自己的开发者密钥、极小中继，各自的安全影响面、陌生用户体验、运维成本。\n  范围：只写 ADR 与迁移草图，不写实现。\n  不做：不在 ADR 里替用户选。\n  验收：ADR 含三条路的对比表、Codex 评审的反对意见原文与回应、每条路对 1.2 与 1.3 的影响；Status: Proposed。\n  验证：—\n  建议技能：research（查 Apple 文档与同类开源做法）、writing-for-agents（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n写 docs/adr/0012-apns-key-delivery.md。背景：vision Q8 目标是关闭 App 后仍能送达且不做 vibebuddy 中继；PR #40 的 Codex 评审指出把 APNs 签名密钥打进公开分发的 App 不是成熟做法（任何下载者可提取伪造推送，泄露只能全量换钥）。比较三条路：1）内置密钥 + 轮换 + 只向配对流程登记的 token 发送 + 隐私说明；2）每个用户自己的 Apple 开发者密钥（陌生用户几乎不可能）；3）极小中继（违反无服务器决定，多一份运维）。用 /research 查 Apple 对 provider token 的安全指引与同类开源 Mac App 的做法，附引用。Status: Proposed，等 DEC-APNS。\n\n分支与工作区：从 origin/main 新建分支 claude/a-11-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-11）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：A-11 PR #53 待评审合并：APNs 密钥方案 ADR。\n票 / 位置：docs/adr/0012-apns-key-delivery.md（#53；与 #54 的 0012 撞号，后合者改 0013）\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q8 关闭 App 后送达：不做中继，手段待 ADR；Q4 一周零漏接）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：给用户一份能拍板的 ADR：内置 .p8（含轮换、只向配对登记 token 发送）、每用户自己的开发者密钥、极小中继，各自的安全影响面、陌生用户体验、运维成本。\n  范围：只写 ADR 与迁移草图，不写实现。\n  不做：不在 ADR 里替用户选。\n  验收：ADR 含三条路的对比表、Codex 评审的反对意见原文与回应、每条路对 1.2 与 1.3 的影响；Status: Proposed。\n  验证：—\n  建议技能：research（查 Apple 文档与同类开源做法）、writing-for-agents（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n写 docs/adr/0012-apns-key-delivery.md。背景：vision Q8 目标是关闭 App 后仍能送达且不做 vibebuddy 中继；PR #40 的 Codex 评审指出把 APNs 签名密钥打进公开分发的 App 不是成熟做法（任何下载者可提取伪造推送，泄露只能全量换钥）。比较三条路：1）内置密钥 + 轮换 + 只向配对流程登记的 token 发送 + 隐私说明；2）每个用户自己的 Apple 开发者密钥（陌生用户几乎不可能）；3）极小中继（违反无服务器决定，多一份运维）。用 /research 查 Apple 对 provider token 的安全指引与同类开源 Mac App 的做法，附引用。Status: Proposed，等 DEC-APNS。\n\n分支与工作区：从 origin/main 新建分支 claude/a-11-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（A-11）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "A-12",
@@ -912,7 +988,8 @@
    "deps": [
     "M-06",
     "M-09",
-    "M-10"
+    "M-10",
+    "W-3"
    ],
    "ticket": ".scratch/mobile-watch-task-control/issues/11-cross-device-acceptance.md",
    "vision": [
@@ -930,28 +1007,84 @@
    "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：M-11 跨端整体验收与支持范围收尾。\n票 / 位置：.scratch/mobile-watch-task-control/issues/11-cross-device-acceptance.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q35 官方依据、真机验证；steer 失败不得静默改 start；Q27 四家真机验收矩阵）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：Mac 在场 / 离场、手机锁定 / 解锁、Watch 佩戴 / 锁定、Focus、网络中断、语音误识别、重复点击、跨端确认撤销全部走一遍；未通过的能力不得宣传为已支持。\n  范围：真机矩阵与文案收尾。\n  不做：—\n  验收：票 11 勾选；README 与 App Store 文案只写通过的能力。\n  验证：真机。\n  建议技能：—（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n按票 11 的矩阵在 Hermes、手表与 Mac 上验收，结果写回；未通过的能力从 README / 文案里去掉或标未支持。\n\n这一步只有你本人能做（真机、签名、账号或决策）。完成后把结果写回票的 Status 行与验收段，截图放票里指定的目录；有失败就开修复票而不是改判据。做完在本图把 M-11 标 done，协调会话会据此派下游。"
   },
   {
-   "id": "F-2",
+   "id": "W-1",
    "lane": "M",
-   "title": "表盘复杂功能 + Smart Stack",
+   "title": "关注任务表盘组件（模块表盘看最需要关注的任务）",
    "version": "1.2",
    "owner": "A",
    "status": "ready",
    "executor": null,
    "pr": null,
    "deps": [],
-   "ticket": ".scratch/watchos-companion/issues/10-complications-smart-stack.md（待建）",
+   "ticket": ".scratch/watch-complication/issues/01-followed-task-complication.md · PRD + PROTOTYPE.html",
    "vision": [
-    "Q12"
+    "Q12",
+    "Q33"
    ],
    "spec": {
-    "goal": "圆形与矩形复杂功能显示三色计数；Smart Stack 在有 needsResponse 时用 relevance 上浮。",
-    "scope": "watchOS WidgetKit，App Group 共享 WatchDashboardState。",
-    "non": "—",
-    "accept": "Simulator 各尺寸截图；无数据显示占位。",
-    "verify": "构建。",
+    "goal": "模块表盘上一眼看到当前最需要关注的任务（任务名优先布局，已由用户在原型上确认）。",
+    "scope": "watchOS WidgetKit 复杂功能；数据经 App Group 来自 iPhone 转发的 WatchDashboardState；票 01 的 handoff 文件已写好实现步骤。",
+    "non": "Smart Stack 与三色计数另议。",
+    "accept": "票 01 的验收项；Simulator 各尺寸截图。",
+    "verify": "Watch 构建；真机在 M-11。",
     "skills": "implement"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：F-2 表盘复杂功能 + Smart Stack。\n票 / 位置：.scratch/watchos-companion/issues/10-complications-smart-stack.md（待建）\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q12 手表成为独立交互端）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：圆形与矩形复杂功能显示三色计数；Smart Stack 在有 needsResponse 时用 relevance 上浮。\n  范围：watchOS WidgetKit，App Group 共享 WatchDashboardState。\n  不做：—\n  验收：Simulator 各尺寸截图；无数据显示占位。\n  验证：构建。\n  建议技能：implement（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n新建票并实现 watchOS WidgetKit 复杂功能与 Smart Stack 卡片，数据来自 iPhone 转发的 WatchDashboardState（App Group）。\n\n分支与工作区：从 origin/main 新建分支 claude/f-2-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（F-2）写在 PR 描述第一行，方便协调会话对账。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：W-1 关注任务表盘组件（模块表盘看最需要关注的任务）。\n票 / 位置：.scratch/watch-complication/issues/01-followed-task-complication.md · PRD + PROTOTYPE.html\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q12 手表成为独立交互端；Q33 重要任务优先提醒，尊重系统路由）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：模块表盘上一眼看到当前最需要关注的任务（任务名优先布局，已由用户在原型上确认）。\n  范围：watchOS WidgetKit 复杂功能；数据经 App Group 来自 iPhone 转发的 WatchDashboardState；票 01 的 handoff 文件已写好实现步骤。\n  不做：Smart Stack 与三色计数另议。\n  验收：票 01 的验收项；Simulator 各尺寸截图。\n  验证：Watch 构建；真机在 M-11。\n  建议技能：implement（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n按 .scratch/watch-complication/PRD.md、PROTOTYPE.html 与 issues/01-handoff.md 实现：模块表盘复杂功能显示最需要关注的任务（任务名优先）；数据来源 App Group 共享的 WatchDashboardState。\n\n分支与工作区：从 origin/main 新建分支 claude/w-1-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（W-1）写在 PR 描述第一行，方便协调会话对账。"
+  },
+  {
+   "id": "W-2",
+   "lane": "M",
+   "title": "点击表盘进入任务并同步已读",
+   "version": "1.2",
+   "owner": "A",
+   "status": "blocked",
+   "executor": null,
+   "pr": null,
+   "deps": [
+    "W-1"
+   ],
+   "ticket": ".scratch/watch-complication/issues/02-open-and-acknowledge-completion.md（含 02-handoff、02-mac-handoff）",
+   "vision": [
+    "Q12",
+    "Q37"
+   ],
+   "spec": {
+    "goal": "点表盘进入对应任务；该轮完成的已读状态经 iPhone 同步到 Mac（acknowledge）。",
+    "scope": "深链、WatchRelay、Mac 侧 acknowledge 路径（02-mac-handoff）。",
+    "non": "—",
+    "accept": "票 02 验收项。",
+    "verify": "构建；真机 M-11。",
+    "skills": "implement"
+   },
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：W-2 点击表盘进入任务并同步已读。\n票 / 位置：.scratch/watch-complication/issues/02-open-and-acknowledge-completion.md（含 02-handoff、02-mac-handoff）\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q12 手表成为独立交互端；Q37 Watch 按状态呈现）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：点表盘进入对应任务；该轮完成的已读状态经 iPhone 同步到 Mac（acknowledge）。\n  范围：深链、WatchRelay、Mac 侧 acknowledge 路径（02-mac-handoff）。\n  不做：—\n  验收：票 02 验收项。\n  验证：构建；真机 M-11。\n  建议技能：implement（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n按票 02 与两份 handoff 实现：表盘点击深链到任务详情；完成已读经 WatchRelay → iPhone → /acknowledge 同步；Mac 侧按 02-mac-handoff 补路径。\n\n分支与工作区：从 origin/main 新建分支 claude/w-2-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（W-2）写在 PR 描述第一行，方便协调会话对账。"
+  },
+  {
+   "id": "W-3",
+   "lane": "M",
+   "title": "表盘组件跨断连 / 重启 / 来源切换保持正确",
+   "version": "1.2",
+   "owner": "A",
+   "status": "blocked",
+   "executor": null,
+   "pr": null,
+   "deps": [
+    "W-1",
+    "W-2"
+   ],
+   "ticket": ".scratch/watch-complication/issues/03-recovery-and-source-isolation.md",
+   "vision": [
+    "Q12",
+    "Q35"
+   ],
+   "spec": {
+    "goal": "断连、重启、观测来源切换时表盘不显示过期或错误任务；无数据显示占位而不是 0。",
+    "scope": "状态过期判定、来源隔离、恢复路径。",
+    "non": "—",
+    "accept": "票 03 验收项。",
+    "verify": "构建 + 断连场景 Simulator；真机 M-11。",
+    "skills": "tdd、implement"
+   },
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：W-3 表盘组件跨断连 / 重启 / 来源切换保持正确。\n票 / 位置：.scratch/watch-complication/issues/03-recovery-and-source-isolation.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q12 手表成为独立交互端；Q35 官方依据、真机验证；steer 失败不得静默改 start）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：断连、重启、观测来源切换时表盘不显示过期或错误任务；无数据显示占位而不是 0。\n  范围：状态过期判定、来源隔离、恢复路径。\n  不做：—\n  验收：票 03 验收项。\n  验证：构建 + 断连场景 Simulator；真机 M-11。\n  建议技能：tdd、implement（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n按票 03 实现过期与恢复规则，补断连 / 重启 / 来源切换的测试。\n\n分支与工作区：从 origin/main 新建分支 claude/w-3-<slug>（若票指定了现有 worktree / 分支则用它），worktree 放 .claude/worktrees/<slug>；不要 rebase 到本地 main；不要用 bare git stash（栈是共享的）；main 只接受 PR。若依赖的 PR 尚未合并，把工作叠在那个 PR 分支上并在 PR 描述里说明。\n\n票据回写：领票时不改票的 Status（只用仓库规定的标签：needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix，以及既有的收口词 done），在票里加一行「**Executor:** <你> · 分支 <名> · <时间>」；完成时把 Status 改为 ready-for-human（需要真机）或 done（纯代码且已验证），附证据；不要把「代码完成」写成 done。新票按 docs/agents/issue-tracker.md 的格式建在票路径所示位置。\n\n验证（至少跑改动覆盖到的部分，把命令与结果数字写进 PR）：\n  cd VibeBuddyKit && swift test\n  cd VibeBuddyMac && swift test\n  cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n  cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO\n  cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build\n不要给 iOS scheme 传 -sdk iphonesimulator（会把 Watch 目标编到 iOS SDK，产生假错误）。\n\n边界：不部署、不发布、不改已安装的 App、不碰端口 9876 上正在运行的守护进程、不动真机、不改 ~/.claude 全局配置、不读取或打印任何密钥；这些只有用户能做。\n\nPR：标题用 Conventional Commits；描述分 Summary / Validation / Not verified here；不加署名行。main 的规则要求每条评审线程（含 Codex 机器人的 P1 / P2）先修复或答复后解决才能合并；合并由协调会话或用户执行。收尾回复里给出 PR 链接、跑过的验证与留给真机的项，并把本图的节点 id（W-3）写在 PR 描述第一行，方便协调会话对账。"
   },
   {
    "id": "F-3",


### PR DESCRIPTION
ROADMAP

## Summary
- Status refresh from repo facts (main 7b41256): A-05 #56, A-06 #57, A-08 #55, A-11 #53 and S-2 #54 are pr-open; S-1/S-3/S-4 done.
- New nodes: S-6 (one registry record per phone — the closed #50 / ticket 14, to be re-raised), W-1..W-3 (watch-complication PRD, replacing the generic F-2); M-11 now depends on W-3.
- howToUse now records the merge order for the three overlapping notification PRs (#57 → #56 → #55), the docs/adr/0012 number collision between #53 and #54, and that the Codex dedup worktree is superseded by #54.
- Prompts regenerated; page adds a progress table and an architecture figure.

## Validation
- Docs only; node parse and dependency check pass (55 nodes).