### PR TITLE
fix(quota): let Grok billing proxy run after ACP incompatibleFormat

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
@@ -365,18 +365,22 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
                 )
             } catch {
                 try Task.checkCancellation()
-                guard Self.allowsLogFallback(after: error) else { throw error }
-                if let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(
+                // Log and proxy are independent: incompatibleFormat must not
+                // read a stale log, but still may try the billing proxy.
+                if Self.allowsLogFallback(after: error),
+                   let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(
                     in: logURL,
                     now: Date()
-                ) {
+                   ) {
                     return snapshot
                 }
-                if proxyEnabled, let snapshot = await Self.fetchProxyFallback(
+                if Self.allowsProxyFallback(after: error),
+                   proxyEnabled,
+                   let snapshot = await Self.fetchProxyFallback(
                     authFileURL: authFileURL,
                     endpoint: proxyEndpoint,
                     transport: proxyTransport
-                ) {
+                   ) {
                     return snapshot
                 }
                 throw error
@@ -386,8 +390,9 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
         }
     }
 
-    /// Best-effort proxy: never upgrades a hard auth/format failure from ACP, and
-    /// never invents a reading when the bearer is missing.
+    /// Best-effort proxy: never upgrades a hard auth failure from ACP, and
+    /// never invents a reading when the bearer is missing. Format failures
+    /// (no usable percent) are eligible — that is the billing-proxy case.
     static func fetchProxyFallback(
         authFileURL: URL,
         endpoint: URL,
@@ -419,6 +424,23 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
             switch usage {
             case .providerUnavailable, .timedOut, .offline, .unknown: return true
             case .notLoggedIn, .rateLimited, .incompatibleFormat: return false
+            }
+        default: return true
+        }
+    }
+
+    /// Proxy covers the same unreachable/timeout cases as the log, plus
+    /// `.incompatibleFormat` (ACP answered but with no usable percent). Hard
+    /// auth, rate limits, and cancellation stay terminal.
+    static func allowsProxyFallback(after error: any Error) -> Bool {
+        switch error {
+        case is CancellationError: return false
+        case let usage as AccountUsageError:
+            switch usage {
+            case .providerUnavailable, .timedOut, .offline, .unknown, .incompatibleFormat:
+                return true
+            case .notLoggedIn, .rateLimited:
+                return false
             }
         default: return true
         }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
@@ -474,6 +474,127 @@ struct GrokUsageProviderTests {
     }
 
 
+    @Test("incompatibleFormat ACP still attempts billing proxy without reading the log")
+    func proxyFallbackAfterIncompatibleFormat() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // A fresh log reading that must NOT be used for incompatibleFormat.
+        let logURL = directory.appendingPathComponent("unified.jsonl")
+        try (Self.logLine(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            percent: "72.0"
+        ) + Data("\n".utf8)).write(to: logURL)
+
+        let auth = directory.appendingPathComponent("auth.json")
+        try Data("""
+        {
+          "https://auth.x.ai::openid": {
+            "key": "token-456",
+            "expires_at": "2099-01-01T00:00:00Z"
+          }
+        }
+        """.utf8).write(to: auth)
+
+        // Period present, no usable creditPercent — exactly #106 / #112.
+        let agent = try Self.writeFakeAgent(
+            in: directory,
+            transcript: directory.appendingPathComponent("stdin.txt"),
+            reply: #"{"jsonrpc":"2.0","id":2,"result":{"config":{"currentPeriod":{"start":"2026-08-30T11:36:49Z","end":"2026-09-06T11:36:49Z"},"onDemandCap":{"val":100}}}}"#
+        )
+
+        let endpoint = URL(string: "https://grok.test/v1/billing?format=credits")!
+        let proxyHits = ProxyHitCounter()
+        let transport = ScriptedProxyTransport(handler: { request in
+            proxyHits.increment()
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token-456")
+            let body = Data("""
+            {"config":{"creditUsagePercent":55.0,"currentPeriod":{"start":"2026-08-06T00:00:00Z","end":"2026-08-13T00:00:00Z"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0}},"subscriptionTier":"SuperGrok"}
+            """.utf8)
+            let response = HTTPURLResponse(
+                url: endpoint, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (body, response)
+        })
+
+        let snapshot = try await GrokUsageProvider(
+            executableURL: agent,
+            arguments: [],
+            timeout: 5,
+            logURL: logURL,
+            authFileURL: auth,
+            proxyEndpoint: endpoint,
+            proxyTransport: transport
+        ).fetch()
+
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.primary?.usedPercent == 55)
+        #expect(snapshot.planType == "SuperGrok")
+        #expect(proxyHits.count == 1)
+        // Log gate stays closed for this error; proxy gate opens.
+        #expect(!GrokUsageProvider.allowsLogFallback(after: AccountUsageError.incompatibleFormat))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.incompatibleFormat))
+    }
+
+    @Test("notLoggedIn skips both log and proxy fallbacks")
+    func notLoggedInSkipsProxy() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory.appendingPathComponent("unified.jsonl")
+        try (Self.logLine(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            percent: "72.0"
+        ) + Data("\n".utf8)).write(to: logURL)
+        let auth = directory.appendingPathComponent("auth.json")
+        try Data("""
+        {"https://auth.x.ai::openid":{"key":"token-789","expires_at":"2099-01-01T00:00:00Z"}}
+        """.utf8).write(to: auth)
+        let agent = try Self.writeFakeAgent(
+            in: directory,
+            transcript: directory.appendingPathComponent("stdin.txt"),
+            reply: #"{"jsonrpc":"2.0","id":2,"error":{"code":-32000,"message":"Authentication required","data":"Run `grok login` to authenticate."}}"#
+        )
+        let endpoint = URL(string: "https://grok.test/v1/billing?format=credits")!
+        let proxyHits = ProxyHitCounter()
+        let transport = ScriptedProxyTransport(handler: { _ in
+            proxyHits.increment()
+            throw URLError(.badServerResponse)
+        })
+
+        await #expect(throws: AccountUsageError.notLoggedIn) {
+            try await GrokUsageProvider(
+                executableURL: agent,
+                arguments: [],
+                timeout: 5,
+                logURL: logURL,
+                authFileURL: auth,
+                proxyEndpoint: endpoint,
+                proxyTransport: transport
+            ).fetch()
+        }
+        #expect(proxyHits.count == 0)
+        #expect(!GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.notLoggedIn))
+        #expect(!GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.rateLimited))
+        #expect(!GrokUsageProvider.allowsProxyFallback(after: CancellationError()))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.providerUnavailable))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.timedOut))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.offline))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.unknown))
+    }
+
+    private final class ProxyHitCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+        func increment() {
+            lock.lock(); defer { lock.unlock() }
+            value += 1
+        }
+    }
+
     private struct ScriptedProxyTransport: GrokCreditsProxyTransport {
         let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
         func proxyData(for request: URLRequest) async throws -> (Data, URLResponse) {


### PR DESCRIPTION
## Summary
- Decouple Grok billing-proxy eligibility from log fallback: `allowsProxyFallback` is true for `.incompatibleFormat` (and unreachable/timeout/offline/unknown), false for `.notLoggedIn` / `.rateLimited` / cancellation.
- Restructure `GrokUsageProvider.fetch` catch so proxy is not behind the log gate; log still skips `.incompatibleFormat`.
- Unit tests: proxy-after-incompatibleFormat (log present but unused), and notLoggedIn never hits proxy.

Fixes #112

## Test plan
- [x] `cd VibeBuddyMac && swift test --filter GrokUsageProviderTests` — 23/23 passed (incl. new incompatibleFormat + notLoggedIn proxy tests)
- [ ] Manual: ACP returns period-only / no creditPercent → proxy still consulted when `auth.json` bearer present