### PR TITLE
fix(quota): Cursor cookie mode hot-reload + monthly window on Watch/widgets

### DIFF
--- a/VibeBuddyApp/Watch/WatchFormat.swift
+++ b/VibeBuddyApp/Watch/WatchFormat.swift
@@ -131,9 +131,10 @@ enum WatchQuotaVoice {
     }
 
     static func summary(_ quota: ProviderQuota, freshness: QuotaFreshness, now: Date) -> String {
-        QuotaWindowKind.allCases.map { kind in
-            let reading = quota.window(kind)
-            let name = kind == .weekly ? String(localized: "Weekly remaining") : windowName(reading)
+        let exact = QuotaWindowKind.allCases.map { quota.window($0) }
+        let readings = exact.contains { $0.remainingPercent != nil } ? exact : [quota.displayWindow()]
+        return readings.map { reading in
+            let name = windowName(reading)
             switch reading.status(now: now) {
             case .awaitingReset: return name + ": " + String(localized: "Reset reached · awaiting update")
             case .unavailable: return name + ": " + String(localized: "Unavailable")

--- a/VibeBuddyApp/Watch/WatchHomeView.swift
+++ b/VibeBuddyApp/Watch/WatchHomeView.swift
@@ -150,13 +150,15 @@ struct WatchQuotaStrips: View {
 
     private func strip(_ quota: ProviderQuota) -> some View {
         let freshness = quota.freshness(now: now)
+        // Prefer weekly; fall back to short / otherWindows (Cursor/Grok monthly).
+        let reading = quota.displayWindow(preferring: .weekly)
         return HStack(spacing: 6) {
             Text(quota.provider.displayName)
                 .font(.caption2)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
                 .frame(width: 44, alignment: .leading)
-            if let remaining = quota.window(.weekly).currentRemainingPercent(now: now) {
+            if let remaining = reading.currentRemainingPercent(now: now) {
                 ProgressView(value: Double(remaining), total: 100)
                     .tint(freshness == .stale ? Color.secondary
                           : (remaining <= 10 ? CompanionPalette.status(.requiresInput) : CompanionPalette.accent))
@@ -165,7 +167,7 @@ struct WatchQuotaStrips: View {
                     .monospacedDigit()
                     .frame(width: 32, alignment: .trailing)
             } else {
-                Text(quota.window(.weekly).status(now: now) == .awaitingReset ? "Reset reached · awaiting update" : "Window unavailable")
+                Text(reading.status(now: now) == .awaitingReset ? "Reset reached · awaiting update" : "Window unavailable")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/VibeBuddyApp/Watch/WatchQuotaView.swift
+++ b/VibeBuddyApp/Watch/WatchQuotaView.swift
@@ -3,13 +3,13 @@ import VibeBuddyKit
 
 /// Weekly allowance in full: remaining first, then the context that makes a
 /// percentage useful — when it resets, how the short window looks, how old the
-/// reading is. Codex and Claude are always shown apart, and each carries its own
-/// freshness, so a healthy source never covers for a broken one.
+/// reading is. Each provider is shown apart with its own freshness, so a healthy
+/// source never covers for a broken one.
 struct WatchQuotaView: View {
     let state: WatchDashboardState
     let connection: WatchConnection
     let now: Date
-    var selection: WatchQuotaSelection = .both
+    var selection: WatchQuotaSelection = .all
 
     var body: some View {
         NavigationStack {
@@ -19,7 +19,7 @@ struct WatchQuotaView: View {
                     if state.quotas.isEmpty {
                         Text("No quota sources")
                             .font(.headline)
-                        Text("Sign in to Codex or Claude Code on your Mac to see weekly allowance here.")
+                        Text("Sign in to Codex, Claude, Cursor, or Grok on your Mac to see allowance here.")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)

--- a/VibeBuddyApp/WatchShared/WatchQuotaSelection.swift
+++ b/VibeBuddyApp/WatchShared/WatchQuotaSelection.swift
@@ -2,20 +2,35 @@ import Foundation
 import VibeBuddyKit
 
 /// A destination, never a transported quota reading or task acknowledgement.
+///
+/// Raw values are deep-link path segments (`vibebuddy://quota/<raw>`). Keep
+/// legacy `codex` / `claude` / `both` so saved complication URLs keep working;
+/// unknown future paths fall back to `.both` instead of failing open.
 enum WatchQuotaSelection: String, CaseIterable, Identifiable {
-    case codex, claude, both
+    case codex, claude, grok, cursor, both, all
     var id: String { rawValue }
     var providers: [AccountUsageProvider] {
         switch self {
         case .codex: [.codex]
         case .claude: [.claude]
+        case .grok: [.grok]
+        case .cursor: [.cursor]
         case .both: [.codex, .claude]
+        case .all: AccountUsageProvider.allCases
         }
     }
     var url: URL { URL(string: "vibebuddy://quota/\(rawValue)")! }
     init?(url: URL) {
         guard url.scheme == "vibebuddy", url.host == "quota",
               url.query == nil, url.fragment == nil else { return nil }
-        self.init(rawValue: String(url.path.dropFirst()))
+        let path = String(url.path.dropFirst())
+        guard !path.isEmpty else { return nil }
+        if let known = Self(rawValue: path) {
+            self = known
+        } else {
+            // Tolerate unknown future path segments so an older Watch build
+            // still opens quota detail instead of ignoring the deep link.
+            self = .both
+        }
     }
 }

--- a/VibeBuddyApp/WatchWidget/QuotaWidget.swift
+++ b/VibeBuddyApp/WatchWidget/QuotaWidget.swift
@@ -4,10 +4,11 @@ import WidgetKit
 import VibeBuddyKit
 
 enum QuotaPlatform: String, AppEnum {
-    case codex, claude, both
+    case codex, claude, grok, cursor, both, all
     static let typeDisplayRepresentation: TypeDisplayRepresentation = "Platform"
     static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
-        .codex: "Codex", .claude: "Claude", .both: "Codex + Claude"
+        .codex: "Codex", .claude: "Claude", .grok: "Grok", .cursor: "Cursor",
+        .both: "Codex + Claude", .all: "All providers"
     ]
     var selection: WatchQuotaSelection { WatchQuotaSelection(rawValue: rawValue)! }
 }
@@ -117,7 +118,15 @@ struct QuotaWidgetView: View {
     private var now: Date { max(entry.date, Date()) }
     private var providers: [AccountUsageProvider] { entry.configuration.platform.selection.providers }
     private func window(_ provider: AccountUsageProvider, kind: QuotaWindowKind? = nil) -> QuotaWindow {
-        entry.quotas.first { $0.provider == provider }?.window(kind ?? entry.configuration.period.kind)
+        let preferred = kind ?? entry.configuration.period.kind
+        // Single-period styles fall back to otherWindows when weekly/short are
+        // missing (Cursor/Grok billing periods). Dual-window keeps exact kinds.
+        let quota = entry.quotas.first { $0.provider == provider }
+        if kind == nil {
+            return quota?.displayWindow(preferring: preferred)
+                ?? QuotaWindow(remainingPercent: nil, durationMinutes: nil, resetsAt: nil, observedAt: nil)
+        }
+        return quota?.window(preferred)
             ?? QuotaWindow(remainingPercent: nil, durationMinutes: nil, resetsAt: nil, observedAt: nil)
     }
     private func label(_ provider: AccountUsageProvider) -> String {
@@ -281,7 +290,7 @@ struct QuotaWidget: Widget {
             QuotaWidgetView(entry: $0)
         }
         .configurationDisplayName("Quota")
-        .description("Codex and Claude remaining allowance.")
+        .description("Codex, Claude, Cursor, and Grok remaining allowance.")
         .supportedFamilies([.accessoryCircular])
     }
 }

--- a/VibeBuddyApp/WatchWidget/QuotaWidget.swift
+++ b/VibeBuddyApp/WatchWidget/QuotaWidget.swift
@@ -64,7 +64,7 @@ struct QuotaProvider: AppIntentTimelineProvider {
         let quotas = readQuotas()
         let windows = quotas.filter { configuration.platform.selection.providers.contains($0.provider) }
             .flatMap { quota in
-                configuration.style == .dualWindow ? QuotaWindowKind.allCases.map { quota.window($0) } : [quota.window(configuration.period.kind)]
+                configuration.style == .dualWindow ? QuotaWindowKind.allCases.map { quota.window($0) } : [quota.displayWindow(preferring: configuration.period.kind)]
             }
         let boundaries = windows.flatMap { window in
             [window.observedAt?.addingTimeInterval(ProviderQuota.staleAfter), window.resetsAt].compactMap { $0 }
@@ -146,8 +146,9 @@ struct QuotaWidgetView: View {
         }
     }
     private func periodLabel(_ reading: QuotaWindow, kind: QuotaWindowKind? = nil) -> String {
-        if (kind ?? entry.configuration.period.kind) == .weekly { return String(localized: "Wk") }
+        if reading.durationMinutes == 10080 { return String(localized: "Wk") }
         guard let minutes = reading.durationMinutes else { return String(localized: "Short") }
+        if minutes >= 1440 { return "\(minutes / 1440)d" }
         return minutes % 60 == 0 ? "\(minutes / 60)h" : "\(minutes)m"
     }
     private var differentPeriods: Bool {
@@ -225,7 +226,7 @@ struct QuotaWidgetView: View {
                     Text(label(provider)).fontWeight(.bold)
                     VStack(spacing: 0) {
                         ForEach(QuotaWindowKind.allCases, id: \.self) { kind in
-                            let reading = window(provider, kind: kind)
+                            let reading = window(provider, kind: entry.configuration.style == .dualWindow ? kind : nil)
                             Text("\(periodLabel(reading, kind: kind)) \(value(reading))")
                         }
                     }
@@ -269,7 +270,7 @@ struct QuotaWidgetView: View {
         providers.map { provider in
             let kinds = entry.configuration.style == .dualWindow ? QuotaWindowKind.allCases : [entry.configuration.period.kind]
             return kinds.map { kind in
-            let reading = window(provider, kind: kind)
+            let reading = window(provider, kind: entry.configuration.style == .dualWindow ? kind : nil)
             let status: String
             switch reading.status(now: now) {
             case .live: status = String(localized: "Remaining")

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -188,7 +188,8 @@ public extension ProviderQuota {
         let alternate: QuotaWindowKind = kind == .weekly ? .short : .weekly
         let secondary = window(alternate)
         if secondary.remainingPercent != nil { return secondary }
-        if let other = (otherWindows ?? []).first(where: { $0.remainingPercent != nil }) {
+        if var other = (otherWindows ?? []).first(where: { $0.remainingPercent != nil }) {
+            other.isCached = other.isCached == true || isCached == true
             return other
         }
         return preferred

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -173,4 +173,24 @@ public extension ProviderQuota {
                                resetsAt: shortWindowResetsAt, observedAt: observedAt, isCached: isCached)
         }
     }
+
+    /// Compact surfaces (Watch home strips, weekly/short widgets) prefer the
+    /// requested window. When weekly and short are both missing — Cursor/Grok
+    /// billing periods land in `otherWindows` — fall back to the first other
+    /// window that has a remaining percent so freshness and the strip agree.
+    ///
+    /// Choice for #113: fall back to `otherWindows` rather than promoting a
+    /// billing-cycle window as a first-class `QuotaWindowKind`. Weekly/short
+    /// stay exact; monthly periods remain labeled by duration via otherWindows.
+    func displayWindow(preferring kind: QuotaWindowKind = .weekly) -> QuotaWindow {
+        let preferred = window(kind)
+        if preferred.remainingPercent != nil { return preferred }
+        let alternate: QuotaWindowKind = kind == .weekly ? .short : .weekly
+        let secondary = window(alternate)
+        if secondary.remainingPercent != nil { return secondary }
+        if let other = (otherWindows ?? []).first(where: { $0.remainingPercent != nil }) {
+            return other
+        }
+        return preferred
+    }
 }

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("ProviderQuota displayWindow")
+struct ProviderQuotaDisplayWindowTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test("Weekly wins when present")
+    func prefersWeekly() {
+        let quota = ProviderQuota(
+            provider: .codex,
+            weeklyRemainingPercent: 68,
+            weeklyWindowDurationMinutes: 10_080,
+            shortWindowRemainingPercent: 84,
+            shortWindowDurationMinutes: 300,
+            otherWindows: [
+                QuotaWindow(remainingPercent: 60, durationMinutes: 43_200, resetsAt: nil, observedAt: now)
+            ],
+            observedAt: now
+        )
+        #expect(quota.displayWindow(preferring: .weekly).remainingPercent == 68)
+        #expect(quota.displayWindow(preferring: .short).remainingPercent == 84)
+    }
+
+    @Test("Falls back to short when weekly is missing")
+    func fallsBackToShort() {
+        let quota = ProviderQuota(
+            provider: .codex,
+            shortWindowRemainingPercent: 84,
+            shortWindowDurationMinutes: 300,
+            otherWindows: [
+                QuotaWindow(remainingPercent: 60, durationMinutes: 43_200, resetsAt: nil, observedAt: now)
+            ],
+            observedAt: now
+        )
+        #expect(quota.displayWindow(preferring: .weekly).remainingPercent == 84)
+    }
+
+    @Test("Falls back to first usable otherWindows for monthly Cursor/Grok periods")
+    func fallsBackToOtherWindows() {
+        let other = QuotaWindow(
+            remainingPercent: 60,
+            durationMinutes: 43_200,
+            resetsAt: now.addingTimeInterval(86_400),
+            observedAt: now
+        )
+        let quota = ProviderQuota(
+            provider: .cursor,
+            otherWindows: [other],
+            observedAt: now
+        )
+        #expect(quota.window(.weekly).remainingPercent == nil)
+        #expect(quota.freshness(now: now) == .live)
+        let display = quota.displayWindow(preferring: .weekly)
+        #expect(display.remainingPercent == 60)
+        #expect(display.currentRemainingPercent(now: now) == 60)
+        #expect(display.status(now: now) == .live)
+        #expect(quota.displayWindow(preferring: .short).remainingPercent == 60)
+    }
+
+    @Test("Unavailable stays unavailable when nothing is usable")
+    func unavailableWhenEmpty() {
+        let quota = ProviderQuota.unavailable(.cursor, reason: "Collection is turned off")
+        #expect(quota.displayWindow(preferring: .weekly).remainingPercent == nil)
+        #expect(quota.displayWindow(preferring: .weekly).status(now: now) == .unavailable)
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
@@ -59,6 +59,15 @@ struct ProviderQuotaDisplayWindowTests {
         #expect(quota.displayWindow(preferring: .short).remainingPercent == 60)
     }
 
+    @Test("Relay cache state applies to monthly fallback")
+    func cachedMonthlyFallback() {
+        var quota = ProviderQuota(provider: .cursor, otherWindows: [
+            QuotaWindow(remainingPercent: 60, durationMinutes: 43200, resetsAt: nil, observedAt: now)
+        ], observedAt: now)
+        quota.isCached = true
+        #expect(quota.displayWindow().status(now: now) == .stale)
+    }
+
     @Test("Unavailable stays unavailable when nothing is usable")
     func unavailableWhenEmpty() {
         let quota = ProviderQuota.unavailable(.cursor, reason: "Collection is turned off")

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
@@ -173,20 +173,25 @@ struct CursorLegacyModelUsageDTO: Decodable {
 
 /// Reads Cursor plan allowance via session Cookie + `usage-summary`.
 /// Cookie may come from a pasted header (#104) or optional browser import (#105).
+///
+/// Cookie source mode is resolved on every `fetch()` (via `cookieMode`), so a
+/// Settings Picker change takes effect on the next refresh without restarting.
 public struct CursorUsageProvider: AccountUsageProviding {
     public static let defaultEndpoint = URL(string: "https://cursor.com/api/usage-summary")!
 
     private let cookie: String?
-    private let cookieMode: CursorCookieSourceMode
+    private let cookieMode: @Sendable () -> CursorCookieSourceMode
     private let cookieImporter: CursorBrowserCookieImporting
+    private let persistImportedCookie: @Sendable (String) -> Void
     private let endpoint: URL
     private let transport: CursorUsageTransport
     private let timeout: TimeInterval
 
     public init(
         cookie: String? = nil,
-        cookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode(),
+        cookieMode: @escaping @Sendable () -> CursorCookieSourceMode = { CursorCookieSourceSettings.mode() },
         cookieImporter: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
+        persistImportedCookie: @escaping @Sendable (String) -> Void = { CursorSessionCookieStore.save($0) },
         endpoint: URL = defaultEndpoint,
         transport: CursorUsageTransport = URLSession.shared,
         timeout: TimeInterval = 15
@@ -194,6 +199,7 @@ public struct CursorUsageProvider: AccountUsageProviding {
         self.cookie = cookie
         self.cookieMode = cookieMode
         self.cookieImporter = cookieImporter
+        self.persistImportedCookie = persistImportedCookie
         self.endpoint = endpoint
         self.transport = transport
         self.timeout = timeout
@@ -201,10 +207,11 @@ public struct CursorUsageProvider: AccountUsageProviding {
 
     public func fetch() async throws -> AccountUsageSnapshot {
         let cookie = try CursorCookieResolver.resolve(
-            mode: cookieMode,
+            mode: cookieMode(),
             manualCookie: cookie,
             importer: cookieImporter,
-            allowKeychainPrompt: false
+            allowKeychainPrompt: false,
+            persistImportedCookie: persistImportedCookie
         )
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -655,7 +655,7 @@ struct AccountUsageTests {
 
     @Test("Cursor collector without a cookie stays unavailable, never 0%")
     func cursorProviderRequiresCookie() async throws {
-        let provider = CursorUsageProvider(cookie: nil, cookieMode: .manual, transport: MissingCookieTransport())
+        let provider = CursorUsageProvider(cookie: nil, cookieMode: { .manual }, transport: MissingCookieTransport())
         do {
             _ = try await provider.fetch()
             Issue.record("CursorUsageProvider must not succeed without a cookie")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
@@ -53,7 +53,7 @@ struct CursorBrowserCookieImporterTests {
     func providerSurvivesImportFailure() async {
         let provider = CursorUsageProvider(
             cookie: nil,
-            cookieMode: .browserAuto,
+            cookieMode: { .browserAuto },
             cookieImporter: FailingImporter(),
             transport: MissingTransport()
         )

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorUsageProviderTests.swift
@@ -72,6 +72,51 @@ struct CursorUsageProviderTests {
         #expect(snapshot.primary?.usedPercent == 40)
     }
 
+    @Test("cookie source mode is re-read on each fetch, not frozen at init")
+    func cookieModeRereadEachFetch() async throws {
+        let endpoint = URL(string: "https://cursor.test/api/usage-summary")!
+        let body = try Self.fixture("usage-summary-plan-only")
+        final class FetchProbe: @unchecked Sendable {
+            var mode: CursorCookieSourceMode = .manual
+            var cookiesSeen: [String] = []
+            let lock = NSLock()
+            func noteCookie(_ value: String) {
+                lock.lock(); cookiesSeen.append(value); lock.unlock()
+            }
+            func snapshotCookies() -> [String] {
+                lock.lock(); defer { lock.unlock() }; return cookiesSeen
+            }
+        }
+        let probe = FetchProbe()
+        let transport = ScriptedCursorTransport { request in
+            probe.noteCookie(request.value(forHTTPHeaderField: "Cookie") ?? "")
+            let response = HTTPURLResponse(
+                url: endpoint, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (body, response)
+        }
+        let provider = CursorUsageProvider(
+            cookie: "WorkosCursorSessionToken=manual",
+            cookieMode: { probe.mode },
+            cookieImporter: ScriptedModeImporter(header: "WorkosCursorSessionToken=imported"),
+            persistImportedCookie: { _ in },
+            endpoint: endpoint,
+            transport: transport
+        )
+        _ = try await provider.fetch()
+        probe.mode = .browserAuto
+        _ = try await provider.fetch()
+        #expect(probe.snapshotCookies() == [
+            "WorkosCursorSessionToken=manual",
+            "WorkosCursorSessionToken=imported",
+        ])
+    }
+
+    private struct ScriptedModeImporter: CursorBrowserCookieImporting {
+        let header: String
+        func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String { header }
+    }
+
     private struct ScriptedCursorTransport: CursorUsageTransport {
         let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
         func cursorData(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
@@ -237,6 +237,35 @@ struct ProviderQuotaProjectionTests {
         }
     }
 
+    // MARK: Cursor / Grok billing periods (#113 H3)
+
+    @Test("A Cursor monthly billing window stays in otherWindows and is usable for display")
+    func cursorMonthlyBillingProjectsToOtherWindows() throws {
+        // Mid-cycle relative to usage-summary-plan-only (Aug→Sep 2026 billing window).
+        let observed = ISO8601DateFormatter().date(from: "2026-08-15T12:00:00Z")!
+        let url = try #require(Bundle.module.url(
+            forResource: "usage-summary-plan-only",
+            withExtension: "json",
+            subdirectory: "Fixtures/cursor"
+        ))
+        let data = try Data(contentsOf: url)
+        let snapshot = try CursorUsageSummaryDecoder.decode(data, fetchedAt: observed)
+        let result = ProviderQuota(.available(snapshot, nextRefreshAt: nil), provider: .cursor)
+        #expect(result.provider == .cursor)
+        #expect(result.weeklyRemainingPercent == nil)
+        #expect(result.shortWindowRemainingPercent == nil)
+        #expect(result.otherWindows?.first?.remainingPercent == 60)
+        #expect(result.otherWindows?.first?.durationMinutes == 31 * 24 * 60)
+        #expect(result.observedAt == observed)
+        #expect(result.freshness(now: observed) == .live)
+        #expect(result.unavailableReason == nil)
+        // Watch/home surfaces must not show "Window unavailable" while live.
+        let display = result.displayWindow(preferring: .weekly)
+        #expect(display.remainingPercent == 60)
+        #expect(display.currentRemainingPercent(now: observed) == 60)
+        #expect(display.status(now: observed) == .live)
+    }
+
     // MARK: both providers at once
 
     private func codexState(usedWeekly: Int) -> AccountUsageState {


### PR DESCRIPTION
Fixes #113

## Summary
- **H2** — `CursorUsageProvider` re-reads cookie source mode on every `fetch()` (injectable `() -> CursorCookieSourceMode`), so Manual ↔ Import from browser takes effect on the next refresh without restarting the Mac app.
- **H3** — Watch home strips and single-period quota widgets use `ProviderQuota.displayWindow(preferring:)`, which falls back to the first usable `otherWindows` remaining % when weekly/short are missing. Cursor/Grok ~monthly billing periods no longer show “Window unavailable” next to live freshness.
- **M4** — `WatchQuotaSelection` / `QuotaPlatform` include `cursor`, `grok`, and `all`; legacy `codex` / `claude` / `both` URLs still work; unknown quota deep-link paths fall back to `.both`. Empty-state / widget copy updated. Quota tab defaults to `.all`.

## H3 design choice (documented)
Prefer **fallback to `otherWindows`** over promoting a billing-cycle window as a first-class `QuotaWindowKind`. Weekly/short stay exact duration buckets; monthly periods keep duration-based labels via `otherWindows` / detail rows.

## Out of scope
- Does **not** touch #111 SessionStore wire gate (separate PR).
- Stays off #112 / #114.

## Test plan
- [x] `cd VibeBuddyKit && swift test --filter ProviderQuotaDisplayWindowTests` (4 passed)
- [x] `cd VibeBuddyMac && swift test --filter 'CursorUsageProviderTests|ProviderQuotaProjectionTests|CursorBrowserCookieImporterTests'` (29 passed)
  - includes `cookieModeRereadEachFetch` and `cursorMonthlyBillingProjectsToOtherWindows`
- [ ] Manual: change Cursor cookie source in Settings → refresh → mode applies without restart
- [ ] Manual: Watch home strip with live Cursor monthly reading shows a remaining % (not “Window unavailable” + live)