### PR TITLE
fix(apns): keep one registry record per identified phone

### DIFF
--- a/VibeBuddyApp/Sources/PushRegistration.swift
+++ b/VibeBuddyApp/Sources/PushRegistration.swift
@@ -71,6 +71,9 @@ final class PushRegistration {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try? JSONEncoder().encode(DeviceRegistrationPayload(
             token: token,
+            // A retained Keychain identity lets a rotated token replace this
+            // phone's existing record on the Mac.
+            deviceID: PushDeviceIdentity.current(),
             name: UIDevice.current.name,
             model: UIDevice.current.model,
             systemVersion: "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -37,6 +37,69 @@ public enum KeychainStore {
     }
 }
 
+/// The phone's stable push identity: one UUID, minted on first use and kept in
+/// the Keychain to retain it when the app container is replaced. Reinstall
+/// and restore behavior still require device acceptance. Without an identity
+/// surviving token rotation the Mac's registry sees each new token as a new phone and keeps
+/// the old one — with the switches it uploaded last time. See
+/// `DeviceRegistrationPayload.deviceID`.
+public enum PushDeviceIdentity {
+    public static let keychainKey = "pushDeviceID"
+
+    public enum Lookup: Equatable {
+        case found(String), missing, unavailable
+    }
+
+    /// Create only when storage positively reports no identity. Transient
+    /// access failures must not replace an existing ID or advertise a new one.
+    public static func current(
+        read: (String) -> Lookup = readIdentity,
+        write: (String, String) -> Bool = addIdentity,
+        mint: () -> String = { UUID().uuidString }
+    ) -> String? {
+        switch read(keychainKey) {
+        case .found(let value): return valid(value)
+        case .unavailable: return nil
+        case .missing:
+            _ = write(mint(), keychainKey)
+            // Add-only also handles another caller winning creation: read the
+            // durable winner instead of overwriting it with our own UUID.
+            guard case .found(let stored) = read(keychainKey) else { return nil }
+            return valid(stored)
+        }
+    }
+
+    private static func valid(_ value: String) -> String? {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
+    }
+
+    private static func query(_ key: String) -> [String: Any] {
+        [kSecClass as String: kSecClassGenericPassword,
+         kSecAttrService as String: "com.vibebuddy.secrets",
+         kSecAttrAccount as String: key]
+    }
+
+    public static func readIdentity(_ key: String) -> Lookup {
+        var request = query(key)
+        request[kSecReturnData as String] = true
+        request[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(request as CFDictionary, &item)
+        if status == errSecItemNotFound { return .missing }
+        guard status == errSecSuccess, let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else { return .unavailable }
+        return .found(value)
+    }
+
+    public static func addIdentity(_ value: String, for key: String) -> Bool {
+        guard let data = valid(value)?.data(using: .utf8) else { return false }
+        var request = query(key)
+        request[kSecValueData as String] = data
+        request[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(request as CFDictionary, nil) == errSecSuccess
+    }
+}
+
 /// The language the voice companion converses in — drives speech recognition,
 /// the model's reply language, and the spoken voice. Independent of the app's UI
 /// language (which is English).

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -628,6 +628,11 @@ public struct PairingPayload: Codable, Sendable, Equatable {
 /// can arrive in either order.
 public struct DeviceRegistrationPayload: Codable, Sendable, Equatable {
     public var token: String?
+    /// The phone's stable identity, minted once and retained in its Keychain.
+    /// The Mac replaces tokens reported under the same identity, keeping one
+    /// record for that identity. Optional so older payloads decode unchanged;
+    /// a payload without it is keyed on its token alone.
+    public var deviceID: String?
     public var name: String?
     public var model: String?
     public var systemVersion: String?
@@ -639,11 +644,12 @@ public struct DeviceRegistrationPayload: Codable, Sendable, Equatable {
     /// decode unchanged; the Mac treats a missing value as the default set.
     public var categories: NotificationCategoryPrefs?
 
-    public init(token: String? = nil, name: String? = nil,
+    public init(token: String? = nil, deviceID: String? = nil, name: String? = nil,
                 model: String? = nil, systemVersion: String? = nil,
                 playSound: Bool? = nil, quietMode: Bool? = nil,
                 categories: NotificationCategoryPrefs? = nil) {
         self.token = token
+        self.deviceID = deviceID
         self.name = name
         self.model = model
         self.systemVersion = systemVersion

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/WireCodingTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/WireCodingTests.swift
@@ -81,6 +81,56 @@ struct WireCodingTests {
         let legacy = try JSONDecoder().decode(DeviceRegistrationPayload.self,
                                               from: Data(#"{"token":"t","playSound":true}"#.utf8))
         #expect(legacy.categories == nil)
+        #expect(legacy.deviceID == nil)
+        // The stable identity rides along and round-trips.
+        var identified = p
+        identified.deviceID = "3E1D-hermes"
+        #expect(try roundTrip(identified).deviceID == "3E1D-hermes")
+    }
+
+    @Test("PushDeviceIdentity mints once and then reads back the same value")
+    func pushDeviceIdentityIsStable() {
+        var stored: [String: String] = [:]
+        var minted = 0
+        let mint = { minted += 1; return "id-\(minted)" }
+        let first = PushDeviceIdentity.current(
+            read: { stored[$0].map(PushDeviceIdentity.Lookup.found) ?? .missing },
+            write: { stored[$1] = $0; return true }, mint: mint)
+        let second = PushDeviceIdentity.current(
+            read: { stored[$0].map(PushDeviceIdentity.Lookup.found) ?? .missing },
+            write: { stored[$1] = $0; return true }, mint: mint)
+        #expect(first == "id-1")
+        #expect(second == first)
+        #expect(minted == 1)
+        // A blank stored value counts as none — it must not become the identity.
+        stored[PushDeviceIdentity.keychainKey] = ""
+        #expect(PushDeviceIdentity.current(
+            read: { stored[$0].map(PushDeviceIdentity.Lookup.found) ?? .missing },
+            write: { stored[$1] = $0; return true }, mint: mint) == nil)
+    }
+
+    @Test("an unavailable identity store never advertises an unpersisted device id")
+    func pushIdentityRequiresPersistence() {
+        let identity = PushDeviceIdentity.current(read: { _ in .missing }, write: { _, _ in false }, mint: { "temporary" })
+        #expect(identity == nil)
+    }
+
+    @Test("temporary identity read failure never invokes a replacing write")
+    func pushIdentityReadFailureNeverWrites() {
+        var writes = 0
+        let identity = PushDeviceIdentity.current(read: { _ in .unavailable },
+            write: { _, _ in writes += 1; return true }, mint: { "replacement" })
+        #expect(identity == nil)
+        #expect(writes == 0)
+    }
+
+    @Test("competing identity creation reads the persisted winner")
+    func pushIdentityCreationRace() {
+        var stored: String?
+        let identity = PushDeviceIdentity.current(
+            read: { _ in stored.map(PushDeviceIdentity.Lookup.found) ?? .missing },
+            write: { _, _ in stored = "other-caller"; return false }, mint: { "ours" })
+        #expect(identity == "other-caller")
     }
 
     // 5. Wire-format stability — rawValues are the documented strings

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/DeviceRegistry.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/DeviceRegistry.swift
@@ -104,22 +104,35 @@ struct DeviceRegistry {
     /// Upsert a device, merging in only the preference fields this payload
     /// carries — a phone that reconnects before its APNs callback fires keeps
     /// the switches it uploaded last time.
+    ///
+    /// The phone's `deviceID` names it; a new token reported under the same
+    /// id replaces its old record. Keying on the token alone left the old one
+    /// standing, and Apple keeps delivering to a superseded token for a while,
+    /// so a category the user had since switched off was still pushed through
+    /// the stale record. A payload without an id (an older phone build, a raw
+    /// token POST) is keyed on its token, and a record without an id is adopted
+    /// by the first identified payload that carries the same token.
     mutating func upsert(_ payload: DeviceRegistrationPayload, now: Date) {
         guard let token = payload.token, !token.isEmpty, !blocked.contains(token) else { return }
-        let existing = entries.first { $0.device.token == token }
+        let id = payload.deviceID.flatMap { $0.isEmpty ? nil : $0 }
+        let existing = id.flatMap { id in entries.first { $0.device.deviceID == id } }
+            ?? entries.first { $0.device.token == token }
         var merged = existing?.device ?? DeviceRegistrationPayload(token: token)
         merged.token = token
+        if let id { merged.deviceID = id }
         if let v = payload.name { merged.name = v }
         if let v = payload.model { merged.model = v }
         if let v = payload.systemVersion { merged.systemVersion = v }
         if let v = payload.playSound { merged.playSound = v }
         if let v = payload.quietMode { merged.quietMode = v }
         if let v = payload.categories { merged.categories = v }
-        entries.removeAll { $0.device.token == token }
+        entries.removeAll { $0.device.token == token || (id != nil && $0.device.deviceID == id) }
         // Re-registering does not re-prove the token: a phone that reconnects
-        // keeps whatever standing it had with Apple.
+        // keeps whatever standing it had with Apple. A *new* token starts from
+        // nothing, whoever the phone is — Apple has not accepted it yet.
+        let standing = existing?.device.token == token ? existing?.lastAcceptedAt : nil
         entries.append(DeviceRegistryEntry(device: merged, registeredAt: now,
-                                           lastAcceptedAt: existing?.lastAcceptedAt))
+                                           lastAcceptedAt: standing))
         entries = Self.pruned(entries, capacity: capacity)
         persistBestEffort()
     }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/DeviceRegistryTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/DeviceRegistryTests.swift
@@ -56,6 +56,77 @@ struct DeviceRegistryTests {
         #expect(await tokens.devices().count == 1)
     }
 
+    // MARK: One phone, one record
+
+    /// The 02:01 case: the user switched a category off, but the same phone's
+    /// older token was still on file with the switch on, and Apple still
+    /// delivered to it.
+    @Test func reinstalledPhoneReplacesItsOldTokenInsteadOfSittingBesideIt() async throws {
+        let url = tempURL()
+        let tokens = DeviceTokens(url: url)
+        var on = NotificationCategoryPrefs.default
+        on.set(NotificationSound.agentDone, enabled: true)
+        await tokens.register(DeviceRegistrationPayload(
+            token: "old", deviceID: "hermes", name: "Hermes", categories: on))
+
+        var off = NotificationCategoryPrefs.default
+        off.set(NotificationSound.agentDone, enabled: false)
+        await tokens.register(DeviceRegistrationPayload(
+            token: "new", deviceID: "hermes", name: "Hermes", categories: off))
+
+        let devices = await tokens.devices()
+        #expect(devices.count == 1)
+        #expect(devices.first?.token == "new")
+        #expect(devices.first?.categories?.isEnabled(NotificationSound.agentDone) == false)
+        #expect(await DeviceTokens(url: url).all() == ["new"])   // the old token is gone from disk too
+    }
+
+    @Test func newTokenStartsWithoutTheOldTokensStanding() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        await tokens.register(DeviceRegistrationPayload(token: "old", deviceID: "hermes"))
+        await tokens.applySendResult(sent(200), token: "old")
+
+        await tokens.register(DeviceRegistrationPayload(token: "new", deviceID: "hermes"))
+        // Apple has never accepted "new": BadDeviceToken can evict it.
+        #expect(await tokens.applySendResult(sent(400, reason: "BadDeviceToken"), token: "new"))
+        #expect(await tokens.all().isEmpty)
+    }
+
+    @Test func recordWithoutAnIDIsAdoptedByTheSameToken() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        var prefs = NotificationCategoryPrefs.default
+        prefs.set(NotificationSound.agentDone, enabled: false)
+        // Written by the previous phone build, or by the raw-token POST.
+        await tokens.register(DeviceRegistrationPayload(token: "abc", categories: prefs))
+        await tokens.applySendResult(sent(200), token: "abc")
+
+        await tokens.register(DeviceRegistrationPayload(token: "abc", deviceID: "hermes", name: "Hermes"))
+        let devices = await tokens.devices()
+        #expect(devices.count == 1)
+        #expect(devices.first?.deviceID == "hermes")
+        #expect(devices.first?.categories?.isEnabled(NotificationSound.agentDone) == false)
+        // Same token, so its standing with Apple carries over.
+        #expect(await tokens.applySendResult(sent(400, reason: "BadDeviceToken"), token: "abc") == false)
+    }
+
+    @Test func twoPhonesStayTwoRecords() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        await tokens.register(DeviceRegistrationPayload(token: "a", deviceID: "hermes"))
+        await tokens.register(DeviceRegistrationPayload(token: "b", deviceID: "second-phone"))
+        await tokens.register(DeviceRegistrationPayload(token: "a2", deviceID: "hermes"))
+        #expect(Set(await tokens.all()) == ["a2", "b"])
+        #expect(await tokens.devices().count == 2)
+    }
+
+    @Test func partialReportUnderTheSameIDKeepsPrefs() async throws {
+        let tokens = DeviceTokens(url: tempURL())
+        await tokens.register(DeviceRegistrationPayload(
+            token: "old", deviceID: "hermes", playSound: false))
+        // Token rotated; this report carries no switches.
+        await tokens.register(DeviceRegistrationPayload(token: "new", deviceID: "hermes"))
+        #expect(await tokens.devices().first?.playSound == false)
+    }
+
     @Test func tokenlessPayloadIsNotRegistered() async throws {
         let tokens = DeviceTokens(url: tempURL())
         await tokens.register(DeviceRegistrationPayload(name: "Hermes"))


### PR DESCRIPTION
S-6

## Summary

- Give each phone a Keychain-held device ID and include it in registration. A token rotation under that ID replaces its previous registry record while merging current preferences. A new token starts without the previous token's APNs acceptance history, as required by ticket 14.
- Preserve the identity on transient Keychain failures: only create when the item is absent, use add-only storage, and read back the winning identity after concurrent creation. Existing voice credential storage is unchanged.
- Keep the specified token behavior for payloads without device IDs. Deduplication applies after a stable identity has been established. Historical ID-less records with different tokens cannot safely be attributed to one phone; deleting by name or in bulk could remove other phones, so this change does not do that.

## Validation

- `cd VibeBuddyKit && swift test`: 291 tests in 36 suites passed.
- `cd VibeBuddyMac && swift test`: 680 tests in 72 suites passed.
- iOS / Watch / Widget build: passed with generic iOS Simulator destination and `CODE_SIGNING_ALLOWED=NO`.
- iOS app tests: 34 passed on iOS 26.2 simulator `39E5905F-6A6B-4877-A371-385DA0037287`.
- Mac app build: passed with `-scheme VibeBuddyMacApp -destination platform=macOS CODE_SIGNING_ALLOWED=NO`.
- Independent code review: no remaining P1/P2 findings. `git diff --check` passed.

## Not verified here

- Ticket 14 remains ready-for-human: actual phone reinstall / token rotation, retained identity, category-off delivery, and Forget / reconnect acceptance still need Hermes and the user's Mac.
- No physical-device installation, daemon change, deployment, or release was performed. Keychain persistence across reinstall/restore is not claimed as verified by simulated storage tests.
