### PR TITLE
feat(session): distinguish answer, steer, and continue

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,9 +76,18 @@ code, and tests — don't drift to synonyms.
   the agent's own prompt takes the answer and the phone gets a **read-only
   card** (`answerable: false`); away → the daemon holds the prompt for the
   phone. Applies to the hook gate, the question relay and app-server requests.
-- **Steer** — free text for a Codex thread sent through the app-server daemon:
-  `turn/steer` while a turn runs, `turn/start` when idle (a cold thread is
-  resumed first). Codex threads never take typed input through a terminal.
+- **Steer** — free text for a running Codex turn (`turn/steer`, with
+  `expectedTurnId` when known). Failure is reported; it must not fall back to
+  `turn/start`. A finished session uses **continue** (`turn/start`) instead.
+  Codex threads never take typed input through a terminal.
+- **Session action / SessionActionIntent** — what free text on an existing
+  session means: **answer** (bind to the current question), **steer**
+  (supplement the running turn), **continue** (open the next turn). Distinct
+  from Approval and from New task. The daemon re-checks the live question /
+  turn before executing; an expired Answer does not become a steer. The
+  client shows not-sent / sending / accepted / failed / unknown; accepted is
+  not working or finished. Duplicate taps reuse a `requestId`; a lost receipt
+  stays unknown and is not resent. No connection (Q16) is not-sent.
 - **Attach** — the jump for a Claude *background session* (`claude --bg`,
   agent view, Desktop Dispatch): it has no window, so `ClaudeBackgroundSessions`
   reads the supervisor's `~/.claude/jobs/<id>/state.json` (read-only) and

--- a/VibeBuddyApp/Shared/DecisionClient.swift
+++ b/VibeBuddyApp/Shared/DecisionClient.swift
@@ -12,6 +12,9 @@ protocol DecisionClient: Sendable {
     /// Structured answers keyed by question id (option labels, or a typed
     /// reply), for the agents that take them through their own contract.
     func answer(_ pairing: PairingPayload, sessionId: String, answers: QuestionAnswers) async
+    /// One existing-session action with intent and a request id. The outcome
+    /// is what the phone may show: accepted is not working or finished.
+    func submitSessionAction(_ pairing: PairingPayload, request: SessionActionRequest) async -> SessionActionOutcome
     /// Returns what the Mac reported, or `nil` if it couldn't be reached.
     func jump(_ pairing: PairingPayload, sessionId: String) async -> JumpOutcome?
     func acknowledge(_ pairing: PairingPayload, sessionId: String) async
@@ -24,6 +27,14 @@ protocol DecisionClient: Sendable {
 
 extension DecisionClient {
     func dispatch(_ pairing: PairingPayload, request: DispatchRequest) async -> DispatchOutcome? { nil }
+    func submitSessionAction(_ pairing: PairingPayload, request: SessionActionRequest) async -> SessionActionOutcome {
+        if let answers = request.answers, !answers.isEmpty {
+            await answer(pairing, sessionId: request.sessionID, answers: answers)
+        } else if let text = request.text {
+            await answer(pairing, sessionId: request.sessionID, answer: text)
+        }
+        return .accepted
+    }
 }
 
 extension DecisionClient {
@@ -75,23 +86,35 @@ struct HTTPDecisionClient: DecisionClient {
     }
 
     func answer(_ pairing: PairingPayload, sessionId: String, answer: String) async {
-        guard let url = URL(string: "http://\(pairing.host):\(pairing.port)/answer") else { return }
-        var req = URLRequest(url: url)
-        req.httpMethod = "POST"
-        req.setValue("Bearer \(pairing.token)", forHTTPHeaderField: "Authorization")
-        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try? JSONSerialization.data(withJSONObject: ["sessionId": sessionId, "answer": answer])
-        _ = try? await URLSession.shared.data(for: req)
+        _ = await submitSessionAction(pairing, request: SessionActionRequest(sessionID: sessionId, text: answer))
     }
 
     func answer(_ pairing: PairingPayload, sessionId: String, answers: QuestionAnswers) async {
-        guard let url = URL(string: "http://\(pairing.host):\(pairing.port)/answer") else { return }
+        _ = await submitSessionAction(pairing, request: SessionActionRequest(sessionID: sessionId, answers: answers))
+    }
+
+    func submitSessionAction(_ pairing: PairingPayload, request: SessionActionRequest) async -> SessionActionOutcome {
+        guard let url = URL(string: "http://\(pairing.host):\(pairing.port)/answer") else {
+            return .notSent(String(localized: "Couldn't reach your Mac — not sent"))
+        }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("Bearer \(pairing.token)", forHTTPHeaderField: "Authorization")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try? JSONSerialization.data(withJSONObject: ["sessionId": sessionId, "answers": answers])
-        _ = try? await URLSession.shared.data(for: req)
+        var body: [String: Any] = ["sessionId": request.sessionID, "requestId": request.requestID]
+        if let intent = request.intent { body["intent"] = intent.rawValue }
+        if let questionID = request.questionID { body["questionId"] = questionID }
+        if let text = request.text { body["answer"] = text }
+        if let answers = request.answers { body["answers"] = answers }
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            guard let http = resp as? HTTPURLResponse else { return .unknown }
+            let fields = (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
+            return SessionActionOutcome.fromHTTP(statusCode: http.statusCode, body: fields)
+        } catch {
+            return .unknown
+        }
     }
 
     func dispatch(_ pairing: PairingPayload, request: DispatchRequest) async -> DispatchOutcome? {

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -284,33 +284,86 @@ final class DashboardStore: ObservableObject {
 
     /// Answers from the question card, keyed by question id.
     func answer(_ sessionId: String, answers: QuestionAnswers) {
-        guard !answers.isEmpty else { return }
-        if isDemo {
-            let flat = answers.values.flatMap { $0 }.joined(separator: ", ")
-            answer(sessionId, answer: flat)
-            return
-        }
-        guard let pairing else { return }
-        Task { await decisionClient.answer(pairing, sessionId: sessionId, answers: answers) }
+        Task { await submitAction(sessionId: sessionId, answers: answers) }
     }
 
     func answer(_ sessionId: String, answer: String) {
-        guard !answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        if isDemo {
-            let resolved = (groups.needsResponse + groups.working + groups.done).map { s -> AgentSession in
-                guard s.id == sessionId else { return s }
-                var s = s
-                s.pendingQuestion = nil
-                s.waitKind = nil
-                s.status = .working
-                s.summary = "Answered from phone: \(answer)"
-                return s
-            }
-            install(resolved)
-            return
+        Task { await submitAction(sessionId: sessionId, text: answer) }
+    }
+
+    /// Send one existing-session action. Duplicate taps reuse the in-flight
+    /// request id; a lost receipt stays `unknown` and is not resent.
+    @discardableResult
+    func submitAction(sessionId: String, text: String? = nil, answers: QuestionAnswers? = nil) async -> SessionActionOutcome {
+        let typed = text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if (typed == nil || typed?.isEmpty == true) && (answers == nil || answers?.isEmpty == true) {
+            return publishAction(.failed(String(localized: "Empty instruction")))
         }
-        guard let pairing else { return }
-        Task { await decisionClient.answer(pairing, sessionId: sessionId, answer: answer) }
+        if !isDemo {
+            guard pairing != nil, state == .connected else {
+                return publishAction(.notSent(String(localized: "Couldn't reach your Mac — not sent")))
+            }
+        }
+        guard let session = allSessions.first(where: { $0.id == sessionId }) else {
+            return publishAction(.failed(String(localized: "No matching session.")))
+        }
+        let support = SessionActionSupport.resolve(for: session)
+        if let reason = support.unsupportedReason {
+            return publishAction(.failed(reason))
+        }
+        if isDemo {
+            applyDemoAction(sessionId: sessionId, text: typed ?? answers.map { $0.values.flatMap { $0 }.joined(separator: ", ") } ?? "")
+            return publishAction(.accepted)
+        }
+        guard let pairing else {
+            return publishAction(.notSent(String(localized: "Couldn't reach your Mac — not sent")))
+        }
+        if actionPhase == .sending {
+            return actionReceipt ?? .unknown
+        }
+        let request = SessionActionRequest(
+            sessionID: sessionId,
+            intent: support.intent,
+            questionID: session.pendingQuestion?.id,
+            text: typed,
+            answers: answers)
+        inFlightRequestIDs.insert(request.requestID)
+        actionPhase = .sending
+        actionReceipt = nil
+        showToast(String(localized: "Sending…"))
+        let outcome = await decisionClient.submitSessionAction(pairing, request: request)
+        inFlightRequestIDs.remove(request.requestID)
+        actionPhase = .idle
+        return publishAction(outcome)
+    }
+
+    private func applyDemoAction(sessionId: String, text: String) {
+        let resolved = allSessions.map { s -> AgentSession in
+            guard s.id == sessionId else { return s }
+            var s = s
+            s.pendingQuestion = nil
+            s.waitKind = nil
+            s.status = .working
+            s.summary = "Answered from phone: \(text)"
+            return s
+        }
+        install(resolved)
+    }
+
+    private func publishAction(_ outcome: SessionActionOutcome) -> SessionActionOutcome {
+        actionReceipt = outcome
+        showToast(Self.actionMessage(outcome))
+        return outcome
+    }
+
+    /// Honest copy: accepted is not working or finished; unknown is not resent.
+    static func actionMessage(_ outcome: SessionActionOutcome) -> String {
+        switch outcome {
+        case .notSent(let why): return why
+        case .accepted: return String(localized: "Accepted — not yet working or finished")
+        case .failed(let why): return why
+        case .unknown: return String(localized: "Sent, but the result is unknown — not resent")
+        }
     }
 
     private static func demoSessions() -> [AgentSession] {
@@ -401,6 +454,16 @@ final class DashboardStore: ObservableObject {
     /// A brief, self-clearing status line for one-shot actions (e.g. jump result).
     @Published var toast: String?
     private var toastTask: Task<Void, Never>?
+    /// Last existing-session send: sending, or the receipt the composer shows.
+    @Published private(set) var actionPhase: ActionPhase = .idle
+    @Published private(set) var actionReceipt: SessionActionOutcome?
+    /// Request ids currently in flight, so a second tap is not another send.
+    private var inFlightRequestIDs: Set<String> = []
+
+    enum ActionPhase: Equatable {
+        case idle
+        case sending
+    }
 
     /// Start a new task on the Mac. Returns the Mac's answer as a toast-ready
     /// line; nil when it could not be reached.

--- a/VibeBuddyApp/Sources/DashboardView.swift
+++ b/VibeBuddyApp/Sources/DashboardView.swift
@@ -70,6 +70,10 @@ struct DashboardView: View {
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             StreamComposer(target: replyTarget,
+                           macName: connection.pairing?.macName,
+                           reachable: dashboard.state == .connected,
+                           sending: dashboard.actionPhase == .sending,
+                           receipt: dashboard.actionReceipt,
                            clearTarget: { replyTo = nil },
                            send: send(_:))
                 .background(CompanionPalette.bg)
@@ -148,7 +152,7 @@ struct DashboardView: View {
             showNewTask = true
             return
         }
-        dashboard.answer(target.id, answer: text)
+        Task { await dashboard.submitAction(sessionId: target.id, text: text) }
         replyTo = nil
     }
 
@@ -240,8 +244,11 @@ enum ReplyMeaning: Equatable {
 
     init(target: AgentSession?) {
         guard let target else { self = .newTask; return }
-        if let q = target.pendingQuestion, q.isAnswerable { self = .answer; return }
-        self = target.status == .done ? .continuation : .instruction
+        switch SessionActionSupport.resolve(for: target).intent {
+        case .answer: self = .answer
+        case .steer: self = .instruction
+        case .continue: self = .continuation
+        }
     }
 
     var verb: LocalizedStringKey {
@@ -250,6 +257,15 @@ enum ReplyMeaning: Equatable {
         case .instruction: "Send instruction"
         case .continuation: "Continue"
         case .newTask: "New task"
+        }
+    }
+
+    var verbLabel: String {
+        switch self {
+        case .answer: String(localized: "Answer")
+        case .instruction: String(localized: "Send instruction")
+        case .continuation: String(localized: "Continue")
+        case .newTask: String(localized: "New task")
         }
     }
 
@@ -262,11 +278,8 @@ enum ReplyMeaning: Equatable {
         }
     }
 
-    /// Instructions and continuations travel through the Codex app-server; a
-    /// Claude Code session has no such channel from the phone yet.
     func unsupportedReason(for target: AgentSession?) -> String? {
-        guard let target, self == .instruction || self == .continuation, target.agent != .codex else { return nil }
-        return String(localized: "\(target.agent.displayName) sessions can't take instructions from the phone yet — use the terminal.")
+        target.flatMap { SessionActionSupport.resolve(for: $0).unsupportedReason }
     }
 }
 
@@ -282,10 +295,7 @@ private struct MessageRow: View {
     @EnvironmentObject private var dashboard: DashboardStore
 
     private var state: TaskPresentationState { session.presentationState }
-    private var canReply: Bool {
-        if let q = session.pendingQuestion, q.isAnswerable { return true }
-        return session.agent == .codex
-    }
+    private var canReply: Bool { true }
 
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
@@ -421,6 +431,10 @@ private struct MessageRow: View {
 /// a reply target the banner names both; without one the text is a new task.
 private struct StreamComposer: View {
     let target: AgentSession?
+    let macName: String?
+    let reachable: Bool
+    let sending: Bool
+    let receipt: SessionActionOutcome?
     let clearTarget: () -> Void
     let send: (String) -> Void
     @State private var draft = ""
@@ -429,7 +443,8 @@ private struct StreamComposer: View {
     private var meaning: ReplyMeaning { ReplyMeaning(target: target) }
     private var unsupported: String? { meaning.unsupportedReason(for: target) }
     private var canSend: Bool {
-        unsupported == nil && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        reachable && !sending && unsupported == nil
+            && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     var body: some View {
@@ -437,8 +452,10 @@ private struct StreamComposer: View {
             if let target {
                 HStack(spacing: 8) {
                     VStack(alignment: .leading, spacing: 1) {
-                        Text("Replying to \(target.displayTitle) · \(target.presentationState.label)")
+                        Text(SessionActionSupport.targetCaption(macName: macName, session: target))
                             .font(CompanionType.font(10, .heavy)).foregroundStyle(CompanionPalette.ink2)
+                        Text("\(meaning.verbLabel) · \(target.displayTitle) · \(target.presentationState.label)")
+                            .font(CompanionType.font(11, .bold)).foregroundStyle(CompanionPalette.ink2)
                         Text(unsupported ?? target.summary ?? ToolActivity.label(for: target))
                             .font(CompanionType.font(12, .bold))
                             .foregroundStyle(unsupported == nil ? CompanionPalette.ink : CompanionPalette.status(.error))
@@ -480,9 +497,27 @@ private struct StreamComposer: View {
             }
             .background(CompanionPalette.bg3, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
             .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+            if sending {
+                Text("Sending…")
+                    .font(CompanionType.font(11, .bold)).foregroundStyle(CompanionPalette.ink2)
+            } else if !reachable {
+                Text("Couldn't reach your Mac — not sent")
+                    .font(CompanionType.font(11, .bold)).foregroundStyle(CompanionPalette.status(.error))
+            } else if let receipt {
+                Text(DashboardStore.actionMessage(receipt))
+                    .font(CompanionType.font(11, .bold))
+                    .foregroundStyle(receiptColor(receipt))
+            }
         }
         .padding(.horizontal, 12).padding(.top, 6).padding(.bottom, 8)
         .onChange(of: target?.id) { _, id in if id != nil { focused = true } }
+    }
+
+    private func receiptColor(_ receipt: SessionActionOutcome) -> Color {
+        switch receipt {
+        case .accepted: CompanionPalette.ink2
+        case .unknown, .notSent, .failed: CompanionPalette.status(.error)
+        }
     }
 
     private func submit() {

--- a/VibeBuddyApp/Tests/DashboardStoreTests.swift
+++ b/VibeBuddyApp/Tests/DashboardStoreTests.swift
@@ -19,6 +19,20 @@ private actor DecisionRecorder: DecisionClient {
     func jump(_ pairing: PairingPayload, sessionId: String) async -> JumpOutcome? { nil }
 }
 
+private actor ActionRecorder: DecisionClient {
+    private(set) var submits: [SessionActionRequest] = []
+
+    func acknowledge(_ pairing: PairingPayload, sessionId: String) async {}
+    func setAttention(_ pairing: PairingPayload, sessionId: String, level: SessionAttention?) async {}
+    func decide(_ pairing: PairingPayload, approvalId: String, decision: ApprovalDecision) async -> Bool { true }
+    func answer(_ pairing: PairingPayload, sessionId: String, answer: String) async {}
+    func jump(_ pairing: PairingPayload, sessionId: String) async -> JumpOutcome? { nil }
+    func submitSessionAction(_ pairing: PairingPayload, request: SessionActionRequest) async -> SessionActionOutcome {
+        submits.append(request)
+        return .accepted
+    }
+}
+
 @MainActor
 final class DashboardStoreTests: XCTestCase {
     func testColdStartDeepLinkReplaysAcknowledgementAfterPairingStarts() async throws {
@@ -66,6 +80,34 @@ final class DashboardStoreTests: XCTestCase {
         let sent = await decisions.attentions
         XCTAssertEqual(sent.map(\.sessionId), ["s"])
         XCTAssertEqual(sent.map(\.level), [.followed])
+        store.stop()
+    }
+
+    /// The Mac's device registry can be emptied by a Mac restart while this app
+    /// is only backgrounded. Reporting once per launch left the Mac unable to
+    /// push until the phone next cold-launched; every reconnect must repair it.
+    func testDisconnectedActionIsNotSent() async throws {
+        let decisions = ActionRecorder()
+        let store = DashboardStore(streamer: EmptyStreamer(), notifier: SilentNotifier(),
+                                   decisionClient: decisions, watchRelay: nil)
+        store.start(PairingPayload(host: "127.0.0.1", port: 9, token: "test"))
+        let outcome = await store.submitAction(sessionId: "s", text: "keep going")
+        XCTAssertEqual(outcome, .notSent("Couldn't reach your Mac — not sent"))
+        let sentWhileDisconnected = await decisions.submits
+        XCTAssertEqual(sentWhileDisconnected.count, 0)
+        store.stop()
+    }
+
+    func testDemoCodexSteerIsAcceptedNotWorking() async throws {
+        let decisions = ActionRecorder()
+        let store = DashboardStore(streamer: EmptyStreamer(), notifier: SilentNotifier(),
+                                   decisionClient: decisions, watchRelay: nil)
+        store.startDemo()
+        let outcome = await store.submitAction(sessionId: "demo-work", text: "also run the tests")
+        XCTAssertEqual(outcome, .accepted)
+        XCTAssertEqual(store.toast, DashboardStore.actionMessage(.accepted))
+        let sentInDemo = await decisions.submits
+        XCTAssertEqual(sentInDemo.count, 0)
         store.stop()
     }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SessionAction.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SessionAction.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// What free text on an existing session means. Distinct from Approval
+/// (native allow/deny) and from New task (a new session). Vision Q29.
+public enum SessionActionIntent: String, Codable, Sendable {
+    /// Bind to the current waiting question. An expired question must not
+    /// become an instruction.
+    case answer
+    /// Join the running turn (`turn/steer`). Failure must not start a turn.
+    case steer
+    /// Open the next turn on a finished session (`turn/start`).
+    case `continue`
+}
+
+/// What the client may honestly say after a send. Accepted means the daemon
+/// took the request — not that the session is working or finished.
+public enum SessionActionOutcome: Equatable, Sendable {
+    case notSent(String)
+    case accepted
+    case failed(String)
+    case unknown
+}
+
+/// Phone/Mac shared rule: which intent a session's composer should send,
+/// and whether that agent can actually do it right now.
+public struct SessionActionSupport: Equatable, Sendable {
+    public var intent: SessionActionIntent
+    public var unsupportedReason: String?
+
+    public init(intent: SessionActionIntent, unsupportedReason: String? = nil) {
+        self.intent = intent
+        self.unsupportedReason = unsupportedReason
+    }
+
+    public var isAvailable: Bool { unsupportedReason == nil }
+
+    public static func resolve(for session: AgentSession) -> SessionActionSupport {
+        if let question = session.pendingQuestion {
+            let reason = question.isAnswerable
+                ? nil
+                : String(localized: "You're at the Mac — answer this in the agent's own prompt.")
+            return SessionActionSupport(intent: .answer, unsupportedReason: reason)
+        }
+        let intent: SessionActionIntent = session.status == .done ? .continue : .steer
+        guard session.agent == .codex else {
+            return SessionActionSupport(
+                intent: intent,
+                unsupportedReason: String(localized: "\(session.agent.displayName) sessions can't take instructions from the phone yet — use the terminal."))
+        }
+        return SessionActionSupport(intent: intent)
+    }
+
+    /// Shown before send: which Mac, project and agent will receive this.
+    public static func targetCaption(macName: String?, session: AgentSession) -> String {
+        let trimmed = macName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let mac = trimmed.isEmpty ? String(localized: "Mac") : trimmed
+        return "\(mac) · \(session.project) · \(session.agent.shortName)"
+    }
+}
+
+/// Client → daemon payload for `/answer`. `intent` and `requestID` are how
+/// the daemon refuses an expired answer and ignores a duplicate tap.
+public struct SessionActionRequest: Equatable, Sendable {
+    public var sessionID: String
+    public var intent: SessionActionIntent?
+    public var requestID: String
+    public var questionID: String?
+    public var text: String?
+    public var answers: QuestionAnswers?
+
+    public init(sessionID: String,
+                intent: SessionActionIntent? = nil,
+                requestID: String = UUID().uuidString,
+                questionID: String? = nil,
+                text: String? = nil,
+                answers: QuestionAnswers? = nil) {
+        self.sessionID = sessionID
+        self.intent = intent
+        self.requestID = requestID
+        self.questionID = questionID
+        self.text = text
+        self.answers = answers
+    }
+}
+
+public extension SessionActionOutcome {
+    /// Map a daemon `/answer` HTTP result. No response at all is the caller's
+    /// job (`notSent` before the request, `unknown` after a transport error).
+    static func fromHTTP(statusCode: Int, body: [String: String]) -> SessionActionOutcome {
+        switch body["status"] {
+        case "accepted": return .accepted
+        case "failed": return .failed(body["error"] ?? String(localized: "The Mac refused"))
+        case "unknown": return .unknown
+        default:
+            if statusCode == 202 {
+                return .failed(body["error"] ?? String(localized: "Not delivered"))
+            }
+            if (200..<300).contains(statusCode) { return .accepted }
+            return .failed(body["error"] ?? String(localized: "The Mac refused"))
+        }
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SessionActionTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SessionActionTests.swift
@@ -1,0 +1,78 @@
+import Testing
+import Foundation
+@testable import VibeBuddyKit
+
+@Suite("Session action semantics")
+struct SessionActionTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func session(
+        agent: AgentKind = .codex,
+        status: SessionStatus,
+        question: PendingQuestion? = nil,
+        approval: PendingApproval? = nil,
+        project: String = "ios-vibebuddy"
+    ) -> AgentSession {
+        AgentSession(
+            id: "s", agent: agent, project: project,
+            status: status,
+            waitKind: question != nil ? .question : approval != nil ? .permission : nil,
+            pendingApproval: approval,
+            pendingQuestion: question,
+            statusSince: now, updatedAt: now)
+    }
+
+    @Test("an answerable question is Answer, not an instruction")
+    func questionIsAnswer() {
+        let q = PendingQuestion(id: "q1", prompt: "Which one?")
+        let support = SessionActionSupport.resolve(for: session(status: .needsResponse, question: q))
+        #expect(support.intent == .answer)
+        #expect(support.isAvailable)
+    }
+
+    @Test("a read-only question stays Answer and names the Mac prompt")
+    func readOnlyQuestionDoesNotBecomeSteer() {
+        let q = PendingQuestion(id: "q1", prompt: "Which one?", answerable: false)
+        let support = SessionActionSupport.resolve(for: session(status: .needsResponse, question: q))
+        #expect(support.intent == .answer)
+        #expect(support.unsupportedReason != nil)
+        #expect(support.unsupportedReason?.contains("Mac") == true)
+    }
+
+    @Test("a running Codex session is a steer; a done one is continue")
+    func codexByStatus() {
+        #expect(SessionActionSupport.resolve(for: session(status: .working)).intent == .steer)
+        #expect(SessionActionSupport.resolve(for: session(status: .done)).intent == .continue)
+        #expect(SessionActionSupport.resolve(for: session(status: .working)).isAvailable)
+        #expect(SessionActionSupport.resolve(for: session(status: .done)).isAvailable)
+    }
+
+    @Test("Claude cannot take steer or continue from the phone")
+    func claudeInstructionIsUnsupported() {
+        let working = SessionActionSupport.resolve(for: session(agent: .claudeCode, status: .working))
+        #expect(working.intent == .steer)
+        #expect(working.unsupportedReason?.contains("Claude") == true)
+        let done = SessionActionSupport.resolve(for: session(agent: .claudeCode, status: .done))
+        #expect(done.intent == .continue)
+        #expect(done.unsupportedReason != nil)
+    }
+
+    @Test("the send caption names Mac, project and agent")
+    func targetCaption() {
+        let s = session(status: .working, project: "search-indexer")
+        #expect(SessionActionSupport.targetCaption(macName: "Studio", session: s)
+                == "Studio · search-indexer · Codex")
+        #expect(SessionActionSupport.targetCaption(macName: "  ", session: s)
+                .hasPrefix("Mac ·"))
+    }
+
+    @Test("HTTP 200 accepted is not a transport miss; 202 and 409 are failures")
+    func httpMapping() {
+        #expect(SessionActionOutcome.fromHTTP(statusCode: 200, body: ["status": "accepted"]) == .accepted)
+        #expect(SessionActionOutcome.fromHTTP(statusCode: 202, body: ["status": "failed", "error": "gone"])
+                == .failed("gone"))
+        #expect(SessionActionOutcome.fromHTTP(statusCode: 409, body: ["status": "failed", "error": "expired"])
+                == .failed("expired"))
+        #expect(SessionActionOutcome.fromHTTP(statusCode: 503, body: ["error": "down"]) == .failed("down"))
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerMonitor.swift
@@ -437,35 +437,51 @@ public actor CodexAppServerMonitor {
         client.respond(id: id, result: ["answers": payload])
     }
 
-    /// Put free text into a thread (ticket 04): `turn/steer` joins a running
-    /// turn, `turn/start` opens one on an idle thread, and a thread the daemon
-    /// has unloaded is resumed first. Nothing about the thread's model,
-    /// approval policy or sandbox is touched. False when there is no
-    /// connection or the daemon refused.
-    public func steer(threadID: String, text: String, isActive: Bool) async -> Bool {
+    /// Join a running turn. Does not start a new one when steer fails (Q35).
+    /// Sends `expectedTurnId` when the reducer still knows the active turn.
+    public func steer(threadID: String, text: String) async -> Bool {
         guard let client, state.connected else { return false }
+        guard await resumeIfNeeded(threadID: threadID) else { return false }
+        var input: [String: Any] = ["threadId": threadID, "input": [["type": "text", "text": text]]]
+        if let turnID = reducer.threads[threadID]?.activeTurnID {
+            input["expectedTurnId"] = turnID
+        }
+        do {
+            _ = try await client.request("turn/steer", params: input)
+            return true
+        } catch {
+            state.lastError = "turn/steer \(threadID.suffix(8)): \(error)"
+            return false
+        }
+    }
+
+    /// Open the next turn on an idle or cold thread. Resume first when the
+    /// daemon has unloaded it. Nothing about model, approval or sandbox.
+    public func startTurn(threadID: String, text: String) async -> Bool {
+        guard let client, state.connected else { return false }
+        guard await resumeIfNeeded(threadID: threadID) else { return false }
         let input: [String: Any] = ["threadId": threadID, "input": [["type": "text", "text": text]]]
-        if reducer.threads[threadID]?.loaded != true {
-            do {
-                let result = try await client.request("thread/resume", params: ["threadId": threadID, "excludeTurns": true])
-                subscribed.insert(threadID)
-                if let thread = result["thread"] as? [String: Any] {
-                    _ = reducer.seed(thread: thread, receivedAt: Date())
-                }
-            } catch {
-                state.lastError = "thread/resume \(threadID.suffix(8)): \(error)"
-                return false
-            }
-        }
-        if isActive {
-            if (try? await client.request("turn/steer", params: input)) != nil { return true }
-            // The turn ended between the snapshot and the call: start one.
-        }
         do {
             _ = try await client.request("turn/start", params: input)
             return true
         } catch {
             state.lastError = "turn/start \(threadID.suffix(8)): \(error)"
+            return false
+        }
+    }
+
+    private func resumeIfNeeded(threadID: String) async -> Bool {
+        guard let client else { return false }
+        guard reducer.threads[threadID]?.loaded != true else { return true }
+        do {
+            let result = try await client.request("thread/resume", params: ["threadId": threadID, "excludeTurns": true])
+            subscribed.insert(threadID)
+            if let thread = result["thread"] as? [String: Any] {
+                _ = reducer.seed(thread: thread, receivedAt: Date())
+            }
+            return true
+        } catch {
+            state.lastError = "thread/resume \(threadID.suffix(8)): \(error)"
             return false
         }
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerReducer.swift
@@ -19,6 +19,10 @@ public struct CodexAppServerReducer: Sendable, Equatable {
         public var branch: String?
         public var model: String?
         public var loaded: Bool
+        /// The running turn, when the daemon has named one. `turn/steer`
+        /// sends it as `expectedTurnId` so a late steer cannot attach to
+        /// a later turn.
+        public var activeTurnID: String?
     }
 
     public private(set) var threads: [String: ThreadFacts] = [:]
@@ -33,7 +37,7 @@ public struct CodexAppServerReducer: Sendable, Equatable {
         guard let id = thread["id"] as? String, !id.isEmpty else { return [] }
         if Self.isSubagentThread(thread) { return [] }
         let source = Self.sourceName(thread["source"])
-        var facts = threads[id] ?? ThreadFacts(cwd: nil, isDesktop: false, branch: nil, model: nil, loaded: false)
+        var facts = threads[id] ?? ThreadFacts(cwd: nil, isDesktop: false, branch: nil, model: nil, loaded: false, activeTurnID: nil)
         if let cwd = thread["cwd"] as? String, !cwd.isEmpty { facts.cwd = cwd }
         facts.isDesktop = source == "vscode"
         if let git = thread["gitInfo"] as? [String: Any], let branch = git["branch"] as? String, !branch.isEmpty {
@@ -41,6 +45,7 @@ public struct CodexAppServerReducer: Sendable, Equatable {
         }
         let status = thread["status"] as? [String: Any]
         facts.loaded = (status?["type"] as? String).map { $0 != "notLoaded" } ?? false
+        if (status?["type"] as? String) == "idle" { facts.activeTurnID = nil }
         threads[id] = facts
         guard facts.loaded, let status else { return [] }
         return statusEvents(threadID: id, status: status, receivedAt: receivedAt, includeBranch: true)
@@ -58,18 +63,26 @@ public struct CodexAppServerReducer: Sendable, Equatable {
             return seed(thread: thread, receivedAt: receivedAt)
         case "thread/status/changed":
             guard let id = params["threadId"] as? String, let status = params["status"] as? [String: Any] else { return [] }
-            var facts = threads[id] ?? ThreadFacts(cwd: nil, isDesktop: false, branch: nil, model: nil, loaded: false)
+            var facts = threads[id] ?? ThreadFacts(cwd: nil, isDesktop: false, branch: nil, model: nil, loaded: false, activeTurnID: nil)
             facts.loaded = (status["type"] as? String) != "notLoaded"
+            if (status["type"] as? String) == "idle" { facts.activeTurnID = nil }
             threads[id] = facts
             guard facts.loaded else { return [] }
             return statusEvents(threadID: id, status: status, receivedAt: receivedAt, includeBranch: false)
         case "turn/started":
             guard let id = params["threadId"] as? String else { return [] }
             let turn = params["turn"] as? [String: Any]
+            if let turnID = turn?["id"] as? String {
+                var facts = threads[id] ?? ThreadFacts(cwd: nil, isDesktop: false, branch: nil, model: nil, loaded: true, activeTurnID: nil)
+                facts.activeTurnID = turnID
+                facts.loaded = true
+                threads[id] = facts
+            }
             return [event(.userPromptSubmit, threadID: id, receivedAt: receivedAt,
                           turnID: turn?["id"] as? String)]
         case "turn/completed":
             guard let id = params["threadId"] as? String else { return [] }
+            threads[id]?.activeTurnID = nil
             let turn = params["turn"] as? [String: Any] ?? [:]
             let status = turn["status"] as? String ?? "completed"
             let message: String?

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/QuestionRegistry.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/QuestionRegistry.swift
@@ -68,53 +68,147 @@ public actor QuestionRegistry {
     private func forgetEarly(sessionID: String) { early[sessionID] = nil }
 }
 
-/// Where a phone or Mac answer goes: to the agent waiting on it through its
-/// own contract when it is, else typed into the session's terminal (tmux only),
-/// else nowhere — the caller reports "not delivered".
+/// Recent `/answer` request ids, so a duplicate tap returns the first result
+/// instead of running the action twice. Lost after a daemon restart — the
+/// client must then show unknown, not claim exactly-once.
+public actor ActionRequestLog {
+    private var seen: [String: SessionActionDelivery] = [:]
+    private var order: [String] = []
+    private let limit = 64
+
+    public init() {}
+
+    public func recall(_ id: String) -> SessionActionDelivery? { seen[id] }
+
+    public func remember(_ id: String, _ result: SessionActionDelivery) {
+        if seen[id] == nil { order.append(id) }
+        seen[id] = result
+        while order.count > limit {
+            seen.removeValue(forKey: order.removeFirst())
+        }
+    }
+}
+
+/// Daemon-side result of one session action. The phone maps this onto
+/// `SessionActionOutcome` (adding not-sent / unknown around the transport).
+public enum SessionActionDelivery: Equatable, Sendable {
+    case accepted
+    case failed(String)
+}
+
+/// Where a phone or Mac action goes: to the waiting agent through its own
+/// contract, else Codex `turn/steer` / `turn/start` by intent, else a tmux
+/// pane for an old no-intent Claude reply. Steer never becomes start.
 public struct AnswerDispatch: Sendable {
     public let store: SessionStore
     public let questions: QuestionRegistry
     public let inject: @Sendable (TerminalRef, String) -> Void
-    /// Codex: put free text into the thread through the app-server daemon
-    /// (`turn/steer` while a turn runs, `turn/start` when idle). Arguments:
-    /// thread id, text, whether the session is currently active.
-    public let steer: @Sendable (String, String, Bool) async -> Bool
+    /// Codex `turn/steer` only. False when the daemon refused or there is no
+    /// connection — the caller must not start a turn.
+    public let steer: @Sendable (String, String) async -> Bool
+    /// Codex `turn/start` (resume first when the thread is cold).
+    public let startTurn: @Sendable (String, String) async -> Bool
+    public let requests: ActionRequestLog
 
     public init(store: SessionStore, questions: QuestionRegistry,
                 inject: @escaping @Sendable (TerminalRef, String) -> Void,
-                steer: @escaping @Sendable (String, String, Bool) async -> Bool = { _, _, _ in false }) {
+                steer: @escaping @Sendable (String, String) async -> Bool = { _, _ in false },
+                startTurn: @escaping @Sendable (String, String) async -> Bool = { _, _ in false },
+                requests: ActionRequestLog = ActionRequestLog()) {
         self.store = store
         self.questions = questions
         self.inject = inject
         self.steer = steer
+        self.startTurn = startTurn
+        self.requests = requests
     }
 
-    /// `answers` are keyed by question id; `text` is a plain reply (voice, an
-    /// older phone build). Either fills the other in.
+    /// Older callers: infer intent from the live session and return whether
+    /// anything was delivered.
     @discardableResult
     public func deliver(sessionID: String, text: String?, answers: QuestionAnswers?) async -> Bool {
-        let session = await store.snapshot(now: Date()).sessions.first { $0.id == sessionID }
+        let result = await deliver(SessionActionRequest(sessionID: sessionID, text: text, answers: answers))
+        if case .accepted = result { return true }
+        return false
+    }
+
+    public func deliver(_ request: SessionActionRequest) async -> SessionActionDelivery {
+        if let prior = await requests.recall(request.requestID) { return prior }
+        let result = await execute(request)
+        await requests.remember(request.requestID, result)
+        return result
+    }
+
+    private func execute(_ request: SessionActionRequest) async -> SessionActionDelivery {
+        let session = await store.snapshot(now: Date()).sessions.first { $0.id == request.sessionID }
         let pending = session?.pendingQuestion
-        let structured = Self.normalize(answers: answers, text: text, for: pending)
-        if !structured.isEmpty, await questions.isWaiting(sessionID: sessionID) {
-            await questions.resolve(sessionID: sessionID, answers: structured)
-            return true
+        let waiting = await questions.isWaiting(sessionID: request.sessionID)
+        let structured = Self.normalize(answers: request.answers, text: request.text, for: pending)
+        let typed = request.text ?? Self.flatten(structured)
+        let intent = request.intent ?? inferredIntent(session: session, waiting: waiting, pending: pending)
+
+        if intent == .answer {
+            if let questionID = request.questionID, let pending,
+               pending.id != questionID, !pending.items.contains(where: { $0.id == questionID }) {
+                return .failed("This question is no longer waiting")
+            }
+            guard waiting, !structured.isEmpty else {
+                return .failed("This question is no longer waiting")
+            }
+            await questions.resolve(sessionID: request.sessionID, answers: structured)
+            return .accepted
         }
-        let typed = text ?? Self.flatten(structured)
-        guard !typed.isEmpty else { return false }
-        if session?.agent == .codex {
-            // Codex threads take instructions through the daemon, never through
-            // a terminal: the thread may live in Desktop, and typing into a
-            // pane cannot address a specific thread anyway.
-            let active = session.map { $0.status != .done } ?? false
-            guard await steer(sessionID, typed, active) else { return false }
-            await store.endQuestion(sessionID: sessionID, at: Date())
-            return true
+
+        guard !typed.isEmpty else { return .failed("Empty instruction") }
+
+        if intent == .steer {
+            guard session?.agent == .codex else {
+                return .failed("\(session?.agent.displayName ?? "This agent") sessions can't take instructions from here")
+            }
+            guard session?.status != .done else {
+                return .failed("This turn has already ended")
+            }
+            guard await steer(request.sessionID, typed) else {
+                return .failed("The agent refused the instruction")
+            }
+            await store.endQuestion(sessionID: request.sessionID, at: Date())
+            return .accepted
         }
-        guard let ref = await store.terminalRef(for: sessionID) else { return false }
+
+        if intent == .continue {
+            guard session?.agent == .codex else {
+                return .failed("\(session?.agent.displayName ?? "This agent") sessions can't continue from here")
+            }
+            guard session?.status == .done else {
+                return .failed("This session is still running")
+            }
+            guard await startTurn(request.sessionID, typed) else {
+                return .failed("Couldn't start the next turn")
+            }
+            return .accepted
+        }
+
+        // No explicit intent and not a Codex thread: the old Claude "type into
+        // the pane" path. Never used when a question was pending — that already
+        // took the answer branch and failed if nothing was waiting.
+        guard request.intent == nil else {
+            return .failed("This agent can't take that action from here")
+        }
+        guard let ref = await store.terminalRef(for: request.sessionID) else {
+            return .failed("Nothing was waiting, and there is no tmux pane to type into.")
+        }
         inject(ref, typed)
-        await store.endQuestion(sessionID: sessionID, at: Date())
-        return true
+        await store.endQuestion(sessionID: request.sessionID, at: Date())
+        return .accepted
+    }
+
+    /// When an older client omits intent: a live or leftover question is
+    /// Answer (and will fail if the wait is gone); Codex follows status;
+    /// everything else falls through to tmux.
+    private func inferredIntent(session: AgentSession?, waiting: Bool, pending: PendingQuestion?) -> SessionActionIntent? {
+        if waiting || pending != nil { return .answer }
+        guard session?.agent == .codex else { return nil }
+        return session?.status == .done ? .continue : .steer
     }
 
     /// A plain text answer maps onto the first question; structured answers

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -71,6 +71,8 @@ public struct VibeBuddyServer: Sendable {
     /// default pushes to paired phones over APNs (the headless daemon); the
     /// menu-bar app supplies its own that also posts a local banner.
     public let onCompletionReminder: (@Sendable (AgentSession) async -> Bool)?
+    /// Dedup for `/answer` request ids across the life of this process.
+    public let actionRequests: ActionRequestLog
 
     public init(store: SessionStore, token: String, host: String = "0.0.0.0",
                 port: Int = 9876, pusher: APNsPusher? = nil,
@@ -100,7 +102,8 @@ public struct VibeBuddyServer: Sendable {
                 },
                 onDispatch: (@Sendable (DispatchRequest) async -> DispatchOutcome)? = nil,
                 claudeLauncher: ClaudeBackgroundLauncher = ClaudeBackgroundLauncher(),
-                onCompletionReminder: (@Sendable (AgentSession) async -> Bool)? = nil) {
+                onCompletionReminder: (@Sendable (AgentSession) async -> Bool)? = nil,
+                actionRequests: ActionRequestLog = ActionRequestLog()) {
         self.store = store
         self.token = token
         self.host = host
@@ -131,6 +134,7 @@ public struct VibeBuddyServer: Sendable {
         self.claudeLauncher = claudeLauncher
         self.onDevicePaired = onDevicePaired
         self.onCompletionReminder = onCompletionReminder
+        self.actionRequests = actionRequests
     }
 
     /// Run the HTTP service and its Codex rollout source under one lifetime.
@@ -792,17 +796,19 @@ public struct VibeBuddyServer: Sendable {
             }
         }
 
-        // `{"sessionId", "answer"?: text, "answers"?: {questionId: [labels]}}`.
-        // Structured answers reach a waiting agent through its own contract;
-        // plain text (voice, older phone builds) maps onto the first question,
-        // or is typed into the terminal when nothing is waiting. 202 says the
-        // answer had nowhere to go.
+        // `{"sessionId", "intent"?, "requestId"?, "questionId"?, "answer"?, "answers"?}`.
+        // Intent is Answer / steer / continue (Q29). A missing intent is inferred
+        // from the live session; an expired Answer still does not become steer.
         let monitor = self.codexAppServerMonitor
         let dispatch = AnswerDispatch(store: store, questions: questionRegistry, inject: self.onAnswer,
-                                      steer: { sessionID, text, active in
-                                          await monitor?.steer(threadID: sessionID, text: text, isActive: active) ?? false
-                                      })
-        authed.post("answer") { request, _ -> HTTPResponse.Status in
+                                      steer: { sessionID, text in
+                                          await monitor?.steer(threadID: sessionID, text: text) ?? false
+                                      },
+                                      startTurn: { sessionID, text in
+                                          await monitor?.startTurn(threadID: sessionID, text: text) ?? false
+                                      },
+                                      requests: self.actionRequests)
+        authed.post("answer") { request, _ -> Response in
             let buffer = try await request.body.collect(upTo: 64 * 1024)
             guard let o = try? JSONSerialization.jsonObject(with: Data(buffer: buffer)) as? [String: Any],
                   let sid = o["sessionId"] as? String
@@ -816,10 +822,17 @@ public struct VibeBuddyServer: Sendable {
                 }
             }
             guard !(text ?? "").isEmpty || !answers.isEmpty else { throw HTTPError(.badRequest) }
-            let delivered = await dispatch.deliver(sessionID: sid, text: text, answers: answers.isEmpty ? nil : answers)
-            // Answering counts as driving the session (automatic attention).
-            if delivered { await store.recordInteraction(sessionID: sid) }
-            return delivered ? .ok : .accepted
+            let intent = (o["intent"] as? String).flatMap(SessionActionIntent.init(rawValue:))
+            let action = SessionActionRequest(
+                sessionID: sid,
+                intent: intent,
+                requestID: (o["requestId"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? UUID().uuidString,
+                questionID: o["questionId"] as? String,
+                text: text,
+                answers: answers.isEmpty ? nil : answers)
+            let delivered = await dispatch.deliver(action)
+            if case .accepted = delivered { await store.recordInteraction(sessionID: sid) }
+            return Self.actionResponse(delivered, requestID: action.requestID, explicitIntent: intent != nil)
         }
 
         return router
@@ -877,6 +890,26 @@ public struct VibeBuddyServer: Sendable {
         return Response(status: .ok,
                         headers: [.contentType: "application/json"],
                         body: .init(byteBuffer: ByteBuffer(string: json)))
+    }
+
+    /// `/answer` body: accepted is 200; an explicit-intent failure is 409 so
+    /// the phone can show it; an old client with nowhere to go stays 202.
+    static func actionResponse(_ result: SessionActionDelivery, requestID: String,
+                               explicitIntent: Bool) -> Response {
+        var body: [String: String] = ["requestId": requestID]
+        let status: HTTPResponse.Status
+        switch result {
+        case .accepted:
+            body["status"] = "accepted"
+            status = .ok
+        case .failed(let why):
+            body["status"] = "failed"
+            body["error"] = why
+            status = explicitIntent ? .conflict : .accepted
+        }
+        let data = (try? JSONEncoder().encode(body)) ?? Data()
+        return Response(status: status, headers: [.contentType: "application/json"],
+                        body: .init(byteBuffer: ByteBuffer(bytes: data)))
     }
 
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PresenceAndSteerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PresenceAndSteerTests.swift
@@ -148,24 +148,25 @@ struct CodexSteerTests {
         defer { h.stop() }
         #expect(await h.connected())
         await h.activate("thr-live")
-        #expect(await h.monitor.steer(threadID: "thr-live", text: "also run the tests", isActive: true))
+        #expect(await h.monitor.steer(threadID: "thr-live", text: "also run the tests"))
         #expect(h.connection.calls.last == "turn/steer")
-        #expect(await h.monitor.steer(threadID: "thr-live", text: "start over", isActive: false))
+        #expect(await h.monitor.startTurn(threadID: "thr-live", text: "start over"))
         #expect(h.connection.calls.last == "turn/start")
-        #expect(await h.monitor.steer(threadID: "thr-cold", text: "hello", isActive: false))
+        #expect(await h.monitor.startTurn(threadID: "thr-cold", text: "hello"))
         #expect(h.connection.calls.suffix(2) == ["thread/resume", "turn/start"])
     }
 
-    @Test("a steer the daemon refuses falls back to a new turn")
-    func steerFallsBack() async throws {
+    @Test("a steer the daemon refuses does not start a new turn")
+    func steerFailureDoesNotStart() async throws {
         let h = Harness()
         defer { h.stop() }
         #expect(await h.connected())
         await h.activate("thr-x")
-        h.connection.set("turn/steer", [:])       // the fake answers; remove to make it fail
+        h.connection.set("turn/steer", [:])
         h.connection.fail("turn/steer")
-        #expect(await h.monitor.steer(threadID: "thr-x", text: "hi", isActive: true))
-        #expect(h.connection.calls.suffix(2) == ["turn/steer", "turn/start"])
+        #expect(await h.monitor.steer(threadID: "thr-x", text: "hi") == false)
+        #expect(h.connection.calls.last == "turn/steer")
+        #expect(!h.connection.calls.contains("turn/start"))
     }
 
     @Test("the answer dispatch sends Codex text to the daemon and never types into a pane")
@@ -174,16 +175,52 @@ struct CodexSteerTests {
         await store.ingest(HookEvent(kind: .userPromptSubmit, sessionID: "thr-d", agent: .codex, cwd: "/x/p",
                                      observationSource: .appserver, timestamp: Date()))
         await store.setTerminalRef(sessionID: "thr-d", TerminalRef(termProgram: "tmux", tmux: "/tmp/s,1,0", tmuxPane: "%1"))
-        final class Box: @unchecked Sendable { var steered: [(String, String, Bool)] = []; var typed: [String] = [] }
+        final class Box: @unchecked Sendable { var steered: [String] = []; var started: [String] = []; var typed: [String] = [] }
         let box = Box()
         let dispatch = AnswerDispatch(store: store, questions: QuestionRegistry(),
                                       inject: { _, text in box.typed.append(text) },
-                                      steer: { id, text, active in box.steered.append((id, text, active)); return true })
+                                      steer: { _, text in box.steered.append(text); return true },
+                                      startTurn: { _, text in box.started.append(text); return true })
         #expect(await dispatch.deliver(sessionID: "thr-d", text: "use postgres", answers: nil))
         #expect(box.typed.isEmpty)
-        #expect(box.steered.count == 1)
-        #expect(box.steered.first?.1 == "use postgres")
-        #expect(box.steered.first?.2 == true)          // working → steer
+        #expect(box.steered == ["use postgres"])
+        #expect(box.started.isEmpty)
+    }
+
+    @Test("an expired Answer does not become a steer")
+    func expiredAnswerDoesNotSteer() async throws {
+        let store = SessionStore()
+        await store.ingest(HookEvent(kind: .userPromptSubmit, sessionID: "thr-e", agent: .codex, cwd: "/x/p",
+                                     observationSource: .appserver, timestamp: Date()))
+        final class Box: @unchecked Sendable { var steered = 0; var started = 0 }
+        let box = Box()
+        let dispatch = AnswerDispatch(store: store, questions: QuestionRegistry(),
+                                      inject: { _, _ in },
+                                      steer: { _, _ in box.steered += 1; return true },
+                                      startTurn: { _, _ in box.started += 1; return true })
+        let result = await dispatch.deliver(SessionActionRequest(
+            sessionID: "thr-e", intent: .answer, requestID: "r1",
+            questionID: "q-old", text: "yes"))
+        #expect(result == .failed("This question is no longer waiting"))
+        #expect(box.steered == 0)
+        #expect(box.started == 0)
+    }
+
+    @Test("a duplicate requestId is not executed again")
+    func duplicateRequestIdIsNotReplayed() async throws {
+        let store = SessionStore()
+        await store.ingest(HookEvent(kind: .userPromptSubmit, sessionID: "thr-dup", agent: .codex, cwd: "/x/p",
+                                     observationSource: .appserver, timestamp: Date()))
+        final class Box: @unchecked Sendable { var steered = 0 }
+        let box = Box()
+        let dispatch = AnswerDispatch(store: store, questions: QuestionRegistry(),
+                                      inject: { _, _ in },
+                                      steer: { _, _ in box.steered += 1; return true })
+        let request = SessionActionRequest(sessionID: "thr-dup", intent: .steer,
+                                           requestID: "same", text: "retry")
+        #expect(await dispatch.deliver(request) == .accepted)
+        #expect(await dispatch.deliver(request) == .accepted)
+        #expect(box.steered == 1)
     }
 
     @Test("present: an approval request shows a read-only card and is never answered from here")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/QuestionRoutesTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/QuestionRoutesTests.swift
@@ -105,8 +105,8 @@ struct QuestionRoutesTests {
         }
     }
 
-    @Test("after the hook times out the card stays, and a later answer is typed into the terminal")
-    func timeoutFallsBackToInjection() async throws {
+    @Test("after the hook times out an Answer is refused and is not typed as an instruction")
+    func timeoutDoesNotTurnAnswerIntoInstruction() async throws {
         let store = SessionStore()
         let recorder = InjectionRecorder()
         let srv = server(store: store, timeout: .milliseconds(200), recorder: recorder)
@@ -117,20 +117,14 @@ struct QuestionRoutesTests {
                 #expect(String(buffer: res.body).isEmpty)          // Claude shows its own UI
             }
             #expect(await store.snapshot(now: Date()).sessions.first { $0.id == "qs" }?.pendingQuestion != nil)
-            // Nowhere to type: nothing waiting, no terminal → 202.
-            try await client.execute(uri: "/answer", method: .post,
-                headers: [.authorization: "Bearer t0k"],
-                body: ByteBuffer(string: #"{"sessionId":"qs","answers":{"q1":["Summary"]}}"#)) { res in
-                #expect(res.status == .accepted)
-            }
             await store.setTerminalRef(sessionID: "qs", TerminalRef(termProgram: "tmux", tty: "ttys001", tmux: "/tmp/sock,1,0", tmuxPane: "%1"))
             try await client.execute(uri: "/answer", method: .post,
                 headers: [.authorization: "Bearer t0k"],
-                body: ByteBuffer(string: #"{"sessionId":"qs","answers":{"q1":["Summary"],"q2":["Conclusion"]}}"#)) { res in
-                #expect(res.status == .ok)
+                body: ByteBuffer(string: #"{"sessionId":"qs","intent":"answer","requestId":"late","answers":{"q1":["Summary"]}}"#)) { res in
+                #expect(res.status == .conflict)
             }
-            #expect(recorder.all == ["Summary\nConclusion"])
-            #expect(await store.snapshot(now: Date()).sessions.first { $0.id == "qs" }?.pendingQuestion == nil)
+            #expect(recorder.all.isEmpty)
+            #expect(await store.snapshot(now: Date()).sessions.first { $0.id == "qs" }?.pendingQuestion != nil)
         }
     }
 

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -563,17 +563,31 @@ final class MenuBarModel: ObservableObject {
     /// Back-compat for voice + existing callers.
     func decide(_ approvalId: String, approve: Bool) { decide(approvalId, approve ? .allow : .deny) }
 
-    /// Answer a session's question from the Mac card, the same way `/answer`
-    /// does for the phone: to the waiting agent through its own contract,
-    /// else typed into a tmux pane. Reports whether it had anywhere to go.
+    /// Answer or advance a session from the Mac card, the same contract as
+    /// `/answer`: waiting questions go to the agent; Codex steer / continue
+    /// are explicit and never rewrite each other.
     func answer(_ sessionID: String, answers: QuestionAnswers, text: String? = nil) {
-        let dispatch = AnswerDispatch(store: store, questions: questionRegistry,
-                                      inject: { ref, answer in TerminalInjector.inject(answer, into: ref) })
+        let monitor = codexAppServerMonitor
+        let session = sessions.first { $0.id == sessionID }
+        let support = session.map(SessionActionSupport.resolve(for:))
+        let dispatch = AnswerDispatch(
+            store: store, questions: questionRegistry,
+            inject: { ref, answer in TerminalInjector.inject(answer, into: ref) },
+            steer: { id, text in await monitor.steer(threadID: id, text: text) },
+            startTurn: { id, text in await monitor.startTurn(threadID: id, text: text) })
         Task { [weak self] in
-            let delivered = await dispatch.deliver(sessionID: sessionID, text: text,
-                                                   answers: answers.isEmpty ? nil : answers)
+            let result = await dispatch.deliver(SessionActionRequest(
+                sessionID: sessionID,
+                intent: support?.intent,
+                questionID: session?.pendingQuestion?.id,
+                text: text,
+                answers: answers.isEmpty ? nil : answers))
             await MainActor.run {
-                self?.answerFeedback[sessionID] = delivered ? nil : "Nothing was waiting for an answer, and there is no tmux pane to type into."
+                if case .failed(let why) = result {
+                    self?.answerFeedback[sessionID] = why
+                } else {
+                    self?.answerFeedback[sessionID] = nil
+                }
             }
         }
     }


### PR DESCRIPTION
M-02

## Summary
- Phone and Mac send an explicit session intent (`answer` / `steer` / `continue`) so Q29 semantics are visible before send and re-checked on the daemon.
- An expired Answer is refused and never rewritten as an instruction; a refused Codex `turn/steer` no longer falls back to `turn/start` (Q35).
- The composer shows Mac · project · agent, plus not-sent / sending / accepted / failed / unknown. Accepted is not working or finished. Unreachable pairing is not-sent (Q16). Duplicate `requestId`s are not replayed; a lost receipt stays unknown and is not resent.

## Validation
- `cd VibeBuddyKit && swift test` — 273 tests in 34 suites passed
- `cd VibeBuddyMac && swift test` — 643 tests in 67 suites passed
- `cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- `cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO` — 25 tests, 0 failures
- `cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED

Routing evidence in tests: `expiredAnswerDoesNotSteer`, `timeoutDoesNotTurnAnswerIntoInstruction`, `steerFailureDoesNotStart`, `duplicateRequestIdIsNotReplayed`, `testDisconnectedActionIsNotSent`.

## Not verified here
- Real paired iPhone answering a live Claude question, steering a running Codex turn, or continuing a finished Codex session
- Real Codex app-server (beyond the fake daemon used in tests)
- Manual check after a dropped receipt (unknown is implemented, not device-exercised)
- Watch entry points (out of this ticket)