### PR TITLE
feat(quota): Cursor first-class AccountUsageProvider (#103)

### DIFF
--- a/VibeBuddyApp/WatchWidget/QuotaWidget.swift
+++ b/VibeBuddyApp/WatchWidget/QuotaWidget.swift
@@ -120,8 +120,22 @@ struct QuotaWidgetView: View {
         entry.quotas.first { $0.provider == provider }?.window(kind ?? entry.configuration.period.kind)
             ?? QuotaWindow(remainingPercent: nil, durationMinutes: nil, resetsAt: nil, observedAt: nil)
     }
-    private func label(_ provider: AccountUsageProvider) -> String { provider == .codex ? "C" : "CL" }
-    private func color(_ provider: AccountUsageProvider) -> Color { provider == .codex ? .cyan : .orange }
+    private func label(_ provider: AccountUsageProvider) -> String {
+        switch provider {
+        case .codex: return "C"
+        case .claude: return "CL"
+        case .grok: return "G"
+        case .cursor: return "Cu"
+        }
+    }
+    private func color(_ provider: AccountUsageProvider) -> Color {
+        switch provider {
+        case .codex: return .cyan
+        case .claude: return .orange
+        case .grok: return .indigo
+        case .cursor: return .purple
+        }
+    }
     private func periodLabel(_ reading: QuotaWindow, kind: QuotaWindowKind? = nil) -> String {
         if (kind ?? entry.configuration.period.kind) == .weekly { return String(localized: "Wk") }
         guard let minutes = reading.durationMinutes else { return String(localized: "Short") }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -8,6 +8,7 @@ public enum AccountUsageProvider: String, Codable, CaseIterable, Sendable, Ident
     case codex
     case claude
     case grok
+    case cursor
 
     public var id: String { rawValue }
 
@@ -16,6 +17,7 @@ public enum AccountUsageProvider: String, Codable, CaseIterable, Sendable, Ident
         case .codex: return "Codex"
         case .claude: return "Claude"
         case .grok: return "Grok"
+        case .cursor: return "Cursor"
         }
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorPendingUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorPendingUsageProvider.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Placeholder until the Cookie + `usage-summary` collector lands (#104).
+///
+/// Keeps Cursor first-class in the quota vocabulary while always producing an
+/// explicit unavailable reason — never a silent omission and never a fake 0%.
+public struct CursorPendingUsageProvider: AccountUsageProviding {
+    public init() {}
+
+    public func fetch() async throws -> AccountUsageSnapshot {
+        // #104 replaces this with session-cookie auth. Until then, "not signed in"
+        // is the clearest existing reason string for missing Cursor credentials.
+        throw AccountUsageError.notLoggedIn
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -628,6 +628,43 @@ struct AccountUsageTests {
         )
     }
 
+    @Test("Cursor is a first-class usage provider with its own cache and labels")
+    func cursorProviderRegistration() {
+        #expect(AccountUsageProvider.allCases.contains(.cursor))
+        #expect(AccountUsageProvider.cursor.displayName == "Cursor")
+        #expect(AccountUsageProvider.cursor.rawValue == "cursor")
+
+        let home = URL(fileURLWithPath: "/Users/example")
+        let cacheURL = AccountUsageFileCache.defaultFileURL(provider: .cursor, home: home)
+        #expect(cacheURL.lastPathComponent == "cursor-usage.json")
+        #expect(cacheURL != AccountUsageFileCache.defaultFileURL(provider: .codex, home: home))
+
+        #expect(
+            AccountUsageUnavailableReason.notLoggedIn.displayText(provider: .cursor)
+                == "Cursor is not signed in"
+        )
+        #expect(
+            AccountUsageUnavailableReason.collectionDisabled.displayText(provider: .cursor)
+                == "Collection is turned off"
+        )
+        #expect(
+            AccountUsageUnavailableReason.notYetLoaded.displayText(provider: .cursor)
+                == "Waiting for the first refresh"
+        )
+    }
+
+    @Test("Cursor pending provider never invents a 0% remaining reading")
+    func cursorPendingProviderStaysUnavailable() async throws {
+        let provider = CursorPendingUsageProvider()
+        do {
+            _ = try await provider.fetch()
+            Issue.record("CursorPendingUsageProvider must not succeed before #104")
+        } catch let error as AccountUsageError {
+            #expect(error == .notLoggedIn)
+            #expect(error.unavailableReason.displayText(provider: .cursor) == "Cursor is not signed in")
+        }
+    }
+
     @Test("a Grok crossing alerts independently of the other providers")
     func grokAlertsAreIndependent() {
         var monitor = AccountUsageAlertMonitor()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
@@ -264,6 +264,9 @@ struct ProviderQuotaProjectionTests {
         #expect(quotas.map(\.provider) == AccountUsageProvider.allCases)
         #expect(quotas.first { $0.provider == .codex }?.weeklyRemainingPercent == 68)
         #expect(quotas.first { $0.provider == .claude }?.weeklyRemainingPercent == 42)
+        #expect(quotas.first { $0.provider == .cursor }?.weeklyRemainingPercent == nil)
+        #expect(quotas.first { $0.provider == .cursor }?.unavailableReason
+                == "Collection is turned off")
     }
 
     @Test("A failing or disabled provider never changes what the other one reports")

--- a/VibeBuddyMacApp/Sources/AccountUsageCoordinator.swift
+++ b/VibeBuddyMacApp/Sources/AccountUsageCoordinator.swift
@@ -32,6 +32,7 @@ final class AccountUsageCoordinator: ObservableObject {
         case .claude: 15 * 60
         case .codex: 20 * 60
         case .grok: 15 * 60
+        case .cursor: 15 * 60
         }
     }
     private let collectors: [AccountUsageProvider: AccountUsageCollector]
@@ -47,10 +48,12 @@ final class AccountUsageCoordinator: ObservableObject {
         let codexEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey(for: .codex), default: true)
         let claudeEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey(for: .claude), default: true)
         let grokEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey(for: .grok), default: true)
+        let cursorEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey(for: .cursor), default: true)
         collectionEnabled = [
             .codex: codexEnabled,
             .claude: claudeEnabled,
             .grok: grokEnabled,
+            .cursor: cursorEnabled,
         ]
         states = [
             .codex: codexEnabled
@@ -60,6 +63,9 @@ final class AccountUsageCoordinator: ObservableObject {
                 ? .unavailable(.notYetLoaded, lastAttemptAt: nil, nextRefreshAt: nil)
                 : .disabled,
             .grok: grokEnabled
+                ? .unavailable(.notYetLoaded, lastAttemptAt: nil, nextRefreshAt: nil)
+                : .disabled,
+            .cursor: cursorEnabled
                 ? .unavailable(.notYetLoaded, lastAttemptAt: nil, nextRefreshAt: nil)
                 : .disabled,
         ]
@@ -78,6 +84,11 @@ final class AccountUsageCoordinator: ObservableObject {
                 provider: GrokUsageProvider(),
                 cache: AccountUsageFileCache(provider: .grok),
                 enabled: grokEnabled
+            ),
+            .cursor: AccountUsageCollector(
+                provider: CursorPendingUsageProvider(),
+                cache: AccountUsageFileCache(provider: .cursor),
+                enabled: cursorEnabled
             ),
         ]
         alertMonitor = AccountUsageAlertMonitor(


### PR DESCRIPTION
## Summary
Implements #103: Cursor joins Codex/Claude/Grok as a first-class quota provider everywhere vocabulary, toggles, cache keys, projection, and Watch widget labels appear.

Until #104 ships the Cookie + `usage-summary` collector, `CursorPendingUsageProvider` always fails closed with an explicit unavailable reason (`Cursor is not signed in` / collection-off / not-yet-loaded) — never omitted from the list and never a fake 0%.

Matt Pocock: reuse #102 grill/to-spec/to-tickets decisions; no Spec Kit.

## Acceptance criteria
- [x] `AccountUsageProvider` includes `cursor` with stable wire raw value `cursor` and display name Cursor.
- [x] Coordinator default state/toggle/cache keys cover Cursor like the other providers.
- [x] iPhone/Watch quota UI lists Cursor via `ProviderQuota.all` / `allCases` (Watch home iterates quotas); Watch widget label/color cover Cursor.
- [x] Existing Codex/Claude/Grok tests still green; projection/`allCases` tests updated for the fourth provider.

## Test plan
- [x] `cd VibeBuddyMac && swift test --filter 'AccountUsageTests|ProviderQuotaProjectionTests'` — 41 tests passed (Mac local).
- [ ] Manual: Mac Usage toggles show Cursor; with collection on, unavailable reason is clear (not 0%).
- [ ] Manual: relayed snapshot lists Cursor on iPhone/Watch.

## Notes / risks
- Feature PR — **do not merge** until 图灵 → 亚里士多德 → user.
- Collector is intentionally a stub (`CursorPendingUsageProvider`); real Cookie path is #104.
- Did not expand `WatchQuotaSelection` (codex/claude/both) complication destinations; main Watch home list is covered via quotas array.