### PR TITLE
feat(quota): Grok Build CLI billing proxy fallback (#106)

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokCreditsProxy.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokCreditsProxy.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Minimal transport so unit tests can stub the CLI billing proxy without
+/// touching the network.
+public protocol GrokCreditsProxyTransport: Sendable {
+    func proxyData(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: GrokCreditsProxyTransport {
+    public func proxyData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await data(for: request)
+    }
+}
+
+/// `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` — same path
+/// CodexBar documents (MIT). Reimplemented against the public HTTP shape; we do
+/// not vendor CodexBar's UI stack.
+public enum GrokCreditsProxyClient {
+    public static let defaultEndpoint = URL(
+        string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+    )!
+
+    public static func fetch(
+        accessToken: String,
+        endpoint: URL = defaultEndpoint,
+        transport: GrokCreditsProxyTransport,
+        timeout: TimeInterval = 15,
+        userAgent: String = "VibeBuddy"
+    ) async throws -> Data {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("xai-grok-cli", forHTTPHeaderField: "x-xai-token-auth")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await transport.proxyData(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AccountUsageError.unknown
+        }
+        switch http.statusCode {
+        case 200:
+            return data
+        case 401, 403:
+            throw AccountUsageError.notLoggedIn
+        case 429:
+            throw AccountUsageError.rateLimited
+        default:
+            throw AccountUsageError.providerUnavailable
+        }
+    }
+}
+
+/// Reads only the access token (and expiry) from `~/.grok/auth.json`. The token
+/// itself is never logged.
+public enum GrokCLIAuthToken {
+    public static let oidcScopePrefix = "https://auth.x.ai::"
+    public static let legacySessionScope = "https://accounts.x.ai/sign-in"
+
+    public static func loadAccessToken(from authFileURL: URL, now: Date = Date()) -> String? {
+        guard let data = try? Data(contentsOf: authFileURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entry = preferredEntry(in: root) else {
+            return nil
+        }
+        if let expires = entry["expires_at"] as? String,
+           let date = parseExpiry(expires),
+           now >= date {
+            return nil
+        }
+        if let key = entry["key"] as? String, !key.isEmpty {
+            return key
+        }
+        if let access = entry["access_token"] as? String, !access.isEmpty {
+            return access
+        }
+        return nil
+    }
+
+    static func preferredEntry(in root: [String: Any]) -> [String: Any]? {
+        let oidc = root
+            .compactMap { key, value -> (String, [String: Any])? in
+                guard key.hasPrefix(oidcScopePrefix), let entry = value as? [String: Any] else {
+                    return nil
+                }
+                return (key, entry)
+            }
+            .sorted { $0.0 < $1.0 }
+            .first?
+            .1
+        if let oidc { return oidc }
+        return root[legacySessionScope] as? [String: Any]
+    }
+
+    private static func parseExpiry(_ raw: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: raw) { return date }
+        let basic = ISO8601DateFormatter()
+        basic.formatOptions = [.withInternetDateTime]
+        return basic.date(from: raw)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
@@ -74,6 +74,47 @@ public enum GrokUsageResponseDecoder {
         return nil
     }
 
+    /// Decodes `GET …/v1/billing?format=credits` (CodexBar CLI-proxy shape).
+    /// Primary comes from `creditUsagePercent` when present; otherwise from a
+    /// positive on-demand cap/used pair. Period-only answers are not usable.
+    public static func decode(proxyCreditsResponse: Data, fetchedAt: Date) throws -> AccountUsageSnapshot {
+        let envelope: ProxyCreditsEnvelopeDTO
+        do {
+            envelope = try JSONDecoder().decode(ProxyCreditsEnvelopeDTO.self, from: proxyCreditsResponse)
+        } catch {
+            throw AccountUsageError.incompatibleFormat
+        }
+        let config = envelope.config
+        let tier = config?.subscriptionTier ?? envelope.subscriptionTier
+        if config?.creditPercent != nil {
+            return try snapshot(config: config, tier: tier, fetchedAt: fetchedAt)
+        }
+        // On-demand-only proxy answers still fill the single Grok primary window.
+        guard let config,
+              let cap = config.onDemandCap?.val, cap > 0 else {
+            throw AccountUsageError.incompatibleFormat
+        }
+        let used = config.onDemandUsedValue ?? 0
+        let percent = min(100, max(0, used / cap * 100))
+        guard percent.isFinite else { throw AccountUsageError.incompatibleFormat }
+        let start = parseTimestamp(config.periodStart)
+        let resetsAt = parseTimestamp(config.periodEnd)
+        return AccountUsageSnapshot(
+            provider: .grok,
+            planType: tier.flatMap { $0.isEmpty ? nil : $0 },
+            primary: AccountUsageWindow(
+                kind: .primary,
+                usedPercent: Int(percent.rounded()),
+                windowDurationMinutes: duration(from: start, to: resetsAt),
+                resetsAt: resetsAt
+            ),
+            secondary: nil,
+            lifetimeTokens: nil,
+            latestDailyTokens: nil,
+            fetchedAt: fetchedAt
+        )
+    }
+
     private static func snapshot(
         config: BillingConfigDTO?,
         tier: String?,
@@ -181,6 +222,11 @@ private struct BillingEnvelopeDTO: Decodable {
     var error: RPCErrorDTO?
 }
 
+private struct ProxyCreditsEnvelopeDTO: Decodable {
+    var config: BillingConfigDTO?
+    var subscriptionTier: String?
+}
+
 private struct BillingResultDTO: Decodable {
     var config: BillingConfigDTO?
     /// The handler answers `subscription_tier`; `/v1/settings` and some builds
@@ -223,6 +269,8 @@ private struct BillingConfigDTO: Decodable {
     var onDemandUsed: CentDTO?
     var billingPeriodStart: String?
     var billingPeriodEnd: String?
+    /// Present on some CLI-proxy credits payloads (CodexBar).
+    var subscriptionTier: String?
 
     /// Percent of the included allowance. The credits config reports it
     /// directly; the deprecated fields only carry an amount and a limit.
@@ -252,26 +300,39 @@ private struct UnifiedLogRecordDTO: Decodable {
 
 // MARK: - Provider
 
-/// Reads Grok Build's weekly credit quota through the CLI's own ACP server, so
-/// the bearer token in `~/.grok/auth.json` is never touched by VibeBuddy. When
-/// the agent cannot be spawned or reached, the last billing record the CLI
-/// wrote to its unified log stands in.
+/// Reads Grok Build's weekly credit quota through the CLI's own ACP server.
+/// When the agent cannot be spawned or reached, the last billing record the
+/// CLI wrote to its unified log stands in. If that still yields no usable
+/// percent, the CodexBar-documented CLI billing proxy is tried with the local
+/// `~/.grok/auth.json` bearer — same Grok row, never a second provider.
 public final class GrokUsageProvider: AccountUsageProviding, Sendable {
     private let executableURL: URL?
     private let arguments: [String]
     private let timeout: TimeInterval
     private let logURL: URL
+    private let authFileURL: URL
+    private let proxyEndpoint: URL
+    private let proxyTransport: GrokCreditsProxyTransport
+    private let proxyEnabled: Bool
 
     public init(
         executableURL: URL? = nil,
         arguments: [String] = ["agent", "--no-leader", "stdio"],
         timeout: TimeInterval = 10,
-        logURL: URL? = nil
+        logURL: URL? = nil,
+        authFileURL: URL? = nil,
+        proxyEndpoint: URL = GrokCreditsProxyClient.defaultEndpoint,
+        proxyTransport: GrokCreditsProxyTransport = URLSession.shared,
+        proxyEnabled: Bool = true
     ) {
         self.executableURL = executableURL ?? Self.resolveGrokExecutable()
         self.arguments = arguments
         self.timeout = timeout
         self.logURL = logURL ?? Self.defaultLogURL()
+        self.authFileURL = authFileURL ?? GrokHome.url.appendingPathComponent("auth.json")
+        self.proxyEndpoint = proxyEndpoint
+        self.proxyTransport = proxyTransport
+        self.proxyEnabled = proxyEnabled
     }
 
     public func fetch() async throws -> AccountUsageSnapshot {
@@ -305,14 +366,46 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
             } catch {
                 try Task.checkCancellation()
                 guard Self.allowsLogFallback(after: error) else { throw error }
-                guard let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(
+                if let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(
                     in: logURL,
                     now: Date()
-                ) else { throw error }
-                return snapshot
+                ) {
+                    return snapshot
+                }
+                if proxyEnabled, let snapshot = await Self.fetchProxyFallback(
+                    authFileURL: authFileURL,
+                    endpoint: proxyEndpoint,
+                    transport: proxyTransport
+                ) {
+                    return snapshot
+                }
+                throw error
             }
         } onCancel: {
             client.cancel()
+        }
+    }
+
+    /// Best-effort proxy: never upgrades a hard auth/format failure from ACP, and
+    /// never invents a reading when the bearer is missing.
+    static func fetchProxyFallback(
+        authFileURL: URL,
+        endpoint: URL,
+        transport: GrokCreditsProxyTransport,
+        now: Date = Date()
+    ) async -> AccountUsageSnapshot? {
+        guard let token = GrokCLIAuthToken.loadAccessToken(from: authFileURL, now: now) else {
+            return nil
+        }
+        do {
+            let data = try await GrokCreditsProxyClient.fetch(
+                accessToken: token,
+                endpoint: endpoint,
+                transport: transport
+            )
+            return try GrokUsageResponseDecoder.decode(proxyCreditsResponse: data, fetchedAt: now)
+        } catch {
+            return nil
         }
     }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
@@ -313,7 +313,175 @@ struct GrokUsageProviderTests {
         #expect(snapshot.primary != nil)
     }
 
-    // MARK: - Fixtures
+    
+    @Test("CLI proxy credits JSON maps onto the same Grok snapshot shape")
+    func proxyCreditsDecode() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let body = Data("""
+        {
+          "config": {
+            "creditUsagePercent": 12.5,
+            "currentPeriod": {
+              "type": "USAGE_PERIOD_TYPE_WEEKLY",
+              "start": "2026-08-06T00:00:00Z",
+              "end": "2026-08-13T00:00:00Z"
+            },
+            "billingPeriodEnd": "2026-08-13T00:00:00Z",
+            "onDemandCap": { "val": 1000 },
+            "onDemandUsed": { "val": 250 }
+          },
+          "subscriptionTier": "SuperGrok Heavy"
+        }
+        """.utf8)
+        let snapshot = try GrokUsageResponseDecoder.decode(proxyCreditsResponse: body, fetchedAt: now)
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.planType == "SuperGrok Heavy")
+        #expect(snapshot.primary?.usedPercent == 13) // 12.5 rounded
+        #expect(snapshot.secondary?.usedPercent == 25)
+        #expect(snapshot.fetchedAt == now)
+        #expect(snapshot.primary?.usedPercent != 0 || snapshot.primary != nil)
+    }
+
+    @Test("proxy on-demand-only answers still fill the single Grok primary window")
+    func proxyOnDemandOnlyPrimary() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_100)
+        let body = Data("""
+        {
+          "config": {
+            "onDemandCap": { "val": 1000.0 },
+            "onDemandUsed": { "val": 250.0 },
+            "billingPeriodEnd": "2026-08-13T00:00:00Z"
+          }
+        }
+        """.utf8)
+        let snapshot = try GrokUsageResponseDecoder.decode(proxyCreditsResponse: body, fetchedAt: now)
+        #expect(snapshot.primary?.usedPercent == 25)
+        #expect(snapshot.secondary == nil)
+        #expect(snapshot.fetchedAt == now)
+    }
+
+    @Test("period-only proxy answers stay unavailable rather than inventing 0%")
+    func proxyPeriodOnlyRejected() {
+        let body = Data("""
+        {
+          "config": {
+            "currentPeriod": { "end": "2026-08-13T00:00:00Z" },
+            "billingPeriodEnd": "2026-08-14T00:00:00Z"
+          },
+          "subscriptionTier": "SuperGrok Heavy"
+        }
+        """.utf8)
+        #expect(throws: AccountUsageError.incompatibleFormat) {
+            try GrokUsageResponseDecoder.decode(proxyCreditsResponse: body, fetchedAt: Date())
+        }
+    }
+
+    @Test("auth.json reader prefers the OIDC scope key and respects expiry")
+    func authTokenReader() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let auth = directory.appendingPathComponent("auth.json")
+        let future = "2099-01-01T00:00:00Z"
+        let past = "2000-01-01T00:00:00Z"
+        try Data("""
+        {
+          "https://auth.x.ai::openid": {
+            "key": "oidc-token",
+            "expires_at": "\(future)"
+          },
+          "https://accounts.x.ai/sign-in": {
+            "key": "legacy-token",
+            "expires_at": "\(future)"
+          }
+        }
+        """.utf8).write(to: auth)
+        #expect(GrokCLIAuthToken.loadAccessToken(from: auth) == "oidc-token")
+
+        try Data("""
+        {
+          "https://auth.x.ai::openid": {
+            "key": "expired",
+            "expires_at": "\(past)"
+          }
+        }
+        """.utf8).write(to: auth)
+        #expect(GrokCLIAuthToken.loadAccessToken(from: auth) == nil)
+    }
+
+    @Test("unreachable ACP falls through log miss into the billing proxy")
+    func proxyFallbackAfterPrimaryMiss() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let auth = directory.appendingPathComponent("auth.json")
+        try Data("""
+        {
+          "https://auth.x.ai::openid": {
+            "key": "token-123",
+            "expires_at": "2099-01-01T00:00:00Z"
+          }
+        }
+        """.utf8).write(to: auth)
+        let endpoint = URL(string: "https://grok.test/v1/billing?format=credits")!
+        let transport = ScriptedProxyTransport(handler: { request in
+            #expect(request.url == endpoint)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token-123")
+            #expect(request.value(forHTTPHeaderField: "x-xai-token-auth") == "xai-grok-cli")
+            let body = Data("""
+            {"config":{"creditUsagePercent":44.0,"currentPeriod":{"start":"2026-08-06T00:00:00Z","end":"2026-08-13T00:00:00Z"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0}},"subscriptionTier":"SuperGrok"}
+            """.utf8)
+            let response = HTTPURLResponse(
+                url: endpoint, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (body, response)
+        })
+        let snapshot = try await GrokUsageProvider(
+            executableURL: URL(fileURLWithPath: "/bin/false"),
+            arguments: [],
+            timeout: 1,
+            logURL: directory.appendingPathComponent("absent.jsonl"),
+            authFileURL: auth,
+            proxyEndpoint: endpoint,
+            proxyTransport: transport
+        ).fetch()
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.primary?.usedPercent == 44)
+        #expect(snapshot.planType == "SuperGrok")
+    }
+
+    @Test("proxy failure leaves the original primary error in place")
+    func proxyFailureDoesNotMaskPrimary() async {
+        let directory = try! Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let auth = directory.appendingPathComponent("auth.json")
+        try! Data("""
+        {"https://auth.x.ai::openid":{"key":"token-123","expires_at":"2099-01-01T00:00:00Z"}}
+        """.utf8).write(to: auth)
+        let endpoint = URL(string: "https://grok.test/v1/billing?format=credits")!
+        let transport = ScriptedProxyTransport(handler: { _ in
+            throw URLError(.notConnectedToInternet)
+        })
+        await #expect(throws: AccountUsageError.providerUnavailable) {
+            try await GrokUsageProvider(
+                executableURL: URL(fileURLWithPath: "/bin/false"),
+                arguments: [],
+                timeout: 1,
+                logURL: directory.appendingPathComponent("absent.jsonl"),
+                authFileURL: auth,
+                proxyEndpoint: endpoint,
+                proxyTransport: transport
+            ).fetch()
+        }
+    }
+
+
+    private struct ScriptedProxyTransport: GrokCreditsProxyTransport {
+        let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+        func proxyData(for request: URLRequest) async throws -> (Data, URLResponse) {
+            try await handler(request)
+        }
+    }
+
+// MARK: - Fixtures
 
     private static func billingResponse(
         creditUsagePercent: String = "36.0",


### PR DESCRIPTION
## Summary
Implements #106: when Grok Build ACP / `unified.jsonl` has no usable credit percent, vibebuddy falls back to the CodexBar-documented CLI billing proxy (`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` + local `~/.grok/auth.json` bearer). Still one Grok row.

Matt Pocock: reuse #102 decisions; no Spec Kit.

## Acceptance criteria
- [x] Primary path remains ACP + unified log; proxy runs only when primary has no usable percent.
- [x] Proxy success fills the same `AccountUsageSnapshot` shape (primary credit %, optional on-demand) with truthful `fetchedAt`.
- [x] Fixture/unit coverage for proxy JSON; failure leaves prior stale/unavailable behavior unchanged for Codex/Claude (Grok rethrows original primary error).

## Test plan
- [x] `cd VibeBuddyMac && swift test --filter GrokUsageProviderTests` — 21 passed (Mac local).
- [ ] Optional live: `VIBEBUDDY_GROK_LIVE=1` with signed-in CLI.

## Notes / risks
- Feature PR — **do not merge** until 图灵 → 亚里士多德 → user.
- Reads `auth.json` access token for proxy only (never logged).
- Period-only / tier-only proxy payloads rejected (no invented 0%).