### PR TITLE
fix(mac): correct observation configuration and waiting diagnostics

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
@@ -130,6 +130,9 @@ public struct ObservationSourceDiagnostic: Codable, Sendable, Equatable, Identif
     public let source: ObservationSource
     public var health: ObservationHealth
     public var lastObservedAt: Date?
+    /// Extensible diagnostic metadata; existing health raw values stay on the wire.
+    public var reasonCode: String?
+    public var sourceVersion: String?
     public var configuredCoverage: [ObservationEventCoverage]
     public var observedCoverage: [ObservationEventCoverage]
 
@@ -138,11 +141,15 @@ public struct ObservationSourceDiagnostic: Codable, Sendable, Equatable, Identif
         health: ObservationHealth,
         lastObservedAt: Date? = nil,
         configuredCoverage: [ObservationEventCoverage] = [],
-        observedCoverage: [ObservationEventCoverage] = []
+        observedCoverage: [ObservationEventCoverage] = [],
+        reasonCode: String? = nil,
+        sourceVersion: String? = nil
     ) {
         self.source = source
         self.health = health
         self.lastObservedAt = lastObservedAt
+        self.reasonCode = reasonCode
+        self.sourceVersion = sourceVersion
         self.configuredCoverage = configuredCoverage.sorted()
         self.observedCoverage = observedCoverage.sorted()
     }

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ObservationDiagnosticCompatibilityTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ObservationDiagnosticCompatibilityTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("OH-1 active snapshot contract")
+struct ObservationDiagnosticCompatibilityTests {
+    @Test("old phone model decodes a complete snapshot with new and unknown reasons")
+    func oldPhoneDecodesSnapshot() throws {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let rows = [
+            ObservationSourceDiagnostic(source: .hook, health: .temporarilySilent,
+                configuredCoverage: ObservationEventCoverage.allCases, reasonCode: "awaitingActivity"),
+            ObservationSourceDiagnostic(source: .statusline, health: .notInstalled,
+                reasonCode: "optionalSourceNotConfigured"),
+            ObservationSourceDiagnostic(source: .transcript, health: .eventsMissing,
+                reasonCode: "futureReason", sourceVersion: "futureVersion")
+        ]
+        var snapshot = Snapshot(sessions: [], serverTime: now, sourceID: "test-mac",
+            observationDiagnostics: [.init(agent: .claudeCode, sources: rows)],
+            providerQuota: [], recentDirectories: ["/test"], dispatchAgents: [.codex])
+        for status in [SessionStatus.working, .needsResponse, .done] {
+            var reducerSession = AgentSession(id: status.rawValue, agent: .claudeCode, project: "test", status: status,
+                statusSince: now, updatedAt: now)
+            reducerSession.observations = [.init(source: .hook, lastObservedAt: now, health: .healthy)]
+            snapshot.sessions.append(reducerSession)
+        }
+        let data = try JSONEncoder().encode(snapshot)
+        let old = try JSONDecoder().decode(OldSnapshot.self, from: data)
+        #expect(old.sessions == snapshot.sessions)
+        #expect(old.serverTime == snapshot.serverTime)
+        #expect(old.sourceID == snapshot.sourceID)
+        #expect(old.recentDirectories == snapshot.recentDirectories)
+        #expect(old.dispatchAgents == snapshot.dispatchAgents)
+        #expect(old.providerQuota == snapshot.providerQuota)
+        #expect(old.observationDiagnostics?.first?.sources.map(\.health) == snapshot.observationDiagnostics?.first?.sources.map(\.health))
+        #expect(try JSONDecoder().decode(Snapshot.self, from: data) == snapshot)
+        let oldData = try JSONEncoder().encode(old)
+        let newFromOld = try JSONDecoder().decode(Snapshot.self, from: oldData)
+        #expect(newFromOld.observationDiagnostics?.first?.sources.allSatisfy { $0.reasonCode == nil && $0.sourceVersion == nil } == true)
+    }
+}
+
+// Stored properties copied from origin/main ece1e72, before OH-1. The other
+// model types are unchanged by OH-1. This exercises the complete snapshot, not
+// a permissive dictionary or the new diagnostic decoder disguised as an old one.
+private struct OldSnapshot: Codable {
+    var sourceID: String?
+    var sessions: [AgentSession]
+    var serverTime: Date
+    var observationDiagnostics: [OldAgentDiagnostic]?
+    var providerQuota: [ProviderQuota]?
+    var recentDirectories: [String]?
+    var dispatchAgents: [AgentKind]?
+}
+private struct OldAgentDiagnostic: Codable {
+    let agent: AgentKind
+    var sources: [OldSourceDiagnostic]
+}
+private struct OldSourceDiagnostic: Codable {
+    let source: ObservationSource
+    var health: ObservationHealth
+    var lastObservedAt: Date?
+    var configuredCoverage: [ObservationEventCoverage]
+    var observedCoverage: [ObservationEventCoverage]
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ObservationHealthDetector.swift
@@ -223,8 +223,8 @@ public enum ObservationHealthDetector {
         AgentObservationDiagnostic(agent: agent, sources: [daemon, hook, passive].compactMap { $0 })
     }
 
-    /// Claude's status line forwarder: healthy while samples arrive, "events
-    /// missing" when the wrapper is configured but silent, "not installed"
+    /// Claude's status line forwarder: healthy while samples arrive, awaiting
+    /// activity when configured without a sample, "not installed"
     /// when Claude's settings name no vibebuddy status line.
     private static func statusLineEvidence(
         config: URL?,
@@ -235,14 +235,22 @@ public enum ObservationHealthDetector {
     ) -> ObservationSourceDiagnostic {
         let signal = latestSignal(agent: .claudeCode, source: .statusline, in: signals)
         var configured = false
-        if let config, let data = readData(at: config, upToCount: 1 << 20, fileManager: fm),
-           let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-           let statusLine = root["statusLine"] as? [String: Any],
-           (statusLine["command"] as? String)?.contains("vibebuddy-statusline.sh") == true {
-            configured = true
+        if let config, fm.fileExists(atPath: config.path) {
+            guard let data = readData(at: config, upToCount: 1 << 20, fileManager: fm),
+                  let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+                return diagnostic(source: .statusline, signal: signal, fallback: .sourceUnreadable,
+                                  now: now, staleAfter: staleAfter, forceFallback: true)
+            }
+            if let statusLine = root["statusLine"] as? [String: Any],
+               let command = statusLine["command"] as? String {
+                // Keep the existing installer's is_statusline_wrapper boundary;
+                // strict executable parsing below is for lifecycle hooks only.
+                configured = command.contains("vibebuddy-statusline.sh")
+            }
         }
         return diagnostic(source: .statusline, signal: signal,
-                          fallback: configured ? .eventsMissing : .notInstalled,
+                          fallback: configured ? .temporarilySilent : .notInstalled,
+                          reasonCode: configured ? "awaitingActivity" : "optionalSourceNotConfigured",
                           now: now, staleAfter: staleAfter,
                           forceFallback: !configured && signal == nil)
     }
@@ -286,15 +294,17 @@ public enum ObservationHealthDetector {
         }
         guard fm.fileExists(atPath: config.path) else {
             return diagnostic(source: .hook, signal: signal, fallback: .eventsMissing,
-                              now: now, staleAfter: staleAfter)
+                              reasonCode: "configurationIncomplete",
+                              now: now, staleAfter: staleAfter, forceFallback: true)
         }
         guard let data = readData(at: config, upToCount: 1 << 20, fileManager: fm),
               let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-              let hooks = root["hooks"] as? [String: Any] else {
+              root["hooks"] == nil || root["hooks"] is [String: Any] else {
             return diagnostic(source: .hook, signal: signal, fallback: .sourceUnreadable,
-                              now: now, staleAfter: staleAfter)
+                              now: now, staleAfter: staleAfter, forceFallback: true)
         }
 
+        let hooks = root["hooks"] as? [String: Any] ?? [:]
         var coverage = Set<ObservationEventCoverage>()
         var hasManagedHook = false
         var hasAsyncManagedHook = false
@@ -304,7 +314,7 @@ public enum ObservationHealthDetector {
                 guard let commands = group["hooks"] as? [[String: Any]] else { continue }
                 for command in commands {
                     guard let value = command["command"] as? String,
-                          value.contains("vibebuddy-forward.sh") || value.contains("127.0.0.1:9876/hook")
+                          isManagedHook(command, value: value, agent: agent, event: event)
                     else { continue }
                     hasManagedHook = true
                     if command["async"] as? Bool == true { hasAsyncManagedHook = true }
@@ -317,11 +327,86 @@ public enum ObservationHealthDetector {
         // Codex runs `async` hooks detached and drops their output, so an async
         // managed hook is a configuration error rather than a missing event.
         let fallback: ObservationHealth =
-            (agent == .codex && hasAsyncManagedHook) ? .asyncIncompatible : .eventsMissing
+            (agent == .codex && hasAsyncManagedHook) ? .asyncIncompatible
+                : configurationIncomplete ? .eventsMissing : .temporarilySilent
         return diagnostic(source: .hook, signal: signal, fallback: fallback,
+                          reasonCode: fallback == .asyncIncompatible ? nil
+                            : configurationIncomplete ? "configurationIncomplete" : "awaitingActivity",
                           configuredCoverage: Array(coverage), now: now,
                           staleAfter: staleAfter,
                           forceFallback: fallback == .asyncIncompatible || configurationIncomplete)
+    }
+
+    /// Recognize only the installer's executable + agent, never execute inspected
+    /// commands. Claude's exec form keeps paths (including spaces) in `command`.
+    private static func isManagedHook(
+        _ hook: [String: Any], value: String, agent: AgentKind, event: String
+    ) -> Bool {
+        guard hook["type"] == nil || hook["type"] as? String == "command" else { return false }
+        let argv: [String]
+        if let args = hook["args"] {
+            guard let args = args as? [String] else { return false }
+            argv = [value] + args
+        } else {
+            guard let words = literalShellWords(value) else { return false }
+            argv = words
+        }
+        guard let executable = argv.first, executable.hasPrefix("/") else { return false }
+        let name = URL(fileURLWithPath: executable).lastPathComponent
+        let expected: String
+        switch agent {
+        case .claudeCode: expected = "claude"
+        case .codex: expected = "codex"
+        case .grok: expected = "grok"
+        default: return false
+        }
+        if name == "vibebuddy-forward.sh" { return argv.count == 2 && argv[1] == expected }
+        guard name == "approval-hook.sh" else { return false }
+        if agent == .claudeCode {
+            return (argv.count == 1 || argv == [executable, expected])
+                && ["PermissionRequest", "PreToolUse"].contains(event)
+        }
+        return argv == [executable, expected]
+            && event == (agent == .codex ? "PermissionRequest" : "PreToolUse")
+    }
+
+    /// A deliberately bounded literal shell grammar: quotes and escaped paths,
+    /// no operators, expansion, comments, substitutions or command wrappers.
+    private static func literalShellWords(_ command: String) -> [String]? {
+        var words: [String] = []
+        var word = ""
+        var quote: Character?
+        var escaped = false
+        var started = false
+        for c in command {
+            if escaped {
+                guard c != "\n", c != "\r" else { return nil }
+                // Inside double quotes a backslash only escapes shell-special
+                // characters; keep it before ordinary path characters.
+                if quote == "\"", !"$`\"\\".contains(c) { word.append("\\") }
+                word.append(c); escaped = false; started = true; continue
+            }
+            if c == "\\", quote != "'" { escaped = true; started = true; continue }
+            if let q = quote {
+                if c == q { quote = nil }
+                else {
+                    if q == "\"", c == "$" || c == "`" { return nil }
+                    word.append(c)
+                }
+                continue
+            }
+            if c == "'" || c == "\"" { quote = c; started = true }
+            else if c == "\n" || c == "\r" { return nil }
+            else if c == " " || c == "\t" {
+                if started { words.append(word); word = ""; started = false }
+            } else {
+                guard !";|&<>()$`#*?[]{}~".contains(c) else { return nil }
+                word.append(c); started = true
+            }
+        }
+        guard quote == nil, !escaped else { return nil }
+        if started { words.append(word) }
+        return words
     }
 
     private static func passiveEvidence(
@@ -354,7 +439,8 @@ public enum ObservationHealthDetector {
         // by mtime, including files outside the monitor recency window, so a
         // restart still has freshness evidence.
         guard source == .rollout else {
-            return diagnostic(source: source, signal: signal, fallback: .eventsMissing,
+            return diagnostic(source: source, signal: signal, fallback: .temporarilySilent,
+                              reasonCode: "awaitingActivity",
                               now: now, staleAfter: staleAfter)
         }
 
@@ -396,6 +482,7 @@ public enum ObservationHealthDetector {
         source: ObservationSource,
         signal: ObservationRuntimeSignal?,
         fallback: ObservationHealth,
+        reasonCode: String? = nil,
         lastObservedAt: Date? = nil,
         configuredCoverage: [ObservationEventCoverage] = [],
         now: Date,
@@ -421,7 +508,8 @@ public enum ObservationHealthDetector {
             health: health,
             lastObservedAt: signal?.lastObservedAt ?? lastObservedAt,
             configuredCoverage: configuredCoverage,
-            observedCoverage: signal?.observedCoverage ?? [])
+            observedCoverage: signal?.observedCoverage ?? [],
+            reasonCode: (forceFallback || signal == nil) ? reasonCode : nil)
     }
 
     private static func latestSignal(

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -711,6 +711,7 @@ public actor SessionStore {
         var row = cache.value[agentIndex].sources[sourceIndex]
         guard row.health == .healthy || row.health == .temporarilySilent else { return false }
 
+        if row.reasonCode == "awaitingActivity" { row.reasonCode = nil }
         row.lastObservedAt = max(row.lastObservedAt ?? signal.lastObservedAt,
                                  signal.lastObservedAt)
         row.observedCoverage = Array(

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokSessionStoreTests.swift
@@ -152,6 +152,15 @@ struct GrokSessionStoreTests {
     func teardownDoesNotReportAnUnknownVersion() async throws {
         let fixture = try populated()
         defer { fixture.cleanUp() }
+        // Test event recognition with a complete installed configuration; absent
+        // hook files are an independent configuration error in OH-1.
+        let hookConfig = fixture.home.appendingPathComponent("hooks/vibebuddy.json")
+        try FileManager.default.createDirectory(at: hookConfig.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let groups = Dictionary(uniqueKeysWithValues:
+            ["SessionStart", "UserPromptSubmit", "PostToolUse", "Notification"].map {
+                ($0, [["hooks": [["command": "/app/vibebuddy-forward.sh grok"]]]])
+            })
+        try JSONSerialization.data(withJSONObject: ["hooks": groups]).write(to: hookConfig)
         // Diagnostics age against wall-clock time, so this one runs on it.
         let now = Date()
         let store = SessionStore(diagnosticsHome: fixture.home, grokHome: fixture.home)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationCorrectionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationCorrectionTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+@Suite("OH-1 installer to snapshot regressions")
+struct ObservationCorrectionTests {
+    private let now = Date()
+    private var root: URL {
+        URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+    }
+
+    private func install(home: URL, approval: Bool) throws {
+        let scripts = home.appendingPathComponent("scripts with space's")
+        if !FileManager.default.fileExists(atPath: scripts.path) {
+            try FileManager.default.copyItem(at: root.appendingPathComponent("hooks"), to: scripts)
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        // Import real installers; supply a known version instead of spawning Claude.
+        process.arguments = ["-c", """
+        import importlib.util, json, os, pathlib
+        base = pathlib.Path(os.environ['HOME']) / "scripts with space's"
+        for name in ['claude', 'codex', 'grok']:
+            spec = importlib.util.spec_from_file_location(name, base / ('install-' + name + '-hooks.py'))
+            m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+            target = pathlib.Path(os.environ['HOME']) / {'claude':'.claude/settings.json','codex':'.codex/hooks.json','grok':'.grok/hooks/vibebuddy.json'}[name]
+            target.parent.mkdir(parents=True, exist_ok=True)
+            data = json.loads(target.read_text()) if target.exists() else {'hooks': {'Stop': [{'hooks':[{'command':'echo user-hook'}]}]}}
+            if name == 'grok': data = m.build(approval=\(approval ? "True" : "False"))
+            else:
+                m.install(data\(approval ? ", approval=True" : "")) if name == 'codex' else m.install(data)
+                if name == 'claude' and \(approval ? "True" : "False"): m.install_approval(data, (2,1,257))
+            target.write_text(json.dumps(data))
+        """]
+        process.environment = ["HOME": home.path, "PATH": "/usr/bin:/bin",
+                               "GROK_HOME": home.appendingPathComponent(".grok").path]
+        let pipe = Pipe(); process.standardOutput = pipe; process.standardError = pipe
+        try process.run()
+        let output = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0, "\(String(decoding: output, as: UTF8.self))")
+    }
+
+    @Test("ordinary and approval installs wait, then accept partial observed coverage")
+    func installerSnapshot() async throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("oh1-\(UUID())")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        for approval in [false, true] {
+            try install(home: home, approval: approval)
+            try install(home: home, approval: approval)
+            let store = SessionStore(diagnosticsHome: home, grokHome: home.appendingPathComponent(".grok"))
+            let initial = await store.snapshot(now: now)
+            #expect(initial.sessions.isEmpty)
+            #expect(initial.row(.claudeCode, .statusline)?.reasonCode == "optionalSourceNotConfigured")
+            for agent in [AgentKind.claudeCode, .codex, .grok] {
+                let hook = try #require(initial.row(agent, .hook))
+                #expect(hook.health == .temporarilySilent)
+                #expect(hook.reasonCode == "awaitingActivity")
+                #expect(hook.lastObservedAt == nil)
+                #expect(hook.configuredCoverage == ObservationEventCoverage.allCases)
+                await store.ingest(HookEvent(kind: .sessionStart, sessionID: agent.rawValue,
+                    agent: agent, cwd: "/test", observationSource: .hook, timestamp: now))
+            }
+            let active = await store.snapshot(now: now)
+            for agent in [AgentKind.claudeCode, .codex, .grok] {
+                #expect(active.row(agent, .hook)?.health == .healthy)
+                #expect(active.row(agent, .hook)?.reasonCode == nil)
+                #expect(active.row(agent, .hook)?.observedCoverage.contains(.attention) == false)
+            }
+            let stale = await store.snapshot(now: now.addingTimeInterval(601))
+            #expect(stale.row(.codex, .hook)?.health == .temporarilySilent)
+            #expect(stale.row(.codex, .hook)?.reasonCode == nil)
+            #expect(stale.row(.codex, .hook)?.lastObservedAt == now)
+            #expect(stale.sessions.map(\.status) == active.sessions.map(\.status))
+        }
+        let enable = Process()
+        enable.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        enable.arguments = [home.appendingPathComponent("scripts with space's/install-claude-hooks.py").path, "--statusline"]
+        enable.environment = ["HOME": home.path, "PATH": "/usr/bin:/bin"]
+        enable.standardOutput = FileHandle.nullDevice
+        try enable.run(); enable.waitUntilExit()
+        #expect(enable.terminationStatus == 0)
+        let enabledStore = SessionStore(diagnosticsHome: home, grokHome: home.appendingPathComponent(".grok"))
+        let waiting = await enabledStore.snapshot(now: now)
+        #expect(waiting.row(.claudeCode, .statusline)?.health == .temporarilySilent)
+        #expect(waiting.row(.claudeCode, .statusline)?.reasonCode == "awaitingActivity")
+        #expect(waiting.row(.claudeCode, .statusline)?.lastObservedAt == nil)
+        let sample = try #require(StatusLineSample.decode(["session_id": "statusline-only"]))
+        #expect(await enabledStore.applyStatusLine(sample, at: now) == false)
+        let sampled = await enabledStore.snapshot(now: now)
+        #expect(sampled.row(.claudeCode, .statusline)?.health == .healthy)
+        #expect(sampled.row(.claudeCode, .statusline)?.reasonCode == nil)
+        #expect(sampled.sessions.isEmpty)
+    }
+
+    @Test("misleading shell text and misplaced approvals cannot supply coverage")
+    func falseCommands() throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("oh1-\(UUID())")
+        try FileManager.default.createDirectory(at: home.appendingPathComponent(".codex"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let config = home.appendingPathComponent(".codex/hooks.json")
+        let events = ["SessionStart", "UserPromptSubmit", "PostToolUse", "PermissionRequest"]
+        for command in ["echo /app/vibebuddy-forward.sh codex", "# /app/vibebuddy-forward.sh codex",
+                        "/app/vibebuddy-forward.sh\ncodex", "/app/vibebuddy-forward.sh.bak codex", "/app/vibebuddy-forward.sh grok",
+                        "/app/approval-hook.sh codex", "'/app/vibebuddy-forward.sh' codex; echo x"] {
+            let groups = Dictionary(uniqueKeysWithValues: events.map { ($0, [["hooks": [["command": command]]]]) })
+            try JSONSerialization.data(withJSONObject: ["hooks": groups]).write(to: config)
+            let result = ObservationHealthDetector.detect(home: home, signals: [], now: now,
+                grokHome: home.appendingPathComponent("absent"))
+            let hook = try #require(result.first { $0.agent == .codex }?.sources.first { $0.source == .hook })
+            #expect(hook.reasonCode == "configurationIncomplete")
+            #expect(hook.configuredCoverage == (command == "/app/approval-hook.sh codex" ? [.attention] : []))
+        }
+    }
+
+    @Test("Grok passive source waits independently and preserves real read failures")
+    func passiveSignals() throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("oh1-\(UUID())")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        func row(_ signals: [ObservationRuntimeSignal], at: Date) throws -> ObservationSourceDiagnostic {
+            let rows = ObservationHealthDetector.detect(home: nil, signals: signals, now: at, grokHome: home)
+            return try #require(rows.first { $0.agent == .grok }?.sources.first { $0.source == .transcript })
+        }
+        #expect(try row([], at: now).reasonCode == "awaitingActivity")
+        let hook = ObservationRuntimeSignal(agent: .grok, source: .hook, lastObservedAt: now)
+        #expect(try row([hook], at: now).lastObservedAt == nil)
+        let read = ObservationRuntimeSignal(agent: .grok, source: .transcript, lastObservedAt: now)
+        #expect(try row([hook, read], at: now).health == .healthy)
+        #expect(try row([read], at: now.addingTimeInterval(601)).health == .temporarilySilent)
+        let failure = ObservationRuntimeSignal(agent: .grok, source: .transcript, lastObservedAt: now, health: .sourceUnreadable)
+        #expect(try row([failure], at: now).health == .sourceUnreadable)
+        #expect(try row([failure], at: now).reasonCode == nil)
+    }
+}
+
+private extension Snapshot {
+    func row(_ agent: AgentKind, _ source: ObservationSource) -> ObservationSourceDiagnostic? {
+        observationDiagnostics?.first { $0.agent == agent }?.sources.first { $0.source == source }
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ObservationHealthDetectorTests.swift
@@ -81,9 +81,15 @@ struct ObservationHealthDetectorTests {
                     hook: detect(home: home, signals: [stale]).diagnostic(agent: .codex, source: .hook),
                     now: now) == .hooksFeatureDisabled)
             }
+            // A fresh signal overrides the feature flag when the hook configuration
+            // is complete. A genuinely missing file is still actionable in OH-1.
+            let hooksURL = home.appendingPathComponent(".codex/hooks.json")
+            try write(grokHooks(["SessionStart", "UserPromptSubmit", "PostToolUse", "Notification"])
+                .replacingOccurrences(of: "forward.sh grok", with: "forward.sh codex"), to: hooksURL)
             #expect(ObservationHealthDetector.codexHookConfigurationIssue(home: home,
                 hook: detect(home: home, signals: [fresh]).diagnostic(agent: .codex, source: .hook),
                 now: now) == nil)
+            try FileManager.default.removeItem(at: hooksURL)
             #expect(try String(contentsOf: config, encoding: .utf8) == fixture.config)
         }
         try write("[features]\nhooks = false\n", to: config)

--- a/VibeBuddyMacApp/Sources/HookSetup.swift
+++ b/VibeBuddyMacApp/Sources/HookSetup.swift
@@ -35,6 +35,10 @@ final class HookSetup: ObservableObject {
         }
     }
 
+    func enableStatusLine() {
+        run("--statusline", scriptName: "install-claude-hooks.py")
+    }
+
     /// Locate the installer bundled at `Contents/Resources/hooks/`.
     private static func scriptURL(named name: String) -> URL? {
         Bundle.main.resourceURL?.appendingPathComponent("hooks/\(name)")

--- a/VibeBuddyMacApp/Sources/SettingsView.swift
+++ b/VibeBuddyMacApp/Sources/SettingsView.swift
@@ -201,38 +201,83 @@ private struct SetupSettings: View {
             ? ObservationHealthDetector.codexHookConfigurationIssue(
                 home: FileManager.default.homeDirectoryForCurrentUser, hook: source, now: Date()) : nil
         HStack(alignment: .top, spacing: 8) {
-            Image(systemName: source.health.isHealthy && issue == nil
-                  ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .foregroundStyle(source.health.isHealthy && issue == nil ? .green : .orange)
+            Image(systemName: issue != nil ? "exclamationmark.triangle.fill" : source.diagnosticIcon)
+                .foregroundStyle(issue != nil ? .orange : source.diagnosticColor)
                 .frame(width: 16)
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 5) {
                     Text(source.source.displayName).fontWeight(.semibold)
-                    Text("· \(issue?.displayName ?? source.health.displayName)")
+                    Text("· \(issue?.displayName ?? source.diagnosticTitle)")
                         .foregroundStyle(.secondary)
                 }
-                Text(issue?.explanation ?? source.health.explanation(for: source.source))
+                Text(issue?.explanation ?? source.diagnosticExplanation)
                     .font(.caption).foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 if let last = source.lastObservedAt {
                     Text("Last signal \(last, style: .relative)")
                         .font(.caption2).foregroundStyle(.tertiary)
                 }
-                if !source.configuredCoverage.isEmpty || !source.observedCoverage.isEmpty {
-                    let configured = source.configuredCoverageDescription
+                Group {
+                    let configured = source.source == .hook ? source.configuredCoverageDescription : "not applicable"
                     let observed = source.observedCoverageDescription
-                    Text("Coverage: configured \(configured.isEmpty ? "none" : configured); observed \(observed.isEmpty ? "none" : observed)")
+                    Text("Coverage: configured \(configured.isEmpty ? "none" : configured); received this launch \(observed.isEmpty ? "none" : observed)")
                         .font(.caption2).foregroundStyle(.tertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+                if source.source == .statusline, source.reasonCode == "optionalSourceNotConfigured" {
+                    Button("Enable status line information") { setup.enableStatusLine() }
+                        .disabled(setup.running)
+                        .help("Preserves your current status line and its backup.")
+                }
             }
             Spacer(minLength: 8)
-            if source.source == .hook, issue == nil, source.health.needsHookRepair {
+            if source.source == .hook, issue == nil, source.canRepairConfiguration {
                 Button("Repair") { setup.repair(agent) }
                     .disabled(setup.running)
                     .help("Runs the bundled idempotent installer and preserves your other hooks.")
             }
         }
+    }
+}
+
+private extension ObservationSourceDiagnostic {
+    var isInformational: Bool {
+        health == .temporarilySilent || reasonCode == "optionalSourceNotConfigured"
+    }
+    var diagnosticIcon: String {
+        health.isHealthy ? "checkmark.circle.fill"
+            : isInformational ? "info.circle" : "exclamationmark.triangle.fill"
+    }
+    var diagnosticColor: Color { health.isHealthy ? .green : isInformational ? .gray : .orange }
+    var diagnosticTitle: String {
+        switch reasonCode {
+        case "awaitingActivity": source == .hook ? "Configured, awaiting first activity" : "Awaiting activity"
+        case "configurationIncomplete": "Configuration incomplete"
+        case "optionalSourceNotConfigured": "Status line information not enabled"
+        default: health == .temporarilySilent ? "No recent activity" : health.displayName
+        }
+    }
+    var diagnosticExplanation: String {
+        switch reasonCode {
+        case "awaitingActivity":
+            return source == .transcript
+                ? "No transcript has been read since this launch. Transcript reading starts when a Hook reports session activity."
+                : "Configured; no signal received since this launch. A new task can verify this source."
+        case "configurationIncomplete":
+            let missing = ObservationEventCoverage.allCases.filter { !configuredCoverage.contains($0) }
+                .map(\.displayName).joined(separator: ", ")
+            return "Missing hook configuration: \(missing). Configured coverage is separate from events received this launch."
+        case "optionalSourceNotConfigured":
+            return "Optional Claude status line information is not enabled. Hook and Transcript monitoring can continue."
+        default:
+            if source == .statusline, health == .sourceUnreadable {
+                return "Claude's status line configuration cannot be read."
+            }
+            return health.explanation(for: source)
+        }
+    }
+    var canRepairConfiguration: Bool {
+        reasonCode == "configurationIncomplete" || health == .asyncIncompatible
     }
 }
 
@@ -264,15 +309,6 @@ private extension LifecycleJournalEntry {
         case "questionResolved": return "Question resolved"
         case "sessionReconciled": return "Session reconciled"
         default: return "Lifecycle changed"
-        }
-    }
-}
-
-private extension ObservationHealth {
-    var needsHookRepair: Bool {
-        switch self {
-        case .eventsMissing, .asyncIncompatible, .sourceUnreadable, .unknownVersion: true
-        case .healthy, .temporarilySilent, .notInstalled: false
         }
     }
 }

--- a/hooks/install-claude-hooks.py
+++ b/hooks/install-claude-hooks.py
@@ -303,6 +303,12 @@ def main():
     else:
         data = {}
 
+    if mode == "--statusline":
+        changed = install_statusline(data)
+        write(data)
+        print("status line information:", "enabled" if changed else "already enabled")
+        return
+
     if mode == "--uninstall":
         removed = uninstall(data)
         if uninstall_statusline(data):

--- a/hooks/test_install_agent_hooks.py
+++ b/hooks/test_install_agent_hooks.py
@@ -136,6 +136,33 @@ def check_grok_home(fails):
             fails.append("uninstall left vibebuddy.json under $GROK_HOME")
 
 
+def check_statusline_only(fails):
+    """The explicit optional-source action never edits hooks or their approval gates."""
+    with tempfile.TemporaryDirectory() as home:
+        settings = os.path.join(home, ".claude/settings.json")
+        os.makedirs(os.path.dirname(settings))
+        original = {"hooks": {"PermissionRequest": [{"hooks": [{"command": "user gate"}]}]},
+                    "statusLine": {"type": "command", "command": "echo existing", "padding": 2}}
+        with open(settings, "w") as f:
+            json.dump(original, f)
+        env = {"HOME": home, "PATH": "/usr/bin:/bin",
+               "VIBEBUDDY_SUPPORT_DIR": os.path.join(home, "support")}
+        previous = None
+        for _ in range(2):
+            result = subprocess.run([sys.executable, os.path.join(HOOKS, "install-claude-hooks.py"),
+                                     "--statusline"], env=env, capture_output=True, text=True)
+            current = open(settings).read()
+            if result.returncode or json.loads(current)["hooks"] != original["hooks"]:
+                fails.append("statusline-only action failed or changed hooks")
+            if previous is not None and current != previous:
+                fails.append("statusline-only action is not idempotent")
+            previous = current
+            if json.load(open(settings + ".vibebuddy-backup")) != original:
+                fails.append("statusline-only action changed its settings backup")
+            if json.load(open(os.path.join(home, "support/statusline-original.json")))["statusLine"] != original["statusLine"]:
+                fails.append("statusline-only action changed original status line")
+
+
 def check_claude_statusline_wrapper(fails):
     """--install wraps the user's status line (keeping its other fields and
     saving the original command for the wrapper to run), --uninstall restores
@@ -524,6 +551,7 @@ def main():
     check_claude_legacy_gate_migration(fails)
     check_claude_old_cli_keeps_legacy_gate(fails)
     check_claude_statusline_wrapper(fails)
+    check_statusline_only(fails)
 
     if fails:
         print("FAIL:")


### PR DESCRIPTION
OH-1

## Summary

Correct Mac observation diagnostics when approval hooks are already configured or an installed source has had no activity since launch. Recognize the real forwarder/approval executable and agent arguments, including quoted paths; reject text mentions, wrong agents and approval gates on unrelated events. Complete configuration becomes healthy on a fresh signal without requiring observed Turn or Attention events.

Add optional string `reasonCode` and `sourceVersion` to `ObservationSourceDiagnostic`, with `nil` defaults and unchanged wire health values. OH-1 emits only `awaitingActivity` (`temporarilySilent`), `configurationIncomplete` (`eventsMissing`) and `optionalSourceNotConfigured` (`notInstalled`); `sourceVersion` stays unset for OH-2. Clear the waiting reason when SessionStore patches its cache on the first actual signal.

Mac Settings shows waiting/optional sources in gray, distinguishes configured coverage from events received this launch, and restricts Repair to actionable Hook configuration problems for that agent. The explicit status line action uses a new installer `--statusline` entry point that preserves existing hooks, approval gates, the original status line and its backup. Its button sits below the explanation at the existing narrow Settings width. Preserve feature-disabled diagnostics, session authority, approval and notification routes, recovery behavior and Rollout version policy.

## Validation

- `swift test --package-path VibeBuddyKit`: **292 tests, 37 suites, 0 failures**. Includes a complete new snapshot decoded with the pre-change phone model, all three session states, unknown reason strings, and old snapshots decoded by the new model.
- `swift test --package-path VibeBuddyMac`: **684 tests, 73 suites, 0 failures**, after the final Hook parser and first-signal cache fix. Two existing timeout checks had failed under concurrent compilation; they passed when builds were idle, with their thresholds unchanged.
- `swift test --package-path VibeBuddyMac --filter 'Observation|GrokSessionStore'`: **32 tests, 4 suites, 0 failures** after the cache fix.
- `swift test --package-path VibeBuddyMac --filter ObservationCorrectionTests`: **3 tests, 0 failures**, after extending the installer-to-snapshot regression to verify `--statusline` → awaiting activity → `StatusLineSample` → healthy without creating a session.
- `python3 hooks/test_install_agent_hooks.py`: **PASS, 7 CLIs**, including status line-only preservation/backup/idempotency checks. Swift regressions use the actual Claude/Codex/Grok installers in temporary homes for ordinary/approval configuration and malformed command controls.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml`; `xcodebuild -project VibeBuddyMacApp/VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' -derivedDataPath .scratch/oh1-mac-derived CODE_SIGNING_ALLOWED=NO build`: **BUILD SUCCEEDED**, rerun after the final Mac button layout change.
- `xcodegen generate --spec VibeBuddyApp/project.yml`; `xcodebuild -project VibeBuddyApp/VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' -derivedDataPath .scratch/oh1-ios-derived CODE_SIGNING_ALLOWED=NO build`: **BUILD SUCCEEDED**, using the final shared model. Later changes are Mac-only.
- `xcodebuild test -project VibeBuddyApp/VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath .scratch/oh1-ios-derived -only-testing:VibeBuddyAppTests CODE_SIGNING_ALLOWED=NO`: **34 tests, 0 failures**. Mac and iOS xcodebuild runs were sequential and coordinated.
- A temporary read-only candidate reads current local configuration into an independent SessionStore snapshot and renders the exact final Settings observation rows at 440 pt content width. All three Hook configurations have complete coverage; waiting/optional rows are gray. This is partial UI/configuration evidence, not a running app or live-signal acceptance claim. The temporary executable target and generated lockfile changes are not committed.
- Independent code review and `git diff --check` passed. Per-criterion evidence, logs, candidate snapshot and row image are retained locally under `.scratch/observation-health-correction/evidence/oh1/`.

## Not verified here

No installation, release, merge, full Mac app launch, global configuration change or restart of the service on port 9876. The installed binary remains SHA256 `9f3c175985fb244f44f4bf4019465055d71d71e54a151e6234887d2a2f172615`, matching the window-recovery Release binary; its process still started at 14:55:44 before this task.

The separate installed-window/archiving patch is being integrated by the coordinating task and is not included in this branch, which starts from `origin/main` at `ece1e72`. Full Settings-window/button behavior, window recovery, real Claude/Codex/Grok lifecycle receipt, real approval success, a new real Claude status line sample, and phone/device receipt remain unverified. No Grok task was automatically started. The local ticket is `ready-for-human`, not `done`.

Rollout certification/classification and phone UI are outside OH-1. Codex 0.153.4 remains unverified. OH-2 can set the optional strings from `passiveEvidence`/`inspectRollout` and extend the Mac private reason presentation; OH-3 consumes the same optional metadata on the phone. The current phone's old wording is not claimed fixed by this Mac change.
