### PR TITLE
feat(notifications): restore ordinary cues when Mac presence expires

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,9 +73,13 @@ code, and tests — don't drift to synonyms.
   surface (its terminal app, or Codex Desktop for a Desktop thread) is
   frontmost, the screen is unlocked and there was input within two minutes,
   unless the Settings override "Always ask the phone first" is on. Present →
-  the agent's own prompt takes the answer and the phone gets a **read-only
-  card** (`answerable: false`); away → the daemon holds the prompt for the
-  phone. Applies to the hook gate, the question relay and app-server requests.
+  the agent's own prompt takes the answer, the phone gets a **read-only
+  card** (`answerable: false`), and `DeliveryMatrix` caps ordinary cues to
+  `list` (logged as `focusedTerminal`). Away, idle, lock, or an uncertain
+  observation empties that set so a still-open wait recovers its interrupting
+  reminder; the card stays read-only — restoring a cue does not mint remote
+  answer rights. Applies to the hook gate, the question relay, app-server
+  requests, and notification fan-out. Active phone/Watch entries stay visible.
 - **Steer** — free text for a Codex thread sent through the app-server daemon:
   `turn/steer` while a turn runs, `turn/start` when idle (a cold thread is
   resumed first). Codex threads never take typed input through a terminal.
@@ -189,8 +193,9 @@ code, and tests — don't drift to synonyms.
   three surfaces agree. Approvals and questions interrupt at every level (a
   muted session shows them silently); a completion banners for followed and
   normal, is dropped for muted; the nudge is list-only unless followed. Quiet /
-  Focus mode reads every session as `muted`; a session whose own terminal is
-  frontmost is capped to `list`. `list` and `drop` never push.
+  Focus mode reads every session as `muted`; a session `PresencePolicy` says
+  is present is capped to `list`. Leaving presence restores a still-open
+  wait at the matrix level. `list` and `drop` never push.
 - **Completion reminder** — `CompletionReminderSchedule` re-issues the
   `agentDone` cue for a `done`, unread session whose effective attention is
   `followed`, every 5 minutes, at most 12 times per completion (keyed by

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -521,7 +521,8 @@ final class DashboardStore: ObservableObject {
             sessions: snapshot.sessions,
             now: Date(),
             appActive: UIApplication.shared.applicationState == .active,
-            quietMode: SoundPrefs.effectiveQuiet())))
+            quietMode: SoundPrefs.effectiveQuiet(),
+            focusedSessionIDs: Set(snapshot.sessions.filter(\.nativePromptHoldsWait).map(\.id)))))
         var rang = false
         for alert in alerts {
             // A cue a push already delivered is not posted again (ADR-0012), and

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -540,6 +540,12 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.updatedAt = updatedAt
     }
 
+    /// The Mac is holding this wait for the agent's own prompt. The phone card
+    /// is read-only; restoring a reminder does not make it answerable.
+    public var nativePromptHoldsWait: Bool {
+        pendingApproval?.isAnswerable == false || pendingQuestion?.isAnswerable == false
+    }
+
     /// Whether a jump has anywhere to land: a terminal to raise, or a Codex
     /// Desktop thread to open. The one thing every jump control is gated on, so
     /// a Desktop session's button is live for the same reason a terminal

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SoundPolicy.swift
@@ -66,10 +66,9 @@ public struct SoundPolicyInput: Sendable {
     public var appActive: Bool
     /// Quiet / Focus mode: every session is treated as `muted`.
     public var quietMode: Bool
-    /// IDs of sessions whose own terminal window is currently frontmost — the user
-    /// is already looking at them, and the native prompt is right there, so
-    /// nothing about them interrupts: every cue is capped to the list. The Mac
-    /// fills this from the frontmost terminal app; iOS leaves it empty.
+    /// Sessions PresencePolicy currently treats as present (Mac: focused surface,
+    /// unlocked, recent input, override off). Their cues cap to the list. Leaving
+    /// the set restores a still-open wait. iOS fills this from read-only cards.
     public var focusedSessionIDs: Set<String>
 
     public init(sessions: [AgentSession], now: Date, appActive: Bool, quietMode: Bool,
@@ -90,9 +89,10 @@ public struct SoundPolicyInput: Sendable {
 ///     you're not already watching the app;
 ///   - a failed / aborted ending rings the duller `agentStuck` instead;
 ///   - one gentle `longWaitNudge` after a wait drags past the threshold;
-///   - then `DeliveryMatrix` decides how loud each cue is from the session's
-///     attention level, Quiet mode reads every session as `muted`, a focused
-///     terminal caps its session to the list, and a `drop` is never emitted.
+    ///   - then `DeliveryMatrix` decides how loud each cue is from the session's
+    ///     attention level, Quiet mode reads every session as `muted`, a present
+    ///     session caps to the list, leaving presence restores a still-open wait,
+    ///     and a `drop` is never emitted.
 /// Shared by the Mac menu bar, the Mac's push to the phone, and the iOS app so
 /// all three behave identically.
 public final class SoundPolicy {
@@ -102,6 +102,10 @@ public final class SoundPolicy {
     private var lastWaitingSoundAt: [String: Date] = [:]
     /// `statusSince` of the wait we've already nudged, keyed by session id.
     private var nudgedWaitSince: [String: Date] = [:]
+    /// Waits capped because the session was present, keyed by session → statusSince.
+    private var presenceSuppressedWaits: [String: Date] = [:]
+    /// Waits already restored after leaving, so a second leave does not re-ring.
+    private var presenceRestoredWaits: [String: Date] = [:]
 
     public init(config: SoundPolicyConfig = .init()) {
         self.config = config
@@ -112,6 +116,7 @@ public final class SoundPolicy {
         defer {
             previous = Dictionary(uniqueKeysWithValues: input.sessions.map { ($0.id, $0) })
             seenFirstSnapshot = true
+            rememberPresence(input)
         }
         // Never ring the backlog already waiting when we first connect.
         guard seenFirstSnapshot else { return [] }
@@ -120,13 +125,57 @@ public final class SoundPolicy {
         for session in input.sessions {
             guard let sound = boundarySound(prev: previous[session.id], now: session, input: input)
             else { continue }
-            let attention: SessionAttention = input.quietMode ? .muted : session.effectiveAttention
-            var level = DeliveryMatrix.level(for: sound, attention: attention)
-            if input.focusedSessionIDs.contains(session.id) { level = min(level, .list) }
-            guard level != .drop else { continue }
-            alerts.append(SoundAlert(session: session, sound: sound, delivery: level))
+            guard let alert = alert(session: session, sound: sound, input: input) else { continue }
+            alerts.append(alert)
+        }
+        for session in input.sessions {
+            guard let alert = restoredWait(session, input: input) else { continue }
+            alerts.append(alert)
         }
         return alerts
+    }
+
+    private func alert(session: AgentSession, sound: NotificationSound,
+                       input: SoundPolicyInput) -> SoundAlert? {
+        let attention: SessionAttention = input.quietMode ? .muted : session.effectiveAttention
+        var level = DeliveryMatrix.level(for: sound, attention: attention)
+        if input.focusedSessionIDs.contains(session.id) { level = min(level, .list) }
+        guard level != .drop else { return nil }
+        return SoundAlert(session: session, sound: sound, delivery: level)
+    }
+
+    private func rememberPresence(_ input: SoundPolicyInput) {
+        let live = Set(input.sessions.map(\.id))
+        for id in presenceSuppressedWaits.keys where !live.contains(id) {
+            presenceSuppressedWaits.removeValue(forKey: id)
+            presenceRestoredWaits.removeValue(forKey: id)
+        }
+        for session in input.sessions {
+            guard session.status == .needsResponse else {
+                presenceSuppressedWaits.removeValue(forKey: session.id)
+                presenceRestoredWaits.removeValue(forKey: session.id)
+                continue
+            }
+            guard input.focusedSessionIDs.contains(session.id) else { continue }
+            if presenceRestoredWaits[session.id] != session.statusSince {
+                presenceSuppressedWaits[session.id] = session.statusSince
+            }
+        }
+    }
+
+    /// A still-open wait that was capped while present earns its waiting cue
+    /// again once PresencePolicy says away. Handled waits are already cleared.
+    private func restoredWait(_ session: AgentSession, input: SoundPolicyInput) -> SoundAlert? {
+        guard session.status == .needsResponse,
+              presenceSuppressedWaits[session.id] == session.statusSince,
+              !input.focusedSessionIDs.contains(session.id),
+              presenceRestoredWaits[session.id] != session.statusSince
+        else { return nil }
+        presenceRestoredWaits[session.id] = session.statusSince
+        presenceSuppressedWaits.removeValue(forKey: session.id)
+        let sound: NotificationSound = session.waitKind == .permission ? .needsApproval : .needsAnswer
+        lastWaitingSoundAt[session.id] = input.now
+        return alert(session: session, sound: sound, input: input)
     }
 
     /// The cue earned by `session` given its prior state, before the matrix.

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SoundPolicyTests.swift
@@ -246,6 +246,61 @@ struct SoundPolicyTests {
         #expect(alerts.map { "\($0.sound.rawValue):\($0.delivery)" } == ["agent_done:list", "needs_approval:list"])
     }
 
+    @Test("leaving presence restores a still-open wait at full matrix level")
+    func leavingPresenceRestoresWait() {
+        let p = SoundPolicy()
+        let waiting = session("a", .needsResponse, wait: .permission, since: 1)
+        _ = p.evaluate(input([session("a", .working)], now: 0))
+        let present = p.evaluate(input([waiting], now: 1, focused: ["a"]))
+        #expect(present.map(\.delivery) == [.list])
+        let away = p.evaluate(input([waiting], now: 3, focused: []))
+        #expect(away.map(\.sound) == [.needsApproval])
+        #expect(away.map(\.delivery) == [.bannerSound])
+    }
+
+    @Test("an answered wait is not replayed after leaving presence")
+    func leavingPresenceDoesNotReplayHandledWait() {
+        let p = SoundPolicy()
+        _ = p.evaluate(input([session("a", .working)], now: 0))
+        _ = p.evaluate(input([session("a", .needsResponse, wait: .question, since: 1)], now: 1, focused: ["a"]))
+        _ = p.evaluate(input([session("a", .working, since: 2)], now: 2, focused: ["a"]))
+        let away = p.evaluate(input([session("a", .working, since: 2)], now: 3, focused: []))
+        #expect(away.isEmpty)
+    }
+
+    @Test("leaving presence a second time does not re-ring the same wait")
+    func leavingPresenceRestoresOnce() {
+        let p = SoundPolicy()
+        let waiting = session("a", .needsResponse, wait: .question, since: 1)
+        _ = p.evaluate(input([session("a", .working)], now: 0))
+        _ = p.evaluate(input([waiting], now: 1, focused: ["a"]))
+        _ = p.evaluate(input([waiting], now: 3, focused: []))
+        _ = p.evaluate(input([waiting], now: 4, focused: ["a"]))
+        let again = p.evaluate(input([waiting], now: 5, focused: []))
+        #expect(again.isEmpty)
+    }
+
+    @Test("Quiet mode still caps a restored wait — presence never outranks Focus")
+    func leavingPresenceRespectsQuiet() {
+        let p = SoundPolicy()
+        let waiting = session("a", .needsResponse, wait: .permission, since: 1)
+        _ = p.evaluate(input([session("a", .working)], now: 0))
+        _ = p.evaluate(input([waiting], now: 1, focused: ["a"]))
+        let away = p.evaluate(input([waiting], now: 3, quiet: true, focused: []))
+        #expect(away.map(\.sound) == [.needsApproval])
+        #expect(away.map(\.delivery) == [.banner])
+    }
+
+    @Test("a wait first seen while present still restores after leaving — the arrival verdict does not freeze")
+    func firstSnapshotPresentThenLeaveRestores() {
+        let p = SoundPolicy()
+        let waiting = session("a", .needsResponse, wait: .permission, since: 0)
+        #expect(p.evaluate(input([waiting], now: 0, focused: ["a"])).isEmpty)
+        let away = p.evaluate(input([waiting], now: 2, focused: []))
+        #expect(away.map(\.sound) == [.needsApproval])
+        #expect(away.map(\.delivery) == [.bannerSound])
+    }
+
     @Test("done still rings for a session whose terminal is NOT the focused one")
     func doneOtherTerminalRings() {
         let p = SoundPolicy()

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/PresencePolicy.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/PresencePolicy.swift
@@ -7,7 +7,8 @@ import Foundation
 /// time, the user's override) and the daemon applies the verdict to every
 /// blocking path — a hook gate, a question relay, an app-server request.
 /// Present means "let the agent's own prompt take the answer, show the phone a
-/// read-only card"; away means "hold for the phone".
+/// read-only card, and cap ordinary cues to the list"; away means "hold for the
+/// phone" and restores a still-open wait's interrupting reminder.
 public struct PresencePolicy: Sendable, Equatable {
     public struct Input: Sendable, Equatable {
         /// The session's own surface (its terminal app, or Codex Desktop for a
@@ -39,5 +40,18 @@ public struct PresencePolicy: Sendable, Equatable {
         if input.screenLocked { return .away }
         if input.idleSeconds >= idleThreshold { return .away }
         return input.sessionSurfaceFocused ? .present : .away
+    }
+
+    /// Sessions whose interrupting cues should stay on the Mac (DeliveryMatrix
+    /// list cap). Lock, idle, missing observation, or "always ask the phone"
+    /// empty the set — the arrival-time verdict is never reused.
+    public static func suppressingSessionIDs(focused: Set<String>,
+                                             screenLocked: Bool,
+                                             idleSeconds: TimeInterval,
+                                             alwaysAskPhone: Bool) -> Set<String> {
+        guard decide(Input(sessionSurfaceFocused: true, screenLocked: screenLocked,
+                           idleSeconds: idleSeconds, alwaysAskPhone: alwaysAskPhone)) == .present
+        else { return [] }
+        return focused
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PresenceAndSteerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/PresenceAndSteerTests.swift
@@ -27,6 +27,22 @@ struct PresencePolicyTests {
         #expect(PresencePolicy.decide(input(alwaysAsk: true)) == .away)
         #expect(PresencePolicy.decide(input(idle: PresencePolicy.idleThreshold - 1)) == .present)
     }
+
+    @Test("only a live present verdict suppresses interrupting cues; stale or forced-away restores them")
+    func suppressingSessionIDsFollowsTheVerdict() {
+        let focused: Set<String> = ["a", "b"]
+        #expect(PresencePolicy.suppressingSessionIDs(focused: focused, screenLocked: false,
+                                                     idleSeconds: 5, alwaysAskPhone: false) == focused)
+        #expect(PresencePolicy.suppressingSessionIDs(focused: focused, screenLocked: true,
+                                                     idleSeconds: 5, alwaysAskPhone: false).isEmpty)
+        #expect(PresencePolicy.suppressingSessionIDs(focused: focused, screenLocked: false,
+                                                     idleSeconds: PresencePolicy.idleThreshold,
+                                                     alwaysAskPhone: false).isEmpty)
+        #expect(PresencePolicy.suppressingSessionIDs(focused: focused, screenLocked: false,
+                                                     idleSeconds: 5, alwaysAskPhone: true).isEmpty)
+        #expect(PresencePolicy.suppressingSessionIDs(focused: [], screenLocked: false,
+                                                     idleSeconds: 5, alwaysAskPhone: false).isEmpty)
+    }
 }
 
 /// The daemon lets the agent's own prompt take the answer while the person is

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -334,21 +334,23 @@ final class MenuBarModel: ObservableObject {
                 self.lifecycleTimeline = await self.store.recentLifecycle()
                 self.buddySessionIDs = BuddyScope.pruned(self.buddySessionIDs, toLive: snapshot.sessions)
                 self.tickGlanceCards()
-                // Precise suppression: a finishing session stays silent when *its
-                // own* terminal is frontmost, not just when VibeBuddy is.
-                let frontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-                let focused = ForegroundTerminal.focusedSessionIDs(
-                    among: snapshot.sessions, frontmostBundleID: frontmost)
+                // PresencePolicy, not just "terminal frontmost": idle, lock, or
+                // "always ask the phone" empty the set so a stale verdict cannot
+                // keep suppressing. The 2s poll re-evaluates without a new event.
+                let present = Set(snapshot.sessions.compactMap { session in
+                    PresencePolicy.decide(self.presenceInput(for: session.id)) == .present
+                        ? session.id : nil
+                })
                 let alerts = await self.notificationCoordinator.observe(
                     snapshot.sessions,
                     appActive: NSApp.isActive,                 // user looking at VibeBuddy?
                     quietMode: Self.effectiveQuiet(),          // Focus mode (manual or nightly) → every session muted
-                    focusedSessionIDs: focused,                // …or looking at the session's own terminal
+                    focusedSessionIDs: present,                // present sessions cap to the list
                     categories: NotificationCategoryPrefs.loadMac()) // this Mac's own switches
                 await self.refreshNotificationDeliveryHealth()
                 // Off the loop: a push may hold for the phone's receipt, and the
                 // glance must not wait with it.
-                Task { await self.pushToPhones(alerts, focused: focused) }
+                Task { await self.pushToPhones(alerts, focused: present) }
                 await self.pushActivityUpdates(snapshot.sessions)
                 await self.checkBudget(snapshot.sessions)
                 try? await Task.sleep(for: .seconds(2))

--- a/VibeBuddyMacApp/Sources/SettingsView.swift
+++ b/VibeBuddyMacApp/Sources/SettingsView.swift
@@ -141,7 +141,7 @@ private struct SetupSettings: View {
                     get: { model.alwaysAskPhone },
                     set: { model.setAlwaysAskPhone($0) }))
             } header: { Text("Approvals and questions") } footer: {
-                Text("Off: while you are at the Mac — the session's terminal or Codex Desktop in front, screen unlocked, input within the last two minutes — the agent's own prompt takes the answer and the phone shows a read-only card. On: every prompt waits for the phone even at the desk.")
+                Text("Off: while you are at the Mac — the session's terminal or Codex Desktop in front, screen unlocked, input within the last two minutes — the agent's own prompt takes the answer, the phone shows a read-only card, and ordinary reminders stay on the Mac. Leaving, locking, or going idle restores the reminder; the card stays read-only. On: every prompt waits for the phone even at the desk.")
                     .font(.caption)
             }
 


### PR DESCRIPTION
M-04

## Summary
- Stitch #42 `PresencePolicy` into #44 `DeliveryMatrix`: only a live present verdict (focused surface, unlocked, recent input, override off) caps ordinary cues to `list` and records `focusedTerminal`.
- Leaving presence, locking, going idle, or turning on "Always ask the phone first" restores a still-open wait at the matrix level; handled waits are not replayed, and the arrival-time verdict cannot freeze.
- Phone/Watch active entries stay visible. A restored reminder does not change `answerable` on the read-only card.

## Validation
- `cd VibeBuddyKit && swift test` — 281 tests / 33 suites passed
- `cd VibeBuddyMac && swift test` — 646 tests / 68 suites passed
- `cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- `cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO` — 32 tests, 0 failures
- `cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED

## Not verified here
- Real Mac present / lock / idle / away flows on a paired phone and Watch (ordinary push filtered vs read-only card only).
- Important-task exception (M-06 / Q33) is out of scope.