### PR TITLE
chore(release): prepare 1.2 build 6 candidate

### DIFF
--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -47,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app
         MARKETING_VERSION: "1.2"
-        CURRENT_PROJECT_VERSION: "5"
+        CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.widget
         MARKETING_VERSION: "1.2"
-        CURRENT_PROJECT_VERSION: "5"
+        CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -112,7 +112,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
         CODE_SIGN_ENTITLEMENTS: Watch/VibeBuddyWatch.entitlements
         MARKETING_VERSION: "1.2"
-        CURRENT_PROJECT_VERSION: "5"
+        CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -139,7 +139,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp.widget
         MARKETING_VERSION: "1.2"
-        CURRENT_PROJECT_VERSION: "5"
+        CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2

--- a/VibeBuddyMacApp/project.yml
+++ b/VibeBuddyMacApp/project.yml
@@ -64,7 +64,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.mac
         MARKETING_VERSION: "1.2"
-        CURRENT_PROJECT_VERSION: "5"
+        CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "6.0"
         # Build signs ad-hoc; tools/redeploy-mac.sh re-signs the built .app with a
         # stable local Apple Development identity so Keychain ACLs / TCC grants

--- a/docs/release-notes-1.2.md
+++ b/docs/release-notes-1.2.md
@@ -7,6 +7,9 @@ This release focuses on the capabilities already implemented and verified in the
 - Identified phones keep one push registration when their token changes, with current preferences. Historical registrations without a device identity are not automatically removed when their ownership cannot be determined.
 - Companion presentation across Mac, iPhone and Watch, including the followed-task Watch complication, exact completion-read synchronization, and recovery across disconnection or source changes.
 - Clear local guidance when Codex hooks are disabled, without rewriting the user's Codex configuration.
+- Mac and phone diagnostics distinguish sources awaiting activity, optional information not enabled, unverified versions and actual data failures. Codex 0.153.4 remains unverified where lifecycle evidence is incomplete.
+- Reliable Mac dashboard reopening and Glance position retention, plus explicit paste controls for voice-provider settings on Mac and iPhone.
+- A simpler paired-Mac connection menu on the phone and shared agent brand icons across companion views.
 
 The existing Claude Code, Codex and Grok integrations retain their individual capability limits. Phone actions require a reachable paired Mac. Existing new-task dispatch applies to supported Claude Code and Codex configurations; it is not a general remote terminal.
 


### PR DESCRIPTION
H-3

Prepare a replacement candidate from cleaned main, including observation diagnostics, window recovery, paste controls and companion presentation changes. Increment all five targets to build 6; retain version 1.2 and document the included changes. Watch quota WIP remains isolated.

Validation: consistent version/build values, diff check; signed Mac and iOS/Watch candidate builds in progress. Installation authorized by the product owner; no publication in this PR.