### PR TITLE
WQ-4 declare a ClockKit principal class so iOS lists the Watch app in complication configuration

### DIFF
--- a/VibeBuddyApp/Watch/ComplicationController.swift
+++ b/VibeBuddyApp/Watch/ComplicationController.swift
@@ -1,0 +1,19 @@
+import ClockKit
+
+/// Empty ClockKit data source, named by `CLKComplicationPrincipalClass` in the
+/// Watch app's Info.plist. It publishes no ClockKit complications: every real
+/// complication lives in the WidgetKit extension. It exists because iOS's Watch
+/// app adds a third-party app to its complication configuration UI only when the
+/// watch reports a ClockKit principal class, and a single-target watch app never
+/// reports one otherwise, so the quota configuration page showed a placeholder
+/// instead of the app icon.
+final class ComplicationController: NSObject, CLKComplicationDataSource {
+    func getComplicationDescriptors(handler: @escaping ([CLKComplicationDescriptor]) -> Void) {
+        handler([])
+    }
+
+    func getCurrentTimelineEntry(for complication: CLKComplication,
+                                 withHandler handler: @escaping (CLKComplicationTimelineEntry?) -> Void) {
+        handler(nil)
+    }
+}

--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -47,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "8"
+        CURRENT_PROJECT_VERSION: "9"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "8"
+        CURRENT_PROJECT_VERSION: "9"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -107,12 +107,18 @@ targets:
         WKApplication: true
         WKCompanionAppBundleIdentifier: com.vibebuddy.app
         WKRunsIndependentlyOfCompanionApp: false
+        # iOS's Watch app only lists a third-party app in its complication
+        # configuration UI (and fetches its icon) when the watch reports a
+        # ClockKit principal class. The class is an empty data source; every
+        # real complication is WidgetKit. See .scratch/watch-quota/acceptance/
+        # defect-quota-configuration-icon.md.
+        CLKComplicationPrincipalClass: $(PRODUCT_MODULE_NAME).ComplicationController
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
         CODE_SIGN_ENTITLEMENTS: Watch/VibeBuddyWatch.entitlements
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "8"
+        CURRENT_PROJECT_VERSION: "9"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -140,7 +146,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "8"
+        CURRENT_PROJECT_VERSION: "9"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2


### PR DESCRIPTION
WQ-4

## Why

The quota complication's configuration page in the iPhone Watch app showed a white grid placeholder instead of the app icon (WQ-4). Device logs on Hermes (iOS 26, Bridge process, `CompanionApp` category) show that `NTKCompanionAppLibrary` only adds a third-party app when the watch reports a ClockKit principal class (`processRemoteApplication non-nil principal class`); WidgetKit-only single-target watch apps (vibebuddy, Tesla, Spotify…) are never added, so `NTKCompanionConfigurationEditorController` finds no app to match, never calls `setRemoteAppIcon:`, and WidgetKit's placeholder is shown. AppConduit reads the class from the watch's LaunchServices record (`complicationPrincipalClassName`), which comes from the Watch app's top-level `CLKComplicationPrincipalClass`.

## What

- `project.yml`: Watch app Info.plist gains `CLKComplicationPrincipalClass = $(PRODUCT_MODULE_NAME).ComplicationController`; the four mobile bundles move to 1.3(9). Mac stays 1.3(7).
- `Watch/ComplicationController.swift`: an empty `CLKComplicationDataSource` (no descriptors, no timeline). All real complications stay in the WidgetKit extension.

## Verification

- Device build for Hermes: four bundles 1.3(9), strict signatures pass, key and class present in the Watch bundle.
- Installed on Hermes and the paired Apple Watch (devicectl). After a fresh Watch-app launch the log shows `Icon is nil for app: com.vibebuddy.app.watchkitapp` (app now matched, icon fetched asynchronously); the next open of 模块 → 左下 → vibebuddy → 额度 shows the cat icon with the app name. Platform / style / window parameters unchanged; no ClockKit entries appear in the complication picker.
- Known limit: the first configuration open after a cold launch of the phone's Watch app still shows the placeholder once; the second open shows the icon (NanoTimeKit reads the icon synchronously).

Evidence and the full trace live in `.scratch/watch-quota/acceptance/defect-quota-configuration-icon.md` and `icon-trace/` (local ticket files).
