### PR TITLE
fix(release): correct unsupported Watch deployment target

### DIFF
--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -3,7 +3,7 @@ options:
   bundleIdPrefix: com.vibebuddy
   deploymentTarget:
     iOS: "17.0"
-    watchOS: "26.6"
+    watchOS: "26.5"
   createIntermediateGroups: true
   developmentLanguage: en
 
@@ -47,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "10"
+        CURRENT_PROJECT_VERSION: "11"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "10"
+        CURRENT_PROJECT_VERSION: "11"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -118,7 +118,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
         CODE_SIGN_ENTITLEMENTS: Watch/VibeBuddyWatch.entitlements
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "10"
+        CURRENT_PROJECT_VERSION: "11"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -146,7 +146,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "10"
+        CURRENT_PROJECT_VERSION: "11"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2

--- a/docs/app-store-submission-1.3.md
+++ b/docs/app-store-submission-1.3.md
@@ -2,7 +2,7 @@
 
 截图素材已另备：[三端截图与上传清单](app-store-screenshots/1.3/README.md)。含中英文环境原生实拍；中文未翻译标签及未收录的实际表盘组件见素材清单。
 
-状态（2026-09-06 21:52）：按用户明确授权，iPhone / Watch **1.3（10）已提交 App Store，Waiting for Review**；尚未获批或公开上架。Submission ID：`447e220d-5bcb-4344-9335-051f0ee2e891`。Mac **1.3（7）** 已公开在 [GitHub v1.3](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3)。中英文 iPhone / Watch 共 8 张商店截图均从本次最终移动构建重拍上传，旧版截图已移除。半小时真实体验未在本轮补做；提交审核不代表该验收完成。
+状态（2026-09-06 22:09）：移动版 **1.3（10）** 提交后被 Apple 自动校验退回，邮件明确为 **ITMS-90455**：Watch 包的 `MinimumOSVersion=26.6` 不受支持。已将 Watch 宿主与扩展的最低版本改为 **26.5**，四个移动目标统一升至 **1.3（11）**，正在重新打包送审。Submission ID：`447e220d-5bcb-4344-9335-051f0ee2e891`。Mac **1.3（7）** 已公开在 [GitHub v1.3](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3)。商店 8 张中英文截图来自构建 10；构建 11 只调整系统版本要求及构建号，界面与功能一致，继续使用该组截图。半小时真实体验未在本轮补做；提交审核不代表验收、获批或公开上架。
 
 本包是本次商店描述、更新日志和审核说明的入口；旧 `app-store-paste-sheet.md` 是 1.1 历史材料。以下保留文案来源；在线提交已补充公开包不含 APNs 凭据及相关能力边界。下载引导 Ticket 位于 `.scratch/mac-companion-download/issues/01-guide-mac-companion-download.md`，已完成本地实现和模拟器检查，真实配对验收尚待完成。
 

--- a/docs/app-store-submission-1.3.md
+++ b/docs/app-store-submission-1.3.md
@@ -223,7 +223,7 @@ Task data is sourced from the user's Mac; this does not mean all app traffic sta
 ## 本次在线提交补充
 
 - 中英文描述及审核 Notes 明示：公开 Mac 下载不包含项目 APNs 凭据；关闭 App 后的远程推送不是开箱即用功能，需 App 签名团队授权的提供者。没有运营中的 VibeBuddy 云服务。
-- 审核 Notes 明示 Mac 1.3（7）下载、移动 1.3（10）、演示与真实功能的区别，以及 Watch 配置页冷启动首次可能占位、重新打开显示图标的限制。
+- 审核 Notes 明示 Mac 1.3（7）下载、移动 1.3（11）、演示与真实功能的区别，以及 Watch 配置页冷启动首次可能占位、重新打开显示图标的限制。
 - 审核联系人已按用户本轮提供内容填写；个人电话和邮箱不写入仓库。
 - 当前设备仍为移动 1.3（9）；本次未用送审包替换设备安装。
-- App Store 设置为审核通过后自动发布；当前事实仅为 Waiting for Review。
+- App Store 设置为审核通过后自动发布；构建 10 因 ITMS-90455 被退回，修正后的构建 11 已上传，等待处理后重新提交。


### PR DESCRIPTION
H-4

Apple rejected 1.3 (10) with ITMS-90455 because the Watch bundle required unsupported watchOS 26.6. Set the Watch app and extension target to 26.5 and advance all four mobile bundles to build 11; Mac remains 1.3 (7).

Validation: archive and signed App Store export passed. Inspected all four archived Info.plists: build 11 throughout; iOS minimum 17.0, Watch app and widget minimum 26.5, matching the installed SDK. Independent review found no blockers. No UI or functional changes; retain the current build-10 screenshots. Apple upload/resubmission is in progress.
