### PR TITLE
fix(mac): restore reliable dashboard reopening and preserve Glance position

### DIFF
--- a/VibeBuddyMacApp/Sources/AppActivationPolicy.swift
+++ b/VibeBuddyMacApp/Sources/AppActivationPolicy.swift
@@ -1,37 +1,16 @@
 import AppKit
 
-/// Reference-counted Dock visibility. The menu-bar app is `.accessory` (no Dock
-/// icon); it becomes `.regular` while any real window is open and drops back to
-/// `.accessory` when the last one closes.
+/// Activate only the requested ordinary window. Floating panels are never candidates.
 @MainActor
 enum AppActivationPolicy {
-    private static var count = 0
-
-    static func enter() {
-        count += 1
+    static func activate(_ window: NSWindow) {
         NSApp.setActivationPolicy(.regular)
-        NSApp.activate(ignoringOtherApps: true)
-    }
-
-    static func leave() {
-        count = max(0, count - 1)
-        guard count == 0 else { return }
-        NSApp.setActivationPolicy(.accessory)
-    }
-
-    /// Re-assert frontmost activation *after* a window has appeared. `enter()`
-    /// activates before `openWindow`, so on recent macOS the window can end up
-    /// key for the keyboard yet not the frontmost app — every mouse click is
-    /// then swallowed as a click-to-activate. Calling this from the window's
-    /// `onAppear` makes the app active so clicks land on the SwiftUI views.
-    static func activateFront() {
-        DispatchQueue.main.async {
-            if let window = NSApp.windows.first(where: { $0.isVisible && $0.canBecomeKey }) {
-                moveOntoPresentationScreenIfNeeded(window)
-                window.makeKeyAndOrderFront(nil)
-            }
-            NSApp.activate(ignoringOtherApps: true)
+        if window.isMiniaturized { window.deminiaturize(nil) }
+        if !window.styleMask.contains(.fullScreen) {
+            moveOntoPresentationScreenIfNeeded(window)
         }
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private static func moveOntoPresentationScreenIfNeeded(_ window: NSWindow) {

--- a/VibeBuddyMacApp/Sources/AppWindows.swift
+++ b/VibeBuddyMacApp/Sources/AppWindows.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+/// Owns ordinary windows for the lifetime of the app, independently of menu-bar views.
+@MainActor
+final class AppWindows: NSObject, NSWindowDelegate {
+    private let dashboardContent: AnyView
+    private let settingsContent: AnyView
+    private(set) var dashboardWindow: NSWindow?
+    private(set) var settingsWindow: NSWindow?
+
+    init(dashboard: AnyView, settings: AnyView) {
+        dashboardContent = dashboard
+        settingsContent = settings
+    }
+
+    func showDashboard() {
+        if dashboardWindow == nil {
+            dashboardWindow = makeWindow(
+                content: dashboardContent, title: "vibebuddy", id: "dashboard",
+                size: NSSize(width: 1000, height: 660), minimum: NSSize(width: 760, height: 480),
+                resizable: true)
+        }
+        present(dashboardWindow!)
+    }
+
+    func showSettings() {
+        if settingsWindow == nil {
+            settingsWindow = makeWindow(
+                content: settingsContent, title: "Settings", id: "settings",
+                size: NSSize(width: 500, height: 480), minimum: NSSize(width: 500, height: 480),
+                resizable: false)
+        }
+        present(settingsWindow!)
+    }
+
+    private func makeWindow(content: AnyView, title: String, id: String,
+                            size: NSSize, minimum: NSSize, resizable: Bool) -> NSWindow {
+        var style: NSWindow.StyleMask = [.titled, .closable, .miniaturizable]
+        if resizable { style.insert(.resizable) }
+        let window = NSWindow(contentRect: NSRect(origin: .zero, size: size),
+                              styleMask: style, backing: .buffered, defer: false)
+        window.toolbarStyle = resizable ? .unified : .preference
+        window.title = title
+        window.identifier = NSUserInterfaceItemIdentifier("com.vibebuddy.\(id)")
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+        window.contentViewController = NSHostingController(rootView: content)
+        window.contentMinSize = minimum
+        window.setContentSize(size)
+        window.center()
+        window.setFrameAutosaveName("VibeBuddy.\(id)")
+        return window
+    }
+
+    private func present(_ window: NSWindow) {
+        AppActivationPolicy.activate(window)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard let closing = notification.object as? NSWindow else { return }
+        // Closing does not destroy the window. Repeated opens reuse its state;
+        // Dock visibility depends on actual remaining windows, never click counts.
+        let hasOrdinaryWindow = [dashboardWindow, settingsWindow].compactMap { $0 }
+            .contains { $0 !== closing && ($0.isVisible || $0.isMiniaturized) }
+        if !hasOrdinaryWindow { NSApp.setActivationPolicy(.accessory) }
+    }
+}

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -7,7 +7,6 @@ import VibeBuddyMacCore
 /// (Needs you / Working / Done) and one detail card on the right.
 struct DashboardView: View {
     @ObservedObject var model: MenuBarModel
-    @Environment(\.openSettings) private var openSettings
     @State private var statusFilter: TaskPresentationState? = nil
     @State private var query: String = ""
     @State private var showNewTask = false
@@ -46,7 +45,7 @@ struct DashboardView: View {
                     .disabled(model.recentDirectories.isEmpty || model.dispatchAgents.isEmpty)
             }
             ToolbarItem(placement: .primaryAction) {
-                Button { openSettings() } label: { Image(systemName: "gearshape") }
+                Button { NotificationCenter.default.post(name: .openAppSettings, object: nil) } label: { Image(systemName: "gearshape") }
                     .help("Settings")
             }
         }
@@ -68,11 +67,9 @@ struct DashboardView: View {
             }
             .opacity(0)
         }
-        .onAppear { AppActivationPolicy.activateFront() }
         .onChange(of: selection) { _, id in
             if let id { model.acknowledge(id) }
         }
-        .onDisappear { AppActivationPolicy.leave() }
     }
 
     private var groupsColumn: some View {

--- a/VibeBuddyMacApp/Sources/GlobalHotkey.swift
+++ b/VibeBuddyMacApp/Sources/GlobalHotkey.swift
@@ -3,6 +3,7 @@ import AppKit
 import VibeBuddyMacCore
 
 extension Notification.Name {
+    static let openAppSettings = Notification.Name("vibebuddy.openAppSettings")
     static let openDashboard = Notification.Name("vibebuddy.openDashboard")
     static let toggleGlance = Notification.Name("vibebuddy.toggleGlance")
 }

--- a/VibeBuddyMacApp/Sources/SettingsView.swift
+++ b/VibeBuddyMacApp/Sources/SettingsView.swift
@@ -9,25 +9,66 @@ import VibeBuddyMacCore
 struct SettingsView: View {
     @ObservedObject var model: MenuBarModel
 
-    var body: some View {
-        TabView {
-            GeneralSettings(model: model)
-                .tabItem { Label("General", systemImage: "gearshape") }
-            SetupSettings(model: model)
-                .tabItem { Label("Setup", systemImage: "checklist") }
-            GlanceSettings(model: model)
-                .tabItem { Label("Glance", systemImage: "menubar.rectangle") }
-            DeviceSettings(model: model)
-                .tabItem { Label("Devices", systemImage: "iphone.gen3") }
-            NotificationSettings(model: model)
-                .tabItem { Label("Notifications", systemImage: "bell") }
-            AccountUsageSettings(model: model)
-                .tabItem { Label("Usage", systemImage: "gauge.with.dots.needle.50percent") }
-            VoiceSettingsTab(model: model)
-                .tabItem { Label("Voice", systemImage: "waveform") }
+    @StateObject private var hookSetup = HookSetup()
+    @State private var selectedTab: SettingsTab = .general
+
+    private enum SettingsTab: String, CaseIterable {
+        case general = "General", setup = "Setup", glance = "Glance", devices = "Devices"
+        case notifications = "Notifications", usage = "Usage", voice = "Voice"
+
+        var symbol: String {
+            switch self {
+            case .general: "gearshape"
+            case .setup: "checklist"
+            case .glance: "menubar.rectangle"
+            case .devices: "iphone.gen3"
+            case .notifications: "bell"
+            case .usage: "gauge.with.dots.needle.50percent"
+            case .voice: "waveform"
+            }
         }
-        .frame(width: 500, height: 400)
-        .onDisappear { AppActivationPolicy.leave() }
+    }
+
+    var body: some View {
+        // Render navigation in the content, independent of SwiftUI Settings-scene
+        // toolbar adaptation (which collapses all tabs in an AppKit-hosted window).
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                ForEach(SettingsTab.allCases, id: \.self) { tab in
+                    Button { selectedTab = tab } label: {
+                        VStack(spacing: 5) {
+                            Image(systemName: tab.symbol).font(.system(size: 20))
+                            Text(LocalizedStringKey(tab.rawValue)).font(.system(size: 10))
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .contentShape(Rectangle())
+                        .foregroundStyle(selectedTab == tab ? Color.accentColor : Color.secondary)
+                        .background(selectedTab == tab ? Color.accentColor.opacity(0.08) : .clear,
+                                    in: RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(LocalizedStringKey(tab.rawValue))
+                    .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            Divider()
+            Group {
+                switch selectedTab {
+                case .general: GeneralSettings(model: model)
+                case .setup: SetupSettings(model: model, setup: hookSetup)
+                case .glance: GlanceSettings(model: model)
+                case .devices: DeviceSettings(model: model)
+                case .notifications: NotificationSettings(model: model)
+                case .usage: AccountUsageSettings(model: model)
+                case .voice: VoiceSettingsTab(model: model)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(width: 500, height: 480)
     }
 }
 
@@ -37,7 +78,7 @@ struct SettingsView: View {
 /// configs — so it's only ever an explicit button click here.
 private struct SetupSettings: View {
     @ObservedObject var model: MenuBarModel
-    @StateObject private var setup = HookSetup()
+    @ObservedObject var setup: HookSetup
 
     var body: some View {
         Form {

--- a/VibeBuddyMacApp/Sources/SettingsView.swift
+++ b/VibeBuddyMacApp/Sources/SettingsView.swift
@@ -826,6 +826,13 @@ struct HotkeyRecorderView: View {
             }
         }
         .onDisappear { stop() }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { notification in
+            guard let window = notification.object as? NSWindow,
+                  window.identifier == NSUserInterfaceItemIdentifier("com.vibebuddy.settings") else { return }
+            // AppWindows retains the hosting controller after close, so view
+            // disappearance alone cannot own the local keyboard monitor cleanup.
+            stop()
+        }
     }
 
     private func start() {

--- a/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
+++ b/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
@@ -9,15 +9,15 @@ struct VibeBuddyMenuBarApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
     @StateObject private var model: MenuBarModel
     private let role: AppRuntime.Role
-    // Settings → General → "Show icon in menu bar". `isInserted` keeps the
-    // MenuBarExtra scene in the graph (so its label still bridges the global
-    // hotkey to openWindow) while removing the icon from the menu bar.
+    // Visibility affects only the icon; app-level commands stay available.
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
 
     init() {
         let role = AppRuntime.role
         self.role = role
-        _model = StateObject(wrappedValue: MenuBarModel(runtimeEnabled: role == .primary))
+        let model = MenuBarModel(runtimeEnabled: role == .primary)
+        _model = StateObject(wrappedValue: model)
+        delegate.model = model
     }
 
     var body: some Scene {
@@ -30,14 +30,18 @@ struct VibeBuddyMenuBarApp: App {
         }
         .menuBarExtraStyle(.window)
 
-        Window("vibebuddy", id: "dashboard") {
-            DashboardView(model: model)
-                .frame(minWidth: 760, minHeight: 480)
-        }
-        .windowResizability(.contentMinSize)
-
-        Settings {
-            SettingsView(model: model)
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings…") {
+                    NotificationCenter.default.post(name: .openAppSettings, object: nil)
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+            CommandGroup(after: .windowArrangement) {
+                Button("Open Dashboard") {
+                    NotificationCenter.default.post(name: .openDashboard, object: nil)
+                }
+            }
         }
     }
 }
@@ -82,9 +86,30 @@ private enum AppRuntime {
 }
 
 /// Hide the Dock icon — menu-bar-only app.
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let log = Logger(subsystem: "com.vibebuddy.app", category: "lifecycle")
     private var openRequestObserver: NSObjectProtocol?
+    var model: MenuBarModel!
+    private var windows: AppWindows?
+
+    @objc private func openDashboard() {
+        windows?.showDashboard()
+    }
+
+    @objc private func openSettings() {
+        windows?.showSettings()
+    }
+
+    @objc private func toggleGlance() {
+        model.setShowGlance(!model.showGlance)
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // A visible Glance or Settings window does not satisfy a Dashboard request.
+        openDashboard()
+        return false
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard AppRuntime.role == .primary else {
@@ -93,6 +118,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.main.async { NSApp.terminate(nil) }
             return
         }
+        windows = AppWindows(
+            dashboard: AnyView(DashboardView(model: model)),
+            settings: AnyView(SettingsView(model: model)))
+        NotificationCenter.default.addObserver(self, selector: #selector(openDashboard), name: .openDashboard, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(openSettings), name: .openAppSettings, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(toggleGlance), name: .toggleGlance, object: nil)
         NSApp.setActivationPolicy(.accessory)
         // Keep the background daemon alive. macOS cleanly auto-terminates idle
         // accessory apps to reclaim resources (no crash report — exactly the
@@ -103,12 +134,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         openRequestObserver = AppRuntime.observeOpenRequests()
         GlobalHotkey.install()
         Self.log.notice("didFinishLaunching")
+        // Explicit launches show a usable window even when the menu icon is hidden.
+        // Login-item launches remain quiet.
+        let loginLaunch = NSAppleEventManager.shared().currentAppleEvent?
+            .paramDescriptor(forKeyword: keyAEPropData)?.enumCodeValue == keyAELaunchedAsLogInItem
+        if !loginLaunch {
+            if ProcessInfo.processInfo.environment["VIBEBUDDY_DEMO_PAGE"] == "settings" {
+                openSettings()
+            } else {
+                openDashboard()
+            }
+        }
     }
 
-    /// A menu-bar app must NOT quit when the dashboard/settings window closes.
-    /// (Likely cause of the observed clean exits: a window opens via
-    /// AppActivationPolicy.enter() → .regular, then closing the last window
-    /// terminates the app.) Returning false keeps the daemon alive.
+    /// Closing ordinary windows must leave the daemon and Glance running.
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         Self.log.notice("shouldTerminateAfterLastWindowClosed -> false")
         return false
@@ -153,14 +192,9 @@ enum MenuBarGlyph {
     }()
 }
 
-/// The MenuBarExtra label. Always instantiated while the app runs, so its
-/// `.onReceive` is a reliable bridge from the global Carbon hotkey
-/// (`.openDashboard` notification) to SwiftUI's `openWindow`, which is only
-/// available from a View's environment.
+/// Presentation only; hiding the label cannot disconnect app commands.
 struct MenuBarLabel: View {
     @ObservedObject var model: MenuBarModel
-    @Environment(\.openWindow) private var openWindow
-    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         let state = model.presentationSummary.primaryState
@@ -183,28 +217,7 @@ struct MenuBarLabel: View {
                     .accessibilityLabel("\(count) \(state.label)")
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .openDashboard)) { _ in
-            AppActivationPolicy.enter()
-            openWindow(id: "dashboard")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .toggleGlance)) { _ in
-            model.setShowGlance(!model.showGlance)
-        }
-        .task {
-            // Screenshot/exploration mode is intentionally self-contained: open
-            // the window to shoot without depending on a global hotkey or menu
-            // click. A demo instance shares the installed app's bundle id, so
-            // driving its menus over Accessibility is ambiguous — the env var is
-            // the only reliable way to aim a screenshot at Settings.
-            if ProcessInfo.processInfo.environment["VIBEBUDDY_DEMO"] == "1" {
-                AppActivationPolicy.enter()
-                if ProcessInfo.processInfo.environment["VIBEBUDDY_DEMO_PAGE"] == "settings" {
-                    openSettings()
-                } else {
-                    openWindow(id: "dashboard")
-                }
-            }
-        }
+
     }
 }
 
@@ -220,16 +233,13 @@ struct MenuContent: View {
     @ObservedObject var model: MenuBarModel
     @State private var listContentHeight: CGFloat = 0
     @State private var greet = 0
-    @Environment(\.openWindow) private var openWindow
-    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             summaryHead
 
             Button {
-                AppActivationPolicy.enter()
-                openWindow(id: "dashboard")
+                NotificationCenter.default.post(name: .openDashboard, object: nil)
             } label: {
                 HStack(spacing: 8) {
                     Label("Open Dashboard", systemImage: "macwindow")
@@ -312,14 +322,13 @@ struct MenuContent: View {
 
             HStack {
                 Button {
-                    AppActivationPolicy.enter()
-                    openSettings()
+                    NotificationCenter.default.post(name: .openAppSettings, object: nil)
                 } label: {
                     Label("Settings…", systemImage: "gearshape")
                 }
                 .buttonStyle(.borderless)
                 Button {
-                    AppActivationPolicy.enter()
+                    NSApp.activate(ignoringOtherApps: true)
                     Updater.shared.checkForUpdates()
                 } label: {
                     Label("Check for Updates…", systemImage: "arrow.down.circle")

--- a/tools/window-recovery-qa/README.md
+++ b/tools/window-recovery-qa/README.md
@@ -1,0 +1,27 @@
+# Mac window recovery checks
+
+Run the AppKit lifecycle probe from the repository root on a logged-in Mac:
+
+```sh
+swiftc -swift-version 6 VibeBuddyMacApp/Sources/AppActivationPolicy.swift \
+  VibeBuddyMacApp/Sources/AppWindows.swift tools/window-recovery-qa/main.swift \
+  -o /tmp/vibebuddy-window-qa
+/tmp/vibebuddy-window-qa
+```
+
+The probe uses test content and checks retained window identity, Dock policy,
+minimization recovery, and preserving a keyable floating panel's frame.
+
+## Close Settings while recording a shortcut
+
+Exercise the actual app or a separately identified demo bundle:
+
+1. Open Dashboard, then Settings > General.
+2. Click Record next to Open Dashboard. Confirm the control says "Press a combo…".
+3. Close Settings with the red window close button without entering a combination.
+   Do not use Cmd+W: the recorder intentionally captures a valid combination.
+4. In Dashboard, press Cmd+F and type a search term. The term must appear and filter sessions.
+5. Press Cmd+, to reopen Settings. The button must say Record, not Cancel, and the original shortcut must be unchanged.
+
+This catches a local key monitor surviving `NSWindow.close()` when the hosting
+controller is retained and SwiftUI does not run `onDisappear`.

--- a/tools/window-recovery-qa/main.swift
+++ b/tools/window-recovery-qa/main.swift
@@ -1,0 +1,51 @@
+// Run on a logged-in Mac from the repo root (opens temporary test windows):
+// swiftc -swift-version 6 VibeBuddyMacApp/Sources/AppActivationPolicy.swift \
+//   VibeBuddyMacApp/Sources/AppWindows.swift tools/window-recovery-qa/main.swift \
+//   -o /tmp/vibebuddy-window-qa && /tmp/vibebuddy-window-qa
+// Uses test content, no daemon, real sessions, or VibeBuddy preference domain.
+import AppKit
+import SwiftUI
+
+final class FocusablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override func constrainFrameRect(_ frame: NSRect, to screen: NSScreen?) -> NSRect { frame }
+}
+
+let app = NSApplication.shared
+func pump() { RunLoop.current.run(until: Date().addingTimeInterval(0.15)) }
+func check(_ ok: @autoclosure () -> Bool, _ label: String) {
+    guard ok() else { print("FAIL: \(label)"); exit(1) }
+    print("PASS: \(label)")
+}
+let panel = FocusablePanel(contentRect: NSRect(x: 20, y: 300, width: 600, height: 440), styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+panel.isReleasedWhenClosed = false
+panel.isOpaque = false
+panel.backgroundColor = .clear
+panel.level = .mainMenu + 3
+panel.orderFrontRegardless()
+let anchor = panel.frame
+let windows = AppWindows(dashboard: AnyView(Text("Window regression probe")), settings: AnyView(Text("Settings regression probe")))
+windows.showDashboard(); pump()
+let dashboard = windows.dashboardWindow!
+check(panel.frame == anchor, "Opening dashboard preserves focusable Glance panel frame")
+check(dashboard.isVisible, "Dashboard opens")
+for _ in 0..<5 { windows.showDashboard() }
+pump()
+check(windows.dashboardWindow === dashboard, "Repeated open reuses dashboard identity")
+check(panel.frame == anchor, "Repeated activation preserves Glance frame")
+windows.showSettings(); pump()
+let settings = windows.settingsWindow!
+check(settings !== dashboard && settings.isVisible, "Settings has separate visible window")
+dashboard.close(); pump()
+check(app.activationPolicy() == .regular, "Closing dashboard keeps Dock while settings remains")
+settings.close(); pump()
+check(app.activationPolicy() == .accessory, "Closing last ordinary window hides Dock despite visible panel")
+windows.showDashboard(); pump()
+check(windows.dashboardWindow === dashboard && dashboard.isVisible, "Closed dashboard reopens with same identity")
+dashboard.miniaturize(nil); pump()
+check(dashboard.isMiniaturized, "Dashboard minimizes")
+windows.showDashboard(); pump()
+check(!dashboard.isMiniaturized && dashboard.isVisible, "Opening minimized dashboard restores it")
+check(panel.frame == anchor, "Full sequence never moves Glance panel")
+dashboard.close(); settings.close(); panel.close(); pump()
+print("All window identity and lifecycle checks passed")


### PR DESCRIPTION
Closing the Mac dashboard and reopening the app could leave only Glance visible, especially with the menu-bar icon hidden. Dashboard activation could also select the keyable Glance panel and move it away from the screen top.

This change gives Dashboard and Settings explicit retained windows, handles reopen and command notifications at app lifetime, and activates only the requested window. Dock visibility follows actual ordinary windows. Settings retains its seven pages and shares HookSetup state across page changes to prevent concurrent configuration operations.

Validation:
- 11 AppKit window lifecycle checks passed, including repeated open, close/reopen, minimization recovery, and preserving a focusable panel's frame.
- Signed 1.2 (5) candidate installed and exercised with real sessions: startup, hidden-icon Finder reopening, search, settings, and close commands passed.
- Independent dual-display check confirmed Glance remains at Y=0; independent review completed with the HookSetup lifetime finding fixed.
- Release arm64 build against current main passed after rebase; the 11 window checks also passed again.

Physical global hotkey input, login-item startup, and live full-screen behavior have not been manually verified. Existing unrelated worktree changes are excluded.
