### PR TITLE
docs(planning): record build 6 installed for acceptance

### DIFF
--- a/docs/planning/roadmap-2026-09.html
+++ b/docs/planning/roadmap-2026-09.html
@@ -140,7 +140,7 @@ td.mono{white-space:nowrap}
 <header class="top">
   <div class="title">
     <h1>vibebuddy 1.2 路线图</h1>
-    <p>2026-09-06 17:34 · main 4058a2f · OH-1/#78、OH-2/#80、OH-3/#84全部合并；窗口#81、粘贴#82已保留。准备新候选后单独验收，不沿用旧半小时。HTML为唯一正本。</p>
+    <p>2026-09-06 18:07 · main 4b33c69 · 新候选1.2（6）已签名公证并安装三端（#87）；旧候选不再使用。半小时实际验收未开始，尚未发布。HTML为唯一正本。</p>
   </div>
   <div class="stats" id="stats"></div>
 </header>
@@ -354,7 +354,7 @@ td.mono{white-space:nowrap}
   <div class="tbl"><table id="tbl"><thead><tr><th>ID</th><th>工作包</th><th>内容</th><th>版本</th><th>状态</th><th>依赖</th><th>归属</th><th></th></tr></thead><tbody></tbody></table></div>
 </section>
 
-<p class="foot">数据来源：<code>docs/planning/vision-2026-09.md</code>、<code>.scratch/*/issues</code> 的 Status 行、<code>.scratch/mobile-watch-task-control/</code> PRD（11 张票）、<code>gh pr list</code>、各 worktree 的 <code>git status</code>、Claude Code 会话列表。状态以仓库文件为准，本页是 2026-09-06 17:34 的快照（main 4058a2f；OH三票已合并，设备待验）。正本是仓库里的 <code>docs/planning/roadmap-2026-09.html</code>：改 <code>&lt;script&gt;</code> 里的 T / SESSIONS 数组与三处时间戳，再跑 <code>node tools/export-roadmap.js docs/planning/roadmap-2026-09.html docs/planning</code> 重新导出 JSON 与提示词文件，随 PR 一起提交。协调会话每次轮询都应先 git fetch 再核对。</p>
+<p class="foot">数据来源：<code>docs/planning/vision-2026-09.md</code>、<code>.scratch/*/issues</code> 的 Status 行、<code>.scratch/mobile-watch-task-control/</code> PRD（11 张票）、<code>gh pr list</code>、各 worktree 的 <code>git status</code>、Claude Code 会话列表。状态以仓库文件为准，本页是 2026-09-06 18:07 的快照（main 4b33c69；1.2（6）已安装待验）。正本是仓库里的 <code>docs/planning/roadmap-2026-09.html</code>：改 <code>&lt;script&gt;</code> 里的 T / SESSIONS 数组与三处时间戳，再跑 <code>node tools/export-roadmap.js docs/planning/roadmap-2026-09.html docs/planning</code> 重新导出 JSON 与提示词文件，随 PR 一起提交。协调会话每次轮询都应先 git fetch 再核对。</p>
 
 <script>
 const VISION = {
@@ -546,7 +546,7 @@ const T = [
   {id:"H-1",lane:"H",kind:"you",ver:"1.2",title:"四家验收矩阵",path:".scratch/qa-shots/<agent>/",q:["Q27","Q5"],deps:["A-03","B-U","M-11"],
    spec:{goal:"每家一份真机清单：三态各一次、手机批准一次、手表批准一次、App 被杀后 APNs 送达一次。",scope:"Claude、Codex（含 Desktop）、Grok；Cursor 在 1.3。",non:"—",accept:"截图与结果存目录。",verify:"真机。",skills:"—"},
    body:"三家（Cursor 留 1.3）各一份真机清单，截图存 .scratch/qa-shots/<agent>/。"},
-  {id:"H-2",lane:"H",kind:"you",deferred:true,ver:"1.2",title:"等待新候选锁定：半小时零漏接",path:".scratch/release-1.2/issues/02-half-hour-acceptance.md",q:["Q4","Q28"],deps:["S-6","B-3","A-10","OH-3"],
+  {id:"H-2",lane:"H",kind:"you",ver:"1.2",title:"1.2（6）已安装，待半小时实际验收",path:".scratch/release-1.2/issues/02-half-hour-acceptance.md",q:["Q4","Q28"],deps:["S-6","B-3","A-10","OH-3"],
    spec:{goal:"冻结候选连续半小时无新增漏接；修复后重新计时。",scope:"以获准安装的冻结候选执行半小时体验，记录起止时间与漏接增量。",non:"—",accept:"验收窗口内新增漏接为 0；任何一次漏接开票修复后重计半小时。",verify:"Mac 设置页。",skills:"—"},
    body:"按 release-1.2 票02，在具体设备操作获准后使用冻结候选执行连续半小时真实体验。记录成品身份、起止时间、漏接增量和非预期重复；失败修复后锁定新候选并重新计时，不自动安装或替换运行中的 App。"},
   {id:"H-3",lane:"H",kind:"you",ver:"1.2",title:"1.2 候选打包与发布（Mac + 自装 iPhone / Watch）",path:".scratch/release-1.2/issues/03-publish-and-update.md",q:["Q28"],deps:["H-2"],
@@ -561,6 +561,7 @@ const T = [
 ];
 
 const SESSIONS = [
+  ["1.2（6）候选安装", "已安装三端，验收未开始", "来源46c9c17 / PR87；Mac公证和签名通过，手机与Watch签名构建通过；回退包保留", "真实体验后再发布，不复用旧半小时", "H-2 H-3"],
 ["Mac 观察诊断修正", "已合并 #78，真机待验 · 01a07591-038d-7cd3-8c2e-0315d2f50f5f", "立即实施。独占公共 reasonCode 最小契约、Hook识别、等待活动和Mac设置动作；不实现Rollout版本认证及手机页面。", "总控在前置完成后续发", "OH-1"],
 ["Rollout 版本证据与分类", "已合并 #80", "分类实现及验证完成，0.153.4仍未认证；真实信号及设备验收另记", "OH-3已解锁", "OH-2"],
 ["手机观察诊断与双端验收", "已合并 #84 · 2026-09-06T17:34+08:00", "Kit296、Mac689、iOS37/0、17张行图复核通过；设备验收未完成；task 01a07591-ae1e-7631-b7b2-55eaed7ffff3", "准备新候选并单独完成设备验收，不沿用旧半小时", "OH-3"],
@@ -709,7 +710,7 @@ async function copyText(text, toast, ta){
   setTimeout(()=>{ if(toast) toast.textContent=""; },2500);
 }
 document.getElementById("copyjson").addEventListener("click",()=>{
-  const data = { generatedAt:"2026-09-06T17:34+08:00", main:"4058a2f", lanes: LANES.map(l=>({id:l[0],name:l[1]})),
+  const data = { generatedAt:"2026-09-06T18:07+08:00", main:"4b33c69", lanes: LANES.map(l=>({id:l[0],name:l[1]})),
     nodes: T.filter(t=>!["COORD","CODEX","REVIEW"].includes(t.id)).map(t=>({id:t.id,lane:t.lane,title:t.title,version:t.ver,owner:t.kind==="you"?"U":"A",status:(statusOf(t)==="running" ? (/^退回修改/.test(t.title) ? "changes-requested" : /#\d+/.test(t.title) ? "pr-open" : "in-progress") : statusOf(t)),deps:t.deps,ticket:t.path,vision:t.q,spec:t.spec,prompt:promptFor(t)})) };
   copyText(JSON.stringify(data,null,1), document.getElementById("jsontoast"), null);
 });

--- a/docs/planning/roadmap-2026-09.json
+++ b/docs/planning/roadmap-2026-09.json
@@ -1,6 +1,6 @@
 {
- "generatedAt": "2026-09-06T17:34+08:00",
- "main": "4058a2f",
+ "generatedAt": "2026-09-06T18:07+08:00",
+ "main": "4b33c69",
  "howToUse": "正本是 docs/planning/roadmap-2026-09.html；本文件由 tools/export-roadmap.js 导出，不要手改。status 是快照，以仓库事实为准：agent 节点 done = PR 已合并（描述第一行为节点 id）或票 Status done；pr-open = 有开放 PR（pr 字段）；in-progress = 有会话或未提交改动在做；可派 = deps 全 done 且自身非 done/in-progress/pr-open 且 owner A；并发上限 4；优先级 S > A > M > 其余 1.2 > 1.3。票的 Status 只用仓库规定的标签与 done；工作流状态只写 HTML（kind 与标题前缀）。每轮先 git fetch origin 再判断。合并顺序：#57 → #56 → #55（三者都改 Kit 通知类型与 Mac Settings / MenuBarModel，每合一个让下一个合 main）→ #59（Companion 三端，与 #56 的 iPhone 卡片、#55 的 Mac 设置页相碰）→ #62（W-1..3 草稿，先验证）。主工作区 ~/Projects/iOS-vibebuddy 的 main 上仍有 W-1..3 的未提交原件：不 reset、不在主工作区开发。codex/notification-dedup worktree 已被 #54 取代，删除不开 PR。",
  "vision": {
   "Q1": "面向 App Store 公众，你是第一用户",
@@ -90,6 +90,13 @@
   }
  ],
  "sessions": [
+  {
+   "session": "1.2（6）候选安装",
+   "state": "已安装三端，验收未开始",
+   "output": "来源46c9c17 / PR87；Mac公证和签名通过，手机与Watch签名构建通过；回退包保留",
+   "whenDone": "真实体验后再发布，不复用旧半小时",
+   "nodes": "H-2 H-3"
+  },
   {
    "session": "Mac 观察诊断修正",
    "state": "已合并 #78，真机待验 · 01a07591-038d-7cd3-8c2e-0315d2f50f5f",
@@ -1647,10 +1654,10 @@
   {
    "id": "H-2",
    "lane": "H",
-   "title": "等待新候选锁定：半小时零漏接",
+   "title": "1.2（6）已安装，待半小时实际验收",
    "version": "1.2",
    "owner": "U",
-   "status": "blocked",
+   "status": "ready",
    "pr": null,
    "deps": [
     "S-6",
@@ -1671,7 +1678,7 @@
     "verify": "Mac 设置页。",
     "skills": "—"
    },
-   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：H-2 等待新候选锁定：半小时零漏接。\n票 / 位置：.scratch/release-1.2/issues/02-half-hour-acceptance.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 半小时零漏接；Q28 先发一版：1.2 可靠性 + 官方接口 + 手机手表；1.3 陌生用户路径 + App Store）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：冻结候选连续半小时无新增漏接；修复后重新计时。\n  范围：以获准安装的冻结候选执行半小时体验，记录起止时间与漏接增量。\n  不做：—\n  验收：验收窗口内新增漏接为 0；任何一次漏接开票修复后重计半小时。\n  验证：Mac 设置页。\n  建议技能：—（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n按 release-1.2 票02，在具体设备操作获准后使用冻结候选执行连续半小时真实体验。记录成品身份、起止时间、漏接增量和非预期重复；失败修复后锁定新候选并重新计时，不自动安装或替换运行中的 App。\n\n这一步只有你本人能做（真机、签名、账号或决策）。完成后把结果写回票的 Status 行与验收段，截图放票里指定的目录；有失败就开修复票而不是改判据。做完在本图把 H-2 标 done，协调会话会据此派下游。"
+   "prompt": "你在 iOS-vibebuddy 仓库工作（~/Projects/iOS-vibebuddy）。任务：H-2 1.2（6）已安装，待半小时实际验收。\n票 / 位置：.scratch/release-1.2/issues/02-half-hour-acceptance.md\n\n先按顺序读：AGENTS.md → CONTEXT.md → docs/planning/vision-2026-09.md（本任务服务的决策：Q4 半小时零漏接；Q28 先发一版：1.2 可靠性 + 官方接口 + 手机手表；1.3 陌生用户路径 + App Store）→ 上面的票及其引用的 PRD / ADR。已读且未变化的内容不用重复读。\n\n规格（以票为准，这里是摘要）：\n  目标：冻结候选连续半小时无新增漏接；修复后重新计时。\n  范围：以获准安装的冻结候选执行半小时体验，记录起止时间与漏接增量。\n  不做：—\n  验收：验收窗口内新增漏接为 0；任何一次漏接开票修复后重计半小时。\n  验证：Mac 设置页。\n  建议技能：—（技能在 .agents/skills/，按其触发条件用；grill-with-docs 只在票里仍有未决取舍时用，问完立刻把结论写回票）\n\n任务正文：\n按 release-1.2 票02，在具体设备操作获准后使用冻结候选执行连续半小时真实体验。记录成品身份、起止时间、漏接增量和非预期重复；失败修复后锁定新候选并重新计时，不自动安装或替换运行中的 App。\n\n这一步只有你本人能做（真机、签名、账号或决策）。完成后把结果写回票的 Status 行与验收段，截图放票里指定的目录；有失败就开修复票而不是改判据。做完在本图把 H-2 标 done，协调会话会据此派下游。"
   },
   {
    "id": "H-3",


### PR DESCRIPTION
H-2 / H-3

Record signed/notarized 1.2 build 6 installed on Mac, Hermes and Watch after explicit owner authorization. Release acceptance is ready to begin against this frozen candidate; no old observation interval is reused and no publication occurred.

Validation: candidate version/signature checks, Mac health OK, device install results; HTML export and diff check passed.