### PR TITLE
feat(phone): show bounded recent output on session detail

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,6 +132,12 @@ code, and tests — don't drift to synonyms.
 
 ## Observability (2026-09)
 
+- **RecentOutput** — a bounded, authenticated, read-only dialogue slice for one
+  Session (Q31). Carries source (`transcript` / `rollout` / `appserver`),
+  `updatedAt`, a truncation flag, and an unavailability reason when there is no
+  dialogue to show. Thinking, full tool results, images, and terminal dumps are
+  dropped; fetching it never acknowledges a completion or moves Session state.
+  The phone can expand the same slice; it is not a full history.
 - **ObservationSource / ObservationHealth** — which signal currently backs a
   session (`appserver`, `hook`, `rollout`, `transcript`, `recovery`) plus its last-seen time
   and a health verdict (healthy / degraded / unsupported / eventsMissing). Never

--- a/VibeBuddyApp/Shared/DecisionClient.swift
+++ b/VibeBuddyApp/Shared/DecisionClient.swift
@@ -25,10 +25,13 @@ protocol DecisionClient: Sendable {
     /// Set how much a session may interrupt you, or `nil` to return it to the
     /// daemon's automatic level. The Mac owns the value.
     func setAttention(_ pairing: PairingPayload, sessionId: String, level: SessionAttention?) async
+    /// Bounded recent dialogue. Nil when the Mac could not be reached.
+    func recentOutput(_ pairing: PairingPayload, sessionId: String) async -> RecentOutput?
 }
 
 extension DecisionClient {
     func dispatch(_ pairing: PairingPayload, request: DispatchRequest) async -> DispatchOutcome? { nil }
+    func recentOutput(_ pairing: PairingPayload, sessionId: String) async -> RecentOutput? { nil }
     func decideResult(_ pairing: PairingPayload, approvalId: String, decision: ApprovalDecision) async -> WaitActionResult {
         await decide(pairing, approvalId: approvalId, decision: decision) ? .accepted : .failed
     }
@@ -133,6 +136,18 @@ struct HTTPDecisionClient: DecisionClient {
         case 503: return .unavailable(fields["error"] ?? "Unavailable")
         default: return nil
         }
+    }
+
+    func recentOutput(_ pairing: PairingPayload, sessionId: String) async -> RecentOutput? {
+        var comps = URLComponents(string: "http://\(pairing.host):\(pairing.port)/recent-output")
+        comps?.queryItems = [URLQueryItem(name: "sessionId", value: sessionId)]
+        guard let url = comps?.url else { return nil }
+        var req = URLRequest(url: url)
+        req.setValue("Bearer \(pairing.token)", forHTTPHeaderField: "Authorization")
+        guard let (data, resp) = try? await URLSession.shared.data(for: req),
+              let http = resp as? HTTPURLResponse, http.statusCode == 200
+        else { return nil }
+        return try? JSONDecoder().decode(RecentOutput.self, from: data)
     }
 
     func jump(_ pairing: PairingPayload, sessionId: String) async -> JumpOutcome? {

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -27,6 +27,9 @@ final class DashboardStore: ObservableObject {
     /// Set when a Live Activity / deep link asks to open a specific session; the
     /// dashboard scrolls to and highlights it, then clears it via `clearFocus()`.
     @Published var focusedSessionId: String?
+    /// Last fetched recent-output slice per session. Opening the pane reads;
+    /// it never acknowledges a completion.
+    @Published private(set) var recentOutputs: [String: RecentOutput] = [:]
 
     private let streamer: SnapshotStreaming
     private let notifier: AttentionNotifier
@@ -459,6 +462,30 @@ final class DashboardStore: ObservableObject {
         }
         pendingAcknowledgementIDs.remove(sessionId)
         Task { await decisionClient.acknowledge(pairing, sessionId: sessionId) }
+    }
+
+    /// Fetch the bounded recent-output slice. Does not acknowledge completions.
+    func loadRecentOutput(_ sessionId: String) async {
+        if isDemo {
+            recentOutputs[sessionId] = Self.demoRecentOutput(sessionId, from: allSessions)
+            return
+        }
+        guard let pairing else { return }
+        if let output = await decisionClient.recentOutput(pairing, sessionId: sessionId) {
+            recentOutputs[sessionId] = output
+        }
+    }
+
+    private static func demoRecentOutput(_ sessionId: String, from sessions: [AgentSession]) -> RecentOutput {
+        guard let session = sessions.first(where: { $0.id == sessionId }) else {
+            return .unavailable(sessionId: sessionId, reason: .unknownSession)
+        }
+        if let summary = session.summary, !summary.isEmpty {
+            return RecentOutput(
+                sessionId: sessionId, source: .transcript, updatedAt: session.updatedAt,
+                entries: [RecentOutputEntry(role: "assistant", text: summary)])
+        }
+        return RecentOutput(sessionId: sessionId, source: .transcript, updatedAt: session.updatedAt)
     }
 
     /// Set, or with `nil` return to automatic, how much a session may interrupt

--- a/VibeBuddyApp/Sources/DashboardView.swift
+++ b/VibeBuddyApp/Sources/DashboardView.swift
@@ -534,6 +534,7 @@ private struct SessionDetailSheet: View {
                         Text(summary).font(CompanionType.font(14, .semibold)).foregroundStyle(CompanionPalette.ink)
                             .fixedSize(horizontal: false, vertical: true)
                     }
+                    RecentOutputCard(output: dashboard.recentOutputs[session.id])
                     metaCard
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Notifications").font(CompanionType.font(10, .heavy)).textCase(.uppercase).kerning(0.6)
@@ -573,6 +574,7 @@ private struct SessionDetailSheet: View {
         }
         .presentationDetents([.medium, .large])
         .tint(CompanionPalette.accent)
+        .task { await dashboard.loadRecentOutput(session.id) }
     }
 
     private var metaCard: some View {
@@ -615,6 +617,89 @@ private struct SessionDetailSheet: View {
             Spacer()
             Text(value).font(CompanionType.mono(11)).foregroundStyle(CompanionPalette.ink).lineLimit(1).truncationMode(.middle)
         }
+    }
+}
+
+/// Expandable bounded recent dialogue. The expanded text is the same slice
+/// the collapsed preview came from — there is no fuller history behind it.
+private struct RecentOutputCard: View {
+    let output: RecentOutput?
+    @State private var expanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                expanded.toggle()
+            } label: {
+                HStack {
+                    Text("Recent output").font(CompanionType.font(10, .heavy)).textCase(.uppercase).kerning(0.6)
+                        .foregroundStyle(CompanionPalette.ink3)
+                    Spacer()
+                    Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(CompanionPalette.ink3)
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(expanded ? "Hide recent output" : "Show recent output")
+
+            if let output {
+                meta(output)
+                if expanded {
+                    entries(output)
+                } else if let last = output.entries.last {
+                    preview(last)
+                }
+                if !output.statusLine.isEmpty {
+                    Text(output.statusLine)
+                        .font(CompanionType.font(11, .semibold))
+                        .foregroundStyle(CompanionPalette.ink2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else {
+                Text("Loading recent output…")
+                    .font(CompanionType.font(11, .semibold))
+                    .foregroundStyle(CompanionPalette.ink3)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .companionCard()
+    }
+
+    private func meta(_ output: RecentOutput) -> some View {
+        HStack(spacing: 6) {
+            Text(output.sourceLabel)
+            if let updatedAt = output.updatedAt {
+                Text("·")
+                Text(updatedAt, style: .relative).monospacedDigit()
+            }
+        }
+        .font(CompanionType.font(10, .semibold))
+        .foregroundStyle(CompanionPalette.ink3)
+    }
+
+    @ViewBuilder
+    private func entries(_ output: RecentOutput) -> some View {
+        ForEach(Array(output.entries.enumerated()), id: \.offset) { _, entry in
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.role == "assistant" ? "Assistant" : "You")
+                    .font(CompanionType.font(10, .heavy))
+                    .foregroundStyle(entry.role == "assistant" ? CompanionPalette.accent : CompanionPalette.ink3)
+                Text(entry.text)
+                    .font(CompanionType.font(13, .semibold))
+                    .foregroundStyle(CompanionPalette.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func preview(_ entry: RecentOutputEntry) -> some View {
+        Text(entry.text)
+            .font(CompanionType.font(13, .semibold))
+            .foregroundStyle(CompanionPalette.ink)
+            .lineLimit(3)
     }
 }
 

--- a/VibeBuddyApp/Tests/DashboardStoreTests.swift
+++ b/VibeBuddyApp/Tests/DashboardStoreTests.swift
@@ -5,6 +5,10 @@ import VibeBuddyKit
 private actor DecisionRecorder: DecisionClient {
     private(set) var acknowledgedSessionIDs: [String] = []
     private(set) var attentions: [(sessionId: String, level: SessionAttention?)] = []
+    private(set) var recentOutputIDs: [String] = []
+    private var nextOutput: RecentOutput?
+
+    func setNext(_ output: RecentOutput) { nextOutput = output }
 
     func acknowledge(_ pairing: PairingPayload, sessionId: String) async {
         acknowledgedSessionIDs.append(sessionId)
@@ -12,6 +16,11 @@ private actor DecisionRecorder: DecisionClient {
 
     func setAttention(_ pairing: PairingPayload, sessionId: String, level: SessionAttention?) async {
         attentions.append((sessionId, level))
+    }
+
+    func recentOutput(_ pairing: PairingPayload, sessionId: String) async -> RecentOutput? {
+        recentOutputIDs.append(sessionId)
+        return nextOutput ?? RecentOutput(sessionId: sessionId, source: .transcript)
     }
 
     func decide(_ pairing: PairingPayload, approvalId: String, decision: ApprovalDecision) async -> Bool { true }
@@ -89,5 +98,31 @@ final class DashboardStoreTests: XCTestCase {
 
         XCTAssertGreaterThanOrEqual(reports.count, 2)
         XCTAssertEqual(reports.first?.host, "127.0.0.1")
+    }
+
+    func testLoadingRecentOutputDoesNotAcknowledgeCompletion() async throws {
+        let decisions = DecisionRecorder()
+        await decisions.setNext(RecentOutput(
+            sessionId: "s", source: .transcript,
+            entries: [RecentOutputEntry(role: "assistant", text: "done")]))
+        let t = Date(timeIntervalSince1970: 0)
+        let done = AgentSession(id: "s", agent: .claudeCode, project: "p",
+                                status: .done, hasUnreadCompletion: true,
+                                statusSince: t, updatedAt: t)
+        let store = DashboardStore(
+            streamer: ScriptedStreamer(snapshots: [Snapshot(sessions: [done], serverTime: t)]),
+            notifier: SilentNotifier(), decisionClient: decisions, watchRelay: nil)
+        store.start(PairingPayload(host: "127.0.0.1", port: 9, token: "test"))
+        for _ in 0..<50 {
+            if !store.allSessions.isEmpty { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        await store.loadRecentOutput("s")
+        XCTAssertEqual(store.recentOutputs["s"]?.entries.map(\.text), ["done"])
+        XCTAssertEqual(store.allSessions.first?.hasUnreadCompletion, true)
+        let acknowledged = await decisions.acknowledgedSessionIDs
+        XCTAssertEqual(acknowledged, [])
+        store.stop()
     }
 }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/RecentOutput.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/RecentOutput.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Why a bounded recent-output read could not show dialogue.
+public enum RecentOutputUnavailability: String, Codable, Sendable, Equatable {
+    /// The session is not in the current snapshot.
+    case unknownSession
+    /// The session exists but no transcript, rollout, or app-server items are known.
+    case noSource
+    /// A source path exists but could not be read.
+    case unreadable
+    /// The agent has no verified dialogue format for this source.
+    case unsupported
+}
+
+/// One user or assistant line in a bounded recent-output slice.
+public struct RecentOutputEntry: Codable, Equatable, Sendable {
+    public let role: String
+    public let text: String
+
+    public init(role: String, text: String) {
+        self.role = role
+        self.text = text
+    }
+}
+
+/// Authenticated, bounded, read-only recent dialogue for a Session.
+///
+/// This is not a transcript dump and not a completion acknowledgement. Empty
+/// entries with `unavailable == nil` mean the source was readable but held no
+/// dialogue yet. `truncated` means older lines or per-line text were cut.
+public struct RecentOutput: Codable, Equatable, Sendable {
+    public let sessionId: String
+    public let source: ObservationSource?
+    public let updatedAt: Date?
+    public let truncated: Bool
+    public let unavailable: RecentOutputUnavailability?
+    public let entries: [RecentOutputEntry]
+
+    public init(
+        sessionId: String,
+        source: ObservationSource? = nil,
+        updatedAt: Date? = nil,
+        truncated: Bool = false,
+        unavailable: RecentOutputUnavailability? = nil,
+        entries: [RecentOutputEntry] = []
+    ) {
+        self.sessionId = sessionId
+        self.source = source
+        self.updatedAt = updatedAt
+        self.truncated = truncated
+        self.unavailable = unavailable
+        self.entries = unavailable == nil ? entries : []
+    }
+
+    public static func unavailable(
+        sessionId: String,
+        reason: RecentOutputUnavailability,
+        source: ObservationSource? = nil,
+        updatedAt: Date? = nil
+    ) -> RecentOutput {
+        RecentOutput(sessionId: sessionId, source: source, updatedAt: updatedAt,
+                     unavailable: reason)
+    }
+
+    public var sourceLabel: String { source?.displayName ?? "Unknown" }
+
+    /// Empty when the slice is ready and untruncated. Used as the status line
+    /// under the entries — never as a substitute for a pending question.
+    public var statusLine: String {
+        if let unavailable {
+            switch unavailable {
+            case .unknownSession: return "This session is no longer on the Mac."
+            case .noSource: return "No recent output source for this session."
+            case .unreadable: return "The recent output source cannot be read."
+            case .unsupported: return "This agent’s output format is not supported yet."
+            }
+        }
+        if entries.isEmpty { return "No recent output yet." }
+        if truncated { return "Bounded excerpt — not the full history." }
+        return ""
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/RecentOutputTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/RecentOutputTests.swift
@@ -1,0 +1,48 @@
+import Testing
+import Foundation
+@testable import VibeBuddyKit
+
+@Suite("RecentOutput — wire contract")
+struct RecentOutputTests {
+
+    @Test("unavailable carries the reason and never invents entries")
+    func unavailableHasNoEntries() {
+        let output = RecentOutput.unavailable(sessionId: "s", reason: .noSource)
+        #expect(output.sessionId == "s")
+        #expect(output.entries.isEmpty)
+        #expect(output.unavailable == .noSource)
+        #expect(!output.truncated)
+        #expect(output.statusLine == "No recent output source for this session.")
+    }
+
+    @Test("an available empty slice is distinct from unavailable")
+    func emptyIsNotUnavailable() {
+        let output = RecentOutput(sessionId: "s", source: .transcript, entries: [])
+        #expect(output.unavailable == nil)
+        #expect(output.statusLine == "No recent output yet.")
+    }
+
+    @Test("truncation is named without promising a full history")
+    func truncatedStatus() {
+        let output = RecentOutput(
+            sessionId: "s", source: .rollout, truncated: true,
+            entries: [RecentOutputEntry(role: "assistant", text: "done")])
+        #expect(output.statusLine == "Bounded excerpt — not the full history.")
+    }
+
+    @Test("round-trips the fields the phone renders")
+    func roundTrip() throws {
+        let original = RecentOutput(
+            sessionId: "thread-1",
+            source: .appserver,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            truncated: true,
+            entries: [
+                RecentOutputEntry(role: "user", text: "fix the test"),
+                RecentOutputEntry(role: "assistant", text: "patched"),
+            ])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(RecentOutput.self, from: data)
+        #expect(decoded == original)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexRolloutMonitor.swift
@@ -989,7 +989,12 @@ public actor CodexRolloutMonitor {
     /// One deterministic discovery/recovery pass, public so the file-tail
     /// contract can be tested without timers or a running HTTP server.
     public func poll(now: Date) -> [HookEvent] {
-        scan(now: now, installWatchers: isRunning).events
+        scan(now: now, installWatchers: isRunning).events.map(stampPath)
+    }
+
+    /// The rollout file currently tailed for this thread, when the monitor has one.
+    public func rolloutPath(for sessionID: String) -> String? {
+        cursors.first { $0.value.parser.sessionID == sessionID }?.key
     }
 
     public func diagnostics() -> CodexRolloutMonitorDiagnostics {
@@ -1263,10 +1268,17 @@ public actor CodexRolloutMonitor {
         enqueue(result.retired, recordsEvidence: false)
     }
 
+    private func stampPath(_ event: HookEvent) -> HookEvent {
+        if event.transcriptPath != nil { return event }
+        guard let path = cursors.first(where: { $0.value.parser.sessionID == event.sessionID })?.key
+        else { return event }
+        return event.withTranscriptPath(path)
+    }
+
     private func enqueue(_ events: [HookEvent], recordsEvidence: Bool = true) {
         guard isRunning, !events.isEmpty else { return }
         eventQueue.append(contentsOf: events.map {
-            QueuedEvent(event: $0, recordsEvidence: recordsEvidence)
+            QueuedEvent(event: stampPath($0), recordsEvidence: recordsEvidence)
         })
         guard deliveryTask == nil else { return }
         deliveryTask = Task { [weak self] in

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
@@ -120,4 +120,17 @@ public struct HookEvent: Sendable, Equatable {
         self.desktopThreadID = desktopThreadID
         self.probeRetirement = probeRetirement
     }
+
+    /// Stamp the rollout file this event was tailed from, so a later read-only
+    /// recent-output fetch can find the same source without guessing.
+    public func withTranscriptPath(_ path: String) -> HookEvent {
+        HookEvent(
+            kind: kind, sessionID: sessionID, agent: agent, cwd: cwd,
+            toolName: toolName, message: message, waitKind: waitKind,
+            transcriptPath: path, model: model, observationSource: observationSource,
+            toolError: toolError, timestamp: timestamp, childID: childID,
+            childKind: childKind, childName: childName, childType: childType,
+            childAction: childAction, turnID: turnID, enrichment: enrichment,
+            desktopThreadID: desktopThreadID, probeRetirement: probeRetirement)
+    }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/RecentOutputReader.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/RecentOutputReader.swift
@@ -1,0 +1,180 @@
+import Foundation
+import VibeBuddyKit
+
+/// One bounded pass over an already-read source. Pure — no I/O.
+public struct RecentOutputSlice: Equatable, Sendable {
+    public var entries: [TranscriptEntry]
+    public var truncated: Bool
+    public var updatedAt: Date?
+
+    public init(entries: [TranscriptEntry], truncated: Bool = false, updatedAt: Date? = nil) {
+        self.entries = entries
+        self.truncated = truncated
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Per-agent dialogue extractors for the phone's recent-output pane.
+///
+/// Each adapter knows one on-disk / wire shape. Thinking, full tool results,
+/// images, and terminal dumps are dropped; a tool-only turn collapses to a
+/// compact "⚙ name" marker, same as the Mac detail pane.
+public enum RecentOutputReader {
+
+    public static func claude(tail data: Data, limit: Int = 12,
+                              perEntryLimit: Int = 600) -> RecentOutputSlice {
+        bound(TranscriptReader.recentEntries(tail: data, limit: .max, perEntryLimit: .max),
+              limit: limit, perEntryLimit: perEntryLimit)
+    }
+
+    public static func grok(updatesTail data: Data, limit: Int = 12,
+                            perEntryLimit: Int = 600) -> RecentOutputSlice {
+        bound(GrokSessionReader.recentEntries(updatesTail: data, limit: .max,
+                                              perEntryLimit: .max),
+              limit: limit, perEntryLimit: perEntryLimit)
+    }
+
+    public static func codexRollout(tail data: Data, limit: Int = 12,
+                                    perEntryLimit: Int = 600) -> RecentOutputSlice {
+        var entries: [TranscriptEntry] = []
+        var newest: Date?
+        for line in String(decoding: data, as: UTF8.self)
+            .split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let root = try? JSONSerialization.jsonObject(with: Data(line.utf8))
+                    as? [String: Any] else { continue }
+            if let stamp = timestamp(root["timestamp"] as? String) { newest = stamp }
+            guard let entry = codexRolloutEntry(root) else { continue }
+            if entry.role == "assistant",
+               entries.last?.role == "assistant",
+               entries.last?.text == entry.text {
+                continue
+            }
+            entries.append(entry)
+        }
+        var slice = bound(entries, limit: limit, perEntryLimit: perEntryLimit)
+        slice.updatedAt = newest
+        return slice
+    }
+
+    public static func codexAppServer(items: [[String: Any]], limit: Int = 12,
+                                      perEntryLimit: Int = 600) -> RecentOutputSlice {
+        var entries: [TranscriptEntry] = []
+        for item in items {
+            guard let entry = codexAppServerEntry(item) else { continue }
+            entries.append(entry)
+        }
+        return bound(entries, limit: limit, perEntryLimit: perEntryLimit)
+    }
+
+    // MARK: - Codex rollout
+
+    private static func codexRolloutEntry(_ root: [String: Any]) -> TranscriptEntry? {
+        let type = root["type"] as? String
+        if type == "response_item", let payload = root["payload"] as? [String: Any] {
+            return codexResponseItem(payload)
+        }
+        if type == "event_msg", let payload = root["payload"] as? [String: Any] {
+            return codexEventMessage(payload)
+        }
+        return nil
+    }
+
+    private static func codexResponseItem(_ payload: [String: Any]) -> TranscriptEntry? {
+        let itemType = payload["type"] as? String
+        switch itemType {
+        case "message":
+            guard let role = payload["role"] as? String, role == "user" || role == "assistant",
+                  let text = collapse(codexMessageText(payload["content"]))
+            else { return nil }
+            return TranscriptEntry(role: role, text: text)
+        case "function_call", "custom_tool_call", "local_shell_call", "mcp_tool_call":
+            return TranscriptEntry(role: "assistant", text: "⚙ \(codexToolName(payload, itemType: itemType))")
+        default:
+            return nil
+        }
+    }
+
+    private static func codexEventMessage(_ payload: [String: Any]) -> TranscriptEntry? {
+        switch payload["type"] as? String {
+        case "user_message":
+            return collapse(payload["message"] as? String ?? payload["text"] as? String)
+                .map { TranscriptEntry(role: "user", text: $0) }
+        case "agent_message":
+            return collapse(payload["message"] as? String ?? payload["text"] as? String)
+                .map { TranscriptEntry(role: "assistant", text: $0) }
+        case "task_complete":
+            return collapse(payload["last_agent_message"] as? String)
+                .map { TranscriptEntry(role: "assistant", text: $0) }
+        default:
+            return nil
+        }
+    }
+
+    private static func codexMessageText(_ content: Any?) -> String? {
+        if let string = content as? String { return string }
+        guard let blocks = content as? [[String: Any]] else { return nil }
+        var parts: [String] = []
+        for block in blocks {
+            switch block["type"] as? String {
+            case "text", "input_text", "output_text":
+                if let text = block["text"] as? String { parts.append(text) }
+            default:
+                continue
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+
+    private static func codexToolName(_ payload: [String: Any], itemType: String?) -> String {
+        let name = (payload["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let namespace = (payload["namespace"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = [namespace, name].compactMap { $0 }.filter { !$0.isEmpty }
+        if !parts.isEmpty { return parts.joined(separator: "/") }
+        return itemType == "local_shell_call" ? "Shell" : "Tool"
+    }
+
+    // MARK: - Codex app-server items
+
+    private static func codexAppServerEntry(_ item: [String: Any]) -> TranscriptEntry? {
+        switch item["type"] as? String {
+        case "userMessage":
+            return collapse(item["text"] as? String).map { TranscriptEntry(role: "user", text: $0) }
+        case "agentMessage":
+            return collapse(item["text"] as? String).map { TranscriptEntry(role: "assistant", text: $0) }
+        default:
+            return CodexAppServerReducer.toolName(for: item)
+                .map { TranscriptEntry(role: "assistant", text: "⚙ \($0)") }
+        }
+    }
+
+    // MARK: - Shared
+
+    private static func bound(_ entries: [TranscriptEntry], limit: Int,
+                              perEntryLimit: Int) -> RecentOutputSlice {
+        var truncated = entries.count > limit
+        let clipped = entries.suffix(limit).map { entry -> TranscriptEntry in
+            if entry.text.count > perEntryLimit {
+                truncated = true
+                return TranscriptEntry(role: entry.role, text: String(entry.text.prefix(perEntryLimit)))
+            }
+            return entry
+        }
+        return RecentOutputSlice(entries: Array(clipped), truncated: truncated)
+    }
+
+    private static func collapse(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let collapsed = raw
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return collapsed.isEmpty ? nil : collapsed
+    }
+
+    private static func timestamp(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -538,11 +538,90 @@ public actor SessionStore {
     /// for the detail pane. Empty when the session has no known transcript, so
     /// the UI can show a graceful "no transcript" state.
     public func recentTranscript(sessionID: String, limit: Int = 12) -> [TranscriptEntry] {
-        if let directory = grokDirectories[sessionID] {
-            return GrokSessionReader.recentEntries(directory: directory, limit: limit)
+        let output = recentOutput(sessionID: sessionID, limit: limit)
+        return output.entries.map { TranscriptEntry(role: $0.role, text: $0.text) }
+    }
+
+    /// Authenticated recent-output payload for the phone. Read-only: does not
+    /// acknowledge completions or otherwise move Session state.
+    public func recentOutput(
+        sessionID: String,
+        limit: Int = 12,
+        perEntryLimit: Int = 600,
+        rolloutPath: String? = nil,
+        appServerItems: [[String: Any]]? = nil
+    ) -> RecentOutput {
+        guard let session = reducer.sessions[sessionID] else {
+            return .unavailable(sessionId: sessionID, reason: .unknownSession)
         }
-        guard let path = transcriptPaths[sessionID] else { return [] }
-        return TranscriptReader.recentEntries(path: path, limit: limit) ?? []
+        if let directory = grokDirectories[sessionID] {
+            let path = directory.appendingPathComponent("updates.jsonl").path
+            guard let data = Self.readTail(path: path, maxBytes: GrokSessionReader.updatesTailBytes) else {
+                return .unavailable(sessionId: sessionID, reason: .unreadable, source: .transcript)
+            }
+            return finish(
+                sessionID: sessionID, source: .transcript, path: path,
+                RecentOutputReader.grok(updatesTail: data, limit: limit, perEntryLimit: perEntryLimit))
+        }
+        if session.agent == .codex, let items = appServerItems, !items.isEmpty {
+            return finish(
+                sessionID: sessionID, source: .appserver, path: nil,
+                RecentOutputReader.codexAppServer(
+                    items: items, limit: limit, perEntryLimit: perEntryLimit))
+        }
+        let path = rolloutPath ?? transcriptPaths[sessionID]
+        guard let path else {
+            return .unavailable(sessionId: sessionID, reason: .noSource)
+        }
+        let source: ObservationSource = session.agent == .codex ? .rollout : .transcript
+        guard let data = Self.readTail(path: path, maxBytes: 262_144) else {
+            return .unavailable(sessionId: sessionID, reason: .unreadable, source: source)
+        }
+        let slice: RecentOutputSlice
+        switch session.agent {
+        case .codex:
+            let rollout = RecentOutputReader.codexRollout(
+                tail: data, limit: limit, perEntryLimit: perEntryLimit)
+            slice = rollout.entries.isEmpty
+                ? RecentOutputReader.claude(tail: data, limit: limit, perEntryLimit: perEntryLimit)
+                : rollout
+        case .claudeCode:
+            slice = RecentOutputReader.claude(tail: data, limit: limit, perEntryLimit: perEntryLimit)
+        default:
+            let claude = RecentOutputReader.claude(
+                tail: data, limit: limit, perEntryLimit: perEntryLimit)
+            slice = claude.entries.isEmpty
+                ? RecentOutputReader.codexRollout(tail: data, limit: limit, perEntryLimit: perEntryLimit)
+                : claude
+        }
+        return finish(sessionID: sessionID, source: source, path: path, slice)
+    }
+
+    private func finish(
+        sessionID: String,
+        source: ObservationSource,
+        path: String?,
+        _ slice: RecentOutputSlice
+    ) -> RecentOutput {
+        RecentOutput(
+            sessionId: sessionID,
+            source: source,
+            updatedAt: slice.updatedAt ?? path.flatMap(Self.modificationDate),
+            truncated: slice.truncated,
+            entries: slice.entries.map { RecentOutputEntry(role: $0.role, text: $0.text) })
+    }
+
+    private static func readTail(path: String, maxBytes: Int) -> Data? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        do {
+            let end = try handle.seekToEnd()
+            let start = end > UInt64(maxBytes) ? end - UInt64(maxBytes) : 0
+            try handle.seek(toOffset: start)
+            return try handle.readToEnd() ?? Data()
+        } catch {
+            return nil
+        }
     }
 
     /// Privacy-minimized lifecycle diagnostics, newest first.

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -437,6 +437,22 @@ public struct VibeBuddyServer: Sendable {
             )
         }
 
+        // Bounded recent dialogue for one session. Token-gated, read-only:
+        // fetching never acknowledges a completion or moves Session state.
+        let rolloutMonitor = self.codexRolloutMonitor
+        authed.get("recent-output") { request, _ -> Response in
+            guard let sessionID = request.uri.queryParameters["sessionId"].map(String.init),
+                  !sessionID.isEmpty else { throw HTTPError(.badRequest) }
+            let path = await rolloutMonitor?.rolloutPath(for: sessionID)
+            let output = await store.recentOutput(sessionID: sessionID, rolloutPath: path)
+            let data = try JSONEncoder().encode(output)
+            return Response(
+                status: .ok,
+                headers: [.contentType: "application/json"],
+                body: .init(byteBuffer: ByteBuffer(bytes: data))
+            )
+        }
+
         // Privacy-minimized local diagnostics. Token-gated because stable
         // session IDs remain local user metadata.
         authed.get("lifecycle") { _, _ -> Response in

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/RecentOutputReaderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/RecentOutputReaderTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import Foundation
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+@Suite("RecentOutputReader — per-agent formats")
+struct RecentOutputReaderTests {
+
+    @Test("Claude transcript keeps user and assistant prose, drops thinking and tool results")
+    func claudeFiltersNoise() {
+        let lines = [
+            claudeUser("fix the flaky test"),
+            claudeAssistant(blocks: [
+                #"{"type":"thinking","thinking":"I should look around"}"#,
+                #"{"type":"text","text":"Looking at the suite."}"#,
+            ]),
+            claudeToolResult("ok"),
+            claudeAssistant(blocks: [#"{"type":"text","text":"Patched the race."}"#]),
+        ]
+        let slice = RecentOutputReader.claude(tail: data(lines))
+        #expect(slice.entries.map(\.role) == ["user", "assistant", "assistant"])
+        #expect(slice.entries.map(\.text) == [
+            "fix the flaky test", "Looking at the suite.", "Patched the race.",
+        ])
+        #expect(!slice.truncated)
+    }
+
+    @Test("Claude marks truncation when the window or a line is cut")
+    func claudeTruncates() {
+        let lines = [
+            claudeAssistant(blocks: [#"{"type":"text","text":"line 1"}"#]),
+            claudeAssistant(blocks: [#"{"type":"text","text":"line 2"}"#]),
+            claudeAssistant(blocks: [#"{"type":"text","text":"line 3"}"#]),
+            claudeAssistant(blocks: [#"{"type":"text","text":"line 4"}"#]),
+        ]
+        let limited = RecentOutputReader.claude(tail: data(lines), limit: 2)
+        #expect(limited.entries.map(\.text) == ["line 3", "line 4"])
+        #expect(limited.truncated)
+
+        let long = claudeAssistant(blocks: [#"{"type":"text","text":"abcdefghij"}"#])
+        let cut = RecentOutputReader.claude(tail: data([long]), perEntryLimit: 5)
+        #expect(cut.entries.map(\.text) == ["abcde"])
+        #expect(cut.truncated)
+    }
+
+    @Test("Codex rollout keeps dialogue and tool names, drops reasoning and tool output")
+    func codexRolloutFiltersNoise() {
+        let lines = [
+            #"{"timestamp":"2026-09-02T01:00:00Z","type":"session_meta","payload":{"id":"thread-1"}}"#,
+            #"{"timestamp":"2026-09-02T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"fix the flaky test"}]}}"#,
+            #"{"timestamp":"2026-09-02T01:00:02Z","type":"response_item","payload":{"type":"reasoning","summary":[{"text":"secret chain"}]}}"#,
+            #"{"timestamp":"2026-09-02T01:00:03Z","type":"response_item","payload":{"type":"function_call","name":"exec","call_id":"c1"}}"#,
+            #"{"timestamp":"2026-09-02T01:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"c1","output":"full terminal dump"}}"#,
+            #"{"timestamp":"2026-09-02T01:00:05Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Patched the race."}]}}"#,
+        ]
+        let slice = RecentOutputReader.codexRollout(tail: data(lines))
+        #expect(slice.entries.map(\.role) == ["user", "assistant", "assistant"])
+        #expect(slice.entries.map(\.text) == [
+            "fix the flaky test", "⚙ exec", "Patched the race.",
+        ])
+        #expect(slice.updatedAt != nil)
+        #expect(!slice.truncated)
+    }
+
+    @Test("Codex rollout does not duplicate task_complete text already captured")
+    func codexRolloutDedupesCompletion() {
+        let lines = [
+            #"{"timestamp":"2026-09-02T01:00:05Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done"}]}}"#,
+            #"{"timestamp":"2026-09-02T01:00:06Z","type":"event_msg","payload":{"type":"task_complete","last_agent_message":"Done"}}"#,
+        ]
+        let slice = RecentOutputReader.codexRollout(tail: data(lines))
+        #expect(slice.entries.map(\.text) == ["Done"])
+    }
+
+    @Test("Codex app-server items keep user/agent text and skip reasoning plus tool output")
+    func codexAppServerFiltersNoise() {
+        let items: [[String: Any]] = [
+            ["type": "userMessage", "text": "fix the flaky test"],
+            ["type": "reasoning", "text": "secret chain"],
+            ["type": "commandExecution", "command": "git status", "aggregatedOutput": "full terminal dump"],
+            ["type": "agentMessage", "text": "Patched the race."],
+        ]
+        let slice = RecentOutputReader.codexAppServer(items: items)
+        #expect(slice.entries.map(\.role) == ["user", "assistant", "assistant"])
+        #expect(slice.entries.map(\.text) == [
+            "fix the flaky test", "⚙ Shell", "Patched the race.",
+        ])
+    }
+
+    private func data(_ lines: [String]) -> Data {
+        Data(lines.joined(separator: "\n").utf8)
+    }
+
+    private func claudeUser(_ text: String) -> String {
+        #"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"\#(text)"}]}}"#
+    }
+
+    private func claudeAssistant(blocks: [String]) -> String {
+        #"{"type":"assistant","message":{"role":"assistant","content":[\#(blocks.joined(separator: ","))]}}"#
+    }
+
+    private func claudeToolResult(_ text: String) -> String {
+        #"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"\#(text)"}]}}"#
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/RecentOutputStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/RecentOutputStoreTests.swift
@@ -1,0 +1,78 @@
+import Testing
+import Foundation
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+@Suite("SessionStore — recent output")
+struct RecentOutputStoreTests {
+
+    let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("Claude transcript path becomes a sourced, bounded slice")
+    func claudeSource() async throws {
+        let path = NSTemporaryDirectory() + "vb-ro-\(UUID().uuidString).jsonl"
+        let lines = [
+            #"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"fix it"}]}}"#,
+            #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"plan"},{"type":"text","text":"done"}]}}"#,
+        ]
+        try lines.joined(separator: "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let store = SessionStore()
+        let payload = #"{"hook_event_name":"Stop","session_id":"s","cwd":"/x/demo","transcript_path":"\#(path)"}"#
+        await store.ingest(Data(payload.utf8), receivedAt: t0)
+
+        let before = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(before.hasUnreadCompletion)
+
+        let output = await store.recentOutput(sessionID: "s")
+        #expect(output.source == .transcript)
+        #expect(output.unavailable == nil)
+        #expect(output.entries.map(\.text) == ["fix it", "done"])
+        #expect(output.updatedAt != nil)
+
+        let after = try #require(await store.snapshot(now: t0).sessions.first)
+        #expect(after.hasUnreadCompletion == true)
+        #expect(after.statusSince == before.statusSince)
+    }
+
+    @Test("Codex rollout path is parsed as rollout, not as a Claude transcript")
+    func codexRolloutSource() async throws {
+        let path = NSTemporaryDirectory() + "rollout-\(UUID().uuidString).jsonl"
+        let lines = [
+            #"{"timestamp":"2026-09-02T01:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"ship it"}]}}"#,
+            #"{"timestamp":"2026-09-02T01:00:01Z","type":"response_item","payload":{"type":"reasoning","summary":[{"text":"nope"}]}}"#,
+            #"{"timestamp":"2026-09-02T01:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"shipped"}]}}"#,
+        ]
+        try lines.joined(separator: "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let store = SessionStore()
+        await store.ingest(
+            HookEvent(kind: .sessionStart, sessionID: "thread-1", agent: .codex,
+                      transcriptPath: path, observationSource: .rollout, timestamp: t0),
+            recordsEvidence: true)
+
+        let output = await store.recentOutput(sessionID: "thread-1")
+        #expect(output.source == .rollout)
+        #expect(output.entries.map(\.text) == ["ship it", "shipped"])
+    }
+
+    @Test("an unknown session is unavailable and invents no dialogue")
+    func unknownSession() async {
+        let output = await SessionStore().recentOutput(sessionID: "missing")
+        #expect(output.unavailable == .unknownSession)
+        #expect(output.entries.isEmpty)
+    }
+
+    @Test("a known session with no source says so")
+    func noSource() async {
+        let store = SessionStore()
+        await store.ingest(
+            Data(#"{"hook_event_name":"SessionStart","session_id":"s","cwd":"/x/demo"}"#.utf8),
+            receivedAt: t0)
+        let output = await store.recentOutput(sessionID: "s")
+        #expect(output.unavailable == .noSource)
+        #expect(output.entries.isEmpty)
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/VibeBuddyServerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/VibeBuddyServerTests.swift
@@ -369,4 +369,38 @@ struct VibeBuddyServerTests {
             }
         }
     }
+
+    @Test("/recent-output is token-gated, needs a sessionId, and does not acknowledge")
+    func recentOutputRoute() async throws {
+        let path = NSTemporaryDirectory() + "vb-ro-route-\(UUID().uuidString).jsonl"
+        try #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}"#
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let store = SessionStore()
+        await store.ingest(
+            Data(#"{"hook_event_name":"Stop","session_id":"s","cwd":"/x/demo","transcript_path":"\#(path)"}"#.utf8),
+            receivedAt: Date(timeIntervalSince1970: 2))
+        #expect(await store.snapshot(now: .now).sessions.first?.hasUnreadCompletion == true)
+
+        let server = VibeBuddyServer(store: store, token: "t0k")
+        try await server.buildApplication().test(.router) { client in
+            try await client.execute(uri: "/recent-output?sessionId=s", method: .get) { res in
+                #expect(res.status == .unauthorized)
+            }
+            try await client.execute(uri: "/recent-output", method: .get,
+                                     headers: [.authorization: "Bearer t0k"]) { res in
+                #expect(res.status == .badRequest)
+            }
+            try await client.execute(uri: "/recent-output?sessionId=s", method: .get,
+                                     headers: [.authorization: "Bearer t0k"]) { res in
+                #expect(res.status == .ok)
+                let output = try JSONDecoder().decode(RecentOutput.self, from: Data(buffer: res.body))
+                #expect(output.sessionId == "s")
+                #expect(output.source == .transcript)
+                #expect(output.entries.map(\.text) == ["hello"])
+            }
+        }
+        #expect(await store.snapshot(now: .now).sessions.first?.hasUnreadCompletion == true)
+    }
 }

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -536,7 +536,7 @@ private struct TranscriptSheet: View {
     let session: AgentSession
     @ObservedObject var model: MenuBarModel
     @Environment(\.dismiss) private var dismiss
-    @State private var entries: [TranscriptEntry] = []
+    @State private var output: RecentOutput?
     @State private var loaded = false
 
     var body: some View {
@@ -555,7 +555,7 @@ private struct TranscriptSheet: View {
         }
         .frame(minWidth: 460, minHeight: 360)
         .task {
-            entries = await model.transcript(for: session.id)
+            output = await model.recentOutput(for: session.id)
             loaded = true
         }
     }
@@ -564,15 +564,29 @@ private struct TranscriptSheet: View {
     private var content: some View {
         if !loaded {
             ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if entries.isEmpty {
+        } else if let output, output.entries.isEmpty {
             ContentUnavailableView(
                 "No recent output", systemImage: "text.alignleft",
-                description: Text("This session hasn't reported a transcript yet."))
+                description: Text(output.statusLine.isEmpty
+                                  ? "This session hasn't reported a transcript yet."
+                                  : output.statusLine))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
+        } else if let output {
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+                    HStack(spacing: 6) {
+                        Text(output.sourceLabel)
+                        if let updatedAt = output.updatedAt {
+                            Text("·")
+                            Text(updatedAt, style: .relative).monospacedDigit()
+                        }
+                    }
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    if !output.statusLine.isEmpty {
+                        Text(output.statusLine).font(.caption).foregroundStyle(.secondary)
+                    }
+                    ForEach(Array(output.entries.enumerated()), id: \.offset) { _, entry in
                         VStack(alignment: .leading, spacing: 3) {
                             Text(entry.role == "assistant" ? "Assistant" : "You")
                                 .font(.caption2.weight(.semibold))

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -759,7 +759,11 @@ final class MenuBarModel: ObservableObject {
     /// The session's recent output, for the detail pane's "Recent output" sheet.
     /// Reads off the store actor; empty when no transcript is known.
     func transcript(for sessionID: String) async -> [TranscriptEntry] {
-        await store.recentTranscript(sessionID: sessionID)
+        await recentOutput(for: sessionID).entries.map { TranscriptEntry(role: $0.role, text: $0.text) }
+    }
+
+    func recentOutput(for sessionID: String) async -> RecentOutput {
+        await store.recentOutput(sessionID: sessionID)
     }
 
     /// Execute a voice action against the matching session; returns a spoken confirmation.


### PR DESCRIPTION
M-05

## Summary
- Add an authenticated, read-only `GET /recent-output?sessionId=` that returns a bounded dialogue slice (source, `updatedAt`, truncation, unavailability) without acknowledging completions.
- Verify Claude transcript, Codex rollout, Codex app-server items, and Grok updates formats; drop thinking, full tool results, and terminal dumps.
- Show the same slice on the phone session sheet (expandable) and the Mac recent-output pane.

## Validation
- `cd VibeBuddyKit && swift test` — 280 tests / 34 suites passed
- `cd VibeBuddyMac && swift test` — 676 tests / 72 suites passed (10 new RecentOutput cases)
- `cd VibeBuddyApp && xcodegen generate && xcodebuild -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**
- `cd VibeBuddyApp && xcodebuild test -project VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO` — DashboardStoreTests 4/4 passed (including load-does-not-acknowledge); NotificationRelayTests had 1–2 timing flakes (`posted == []` after 200ms) on two runs, different cases each time
- `cd VibeBuddyMacApp && xcodegen generate && xcodebuild -project VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**

## Not verified here
- Real paired iPhone against live Claude / Codex sessions (no data, stale, truncated)
- Watch short recent-output / on-demand speech (out of scope for this ticket)
- Did not deploy, replace an installed app, or touch the running daemon on port 9876