### PR TITLE
feat(quota): optional Cursor browser cookie auto-import (#105)

### DIFF
--- a/VibeBuddyMac/Package.resolved
+++ b/VibeBuddyMac/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4a565c09490b5aadfcf894e6e821e96de2b8e00f2c67302e473220de41fd4cd0",
+  "originHash" : "29538e8fbb0ea158ed4b1a31934de89f37cbf6437ee549e11210fc4faea915e9",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -38,12 +38,12 @@
       }
     },
     {
-      "identity" : "sparkle",
+      "identity" : "sweetcookiekit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle",
+      "location" : "https://github.com/steipete/SweetCookieKit",
       "state" : {
-        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
-        "version" : "2.9.6"
+        "revision" : "d5ea6d92298779ec0c3ddf7d3d99da186a305e14",
+        "version" : "0.5.2"
       }
     },
     {

--- a/VibeBuddyMac/Package.swift
+++ b/VibeBuddyMac/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
+        .package(url: "https://github.com/steipete/SweetCookieKit", from: "0.5.2"),
     ],
     targets: [
         .target(
@@ -22,6 +23,7 @@ let package = Package(
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
                 .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "SweetCookieKit", package: "SweetCookieKit"),
             ]
         ),
         .executableTarget(

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
@@ -1,0 +1,147 @@
+import Foundation
+import SweetCookieKit
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Where Cursor session cookies come from on the Mac (#105).
+public enum CursorCookieSourceMode: String, CaseIterable, Sendable, Identifiable {
+    case manual
+    case browserAuto
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .manual: return "Paste Cookie"
+        case .browserAuto: return "Import from browser"
+        }
+    }
+}
+
+public enum CursorCookieSourceSettings {
+    public static let modeKey = "cursorCookieSourceMode"
+
+    public static func mode(
+        defaults: UserDefaults = .standard
+    ) -> CursorCookieSourceMode {
+        guard let raw = defaults.string(forKey: modeKey),
+              let mode = CursorCookieSourceMode(rawValue: raw) else {
+            return .manual
+        }
+        return mode
+    }
+
+    public static func setMode(
+        _ mode: CursorCookieSourceMode,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(mode.rawValue, forKey: modeKey)
+    }
+}
+
+/// Import seam so unit tests never touch real browser stores.
+public protocol CursorBrowserCookieImporting: Sendable {
+    /// Returns a Cookie request header when a usable Cursor session is found.
+    func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String
+}
+
+/// CodexBar-style Cursor session cookie names / domains (MIT-documented shapes;
+/// reimplemented against SweetCookieKit, not vendoring CodexBar).
+public struct CursorBrowserCookieImporter: CursorBrowserCookieImporting {
+    public static let sessionCookieNames: Set<String> = [
+        "WorkosCursorSessionToken",
+        "__Secure-next-auth.session-token",
+        "next-auth.session-token",
+        "wos-session",
+        "__Secure-wos-session",
+        "authjs.session-token",
+        "__Secure-authjs.session-token",
+    ]
+
+    public static let cookieDomains = [
+        "cursor.com",
+        "www.cursor.com",
+        "cursor.sh",
+        "authenticator.cursor.sh",
+    ]
+
+    private let client: BrowserCookieClient
+    private let browsers: [Browser]
+
+    public init(
+        client: BrowserCookieClient = BrowserCookieClient(),
+        browsers: [Browser] = Browser.defaultImportOrder
+    ) {
+        self.client = client
+        self.browsers = browsers
+    }
+
+    public func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String {
+        let query = BrowserCookieQuery(domains: Self.cookieDomains, domainMatch: .suffix)
+        let load: () throws -> [BrowserCookieStoreRecords] = {
+            try self.client.records(matching: query, in: self.browsers)
+        }
+        let groups: [BrowserCookieStoreRecords]
+        if allowKeychainPrompt {
+            groups = try load()
+        } else {
+            groups = try BrowserCookieKeychainAccessGate.withUserInteractionDisallowed(load)
+        }
+
+        // Prefer a known session cookie name; otherwise accept any non-empty
+        // Cursor-domain cookie set (new auth cookie names).
+        if let header = Self.cookieHeader(from: groups, requireKnownSessionName: true) {
+            return header
+        }
+        if let header = Self.cookieHeader(from: groups, requireKnownSessionName: false) {
+            return header
+        }
+        throw AccountUsageError.notLoggedIn
+    }
+
+    static func cookieHeader(
+        from groups: [BrowserCookieStoreRecords],
+        requireKnownSessionName: Bool
+    ) -> String? {
+        for group in groups {
+            let cookies = BrowserCookieClient.makeHTTPCookies(group.records, origin: .domainBased)
+            guard !cookies.isEmpty else { continue }
+            let hasNamed = cookies.contains { sessionCookieNames.contains($0.name) }
+            if requireKnownSessionName, !hasNamed { continue }
+            return cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+        }
+        return nil
+    }
+}
+
+/// Resolves the Cookie header using the user's chosen source mode.
+public enum CursorCookieResolver {
+    public static func resolve(
+        mode: CursorCookieSourceMode = CursorCookieSourceSettings.mode(),
+        manualCookie: String? = nil,
+        importer: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
+        allowKeychainPrompt: Bool = false,
+        persistImportedCookie: (String) -> Void = { CursorSessionCookieStore.save($0) }
+    ) throws -> String {
+        let manual = (manualCookie ?? CursorSessionCookieStore.load())?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        switch mode {
+        case .manual:
+            guard let manual, !manual.isEmpty else { throw AccountUsageError.notLoggedIn }
+            return manual
+        case .browserAuto:
+            do {
+                let imported = try importer.importSessionCookieHeader(
+                    allowKeychainPrompt: allowKeychainPrompt
+                )
+                persistImportedCookie(imported)
+                return imported
+            } catch {
+                if let manual, !manual.isEmpty { return manual }
+                throw (error as? AccountUsageError) ?? AccountUsageError.notLoggedIn
+            }
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
@@ -171,31 +171,41 @@ struct CursorLegacyModelUsageDTO: Decodable {
     var maxRequestUsage: Int?
 }
 
-/// Reads Cursor plan allowance via a pasted session Cookie + `usage-summary`.
+/// Reads Cursor plan allowance via session Cookie + `usage-summary`.
+/// Cookie may come from a pasted header (#104) or optional browser import (#105).
 public struct CursorUsageProvider: AccountUsageProviding {
     public static let defaultEndpoint = URL(string: "https://cursor.com/api/usage-summary")!
 
     private let cookie: String?
+    private let cookieMode: CursorCookieSourceMode
+    private let cookieImporter: CursorBrowserCookieImporting
     private let endpoint: URL
     private let transport: CursorUsageTransport
     private let timeout: TimeInterval
 
     public init(
         cookie: String? = nil,
+        cookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode(),
+        cookieImporter: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
         endpoint: URL = defaultEndpoint,
         transport: CursorUsageTransport = URLSession.shared,
         timeout: TimeInterval = 15
     ) {
-        self.cookie = cookie ?? CursorSessionCookieStore.load()
+        self.cookie = cookie
+        self.cookieMode = cookieMode
+        self.cookieImporter = cookieImporter
         self.endpoint = endpoint
         self.transport = transport
         self.timeout = timeout
     }
 
     public func fetch() async throws -> AccountUsageSnapshot {
-        guard let cookie, !cookie.isEmpty else {
-            throw AccountUsageError.notLoggedIn
-        }
+        let cookie = try CursorCookieResolver.resolve(
+            mode: cookieMode,
+            manualCookie: cookie,
+            importer: cookieImporter,
+            allowKeychainPrompt: false
+        )
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
         request.timeoutInterval = timeout

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -655,7 +655,7 @@ struct AccountUsageTests {
 
     @Test("Cursor collector without a cookie stays unavailable, never 0%")
     func cursorProviderRequiresCookie() async throws {
-        let provider = CursorUsageProvider(cookie: nil, transport: MissingCookieTransport())
+        let provider = CursorUsageProvider(cookie: nil, cookieMode: .manual, transport: MissingCookieTransport())
         do {
             _ = try await provider.fetch()
             Issue.record("CursorUsageProvider must not succeed without a cookie")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import VibeBuddyMacCore
+
+@Suite("Cursor browser cookie import")
+struct CursorBrowserCookieImporterTests {
+    @Test("resolver in manual mode requires a pasted cookie")
+    func manualRequiresPaste() {
+        #expect(throws: AccountUsageError.notLoggedIn) {
+            try CursorCookieResolver.resolve(
+                mode: .manual,
+                manualCookie: nil,
+                importer: FailingImporter()
+            )
+        }
+        let header = try! CursorCookieResolver.resolve(
+            mode: .manual,
+            manualCookie: "WorkosCursorSessionToken=abc",
+            importer: FailingImporter()
+        )
+        #expect(header == "WorkosCursorSessionToken=abc")
+    }
+
+    @Test("browserAuto uses import then falls back to manual paste")
+    func browserAutoFallback() throws {
+        var persisted: String?
+        let imported = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            importer: ScriptedImporter(header: "WorkosCursorSessionToken=from-browser"),
+            persistImportedCookie: { persisted = $0 }
+        )
+        #expect(imported == "WorkosCursorSessionToken=from-browser")
+        #expect(persisted == imported)
+
+        let fallback = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: "WorkosCursorSessionToken=pasted",
+            importer: FailingImporter()
+        )
+        #expect(fallback == "WorkosCursorSessionToken=pasted")
+
+        #expect(throws: AccountUsageError.notLoggedIn) {
+            try CursorCookieResolver.resolve(
+                mode: .browserAuto,
+                manualCookie: nil,
+                importer: FailingImporter()
+            )
+        }
+    }
+
+    @Test("provider fetch in browserAuto does not crash when import fails")
+    func providerSurvivesImportFailure() async {
+        let provider = CursorUsageProvider(
+            cookie: nil,
+            cookieMode: .browserAuto,
+            cookieImporter: FailingImporter(),
+            transport: MissingTransport()
+        )
+        await #expect(throws: AccountUsageError.notLoggedIn) {
+            try await provider.fetch()
+        }
+    }
+
+    private struct ScriptedImporter: CursorBrowserCookieImporting {
+        let header: String
+        func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String { header }
+    }
+
+    private struct FailingImporter: CursorBrowserCookieImporting {
+        func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String {
+            throw AccountUsageError.notLoggedIn
+        }
+    }
+
+    private struct MissingTransport: CursorUsageTransport {
+        func cursorData(for request: URLRequest) async throws -> (Data, URLResponse) {
+            Issue.record("network should not run without a cookie")
+            throw URLError(.badURL)
+        }
+    }
+}

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -110,6 +110,8 @@ struct AccountUsageSettings: View {
     @ObservedObject var model: MenuBarModel
     @AppStorage("accountUsageAlertThreshold") private var alertThreshold = 90
     @State private var cursorCookie: String = CursorSessionCookieStore.load() ?? ""
+    @State private var cursorCookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode()
+    @State private var cursorImportMessage: String?
 
     var body: some View {
         Form {
@@ -130,23 +132,58 @@ struct AccountUsageSettings: View {
             }
 
             Section {
-                SecureField("Cookie header from cursor.com", text: $cursorCookie)
-                    .textFieldStyle(.roundedBorder)
-                    .onChange(of: cursorCookie) { _, value in
-                        CursorSessionCookieStore.save(value)
+                Picker("Cookie source", selection: $cursorCookieMode) {
+                    ForEach(CursorCookieSourceMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
                     }
-                Button("Paste Cookie") {
-                    guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
-                    let trimmed = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    cursorCookie = trimmed
-                    CursorSessionCookieStore.save(trimmed)
                 }
-                .accessibilityIdentifier("paste-cursorCookie")
+                .onChange(of: cursorCookieMode) { _, mode in
+                    CursorCookieSourceSettings.setMode(mode)
+                }
+
+                if cursorCookieMode == .manual {
+                    SecureField("Cookie header from cursor.com", text: $cursorCookie)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: cursorCookie) { _, value in
+                            CursorSessionCookieStore.save(value)
+                        }
+                    Button("Paste Cookie") {
+                        guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
+                        let trimmed = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        cursorCookie = trimmed
+                        CursorSessionCookieStore.save(trimmed)
+                    }
+                    .accessibilityIdentifier("paste-cursorCookie")
+                } else {
+                    Button("Import Cookie from browser now") {
+                        cursorImportMessage = nil
+                        do {
+                            let header = try CursorBrowserCookieImporter()
+                                .importSessionCookieHeader(allowKeychainPrompt: true)
+                            CursorSessionCookieStore.save(header)
+                            cursorCookie = header
+                            cursorImportMessage = "Imported a Cursor session cookie from the browser."
+                        } catch {
+                            cursorImportMessage = "No usable Cursor session found in the browser. Paste a Cookie header, or sign in at cursor.com and try again."
+                        }
+                    }
+                    .accessibilityIdentifier("import-cursorCookie")
+                    if let cursorImportMessage {
+                        Text(cursorImportMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    SecureField("Last imported / fallback Cookie", text: $cursorCookie)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: cursorCookie) { _, value in
+                            CursorSessionCookieStore.save(value)
+                        }
+                }
             } header: {
                 Text("Cursor session")
             } footer: {
-                Text("Copy the Cookie request header from a logged-in cursor.com network request, then paste it here. Browser auto-import is a later ticket.")
+                Text("Paste mode stores the Cookie header in the Keychain. Browser import reads Safari/Chrome/Firefox cookies for cursor.com (may prompt for Keychain or Full Disk Access); refresh uses a non-interactive import and falls back to the saved Cookie.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
## Summary
Implements #105 on top of merged #104: optional macOS browser cookie auto-import for Cursor (SweetCookieKit), while keeping manual Cookie paste.

Matt Pocock: reuse #102 decisions; no Spec Kit.

## Acceptance criteria
- [x] Auto-import can locate a usable Cursor session when the browser has one; otherwise falls back to manual / unavailable without crashing refresh.
- [x] User can choose auto vs manual; Keychain/browser failures surface as unavailable reasons, not fake zero remaining.
- [x] No change to iPhone/Watch contracts beyond receiving better Mac-side readings.

## Test plan
- [x] `cd VibeBuddyMac && swift test --filter 'CursorBrowserCookieImporterTests|CursorUsageProviderTests|AccountUsageTests/cursorProvider'` — 10 passed (Mac local).
- [ ] Manual: sign in at cursor.com, choose Import from browser, confirm Keychain/FDA prompts if any, then Collect Cursor usage refreshes.

## Notes / risks
- Feature PR — **do not merge** until 图灵 → 亚里士多德 → user.
- Based on latest `origin/main` (includes #109).
- Adds dependency `steipete/SweetCookieKit` (≥0.5.2, MIT). Background refresh uses non-interactive Keychain access.