### PR TITLE
fix(quota): wire forward-compat for unknown AccountUsageProvider (#111)

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -606,6 +606,40 @@ public struct Snapshot: Codable, Sendable, Equatable {
         self.recentDirectories = recentDirectories
         self.dispatchAgents = dispatchAgents
     }
+
+    enum CodingKeys: String, CodingKey {
+        case sourceID, sessions, serverTime, observationDiagnostics
+        case providerQuota, recentDirectories, dispatchAgents
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sourceID = try c.decodeIfPresent(String.self, forKey: .sourceID)
+        sessions = try c.decode([AgentSession].self, forKey: .sessions)
+        serverTime = try c.decode(Date.self, forKey: .serverTime)
+        observationDiagnostics = try c.decodeIfPresent(
+            [AgentObservationDiagnostic].self, forKey: .observationDiagnostics)
+        if c.contains(.providerQuota), try c.decodeNil(forKey: .providerQuota) == false {
+            var unkeyed = try c.nestedUnkeyedContainer(forKey: .providerQuota)
+            let rows = try ProviderQuota.decodeWireArray(from: &unkeyed)
+            providerQuota = rows
+        } else {
+            providerQuota = nil
+        }
+        recentDirectories = try c.decodeIfPresent([String].self, forKey: .recentDirectories)
+        dispatchAgents = try c.decodeIfPresent([AgentKind].self, forKey: .dispatchAgents)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encodeIfPresent(sourceID, forKey: .sourceID)
+        try c.encode(sessions, forKey: .sessions)
+        try c.encode(serverTime, forKey: .serverTime)
+        try c.encodeIfPresent(observationDiagnostics, forKey: .observationDiagnostics)
+        try c.encodeIfPresent(providerQuota, forKey: .providerQuota)
+        try c.encodeIfPresent(recentDirectories, forKey: .recentDirectories)
+        try c.encodeIfPresent(dispatchAgents, forKey: .dispatchAgents)
+    }
 }
 
 /// What the Mac encodes into the pairing QR; the phone scans and stores it.

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -174,3 +174,45 @@ public extension ProviderQuota {
         }
     }
 }
+
+
+// MARK: - Wire forward-compat (#111)
+
+/// Consumes one arbitrary JSON value so a failed element decode can still
+/// advance an unkeyed container.
+enum WireJSONSkip: Decodable {
+    case value
+
+    init(from decoder: Decoder) throws {
+        let single = try decoder.singleValueContainer()
+        if single.decodeNil() { self = .value; return }
+        if (try? single.decode(Bool.self)) != nil { self = .value; return }
+        if (try? single.decode(Int64.self)) != nil { self = .value; return }
+        if (try? single.decode(UInt64.self)) != nil { self = .value; return }
+        if (try? single.decode(Double.self)) != nil { self = .value; return }
+        if (try? single.decode(String.self)) != nil { self = .value; return }
+        if (try? single.decode([WireJSONSkip].self)) != nil { self = .value; return }
+        if (try? single.decode([String: WireJSONSkip].self)) != nil { self = .value; return }
+        self = .value
+    }
+}
+
+public extension ProviderQuota {
+    /// Decode `providerQuota` rows for the wire: an unknown `provider` string
+    /// drops that row instead of failing the enclosing Snapshot / ServerEvent.
+    ///
+    /// Release order (#111): ship this tolerant client decode before (or with)
+    /// any Mac that emits providers outside the peer vocabulary long-term.
+    static func decodeWireArray(from container: inout UnkeyedDecodingContainer) throws -> [ProviderQuota] {
+        var rows: [ProviderQuota] = []
+        while !container.isAtEnd {
+            do {
+                rows.append(try container.decode(ProviderQuota.self))
+            } catch {
+                // Failed decode does not advance; consume the element and continue.
+                _ = try container.decode(WireJSONSkip.self)
+            }
+        }
+        return rows
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaWireCompatTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaWireCompatTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("ProviderQuota wire forward-compat (#111)")
+struct ProviderQuotaWireCompatTests {
+
+    /// App Store v1.3 vocabulary: no `cursor`. Used to prove a HEAD payload
+    /// with `cursor` can still be read when unknown providers are skipped.
+    private enum OldAccountUsageProvider: String, Codable {
+        case codex, claude, grok
+    }
+
+    private struct OldProviderQuota: Codable {
+        var provider: OldAccountUsageProvider
+        var weeklyRemainingPercent: Int?
+        var unavailableReason: String?
+    }
+
+    private func sampleSnapshot(includingCursor: Bool) -> Snapshot {
+        var rows: [ProviderQuota] = [
+            ProviderQuota(provider: .codex, weeklyRemainingPercent: 70),
+            ProviderQuota(provider: .claude, weeklyRemainingPercent: 40),
+            ProviderQuota(provider: .grok, weeklyRemainingPercent: 55),
+        ]
+        if includingCursor {
+            rows.append(ProviderQuota(provider: .cursor, weeklyRemainingPercent: 60))
+        }
+        return Snapshot(
+            sessions: [],
+            serverTime: Date(timeIntervalSince1970: 1_700_000_000),
+            sourceID: "mac-1",
+            providerQuota: rows
+        )
+    }
+
+    @Test("unknown provider string in providerQuota does not kill Snapshot decode")
+    func unknownProviderSkipped() throws {
+        let json = """
+        {"sessions":[],"serverTime":1700000000,
+         "providerQuota":[
+           {"provider":"codex","weeklyRemainingPercent":70},
+           {"provider":"futureProvider","weeklyRemainingPercent":12},
+           {"provider":"claude","weeklyRemainingPercent":40}
+         ]}
+        """.data(using: .utf8)!
+        let snap = try JSONDecoder().decode(Snapshot.self, from: json)
+        #expect(snap.providerQuota?.map(\.provider) == [.codex, .claude])
+        #expect(snap.sessions.isEmpty)
+    }
+
+    @Test("new clients still keep Cursor when present")
+    func newClientKeepsCursor() throws {
+        let snap = sampleSnapshot(includingCursor: true)
+        let data = try JSONEncoder().encode(snap)
+        let back = try JSONDecoder().decode(Snapshot.self, from: data)
+        #expect(back.providerQuota?.map(\.provider).contains(.cursor) == true)
+        #expect(back.providerQuota?.first { $0.provider == .cursor }?.weeklyRemainingPercent == 60)
+
+        let eventData = try JSONEncoder().encode(ServerEvent.snapshot(snap))
+        guard case .snapshot(let fromEvent) = try JSONDecoder().decode(ServerEvent.self, from: eventData) else {
+            Issue.record("expected snapshot event")
+            return
+        }
+        #expect(fromEvent.providerQuota?.map(\.provider).contains(.cursor) == true)
+    }
+
+    @Test("old vocabulary can decode HEAD Snapshot that includes cursor by skipping the row")
+    func oldVocabSkipsCursorRow() throws {
+        // Simulate the lossy array path with the pre-Cursor enum: decode each
+        // row, skip failures (cursor), keep known providers.
+        let head = sampleSnapshot(includingCursor: true)
+        let data = try JSONEncoder().encode(head)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let rows = obj["providerQuota"] as! [[String: Any]]
+        var kept: [OldProviderQuota] = []
+        for row in rows {
+            let rowData = try JSONSerialization.data(withJSONObject: row)
+            if let decoded = try? JSONDecoder().decode(OldProviderQuota.self, from: rowData) {
+                kept.append(decoded)
+            }
+        }
+        #expect(kept.map(\.provider) == [.codex, .claude, .grok])
+        #expect(!kept.map(\.provider.rawValue).contains("cursor"))
+
+        // Production Snapshot decoder keeps known providers (including cursor)
+        // and drops a not-yet-known string without failing the frame.
+        let withFuture = """
+        {"sessions":[],"serverTime":1700000000,
+         "providerQuota":[
+           {"provider":"codex","weeklyRemainingPercent":70},
+           {"provider":"cursor","weeklyRemainingPercent":60},
+           {"provider":"notYetKnown","weeklyRemainingPercent":1}
+         ]}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Snapshot.self, from: withFuture)
+        #expect(decoded.providerQuota?.map(\.provider) == [.codex, .cursor])
+    }
+
+    @Test("ServerEvent.snapshot round-trip keeps known rows after unknown skip")
+    func serverEventSurvivesUnknownProvider() throws {
+        let snapJSON = """
+        {"sessions":[],"serverTime":1700000000,
+         "providerQuota":[
+           {"provider":"codex","weeklyRemainingPercent":10},
+           {"provider":"brandNewProvider","unavailableReason":"x"}
+         ]}
+        """.data(using: .utf8)!
+        let snap = try JSONDecoder().decode(Snapshot.self, from: snapJSON)
+        #expect(snap.providerQuota?.map(\.provider) == [.codex])
+        let event = ServerEvent.snapshot(snap)
+        let back = try JSONDecoder().decode(ServerEvent.self, from: JSONEncoder().encode(event))
+        #expect(back == event)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -526,12 +526,27 @@ public actor SessionStore {
         broadcast()
     }
 
+    /// Peer vocabulary shipped in App Store iOS/Watch before Cursor (#111).
+    private static let peerProviderQuotaVocabulary: Set<AccountUsageProvider> = [
+        .codex, .claude, .grok
+    ]
+
+    private static func wireCompatibleProviderQuota(_ quota: [ProviderQuota]) -> [ProviderQuota] {
+        quota.filter { peerProviderQuotaVocabulary.contains($0.provider) }
+    }
+
     /// The one place a runtime snapshot is assembled: sessions and diagnostics
     /// from the reducer, allowance from beside it.
     private func currentSnapshot(now: Date) -> Snapshot {
         var snapshot = reducer.snapshot(now: now, observationDiagnostics: diagnostics(now: now))
         snapshot.sourceID = sourceID
-        snapshot.providerQuota = providerQuota.isEmpty ? nil : providerQuota
+        // Wire gate (#111): omit providers outside the App Store peer vocabulary
+        // (codex/claude/grok) until iOS/Watch with tolerant providerQuota decode
+        // are live. Local Mac UI still collects Cursor via AccountUsageCoordinator;
+        // only the emitted Snapshot is filtered. Remove this gate after that
+        // client ships, then unrestricted Mac emit is safe.
+        let wireQuota = Self.wireCompatibleProviderQuota(providerQuota)
+        snapshot.providerQuota = wireQuota.isEmpty ? nil : wireQuota
         let directories = recentDirectories()
         snapshot.recentDirectories = directories.isEmpty ? nil : directories
         snapshot.sessions = snapshot.sessions.map { session in

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
@@ -148,9 +148,24 @@ struct SessionStoreTests {
         #expect(after.observationDiagnostics?.health(agent: .codex, source: .rollout) == .healthy)
         #expect(after.observationDiagnostics?.lastObserved(agent: .codex, source: .rollout) == observedAt)
     }
+
+    @Test("wire gate omits cursor from Snapshot while peer vocab remains")
+    func omitsCursorFromWireSnapshot() async {
+        let store = SessionStore(sourceID: "test")
+        await store.setProviderQuota([
+            ProviderQuota(provider: .codex, weeklyRemainingPercent: 70),
+            ProviderQuota(provider: .claude, weeklyRemainingPercent: 40),
+            ProviderQuota(provider: .grok, weeklyRemainingPercent: 55),
+            ProviderQuota(provider: .cursor, weeklyRemainingPercent: 60),
+        ])
+        let snap = await store.snapshot(now: Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(snap.providerQuota?.map(\.provider) == [.codex, .claude, .grok])
+        #expect(snap.providerQuota?.contains { $0.provider == .cursor } != true)
+    }
 }
 
 private extension Array where Element == AgentObservationDiagnostic {
+
     func health(agent: AgentKind, source: ObservationSource) -> ObservationHealth? {
         first(where: { $0.agent == agent })?.sources
             .first(where: { $0.source == source })?.health


### PR DESCRIPTION
## Summary
- **Client**: tolerant `providerQuota` decode on `Snapshot` — unknown `provider` strings drop that row instead of failing the whole `ServerEvent.snapshot` (fixes Opus C1 / DECODE_FAIL on `"cursor"`).
- **Mac short-term gate**: `SessionStore` omits providers outside the App Store peer vocabulary (`codex`/`claude`/`grok`) from emitted Snapshots so shipped iOS/Watch stay connected; local Mac UI still collects Cursor via `AccountUsageCoordinator`.
- **Tests**: Kit coverage for unknown-provider skip + Cursor retained on new clients; Mac `SessionStore` gate test.

## Release order
1. Ship tolerant iOS/Watch decode (this PR’s Kit change) first.
2. Keep the Mac wire gate until that client is live on devices.
3. Then remove the SessionStore peer-vocabulary filter so Cursor (and future providers) emit unrestricted.

## Test plan
- [x] `cd VibeBuddyKit && swift test --filter ProviderQuotaWireCompatTests`
- [x] `cd VibeBuddyKit && swift test --filter 'WireCodingTests|ObservationDiagnosticCompatibility'`
- [x] `cd VibeBuddyMac && swift test --filter 'omitsCursorFromWireSnapshot|ProviderQuotaProjectionTests'`
- [ ] After merge: Mac with Cursor collection + App Store iOS/Watch still reaches `.connected`
- [ ] After tolerant iOS ships: remove Mac gate and confirm Cursor appears on phone/Watch

Closes #111