### PR TITLE
fix(settings): add paste controls for all voice providers on iOS and macOS

### DIFF
--- a/VibeBuddyApp/Sources/SettingsView.swift
+++ b/VibeBuddyApp/Sources/SettingsView.swift
@@ -162,20 +162,20 @@ private struct ProviderSection: View {
     var body: some View {
         Section {
             field(caption: "API Key — paste your own (kept in the Keychain)",
-                  link: "Get an API key", icon: "key", url: provider.apiKeyURL) {
+                  link: "Get an API key", icon: "key", url: provider.apiKeyURL, pasteInto: $apiKey, id: "voiceAPIKey") {
                 SecureField("Paste your \(provider.display) key", text: $apiKey)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
             }
             field(caption: "Model ID — editable, type any model",
-                  link: "Browse available models", icon: "arrow.up.right.square", url: provider.modelsURL) {
+                  link: "Browse available models", icon: "arrow.up.right.square", url: provider.modelsURL, pasteInto: $model, id: "voiceModelID") {
                 TextField(provider.defaultModel, text: $model)
                     .font(.body.monospaced())
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
             }
             field(caption: "Voice ID — editable (blank = auto by language)",
-                  link: "Browse available voices", icon: "arrow.up.right.square", url: provider.voicesURL) {
+                  link: "Browse available voices", icon: "arrow.up.right.square", url: provider.voicesURL, pasteInto: $voice, id: "voiceID") {
                 TextField(exampleVoice, text: $voice)
                     .font(.body.monospaced())
                     .textInputAutocapitalization(.never)
@@ -183,7 +183,7 @@ private struct ProviderSection: View {
             }
             if provider == .qwen {
                 field(caption: "Workspace ID — optional; uses the workspace endpoint when set",
-                      link: "Find your workspace ID", icon: "arrow.up.right.square", url: VoiceProvider.qwenWorkspaceIDURL) {
+                      link: "Find your workspace ID", icon: "arrow.up.right.square", url: VoiceProvider.qwenWorkspaceIDURL, pasteInto: $workspaceID, id: "qwenWorkspaceID") {
                     TextField("e.g. llm-xxxxxxxx", text: $workspaceID)
                         .font(.body.monospaced())
                         .textInputAutocapitalization(.never)
@@ -208,10 +208,26 @@ private struct ProviderSection: View {
     /// provider's list of valid values.
     @ViewBuilder
     private func field<F: View>(caption: LocalizedStringKey, link: LocalizedStringKey, icon: String, url: URL,
+                                pasteInto value: Binding<String>, id: String,
                                 @ViewBuilder _ input: () -> F) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(caption).font(.caption).foregroundStyle(.secondary)
-            input()
+            HStack(spacing: 12) {
+                input()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier(id)
+                PasteButton(payloadType: String.self) { values in
+                    guard let pasted = values.first else { return }
+                    let trimmed = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    value.wrappedValue = trimmed
+                }
+                .labelStyle(.iconOnly)
+                .controlSize(.large)
+                .buttonBorderShape(.roundedRectangle(radius: 10))
+                .fixedSize()
+                .accessibilityIdentifier("paste-\(id)")
+            }
             Link(destination: url) {
                 Label(link, systemImage: icon).font(.caption)
             }

--- a/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -204,3 +204,5 @@
 "Quiet mode (quota unaffected)" = "安静模式（额度提醒不受影响）";
 
 "Quiet mode keeps approvals and questions silent and suppresses other session alerts. Enabled quota alerts still follow the Sound setting." = "安静模式无声显示审批和提问，并抑制其他会话提醒。已开启的额度提醒仍遵循声音设置。";
+
+"Paste" = "粘贴";

--- a/VibeBuddyMacApp/Sources/SettingsView.swift
+++ b/VibeBuddyMacApp/Sources/SettingsView.swift
@@ -636,14 +636,16 @@ private struct ProviderSection: View {
         Section {
             // API key
             field(caption: "API Key — paste your own (kept in the Keychain)",
-                  link: "Get an API key", icon: "key", url: provider.apiKeyURL) {
+                  link: "Get an API key", icon: "key", url: provider.apiKeyURL,
+                  pasteInto: $apiKey, id: "voiceAPIKey") {
                 SecureField("Paste your \(provider.display) key", text: $apiKey)
                     .textFieldStyle(.roundedBorder)
                     .autocorrectionDisabled()
             }
             // Model ID — clearly editable
             field(caption: "Model ID — editable, type any model",
-                  link: "Browse available models", icon: "arrow.up.right.square", url: provider.modelsURL) {
+                  link: "Browse available models", icon: "arrow.up.right.square", url: provider.modelsURL,
+                  pasteInto: $model, id: "voiceModelID") {
                 TextField(provider.defaultModel, text: $model)
                     .textFieldStyle(.roundedBorder)
                     .font(.body.monospaced())
@@ -651,7 +653,8 @@ private struct ProviderSection: View {
             }
             // Voice ID — clearly editable
             field(caption: "Voice ID — editable (blank = auto by language)",
-                  link: "Browse available voices", icon: "arrow.up.right.square", url: provider.voicesURL) {
+                  link: "Browse available voices", icon: "arrow.up.right.square", url: provider.voicesURL,
+                  pasteInto: $voice, id: "voiceID") {
                 TextField(exampleVoice, text: $voice)
                     .textFieldStyle(.roundedBorder)
                     .font(.body.monospaced())
@@ -659,7 +662,8 @@ private struct ProviderSection: View {
             }
             if provider == .qwen {
                 field(caption: "Workspace ID — optional; uses the workspace endpoint when set",
-                      link: "Find your workspace ID", icon: "arrow.up.right.square", url: VoiceProvider.qwenWorkspaceIDURL) {
+                      link: "Find your workspace ID", icon: "arrow.up.right.square", url: VoiceProvider.qwenWorkspaceIDURL,
+                      pasteInto: $workspaceID, id: "qwenWorkspaceID") {
                     TextField("e.g. llm-xxxxxxxx", text: $workspaceID)
                         .textFieldStyle(.roundedBorder)
                         .font(.body.monospaced())
@@ -684,10 +688,30 @@ private struct ProviderSection: View {
     /// provider's list of valid values.
     @ViewBuilder
     private func field<F: View>(caption: LocalizedStringKey, link: LocalizedStringKey, icon: String, url: URL,
+                                pasteInto value: Binding<String>, id: String,
                                 @ViewBuilder _ input: () -> F) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(caption).font(.caption).foregroundStyle(.secondary)
-            input()
+            HStack(spacing: 8) {
+                input()
+                    .labelsHidden()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier(id)
+                Button {
+                    guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
+                    let trimmed = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    value.wrappedValue = trimmed
+                } label: {
+                    Label("Paste", systemImage: "doc.on.clipboard")
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+                .fixedSize()
+                .help("Paste")
+                .accessibilityIdentifier("paste-\(id)")
+            }
             Link(destination: url) {
                 Label(link, systemImage: icon).font(.caption)
             }


### PR DESCRIPTION
Adds a paste button beside API Key, Model ID, and Voice ID for Qwen, OpenAI, and Gemini on iOS and macOS, plus Qwen Workspace ID. Pasted text replaces the corresponding field after trimming surrounding whitespace; empty content preserves the existing value. API keys retain the existing Keychain storage path.

Buttons share each platform’s input-row layout. macOS hides duplicate Form labels to preserve input width and adds a Chinese paste tooltip.

Validation:
- iOS Simulator and macOS Debug builds passed on the final commit integrated with the latest main branch.
- An isolated macOS window using the actual provider section passed paste checks for all three providers and Qwen field reloads, using dummy values and separate storage.
- Static review and diff checks passed.
- iOS runtime acceptance remains unverified because the isolated simulator did not finish booting; no installed app was replaced.
