### PR TITLE
feat(watch): show three-count complications and raise Smart Stack on wait

### DIFF
--- a/VibeBuddyApp/Watch/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyApp/Watch/Resources/zh-Hans.lproj/Localizable.strings
@@ -21,6 +21,8 @@
 "Unavailable · %@" = "不可用 · %@";
 
 /* MARK: Overview */
+"Sessions" = "会话";
+"Needs you" = "需回应";
 "Needs response" = "需回应";
 "Working" = "进行中";
 "Done" = "完成";

--- a/VibeBuddyApp/Watch/VibeBuddyWatch.entitlements
+++ b/VibeBuddyApp/Watch/VibeBuddyWatch.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.vibebuddy.app</string>
+    </array>
+</dict>
+</plist>

--- a/VibeBuddyApp/Watch/VibeBuddyWatchApp.swift
+++ b/VibeBuddyApp/Watch/VibeBuddyWatchApp.swift
@@ -20,4 +20,6 @@ enum WatchPage: String, Hashable {
     case home
     case alerts
     case quota
+    /// Launch-only QA surface for complication screenshots. Not a live tab.
+    case complication
 }

--- a/VibeBuddyApp/Watch/WatchRootView.swift
+++ b/VibeBuddyApp/Watch/WatchRootView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WidgetKit
 import VibeBuddyKit
 
 struct WatchRootView: View {
@@ -28,7 +29,9 @@ struct WatchRootView: View {
         // One verdict per render, derived once from the clock this pass is
         // drawing with, so every page agrees about which link is down.
         let connection = store.state?.connection(now: now, phoneReachable: store.isPhoneReachable) ?? .noData
-        if let state = store.state, connection != .noData {
+        if store.initialPage == .complication {
+            WatchComplicationPreview(state: store.state)
+        } else if let state = store.state, connection != .noData {
             TabView(selection: $page) {
                 WatchHomeView(store: store, state: state, connection: connection, now: now)
                     .tag(WatchPage.home)
@@ -46,6 +49,28 @@ struct WatchRootView: View {
             }
         } else {
             WatchNoDataView()
+        }
+    }
+}
+
+/// Launch-only: the same faces the WidgetKit extension draws, so Simulator
+/// screenshots do not need a real watch-face gallery.
+struct WatchComplicationPreview: View {
+    let state: WatchDashboardState?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 14) {
+                    WatchCountsComplicationView(previewFamily: .accessoryCircular, state: state)
+                        .frame(width: 68, height: 68)
+                    WatchCountsComplicationView(previewFamily: .accessoryRectangular, state: state)
+                        .frame(width: 162, height: 72)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 8)
+            }
+            .navigationTitle("Sessions")
         }
     }
 }

--- a/VibeBuddyApp/Watch/WatchStateStore.swift
+++ b/VibeBuddyApp/Watch/WatchStateStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import VibeBuddyKit
 import WatchConnectivity
+import WidgetKit
 
 /// Everything the Watch knows, and where it came from.
 ///
@@ -50,12 +51,14 @@ final class WatchStateStore: NSObject, ObservableObject {
                 .flatMap(WatchDemoScenario.init(rawValue:)) ?? .normal
             state = scenario.state(now: now)
             isPhoneReachable = scenario.phoneReachable
+            if let state { Self.publishComplication(state) }
         } else {
             // A cold launch shows the last state the iPhone managed to deliver.
             // Its age is recomputed from the current clock, never restored as a
             // verdict, so old numbers cannot masquerade as live ones.
             inbox.accept(defaults.data(forKey: Self.storageKey))
             state = inbox.state
+            if let state { Self.publishComplication(state) }
             activate()
         }
     }
@@ -121,6 +124,14 @@ final class WatchStateStore: NSObject, ObservableObject {
     private func install(_ next: WatchDashboardState) {
         state = next
         approval.reconcile(with: next)
+        Self.publishComplication(next)
+    }
+
+    /// The complication is a separate process. It only sees what we write to
+    /// the App Group — never the in-memory store.
+    private static func publishComplication(_ state: WatchDashboardState) {
+        WatchDashboardStore.save(state)
+        WidgetCenter.shared.reloadTimelines(ofKind: WatchDashboardStore.kind)
     }
 
     private func activate() {

--- a/VibeBuddyApp/WatchShared/WatchCountsComplicationView.swift
+++ b/VibeBuddyApp/WatchShared/WatchCountsComplicationView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import WidgetKit
+import VibeBuddyKit
+
+/// Circular and rectangular three-count faces. Same buckets and Companion
+/// colours as the Watch home; colour is never the only signal.
+struct WatchCountsComplicationView: View {
+    @Environment(\.widgetFamily) private var widgetFamily
+    var previewFamily: WidgetFamily?
+    let state: WatchDashboardState?
+
+    private var family: WidgetFamily { previewFamily ?? widgetFamily }
+    private var placeholder: Bool { state?.showsComplicationPlaceholder ?? true }
+
+    var body: some View {
+        Group {
+            if placeholder {
+                empty
+            } else if family == .accessoryCircular {
+                circular
+            } else {
+                rectangular
+            }
+        }
+    }
+
+    private var empty: some View {
+        VStack(spacing: 2) {
+            Image(systemName: "iphone.gen3.slash")
+            Text("Waiting for iPhone")
+                .font(family == .accessoryCircular ? .caption2 : .headline)
+                .multilineTextAlignment(.center)
+                .minimumScaleFactor(0.7)
+                .lineLimit(family == .accessoryCircular ? 2 : 2)
+        }
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Waiting for iPhone")
+    }
+
+    private var circular: some View {
+        let slots = Self.slots(state?.counts ?? WatchSessionCounts())
+        return VStack(spacing: 1) {
+            ForEach(slots) { slot in
+                HStack(spacing: 3) {
+                    Image(systemName: slot.state.symbolName)
+                        .font(.system(size: 8, weight: .bold))
+                        .frame(width: 9)
+                    Text(slot.value, format: .number)
+                        .font(.system(size: 13, weight: .bold, design: .rounded).monospacedDigit())
+                }
+                .foregroundStyle(slot.tint)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Self.voice(slots))
+    }
+
+    private var rectangular: some View {
+        let slots = Self.slots(state?.counts ?? WatchSessionCounts())
+        return HStack(spacing: 8) {
+            ForEach(slots) { slot in
+                VStack(spacing: 1) {
+                    Image(systemName: slot.state.symbolName)
+                        .font(.system(size: 10, weight: .bold))
+                    Text(slot.value, format: .number)
+                        .font(.system(size: 18, weight: .bold, design: .rounded).monospacedDigit())
+                    Text(slot.title)
+                        .font(.system(size: 9, weight: .semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                }
+                .foregroundStyle(slot.tint)
+                .frame(maxWidth: .infinity)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(slot.title))
+                .accessibilityValue(Text(slot.value, format: .number))
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private struct Slot: Identifiable {
+        var id: TaskPresentationState { state }
+        let state: TaskPresentationState
+        let value: Int
+        let title: LocalizedStringResource
+        var tint: Color {
+            value > 0 ? CompanionPalette.status(state) : Color.secondary
+        }
+    }
+
+    private static func slots(_ counts: WatchSessionCounts) -> [Slot] {
+        [
+            Slot(state: .requiresInput, value: counts.needsResponse, title: "Needs you"),
+            Slot(state: .thinking, value: counts.working, title: "Working"),
+            Slot(state: .completeUnread, value: counts.done, title: "Done"),
+        ]
+    }
+
+    private static func voice(_ slots: [Slot]) -> String {
+        slots.map { "\($0.value) \(String(localized: $0.title))" }.joined(separator: ", ")
+    }
+}

--- a/VibeBuddyApp/WatchShared/WatchDashboardStore.swift
+++ b/VibeBuddyApp/WatchShared/WatchDashboardStore.swift
@@ -1,0 +1,25 @@
+import Foundation
+import VibeBuddyKit
+
+/// App Group mailbox between the Watch app and its WidgetKit extension.
+///
+/// The iPhone still owns the relay. The Watch app is the only process that
+/// writes here; the complication reads the last accepted `WatchDashboardState`
+/// and never talks to the phone itself.
+enum WatchDashboardStore {
+    static let appGroup = "group.com.vibebuddy.app"
+    static let kind = "VibeBuddyWatchCounts"
+    private static let key = "watch-dashboard-state"
+
+    static func load() -> WatchDashboardState? {
+        guard let data = UserDefaults(suiteName: appGroup)?.data(forKey: key) else { return nil }
+        var inbox = WatchStateInbox()
+        inbox.accept(data)
+        return inbox.state
+    }
+
+    static func save(_ state: WatchDashboardState) {
+        guard let data = WatchStateInbox.encode(state) else { return }
+        UserDefaults(suiteName: appGroup)?.set(data, forKey: key)
+    }
+}

--- a/VibeBuddyApp/WatchWidget/Info.plist
+++ b/VibeBuddyApp/WatchWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>vibebuddy</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/VibeBuddyApp/WatchWidget/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyApp/WatchWidget/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Watch complication / Smart Stack — Simplified Chinese. Keys are English. */
+"Waiting for iPhone" = "等待 iPhone";
+"Needs you" = "需回应";
+"Working" = "进行中";
+"Done" = "完成";
+"Sessions" = "会话";
+"needsResponse, working, and done counts." = "需回应、进行中与完成的计数。";

--- a/VibeBuddyApp/WatchWidget/VibeBuddyWatchWidget.entitlements
+++ b/VibeBuddyApp/WatchWidget/VibeBuddyWatchWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.vibebuddy.app</string>
+    </array>
+</dict>
+</plist>

--- a/VibeBuddyApp/WatchWidget/VibeBuddyWatchWidget.swift
+++ b/VibeBuddyApp/WatchWidget/VibeBuddyWatchWidget.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import WidgetKit
+import RelevanceKit
+import VibeBuddyKit
+
+struct CountsEntry: TimelineEntry {
+    let date: Date
+    let state: WatchDashboardState?
+
+    var relevance: TimelineEntryRelevance? {
+        TimelineEntryRelevance(score: state?.smartStackScore(now: date) ?? 0)
+    }
+}
+
+struct CountsProvider: TimelineProvider {
+    func placeholder(in context: Context) -> CountsEntry {
+        CountsEntry(date: Date(), state: nil)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (CountsEntry) -> Void) {
+        if context.isPreview {
+            completion(CountsEntry(date: Date(), state: WatchDemoScenario.permission.state(now: Date())))
+            return
+        }
+        completion(CountsEntry(date: Date(), state: WatchDashboardStore.load()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<CountsEntry>) -> Void) {
+        let now = Date()
+        let state = WatchDashboardStore.load()
+        var entries = [CountsEntry(date: now, state: state)]
+        if let state, !state.showsComplicationPlaceholder {
+            let expiry = state.observedAt.addingTimeInterval(WatchDashboardState.staleAfter)
+            if expiry > now {
+                entries.append(CountsEntry(date: expiry, state: state))
+            }
+        }
+        completion(Timeline(entries: entries, policy: .never))
+    }
+
+    @available(watchOS 11.0, *)
+    func relevance() async -> WidgetRelevance<Void> {
+        let now = Date()
+        guard let state = WatchDashboardStore.load(),
+              state.smartStackScore(now: now) > 0
+        else { return WidgetRelevance([]) }
+        let end = now.addingTimeInterval(WatchDashboardState.staleAfter)
+        return WidgetRelevance([
+            WidgetRelevanceAttribute(context: .date(from: now, to: end)),
+        ])
+    }
+}
+
+@main
+struct VibeBuddyWatchWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: WatchDashboardStore.kind, provider: CountsProvider()) { entry in
+            WatchCountsComplicationView(state: entry.state)
+                .containerBackground(for: .widget) { AccessoryWidgetBackground() }
+        }
+        .configurationDisplayName("Sessions")
+        .description("needsResponse, working, and done counts.")
+        .supportedFamilies([.accessoryCircular, .accessoryRectangular])
+    }
+}
+
+#Preview("Circular", as: .accessoryCircular) {
+    VibeBuddyWatchWidget()
+} timeline: {
+    CountsEntry(date: .now, state: WatchDemoScenario.permission.state(now: .now))
+    CountsEntry(date: .now, state: nil)
+}
+
+#Preview("Rectangular", as: .accessoryRectangular) {
+    VibeBuddyWatchWidget()
+} timeline: {
+    CountsEntry(date: .now, state: WatchDemoScenario.permission.state(now: .now))
+    CountsEntry(date: .now, state: nil)
+}

--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -93,7 +93,9 @@ targets:
     platform: watchOS
     sources:
       - path: Watch
+      - path: WatchShared
     dependencies:
+      - target: VibeBuddyWatchWidget
       - package: VibeBuddyKit
         product: VibeBuddyKit
     info:
@@ -108,6 +110,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
+        CODE_SIGN_ENTITLEMENTS: Watch/VibeBuddyWatch.entitlements
         MARKETING_VERSION: "1.1"
         CURRENT_PROJECT_VERSION: "4"
         SWIFT_VERSION: "6.0"
@@ -115,6 +118,34 @@ targets:
         DEVELOPMENT_TEAM: LQAVR62TK2
         CODE_SIGN_STYLE: Automatic
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+  VibeBuddyWatchWidget:
+    type: app-extension
+    platform: watchOS
+    sources:
+      - path: WatchWidget
+      - path: WatchShared
+    dependencies:
+      - package: VibeBuddyKit
+        product: VibeBuddyKit
+    info:
+      path: WatchWidget/Info.plist
+      properties:
+        CFBundleDisplayName: vibebuddy
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp.widget
+        MARKETING_VERSION: "1.1"
+        CURRENT_PROJECT_VERSION: "4"
+        SWIFT_VERSION: "6.0"
+        TARGETED_DEVICE_FAMILY: "4"
+        DEVELOPMENT_TEAM: LQAVR62TK2
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGN_ENTITLEMENTS: WatchWidget/VibeBuddyWatchWidget.entitlements
+        APPLICATION_EXTENSION_API_ONLY: YES
   VibeBuddyAppTests:
     type: bundle.unit-test
     platform: iOS

--- a/VibeBuddyKit/Sources/VibeBuddyKit/WatchDashboardState.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/WatchDashboardState.swift
@@ -212,6 +212,17 @@ public struct WatchDashboardState: Codable, Equatable, Sendable {
         age(now: now) >= Self.staleAfter
     }
 
+    /// A complication with no relayed state must not invent counts. Empty
+    /// live zeros are a reading; this is the absence of one.
+    public var showsComplicationPlaceholder: Bool { relay == .noData }
+
+    /// Smart Stack score. Zero means "do not rotate to the top"; any waiting
+    /// session while the reading is still current raises the rectangular card.
+    public func smartStackScore(now: Date) -> Float {
+        guard !showsComplicationPlaceholder, !isStale(now: now) else { return 0 }
+        return Float(counts.needsResponse)
+    }
+
     /// The innermost broken link the Watch can prove, given its own clock and
     /// its own view of the phone.
     ///

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/WatchComplicationTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/WatchComplicationTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+@testable import VibeBuddyKit
+
+@Suite("Watch complication projection")
+struct WatchComplicationTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func session(_ id: String, _ status: SessionStatus,
+                         waitKind: WaitKind? = nil) -> AgentSession {
+        AgentSession(
+            id: id, agent: .claudeCode, project: "vibebuddy",
+            status: status, waitKind: waitKind,
+            statusSince: now.addingTimeInterval(-30), updatedAt: now)
+    }
+
+    private func project(_ sessions: [AgentSession],
+                         relay: WatchRelayState = .live,
+                         observed: Date? = nil) -> WatchDashboardState {
+        WatchDashboardProjection.make(
+            snapshot: Snapshot(sessions: sessions, serverTime: now),
+            quotas: [], relay: relay, now: observed ?? now)
+    }
+
+    @Test("No-data is a placeholder, not a row of invented zeros")
+    func noDataIsPlaceholder() {
+        let state = WatchDashboardState.noData(observedAt: now)
+        #expect(state.showsComplicationPlaceholder)
+        #expect(state.counts.isEmpty)
+        #expect(state.smartStackScore(now: now) == 0)
+    }
+
+    @Test("A live empty desk is zeros, not a placeholder")
+    func emptyLiveShowsZeros() {
+        let state = project([])
+        #expect(!state.showsComplicationPlaceholder)
+        #expect(state.counts == WatchSessionCounts())
+        #expect(state.smartStackScore(now: now) == 0)
+    }
+
+    @Test("needsResponse raises the Smart Stack; working and done do not")
+    func waitingRaisesSmartStack() {
+        let waiting = project([
+            session("a", .needsResponse, waitKind: .permission),
+            session("b", .needsResponse, waitKind: .question),
+            session("c", .working),
+        ])
+        #expect(waiting.counts.needsResponse == 2)
+        #expect(waiting.smartStackScore(now: now) == 2)
+
+        let calm = project([session("c", .working), session("d", .done)])
+        #expect(calm.smartStackScore(now: now) == 0)
+    }
+
+    @Test("A stale waiting count does not keep the card at the top")
+    func staleWaitingDoesNotFloat() {
+        let aged = project(
+            [session("a", .needsResponse, waitKind: .question)],
+            observed: now.addingTimeInterval(-WatchDashboardState.staleAfter))
+        #expect(aged.counts.needsResponse == 1)
+        #expect(aged.isStale(now: now))
+        #expect(aged.smartStackScore(now: now) == 0)
+    }
+}

--- a/tools/watch-complication-qa-shots.sh
+++ b/tools/watch-complication-qa-shots.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Screenshot circular + rectangular complication faces on two Watch sizes.
+# Uses the Watch app's launch-only complication preview (same views as WidgetKit).
+#   tools/watch-complication-qa-shots.sh [output-dir]
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out="${1:-$repo/.scratch/qa-shots/watch-10}"
+derived="${WATCH_QA_DERIVED_DATA:-$repo/.build/watch-complication-qa}"
+bundle_id=com.vibebuddy.app.watchkitapp
+
+echo "→ generating + building VibeBuddyWatch"
+(cd "$repo/VibeBuddyApp" && xcodegen generate >/dev/null)
+xcodebuild -project "$repo/VibeBuddyApp/VibeBuddyApp.xcodeproj" \
+  -scheme VibeBuddyWatch -configuration Debug \
+  -destination 'generic/platform=watchOS Simulator' \
+  -derivedDataPath "$derived" build CODE_SIGNING_ALLOWED=NO >/dev/null
+
+app="$derived/Build/Products/Debug-watchsimulator/VibeBuddyWatch.app"
+[[ -d "$app" ]] || { echo "✗ no built app at $app" >&2; exit 1; }
+
+python3 - "$out" "$app" "$bundle_id" <<'PY'
+import json, os, subprocess, sys, time
+
+out, app, bundle_id = sys.argv[1], sys.argv[2], sys.argv[3]
+runtimes = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "runtimes", "--json"]))["runtimes"]
+watch = [r for r in runtimes if r["platform"] == "watchOS" and r["isAvailable"] and r.get("supportedDeviceTypes")]
+if not watch:
+    sys.exit("✗ no watchOS simulator runtime")
+newest = sorted(watch, key=lambda r: r["version"])[-1]
+types = newest["supportedDeviceTypes"]
+
+def mm(device):
+    digits = "".join(c for c in device["identifier"].split("-")[-1] if c.isdigit())
+    return int(digits or 99)
+
+small = min(types, key=mm)
+large = max(types, key=mm)
+pairs = [(small, "small"), (large, "large")]
+if small["identifier"] == large["identifier"]:
+    pairs = [(small, "small")]
+
+os.makedirs(out, exist_ok=True)
+shots = [
+    ("permission", "01-counts"),
+    ("noData", "02-placeholder"),
+    ("empty", "03-empty-zeros"),
+]
+
+def udid_for(name, device_type):
+    devices = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "devices", "--json"]))["devices"]
+    for items in devices.values():
+        for device in items:
+            if device["name"] == name:
+                return device["udid"]
+    return subprocess.check_output(
+        ["xcrun", "simctl", "create", name, device_type["identifier"], newest["identifier"]],
+        text=True).strip()
+
+for device_type, size in pairs:
+    name = f"VibeBuddy Watch QA {size}"
+    udid = udid_for(name, device_type)
+    subprocess.run(["xcrun", "simctl", "bootstatus", udid, "-b"], check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["xcrun", "simctl", "install", udid, app], check=True)
+    for scenario, stem in shots:
+        subprocess.run(["xcrun", "simctl", "terminate", udid, bundle_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        env = os.environ.copy()
+        env["SIMCTL_CHILD_VIBEBUDDY_DEMO"] = "1"
+        env["SIMCTL_CHILD_VIBEBUDDY_WATCH_SCENARIO"] = scenario
+        env["SIMCTL_CHILD_VIBEBUDDY_WATCH_PAGE"] = "complication"
+        subprocess.run(["xcrun", "simctl", "launch", udid, bundle_id], check=True, env=env, stdout=subprocess.DEVNULL)
+        time.sleep(3)
+        path = os.path.join(out, f"{size}-{stem}.png")
+        subprocess.run(["xcrun", "simctl", "io", udid, "screenshot", path], check=True, stdout=subprocess.DEVNULL)
+        print(f"  ✓ {os.path.basename(path)}  ({device_type['name']} / {scenario})")
+
+print(f"→ shots in {out}")
+PY


### PR DESCRIPTION
F-2

## Summary
- Add a watchOS WidgetKit extension that draws circular and rectangular three-color `needsResponse` / `working` / `done` counts from the iPhone-relayed `WatchDashboardState`.
- Share that state through the Watch App Group (`group.com.vibebuddy.app`) so the complication process never talks to the phone itself.
- Raise Smart Stack relevance only while a waiting count is still a live reading; show a Waiting-for-iPhone placeholder when nothing has arrived.

## Validation
- `cd VibeBuddyKit && swift test` — 280 tests in 34 suites
- `cd VibeBuddyMac && swift test` — 666 tests in 70 suites
- `cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED (Watch app embeds `VibeBuddyWatchWidget.appex`)
- `cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO` — 32 tests, 0 failures
- `cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- `tools/watch-complication-qa-shots.sh` — Simulator shots on Apple Watch SE 3 40mm and SE 44mm (counts, placeholder, empty zeros) in `.scratch/qa-shots/watch-10/`

## Not verified here
- Installing the complication on a physical watch face
- Whether Smart Stack actually rotates the card to the top when `needsResponse > 0` (system relevance; needs a worn Watch)
- App Group read/write and signing on a real Apple Watch