### PR TITLE
fix(quota): reviewed Cursor login, independent pools and cookie handling

### DIFF
--- a/VibeBuddyApp/Watch/WatchFormat.swift
+++ b/VibeBuddyApp/Watch/WatchFormat.swift
@@ -131,9 +131,10 @@ enum WatchQuotaVoice {
     }
 
     static func summary(_ quota: ProviderQuota, freshness: QuotaFreshness, now: Date) -> String {
-        QuotaWindowKind.allCases.map { kind in
-            let reading = quota.window(kind)
-            let name = kind == .weekly ? String(localized: "Weekly remaining") : windowName(reading)
+        let exact = QuotaWindowKind.allCases.map { quota.window($0) }
+        let readings = exact.contains { $0.remainingPercent != nil } ? exact : [quota.displayWindow()]
+        return readings.map { reading in
+            let name = windowName(reading)
             switch reading.status(now: now) {
             case .awaitingReset: return name + ": " + String(localized: "Reset reached · awaiting update")
             case .unavailable: return name + ": " + String(localized: "Unavailable")

--- a/VibeBuddyApp/Watch/WatchHomeView.swift
+++ b/VibeBuddyApp/Watch/WatchHomeView.swift
@@ -150,13 +150,15 @@ struct WatchQuotaStrips: View {
 
     private func strip(_ quota: ProviderQuota) -> some View {
         let freshness = quota.freshness(now: now)
+        // Prefer weekly; fall back to short / otherWindows (Cursor/Grok monthly).
+        let reading = quota.displayWindow(preferring: .weekly)
         return HStack(spacing: 6) {
             Text(quota.provider.displayName)
                 .font(.caption2)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
                 .frame(width: 44, alignment: .leading)
-            if let remaining = quota.window(.weekly).currentRemainingPercent(now: now) {
+            if let remaining = reading.currentRemainingPercent(now: now) {
                 ProgressView(value: Double(remaining), total: 100)
                     .tint(freshness == .stale ? Color.secondary
                           : (remaining <= 10 ? CompanionPalette.status(.requiresInput) : CompanionPalette.accent))
@@ -165,7 +167,7 @@ struct WatchQuotaStrips: View {
                     .monospacedDigit()
                     .frame(width: 32, alignment: .trailing)
             } else {
-                Text(quota.window(.weekly).status(now: now) == .awaitingReset ? "Reset reached · awaiting update" : "Window unavailable")
+                Text(reading.status(now: now) == .awaitingReset ? "Reset reached · awaiting update" : "Window unavailable")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/VibeBuddyApp/Watch/WatchQuotaView.swift
+++ b/VibeBuddyApp/Watch/WatchQuotaView.swift
@@ -3,13 +3,13 @@ import VibeBuddyKit
 
 /// Weekly allowance in full: remaining first, then the context that makes a
 /// percentage useful — when it resets, how the short window looks, how old the
-/// reading is. Codex and Claude are always shown apart, and each carries its own
-/// freshness, so a healthy source never covers for a broken one.
+/// reading is. Each provider is shown apart with its own freshness, so a healthy
+/// source never covers for a broken one.
 struct WatchQuotaView: View {
     let state: WatchDashboardState
     let connection: WatchConnection
     let now: Date
-    var selection: WatchQuotaSelection = .both
+    var selection: WatchQuotaSelection = .all
 
     var body: some View {
         NavigationStack {
@@ -19,7 +19,7 @@ struct WatchQuotaView: View {
                     if state.quotas.isEmpty {
                         Text("No quota sources")
                             .font(.headline)
-                        Text("Sign in to Codex or Claude Code on your Mac to see weekly allowance here.")
+                        Text("Sign in to Codex, Claude, Cursor, or Grok on your Mac to see allowance here.")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)

--- a/VibeBuddyApp/WatchShared/WatchQuotaSelection.swift
+++ b/VibeBuddyApp/WatchShared/WatchQuotaSelection.swift
@@ -2,20 +2,35 @@ import Foundation
 import VibeBuddyKit
 
 /// A destination, never a transported quota reading or task acknowledgement.
+///
+/// Raw values are deep-link path segments (`vibebuddy://quota/<raw>`). Keep
+/// legacy `codex` / `claude` / `both` so saved complication URLs keep working;
+/// unknown future paths fall back to `.both` instead of failing open.
 enum WatchQuotaSelection: String, CaseIterable, Identifiable {
-    case codex, claude, both
+    case codex, claude, grok, cursor, both, all
     var id: String { rawValue }
     var providers: [AccountUsageProvider] {
         switch self {
         case .codex: [.codex]
         case .claude: [.claude]
+        case .grok: [.grok]
+        case .cursor: [.cursor]
         case .both: [.codex, .claude]
+        case .all: AccountUsageProvider.allCases
         }
     }
     var url: URL { URL(string: "vibebuddy://quota/\(rawValue)")! }
     init?(url: URL) {
         guard url.scheme == "vibebuddy", url.host == "quota",
               url.query == nil, url.fragment == nil else { return nil }
-        self.init(rawValue: String(url.path.dropFirst()))
+        let path = String(url.path.dropFirst())
+        guard !path.isEmpty else { return nil }
+        if let known = Self(rawValue: path) {
+            self = known
+        } else {
+            // Tolerate unknown future path segments so an older Watch build
+            // still opens quota detail instead of ignoring the deep link.
+            self = .both
+        }
     }
 }

--- a/VibeBuddyApp/WatchWidget/QuotaWidget.swift
+++ b/VibeBuddyApp/WatchWidget/QuotaWidget.swift
@@ -4,10 +4,11 @@ import WidgetKit
 import VibeBuddyKit
 
 enum QuotaPlatform: String, AppEnum {
-    case codex, claude, both
+    case codex, claude, grok, cursor, both, all
     static let typeDisplayRepresentation: TypeDisplayRepresentation = "Platform"
     static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
-        .codex: "Codex", .claude: "Claude", .both: "Codex + Claude"
+        .codex: "Codex", .claude: "Claude", .grok: "Grok", .cursor: "Cursor",
+        .both: "Codex + Claude", .all: "All providers"
     ]
     var selection: WatchQuotaSelection { WatchQuotaSelection(rawValue: rawValue)! }
 }
@@ -117,7 +118,15 @@ struct QuotaWidgetView: View {
     private var now: Date { max(entry.date, Date()) }
     private var providers: [AccountUsageProvider] { entry.configuration.platform.selection.providers }
     private func window(_ provider: AccountUsageProvider, kind: QuotaWindowKind? = nil) -> QuotaWindow {
-        entry.quotas.first { $0.provider == provider }?.window(kind ?? entry.configuration.period.kind)
+        let preferred = kind ?? entry.configuration.period.kind
+        // Single-period styles fall back to otherWindows when weekly/short are
+        // missing (Cursor/Grok billing periods). Dual-window keeps exact kinds.
+        let quota = entry.quotas.first { $0.provider == provider }
+        if kind == nil {
+            return quota?.displayWindow(preferring: preferred)
+                ?? QuotaWindow(remainingPercent: nil, durationMinutes: nil, resetsAt: nil, observedAt: nil)
+        }
+        return quota?.window(preferred)
             ?? QuotaWindow(remainingPercent: nil, durationMinutes: nil, resetsAt: nil, observedAt: nil)
     }
     private func label(_ provider: AccountUsageProvider) -> String {
@@ -281,7 +290,7 @@ struct QuotaWidget: Widget {
             QuotaWidgetView(entry: $0)
         }
         .configurationDisplayName("Quota")
-        .description("Codex and Claude remaining allowance.")
+        .description("Codex, Claude, Cursor, and Grok remaining allowance.")
         .supportedFamilies([.accessoryCircular])
     }
 }

--- a/VibeBuddyApp/WatchWidget/QuotaWidget.swift
+++ b/VibeBuddyApp/WatchWidget/QuotaWidget.swift
@@ -4,10 +4,11 @@ import WidgetKit
 import VibeBuddyKit
 
 enum QuotaPlatform: String, AppEnum {
-    case codex, claude, both
+    case codex, claude, grok, cursor, both, all
     static let typeDisplayRepresentation: TypeDisplayRepresentation = "Platform"
     static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
-        .codex: "Codex", .claude: "Claude", .both: "Codex + Claude"
+        .codex: "Codex", .claude: "Claude", .grok: "Grok", .cursor: "Cursor",
+        .both: "Codex + Claude", .all: "All providers"
     ]
     var selection: WatchQuotaSelection { WatchQuotaSelection(rawValue: rawValue)! }
 }
@@ -63,7 +64,7 @@ struct QuotaProvider: AppIntentTimelineProvider {
         let quotas = readQuotas()
         let windows = quotas.filter { configuration.platform.selection.providers.contains($0.provider) }
             .flatMap { quota in
-                configuration.style == .dualWindow ? QuotaWindowKind.allCases.map { quota.window($0) } : [quota.window(configuration.period.kind)]
+                configuration.style == .dualWindow ? QuotaWindowKind.allCases.map { quota.window($0) } : [quota.displayWindow(preferring: configuration.period.kind)]
             }
         let boundaries = windows.flatMap { window in
             [window.observedAt?.addingTimeInterval(ProviderQuota.staleAfter), window.resetsAt].compactMap { $0 }
@@ -117,7 +118,15 @@ struct QuotaWidgetView: View {
     private var now: Date { max(entry.date, Date()) }
     private var providers: [AccountUsageProvider] { entry.configuration.platform.selection.providers }
     private func window(_ provider: AccountUsageProvider, kind: QuotaWindowKind? = nil) -> QuotaWindow {
-        entry.quotas.first { $0.provider == provider }?.window(kind ?? entry.configuration.period.kind)
+        let preferred = kind ?? entry.configuration.period.kind
+        // Single-period styles fall back to otherWindows when weekly/short are
+        // missing (Cursor/Grok billing periods). Dual-window keeps exact kinds.
+        let quota = entry.quotas.first { $0.provider == provider }
+        if kind == nil {
+            return quota?.displayWindow(preferring: preferred)
+                ?? QuotaWindow(remainingPercent: nil, durationMinutes: nil, resetsAt: nil, observedAt: nil)
+        }
+        return quota?.window(preferred)
             ?? QuotaWindow(remainingPercent: nil, durationMinutes: nil, resetsAt: nil, observedAt: nil)
     }
     private func label(_ provider: AccountUsageProvider) -> String {
@@ -137,8 +146,9 @@ struct QuotaWidgetView: View {
         }
     }
     private func periodLabel(_ reading: QuotaWindow, kind: QuotaWindowKind? = nil) -> String {
-        if (kind ?? entry.configuration.period.kind) == .weekly { return String(localized: "Wk") }
+        if reading.durationMinutes == 10080 { return String(localized: "Wk") }
         guard let minutes = reading.durationMinutes else { return String(localized: "Short") }
+        if minutes >= 1440 { return "\(minutes / 1440)d" }
         return minutes % 60 == 0 ? "\(minutes / 60)h" : "\(minutes)m"
     }
     private var differentPeriods: Bool {
@@ -216,7 +226,7 @@ struct QuotaWidgetView: View {
                     Text(label(provider)).fontWeight(.bold)
                     VStack(spacing: 0) {
                         ForEach(QuotaWindowKind.allCases, id: \.self) { kind in
-                            let reading = window(provider, kind: kind)
+                            let reading = window(provider, kind: entry.configuration.style == .dualWindow ? kind : nil)
                             Text("\(periodLabel(reading, kind: kind)) \(value(reading))")
                         }
                     }
@@ -260,7 +270,7 @@ struct QuotaWidgetView: View {
         providers.map { provider in
             let kinds = entry.configuration.style == .dualWindow ? QuotaWindowKind.allCases : [entry.configuration.period.kind]
             return kinds.map { kind in
-            let reading = window(provider, kind: kind)
+            let reading = window(provider, kind: entry.configuration.style == .dualWindow ? kind : nil)
             let status: String
             switch reading.status(now: now) {
             case .live: status = String(localized: "Remaining")
@@ -281,7 +291,7 @@ struct QuotaWidget: Widget {
             QuotaWidgetView(entry: $0)
         }
         .configurationDisplayName("Quota")
-        .description("Codex and Claude remaining allowance.")
+        .description("Codex, Claude, Cursor, and Grok remaining allowance.")
         .supportedFamilies([.accessoryCircular])
     }
 }

--- a/VibeBuddyApp/WatchWidget/QuotaWidget.swift
+++ b/VibeBuddyApp/WatchWidget/QuotaWidget.swift
@@ -64,7 +64,7 @@ struct QuotaProvider: AppIntentTimelineProvider {
         let quotas = readQuotas()
         let windows = quotas.filter { configuration.platform.selection.providers.contains($0.provider) }
             .flatMap { quota in
-                configuration.style == .dualWindow ? QuotaWindowKind.allCases.map { quota.window($0) } : [quota.window(configuration.period.kind)]
+                configuration.style == .dualWindow ? QuotaWindowKind.allCases.map { quota.window($0) } : [quota.displayWindow(preferring: configuration.period.kind)]
             }
         let boundaries = windows.flatMap { window in
             [window.observedAt?.addingTimeInterval(ProviderQuota.staleAfter), window.resetsAt].compactMap { $0 }
@@ -146,8 +146,9 @@ struct QuotaWidgetView: View {
         }
     }
     private func periodLabel(_ reading: QuotaWindow, kind: QuotaWindowKind? = nil) -> String {
-        if (kind ?? entry.configuration.period.kind) == .weekly { return String(localized: "Wk") }
+        if reading.durationMinutes == 10080 { return String(localized: "Wk") }
         guard let minutes = reading.durationMinutes else { return String(localized: "Short") }
+        if minutes >= 1440 { return "\(minutes / 1440)d" }
         return minutes % 60 == 0 ? "\(minutes / 60)h" : "\(minutes)m"
     }
     private var differentPeriods: Bool {
@@ -225,7 +226,7 @@ struct QuotaWidgetView: View {
                     Text(label(provider)).fontWeight(.bold)
                     VStack(spacing: 0) {
                         ForEach(QuotaWindowKind.allCases, id: \.self) { kind in
-                            let reading = window(provider, kind: kind)
+                            let reading = window(provider, kind: entry.configuration.style == .dualWindow ? kind : nil)
                             Text("\(periodLabel(reading, kind: kind)) \(value(reading))")
                         }
                     }
@@ -269,7 +270,7 @@ struct QuotaWidgetView: View {
         providers.map { provider in
             let kinds = entry.configuration.style == .dualWindow ? QuotaWindowKind.allCases : [entry.configuration.period.kind]
             return kinds.map { kind in
-            let reading = window(provider, kind: kind)
+            let reading = window(provider, kind: entry.configuration.style == .dualWindow ? kind : nil)
             let status: String
             switch reading.status(now: now) {
             case .live: status = String(localized: "Remaining")

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -1,39 +1,101 @@
 import Foundation
 import Security
 
-/// Minimal Keychain wrapper for the one secret we hold: the user's own DashScope
-/// API key. Never written to UserDefaults or committed; read at runtime only.
+/// Minimal Keychain wrapper for secrets we hold (API keys, session cookies).
+/// Never written to UserDefaults or committed; read at runtime only.
 /// Shared by iOS and Mac.
 public enum KeychainStore {
     private static let service = "com.vibebuddy.secrets"
 
-    public static func set(_ value: String?, for key: String) {
-        let query: [String: Any] = [
+    /// Injectable Security operations so unit tests never touch the user's Keychain.
+    public struct Operations: Sendable {
+        public var update: @Sendable ([String: Any], [String: Any]) -> OSStatus
+        public var add: @Sendable ([String: Any]) -> OSStatus
+        public var delete: @Sendable ([String: Any]) -> OSStatus
+        public var copyMatching: @Sendable ([String: Any]) -> (OSStatus, Data?)
+
+        public init(
+            update: @escaping @Sendable ([String: Any], [String: Any]) -> OSStatus,
+            add: @escaping @Sendable ([String: Any]) -> OSStatus,
+            delete: @escaping @Sendable ([String: Any]) -> OSStatus,
+            copyMatching: @escaping @Sendable ([String: Any]) -> (OSStatus, Data?)
+        ) {
+            self.update = update
+            self.add = add
+            self.delete = delete
+            self.copyMatching = copyMatching
+        }
+
+        public static let live = Operations(
+            update: { query, attributes in
+                SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            },
+            add: { item in
+                SecItemAdd(item as CFDictionary, nil)
+            },
+            delete: { query in
+                SecItemDelete(query as CFDictionary)
+            },
+            copyMatching: { query in
+                var request = query
+                request[kSecReturnData as String] = true
+                request[kSecMatchLimit as String] = kSecMatchLimitOne
+                var item: CFTypeRef?
+                let status = SecItemCopyMatching(request as CFDictionary, &item)
+                return (status, item as? Data)
+            }
+        )
+    }
+
+    private static func baseQuery(for key: String) -> [String: Any] {
+        [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
         ]
-        SecItemDelete(query as CFDictionary)
-        guard let value, !value.isEmpty, let data = value.data(using: .utf8) else { return }
+    }
+
+    /// Update-or-add (or delete when clearing). Never delete-then-add for writes:
+    /// a failed add must not leave the account empty. Surfaces the OSStatus.
+    @discardableResult
+    public static func set(
+        _ value: String?,
+        for key: String,
+        operations: Operations = .live
+    ) -> OSStatus {
+        let query = baseQuery(for: key)
+        guard let value, !value.isEmpty, let data = value.data(using: .utf8) else {
+            let status = operations.delete(query)
+            return status == errSecItemNotFound ? errSecSuccess : status
+        }
+
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = operations.update(query, attributes)
+        if updateStatus == errSecSuccess {
+            return errSecSuccess
+        }
+        // Preserve whatever is already stored when update fails for a reason
+        // other than "missing".
+        if updateStatus != errSecItemNotFound {
+            return updateStatus
+        }
+
         var add = query
         add[kSecValueData as String] = data
         add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        SecItemAdd(add as CFDictionary, nil)
+        return operations.add(add)
     }
 
-    public static func get(_ key: String) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-              let data = item as? Data, let s = String(data: data, encoding: .utf8)
+    public static func get(
+        _ key: String,
+        operations: Operations = .live
+    ) -> String? {
+        let (status, data) = operations.copyMatching(baseQuery(for: key))
+        guard status == errSecSuccess,
+              let data,
+              let value = String(data: data, encoding: .utf8)
         else { return nil }
-        return s
+        return value
     }
 }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -606,6 +606,40 @@ public struct Snapshot: Codable, Sendable, Equatable {
         self.recentDirectories = recentDirectories
         self.dispatchAgents = dispatchAgents
     }
+
+    enum CodingKeys: String, CodingKey {
+        case sourceID, sessions, serverTime, observationDiagnostics
+        case providerQuota, recentDirectories, dispatchAgents
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sourceID = try c.decodeIfPresent(String.self, forKey: .sourceID)
+        sessions = try c.decode([AgentSession].self, forKey: .sessions)
+        serverTime = try c.decode(Date.self, forKey: .serverTime)
+        observationDiagnostics = try c.decodeIfPresent(
+            [AgentObservationDiagnostic].self, forKey: .observationDiagnostics)
+        if c.contains(.providerQuota), try c.decodeNil(forKey: .providerQuota) == false {
+            var unkeyed = try c.nestedUnkeyedContainer(forKey: .providerQuota)
+            let rows = try ProviderQuota.decodeWireArray(from: &unkeyed)
+            providerQuota = rows
+        } else {
+            providerQuota = nil
+        }
+        recentDirectories = try c.decodeIfPresent([String].self, forKey: .recentDirectories)
+        dispatchAgents = try c.decodeIfPresent([AgentKind].self, forKey: .dispatchAgents)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encodeIfPresent(sourceID, forKey: .sourceID)
+        try c.encode(sessions, forKey: .sessions)
+        try c.encode(serverTime, forKey: .serverTime)
+        try c.encodeIfPresent(observationDiagnostics, forKey: .observationDiagnostics)
+        try c.encodeIfPresent(providerQuota, forKey: .providerQuota)
+        try c.encodeIfPresent(recentDirectories, forKey: .recentDirectories)
+        try c.encodeIfPresent(dispatchAgents, forKey: .dispatchAgents)
+    }
 }
 
 /// What the Mac encodes into the pairing QR; the phone scans and stores it.

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -173,4 +173,66 @@ public extension ProviderQuota {
                                resetsAt: shortWindowResetsAt, observedAt: observedAt, isCached: isCached)
         }
     }
+
+    /// Compact surfaces (Watch home strips, weekly/short widgets) prefer the
+    /// requested window. When weekly and short are both missing — Cursor/Grok
+    /// billing periods land in `otherWindows` — fall back to the first other
+    /// window that has a remaining percent so freshness and the strip agree.
+    ///
+    /// Choice for #113: fall back to `otherWindows` rather than promoting a
+    /// billing-cycle window as a first-class `QuotaWindowKind`. Weekly/short
+    /// stay exact; monthly periods remain labeled by duration via otherWindows.
+    func displayWindow(preferring kind: QuotaWindowKind = .weekly) -> QuotaWindow {
+        let preferred = window(kind)
+        if preferred.remainingPercent != nil { return preferred }
+        let alternate: QuotaWindowKind = kind == .weekly ? .short : .weekly
+        let secondary = window(alternate)
+        if secondary.remainingPercent != nil { return secondary }
+        if let other = (otherWindows ?? []).first(where: { $0.remainingPercent != nil }) {
+            return other
+        }
+        return preferred
+    }
+}
+
+
+// MARK: - Wire forward-compat (#111)
+
+/// Consumes one arbitrary JSON value so a failed element decode can still
+/// advance an unkeyed container.
+enum WireJSONSkip: Decodable {
+    case value
+
+    init(from decoder: Decoder) throws {
+        let single = try decoder.singleValueContainer()
+        if single.decodeNil() { self = .value; return }
+        if (try? single.decode(Bool.self)) != nil { self = .value; return }
+        if (try? single.decode(Int64.self)) != nil { self = .value; return }
+        if (try? single.decode(UInt64.self)) != nil { self = .value; return }
+        if (try? single.decode(Double.self)) != nil { self = .value; return }
+        if (try? single.decode(String.self)) != nil { self = .value; return }
+        if (try? single.decode([WireJSONSkip].self)) != nil { self = .value; return }
+        if (try? single.decode([String: WireJSONSkip].self)) != nil { self = .value; return }
+        self = .value
+    }
+}
+
+public extension ProviderQuota {
+    /// Decode `providerQuota` rows for the wire: an unknown `provider` string
+    /// drops that row instead of failing the enclosing Snapshot / ServerEvent.
+    ///
+    /// Release order (#111): ship this tolerant client decode before (or with)
+    /// any Mac that emits providers outside the peer vocabulary long-term.
+    static func decodeWireArray(from container: inout UnkeyedDecodingContainer) throws -> [ProviderQuota] {
+        var rows: [ProviderQuota] = []
+        while !container.isAtEnd {
+            do {
+                rows.append(try container.decode(ProviderQuota.self))
+            } catch {
+                // Failed decode does not advance; consume the element and continue.
+                _ = try container.decode(WireJSONSkip.self)
+            }
+        }
+        return rows
+    }
 }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -174,3 +174,45 @@ public extension ProviderQuota {
         }
     }
 }
+
+
+// MARK: - Wire forward-compat (#111)
+
+/// Consumes one arbitrary JSON value so a failed element decode can still
+/// advance an unkeyed container.
+enum WireJSONSkip: Decodable {
+    case value
+
+    init(from decoder: Decoder) throws {
+        let single = try decoder.singleValueContainer()
+        if single.decodeNil() { self = .value; return }
+        if (try? single.decode(Bool.self)) != nil { self = .value; return }
+        if (try? single.decode(Int64.self)) != nil { self = .value; return }
+        if (try? single.decode(UInt64.self)) != nil { self = .value; return }
+        if (try? single.decode(Double.self)) != nil { self = .value; return }
+        if (try? single.decode(String.self)) != nil { self = .value; return }
+        if (try? single.decode([WireJSONSkip].self)) != nil { self = .value; return }
+        if (try? single.decode([String: WireJSONSkip].self)) != nil { self = .value; return }
+        self = .value
+    }
+}
+
+public extension ProviderQuota {
+    /// Decode `providerQuota` rows for the wire: an unknown `provider` string
+    /// drops that row instead of failing the enclosing Snapshot / ServerEvent.
+    ///
+    /// Release order (#111): ship this tolerant client decode before (or with)
+    /// any Mac that emits providers outside the peer vocabulary long-term.
+    static func decodeWireArray(from container: inout UnkeyedDecodingContainer) throws -> [ProviderQuota] {
+        var rows: [ProviderQuota] = []
+        while !container.isAtEnd {
+            do {
+                rows.append(try container.decode(ProviderQuota.self))
+            } catch {
+                // Failed decode does not advance; consume the element and continue.
+                _ = try container.decode(WireJSONSkip.self)
+            }
+        }
+        return rows
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -188,7 +188,8 @@ public extension ProviderQuota {
         let alternate: QuotaWindowKind = kind == .weekly ? .short : .weekly
         let secondary = window(alternate)
         if secondary.remainingPercent != nil { return secondary }
-        if let other = (otherWindows ?? []).first(where: { $0.remainingPercent != nil }) {
+        if var other = (otherWindows ?? []).first(where: { $0.remainingPercent != nil }) {
+            other.isCached = other.isCached == true || isCached == true
             return other
         }
         return preferred

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -173,4 +173,24 @@ public extension ProviderQuota {
                                resetsAt: shortWindowResetsAt, observedAt: observedAt, isCached: isCached)
         }
     }
+
+    /// Compact surfaces (Watch home strips, weekly/short widgets) prefer the
+    /// requested window. When weekly and short are both missing — Cursor/Grok
+    /// billing periods land in `otherWindows` — fall back to the first other
+    /// window that has a remaining percent so freshness and the strip agree.
+    ///
+    /// Choice for #113: fall back to `otherWindows` rather than promoting a
+    /// billing-cycle window as a first-class `QuotaWindowKind`. Weekly/short
+    /// stay exact; monthly periods remain labeled by duration via otherWindows.
+    func displayWindow(preferring kind: QuotaWindowKind = .weekly) -> QuotaWindow {
+        let preferred = window(kind)
+        if preferred.remainingPercent != nil { return preferred }
+        let alternate: QuotaWindowKind = kind == .weekly ? .short : .weekly
+        let secondary = window(alternate)
+        if secondary.remainingPercent != nil { return secondary }
+        if let other = (otherWindows ?? []).first(where: { $0.remainingPercent != nil }) {
+            return other
+        }
+        return preferred
+    }
 }

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/KeychainStoreTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/KeychainStoreTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Security
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("KeychainStore write safety")
+struct KeychainStoreTests {
+    @Test("failed update preserves the previous secret")
+    func failedUpdatePreservesPrevious() {
+        let account = "test.account.issue114"
+        let fake = FakeKeychain([account: Data("previous-secret".utf8)])
+        fake.updateResult = errSecAuthFailed
+
+        let status = KeychainStore.set("replacement", for: account, operations: fake.operations)
+        #expect(status == errSecAuthFailed)
+        #expect(fake.updateCalls == 1)
+        #expect(fake.addCalls == 0)
+        #expect(fake.deleteCalls == 0)
+        #expect(String(data: fake.store[account]!, encoding: .utf8) == "previous-secret")
+        #expect(KeychainStore.get(account, operations: fake.operations) == "previous-secret")
+    }
+
+    @Test("update-or-add writes when the item is missing")
+    func addWhenMissing() {
+        let account = "test.account.issue114.missing"
+        let fake = FakeKeychain()
+        fake.updateResult = errSecItemNotFound
+
+        #expect(KeychainStore.set("fresh", for: account, operations: fake.operations) == errSecSuccess)
+        #expect(KeychainStore.get(account, operations: fake.operations) == "fresh")
+        #expect(fake.addCalls == 1)
+    }
+}
+
+/// In-memory Keychain stand-in. `@unchecked Sendable` so tests can inject it
+/// into `@Sendable` operation closures without touching the real Keychain.
+private final class FakeKeychain: @unchecked Sendable {
+    var store: [String: Data]
+    var updateResult: OSStatus = errSecSuccess
+    var updateCalls = 0
+    var addCalls = 0
+    var deleteCalls = 0
+
+    init(_ store: [String: Data] = [:]) {
+        self.store = store
+    }
+
+    var operations: KeychainStore.Operations {
+        KeychainStore.Operations(
+            update: { [self] query, attributes in
+                self.updateCalls += 1
+                if self.updateResult != errSecSuccess {
+                    return self.updateResult
+                }
+                let key = query[kSecAttrAccount as String] as? String ?? ""
+                guard self.store[key] != nil else { return errSecItemNotFound }
+                if let data = attributes[kSecValueData as String] as? Data {
+                    self.store[key] = data
+                }
+                return errSecSuccess
+            },
+            add: { [self] item in
+                self.addCalls += 1
+                let key = item[kSecAttrAccount as String] as? String ?? ""
+                let data = item[kSecValueData as String] as? Data ?? Data()
+                self.store[key] = data
+                return errSecSuccess
+            },
+            delete: { [self] query in
+                self.deleteCalls += 1
+                let key = query[kSecAttrAccount as String] as? String ?? ""
+                self.store.removeValue(forKey: key)
+                return errSecSuccess
+            },
+            copyMatching: { [self] query in
+                let key = query[kSecAttrAccount as String] as? String ?? ""
+                if let data = self.store[key] {
+                    return (errSecSuccess, data)
+                }
+                return (errSecItemNotFound, nil)
+            }
+        )
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("ProviderQuota displayWindow")
+struct ProviderQuotaDisplayWindowTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test("Weekly wins when present")
+    func prefersWeekly() {
+        let quota = ProviderQuota(
+            provider: .codex,
+            weeklyRemainingPercent: 68,
+            weeklyWindowDurationMinutes: 10_080,
+            shortWindowRemainingPercent: 84,
+            shortWindowDurationMinutes: 300,
+            otherWindows: [
+                QuotaWindow(remainingPercent: 60, durationMinutes: 43_200, resetsAt: nil, observedAt: now)
+            ],
+            observedAt: now
+        )
+        #expect(quota.displayWindow(preferring: .weekly).remainingPercent == 68)
+        #expect(quota.displayWindow(preferring: .short).remainingPercent == 84)
+    }
+
+    @Test("Falls back to short when weekly is missing")
+    func fallsBackToShort() {
+        let quota = ProviderQuota(
+            provider: .codex,
+            shortWindowRemainingPercent: 84,
+            shortWindowDurationMinutes: 300,
+            otherWindows: [
+                QuotaWindow(remainingPercent: 60, durationMinutes: 43_200, resetsAt: nil, observedAt: now)
+            ],
+            observedAt: now
+        )
+        #expect(quota.displayWindow(preferring: .weekly).remainingPercent == 84)
+    }
+
+    @Test("Falls back to first usable otherWindows for monthly Cursor/Grok periods")
+    func fallsBackToOtherWindows() {
+        let other = QuotaWindow(
+            remainingPercent: 60,
+            durationMinutes: 43_200,
+            resetsAt: now.addingTimeInterval(86_400),
+            observedAt: now
+        )
+        let quota = ProviderQuota(
+            provider: .cursor,
+            otherWindows: [other],
+            observedAt: now
+        )
+        #expect(quota.window(.weekly).remainingPercent == nil)
+        #expect(quota.freshness(now: now) == .live)
+        let display = quota.displayWindow(preferring: .weekly)
+        #expect(display.remainingPercent == 60)
+        #expect(display.currentRemainingPercent(now: now) == 60)
+        #expect(display.status(now: now) == .live)
+        #expect(quota.displayWindow(preferring: .short).remainingPercent == 60)
+    }
+
+    @Test("Unavailable stays unavailable when nothing is usable")
+    func unavailableWhenEmpty() {
+        let quota = ProviderQuota.unavailable(.cursor, reason: "Collection is turned off")
+        #expect(quota.displayWindow(preferring: .weekly).remainingPercent == nil)
+        #expect(quota.displayWindow(preferring: .weekly).status(now: now) == .unavailable)
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaDisplayWindowTests.swift
@@ -59,6 +59,15 @@ struct ProviderQuotaDisplayWindowTests {
         #expect(quota.displayWindow(preferring: .short).remainingPercent == 60)
     }
 
+    @Test("Relay cache state applies to monthly fallback")
+    func cachedMonthlyFallback() {
+        var quota = ProviderQuota(provider: .cursor, otherWindows: [
+            QuotaWindow(remainingPercent: 60, durationMinutes: 43200, resetsAt: nil, observedAt: now)
+        ], observedAt: now)
+        quota.isCached = true
+        #expect(quota.displayWindow().status(now: now) == .stale)
+    }
+
     @Test("Unavailable stays unavailable when nothing is usable")
     func unavailableWhenEmpty() {
         let quota = ProviderQuota.unavailable(.cursor, reason: "Collection is turned off")

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaWireCompatTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaWireCompatTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("ProviderQuota wire forward-compat (#111)")
+struct ProviderQuotaWireCompatTests {
+
+    /// App Store v1.3 vocabulary: no `cursor`. Used to prove a HEAD payload
+    /// with `cursor` can still be read when unknown providers are skipped.
+    private enum OldAccountUsageProvider: String, Codable {
+        case codex, claude, grok
+    }
+
+    private struct OldProviderQuota: Codable {
+        var provider: OldAccountUsageProvider
+        var weeklyRemainingPercent: Int?
+        var unavailableReason: String?
+    }
+
+    private func sampleSnapshot(includingCursor: Bool) -> Snapshot {
+        var rows: [ProviderQuota] = [
+            ProviderQuota(provider: .codex, weeklyRemainingPercent: 70),
+            ProviderQuota(provider: .claude, weeklyRemainingPercent: 40),
+            ProviderQuota(provider: .grok, weeklyRemainingPercent: 55),
+        ]
+        if includingCursor {
+            rows.append(ProviderQuota(provider: .cursor, weeklyRemainingPercent: 60))
+        }
+        return Snapshot(
+            sessions: [],
+            serverTime: Date(timeIntervalSince1970: 1_700_000_000),
+            sourceID: "mac-1",
+            providerQuota: rows
+        )
+    }
+
+    @Test("unknown provider string in providerQuota does not kill Snapshot decode")
+    func unknownProviderSkipped() throws {
+        let json = """
+        {"sessions":[],"serverTime":1700000000,
+         "providerQuota":[
+           {"provider":"codex","weeklyRemainingPercent":70},
+           {"provider":"futureProvider","weeklyRemainingPercent":12},
+           {"provider":"claude","weeklyRemainingPercent":40}
+         ]}
+        """.data(using: .utf8)!
+        let snap = try JSONDecoder().decode(Snapshot.self, from: json)
+        #expect(snap.providerQuota?.map(\.provider) == [.codex, .claude])
+        #expect(snap.sessions.isEmpty)
+    }
+
+    @Test("new clients still keep Cursor when present")
+    func newClientKeepsCursor() throws {
+        let snap = sampleSnapshot(includingCursor: true)
+        let data = try JSONEncoder().encode(snap)
+        let back = try JSONDecoder().decode(Snapshot.self, from: data)
+        #expect(back.providerQuota?.map(\.provider).contains(.cursor) == true)
+        #expect(back.providerQuota?.first { $0.provider == .cursor }?.weeklyRemainingPercent == 60)
+
+        let eventData = try JSONEncoder().encode(ServerEvent.snapshot(snap))
+        guard case .snapshot(let fromEvent) = try JSONDecoder().decode(ServerEvent.self, from: eventData) else {
+            Issue.record("expected snapshot event")
+            return
+        }
+        #expect(fromEvent.providerQuota?.map(\.provider).contains(.cursor) == true)
+    }
+
+    @Test("old vocabulary can decode HEAD Snapshot that includes cursor by skipping the row")
+    func oldVocabSkipsCursorRow() throws {
+        // Simulate the lossy array path with the pre-Cursor enum: decode each
+        // row, skip failures (cursor), keep known providers.
+        let head = sampleSnapshot(includingCursor: true)
+        let data = try JSONEncoder().encode(head)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let rows = obj["providerQuota"] as! [[String: Any]]
+        var kept: [OldProviderQuota] = []
+        for row in rows {
+            let rowData = try JSONSerialization.data(withJSONObject: row)
+            if let decoded = try? JSONDecoder().decode(OldProviderQuota.self, from: rowData) {
+                kept.append(decoded)
+            }
+        }
+        #expect(kept.map(\.provider) == [.codex, .claude, .grok])
+        #expect(!kept.map(\.provider.rawValue).contains("cursor"))
+
+        // Production Snapshot decoder keeps known providers (including cursor)
+        // and drops a not-yet-known string without failing the frame.
+        let withFuture = """
+        {"sessions":[],"serverTime":1700000000,
+         "providerQuota":[
+           {"provider":"codex","weeklyRemainingPercent":70},
+           {"provider":"cursor","weeklyRemainingPercent":60},
+           {"provider":"notYetKnown","weeklyRemainingPercent":1}
+         ]}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Snapshot.self, from: withFuture)
+        #expect(decoded.providerQuota?.map(\.provider) == [.codex, .cursor])
+    }
+
+    @Test("ServerEvent.snapshot round-trip keeps known rows after unknown skip")
+    func serverEventSurvivesUnknownProvider() throws {
+        let snapJSON = """
+        {"sessions":[],"serverTime":1700000000,
+         "providerQuota":[
+           {"provider":"codex","weeklyRemainingPercent":10},
+           {"provider":"brandNewProvider","unavailableReason":"x"}
+         ]}
+        """.data(using: .utf8)!
+        let snap = try JSONDecoder().decode(Snapshot.self, from: snapJSON)
+        #expect(snap.providerQuota?.map(\.provider) == [.codex])
+        let event = ServerEvent.snapshot(snap)
+        let back = try JSONDecoder().decode(ServerEvent.self, from: JSONEncoder().encode(event))
+        #expect(back == event)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
@@ -12,6 +12,7 @@ public struct AccountUsageWindow: Codable, Equatable, Sendable, Identifiable {
     public var usedPercent: Int
     public var windowDurationMinutes: Int?
     public var resetsAt: Date?
+    public var label: String?
 
     public var id: AccountUsageWindowKind { kind }
 
@@ -19,12 +20,14 @@ public struct AccountUsageWindow: Codable, Equatable, Sendable, Identifiable {
         kind: AccountUsageWindowKind,
         usedPercent: Int,
         windowDurationMinutes: Int?,
-        resetsAt: Date?
+        resetsAt: Date?,
+        label: String? = nil
     ) {
         self.kind = kind
         self.usedPercent = usedPercent
         self.windowDurationMinutes = windowDurationMinutes
         self.resetsAt = resetsAt
+        self.label = label
     }
 }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import SweetCookieKit
 
 #if canImport(FoundationNetworking)
@@ -7,6 +8,7 @@ import FoundationNetworking
 
 /// Where Cursor session cookies come from on the Mac (#105).
 public enum CursorCookieSourceMode: String, CaseIterable, Sendable, Identifiable {
+    case cursorApp
     case manual
     case browserAuto
 
@@ -14,6 +16,7 @@ public enum CursorCookieSourceMode: String, CaseIterable, Sendable, Identifiable
 
     public var displayName: String {
         switch self {
+        case .cursorApp: return "Cursor app login"
         case .manual: return "Paste Cookie"
         case .browserAuto: return "Import from browser"
         }
@@ -79,6 +82,8 @@ public struct CursorBrowserCookieImporter: CursorBrowserCookieImporting {
     }
 
     public func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String {
+        // SweetCookieKit `.suffix` over-fetches (`evilcursor.com`); we re-filter
+        // with dot-boundary matching before accepting any cookie (#114 M3).
         let query = BrowserCookieQuery(domains: Self.cookieDomains, domainMatch: .suffix)
         let load: () throws -> [BrowserCookieStoreRecords] = {
             try self.client.records(matching: query, in: self.browsers)
@@ -90,15 +95,36 @@ public struct CursorBrowserCookieImporter: CursorBrowserCookieImporting {
             groups = try BrowserCookieKeychainAccessGate.withUserInteractionDisallowed(load)
         }
 
-        // Prefer a known session cookie name; otherwise accept any non-empty
-        // Cursor-domain cookie set (new auth cookie names).
+        // Prefer known session cookie names only. Do not accept the weak
+        // "any cookie on a Cursor-ish domain" fallback — that path can persist
+        // junk into Keychain (#114 M3).
         if let header = Self.cookieHeader(from: groups, requireKnownSessionName: true) {
             return header
         }
-        if let header = Self.cookieHeader(from: groups, requireKnownSessionName: false) {
-            return header
-        }
         throw AccountUsageError.notLoggedIn
+    }
+
+    /// Dot-boundary domain match: `host == domain || host.hasSuffix("." + domain)`.
+    /// Rejects suffix collisions such as `evilcursor.com` vs `cursor.com`.
+    public static func matchesAllowedDomain(
+        _ host: String,
+        allowedDomains: [String] = cookieDomains
+    ) -> Bool {
+        let haystack = normalizeDomain(host)
+        guard !haystack.isEmpty else { return false }
+        return allowedDomains.contains { pattern in
+            let needle = normalizeDomain(pattern)
+            guard !needle.isEmpty else { return false }
+            return haystack == needle || haystack.hasSuffix("." + needle)
+        }
+    }
+
+    static func normalizeDomain(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if value.hasPrefix(".") {
+            value.removeFirst()
+        }
+        return value
     }
 
     static func cookieHeader(
@@ -106,7 +132,9 @@ public struct CursorBrowserCookieImporter: CursorBrowserCookieImporting {
         requireKnownSessionName: Bool
     ) -> String? {
         for group in groups {
-            let cookies = BrowserCookieClient.makeHTTPCookies(group.records, origin: .domainBased)
+            let allowed = group.records.filter { matchesAllowedDomain($0.domain) }
+            guard !allowed.isEmpty else { continue }
+            let cookies = BrowserCookieClient.makeHTTPCookies(allowed, origin: .domainBased)
             guard !cookies.isEmpty else { continue }
             let hasNamed = cookies.contains { sessionCookieNames.contains($0.name) }
             if requireKnownSessionName, !hasNamed { continue }
@@ -121,13 +149,18 @@ public enum CursorCookieResolver {
     public static func resolve(
         mode: CursorCookieSourceMode = CursorCookieSourceSettings.mode(),
         manualCookie: String? = nil,
+        loadManual: () -> String? = { CursorSessionCookieStore.loadManual() },
         importer: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
         allowKeychainPrompt: Bool = false,
-        persistImportedCookie: (String) -> Void = { CursorSessionCookieStore.save($0) }
+        persistImportedCookie: (String) -> Void = {
+            _ = CursorSessionCookieStore.saveImportedIfChanged($0)
+        }
     ) throws -> String {
-        let manual = (manualCookie ?? CursorSessionCookieStore.load())?
+        let manual = (manualCookie ?? loadManual())?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         switch mode {
+        case .cursorApp:
+            return try CursorLocalSession.cookieHeader()
         case .manual:
             guard let manual, !manual.isEmpty else { throw AccountUsageError.notLoggedIn }
             return manual
@@ -139,9 +172,79 @@ public enum CursorCookieResolver {
                 persistImportedCookie(imported)
                 return imported
             } catch {
+                // Independent manual slot — never the imported account (#114 M1).
                 if let manual, !manual.isEmpty { return manual }
                 throw (error as? AccountUsageError) ?? AccountUsageError.notLoggedIn
             }
         }
+    }
+}
+
+
+/// Uses only the selected Cursor app session; never refreshes or persists its token.
+/// Source format: CodexBar CursorAppAuth (MIT), independently implemented here.
+public enum CursorLocalSession {
+    public static func cookieHeader(
+        path: String = NSHomeDirectory() + "/Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+        now: Date = Date()
+    ) throws -> String {
+        guard FileManager.default.fileExists(atPath: path) else { throw AccountUsageError.notLoggedIn }
+        let token: String
+        do { token = try readToken(path: path, immutable: false) }
+        catch let error as DatabaseError {
+            guard error.code == SQLITE_CANTOPEN,
+                  !FileManager.default.fileExists(atPath: path + "-wal"),
+                  !FileManager.default.fileExists(atPath: path + "-shm") else {
+                throw AccountUsageError.providerUnavailable
+            }
+            token = try readToken(path: path, immutable: true)
+        }
+        return try cookieHeader(token: token, now: now)
+    }
+
+    static func cookieHeader(token: String, now: Date) throws -> String {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        let allowedToken = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.")
+        guard parts.count == 3, token.unicodeScalars.allSatisfy(allowedToken.contains) else {
+            throw AccountUsageError.notLoggedIn
+        }
+        var payload = String(parts[1]).replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+        guard let data = Data(base64Encoded: payload),
+              let claims = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let expiration = claims["exp"] as? Double, expiration.isFinite,
+              expiration > now.timeIntervalSince1970 + 60,
+              let subject = claims["sub"] as? String,
+              let user = subject.split(separator: "|").last,
+              !user.isEmpty,
+              user.unicodeScalars.allSatisfy({ CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-")).contains($0) })
+        else { throw AccountUsageError.notLoggedIn }
+        return "WorkosCursorSessionToken=\(user)%3A%3A\(token)"
+    }
+
+    private struct DatabaseError: Error { let code: Int32 }
+    private static func readToken(path: String, immutable: Bool) throws -> String {
+        var db: OpaquePointer?
+        let name = immutable ? URL(fileURLWithPath: path).absoluteString + "?immutable=1" : path
+        let result = sqlite3_open_v2(name, &db, SQLITE_OPEN_READONLY | (immutable ? SQLITE_OPEN_URI : 0), nil)
+        defer { sqlite3_close(db) }
+        guard result == SQLITE_OK else { throw DatabaseError(code: result) }
+        sqlite3_busy_timeout(db, 250)
+        var statement: OpaquePointer?
+        let prepared = sqlite3_prepare_v2(db, "SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken' LIMIT 1", -1, &statement, nil)
+        defer { sqlite3_finalize(statement) }
+        guard prepared == SQLITE_OK else { throw DatabaseError(code: prepared) }
+        let step = sqlite3_step(statement)
+        guard step == SQLITE_ROW else {
+            if step == SQLITE_DONE { throw AccountUsageError.notLoggedIn }
+            throw DatabaseError(code: step)
+        }
+        guard let bytes = sqlite3_column_blob(statement, 0) else { throw AccountUsageError.notLoggedIn }
+        let data = Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, 0)))
+        let utf16 = !data.isEmpty && data.count.isMultiple(of: 2) && stride(from: 1, to: data.count, by: 2).allSatisfy { data[$0] == 0 }
+        guard let token = String(data: data, encoding: utf16 ? .utf16LittleEndian : .utf8), !token.isEmpty else {
+            throw AccountUsageError.notLoggedIn
+        }
+        return token
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
@@ -79,6 +79,8 @@ public struct CursorBrowserCookieImporter: CursorBrowserCookieImporting {
     }
 
     public func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String {
+        // SweetCookieKit `.suffix` over-fetches (`evilcursor.com`); we re-filter
+        // with dot-boundary matching before accepting any cookie (#114 M3).
         let query = BrowserCookieQuery(domains: Self.cookieDomains, domainMatch: .suffix)
         let load: () throws -> [BrowserCookieStoreRecords] = {
             try self.client.records(matching: query, in: self.browsers)
@@ -90,15 +92,36 @@ public struct CursorBrowserCookieImporter: CursorBrowserCookieImporting {
             groups = try BrowserCookieKeychainAccessGate.withUserInteractionDisallowed(load)
         }
 
-        // Prefer a known session cookie name; otherwise accept any non-empty
-        // Cursor-domain cookie set (new auth cookie names).
+        // Prefer known session cookie names only. Do not accept the weak
+        // "any cookie on a Cursor-ish domain" fallback — that path can persist
+        // junk into Keychain (#114 M3).
         if let header = Self.cookieHeader(from: groups, requireKnownSessionName: true) {
             return header
         }
-        if let header = Self.cookieHeader(from: groups, requireKnownSessionName: false) {
-            return header
-        }
         throw AccountUsageError.notLoggedIn
+    }
+
+    /// Dot-boundary domain match: `host == domain || host.hasSuffix("." + domain)`.
+    /// Rejects suffix collisions such as `evilcursor.com` vs `cursor.com`.
+    public static func matchesAllowedDomain(
+        _ host: String,
+        allowedDomains: [String] = cookieDomains
+    ) -> Bool {
+        let haystack = normalizeDomain(host)
+        guard !haystack.isEmpty else { return false }
+        return allowedDomains.contains { pattern in
+            let needle = normalizeDomain(pattern)
+            guard !needle.isEmpty else { return false }
+            return haystack == needle || haystack.hasSuffix("." + needle)
+        }
+    }
+
+    static func normalizeDomain(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if value.hasPrefix(".") {
+            value.removeFirst()
+        }
+        return value
     }
 
     static func cookieHeader(
@@ -106,7 +129,9 @@ public struct CursorBrowserCookieImporter: CursorBrowserCookieImporting {
         requireKnownSessionName: Bool
     ) -> String? {
         for group in groups {
-            let cookies = BrowserCookieClient.makeHTTPCookies(group.records, origin: .domainBased)
+            let allowed = group.records.filter { matchesAllowedDomain($0.domain) }
+            guard !allowed.isEmpty else { continue }
+            let cookies = BrowserCookieClient.makeHTTPCookies(allowed, origin: .domainBased)
             guard !cookies.isEmpty else { continue }
             let hasNamed = cookies.contains { sessionCookieNames.contains($0.name) }
             if requireKnownSessionName, !hasNamed { continue }
@@ -121,11 +146,14 @@ public enum CursorCookieResolver {
     public static func resolve(
         mode: CursorCookieSourceMode = CursorCookieSourceSettings.mode(),
         manualCookie: String? = nil,
+        loadManual: () -> String? = { CursorSessionCookieStore.loadManual() },
         importer: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
         allowKeychainPrompt: Bool = false,
-        persistImportedCookie: (String) -> Void = { CursorSessionCookieStore.save($0) }
+        persistImportedCookie: (String) -> Void = {
+            _ = CursorSessionCookieStore.saveImportedIfChanged($0)
+        }
     ) throws -> String {
-        let manual = (manualCookie ?? CursorSessionCookieStore.load())?
+        let manual = (manualCookie ?? loadManual())?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         switch mode {
         case .manual:
@@ -139,6 +167,7 @@ public enum CursorCookieResolver {
                 persistImportedCookie(imported)
                 return imported
             } catch {
+                // Independent manual slot — never the imported account (#114 M1).
                 if let manual, !manual.isEmpty { return manual }
                 throw (error as? AccountUsageError) ?? AccountUsageError.notLoggedIn
             }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import VibeBuddyKit
 
 #if canImport(FoundationNetworking)
@@ -16,19 +17,49 @@ extension URLSession: CursorUsageTransport {
     }
 }
 
-/// Keychain account for the pasted Cursor session Cookie header (#104).
+/// Keychain accounts for Cursor session Cookie headers (#104 / #114).
+/// Manual paste and browser-imported cookies stay in separate slots so
+/// `browserAuto` refresh cannot wipe the user's pasted fallback.
 public enum CursorSessionCookieStore {
-    public static let keychainAccount = "cursorSessionCookie"
+    /// Manual paste slot (also the browserAuto fallback).
+    public static let manualKeychainAccount = "cursorSessionCookie"
+    /// Browser-imported slot; written only when the imported value changes.
+    public static let importedKeychainAccount = "cursorSessionCookie.imported"
 
-    public static func load(read: (String) -> String? = KeychainStore.get) -> String? {
-        read(keychainAccount)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .nilIfEmpty
+    public static func loadManual(read: (String) -> String? = { KeychainStore.get($0) }) -> String? {
+        normalize(read(manualKeychainAccount))
     }
 
-    public static func save(_ value: String?, write: (String?, String) -> Void = KeychainStore.set) {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
-        write(trimmed?.nilIfEmpty, keychainAccount)
+    @discardableResult
+    public static func saveManual(
+        _ value: String?,
+        write: (String?, String) -> OSStatus = { KeychainStore.set($0, for: $1) }
+    ) -> OSStatus {
+        write(normalize(value), manualKeychainAccount)
+    }
+
+    public static func loadImported(read: (String) -> String? = { KeychainStore.get($0) }) -> String? {
+        normalize(read(importedKeychainAccount))
+    }
+
+    /// Persists the imported cookie only when it differs from the stored value.
+    /// Returns `nil` when no write was needed; otherwise the Keychain OSStatus.
+    @discardableResult
+    public static func saveImportedIfChanged(
+        _ value: String?,
+        read: (String) -> String? = { KeychainStore.get($0) },
+        write: (String?, String) -> OSStatus = { KeychainStore.set($0, for: $1) }
+    ) -> OSStatus? {
+        let trimmed = normalize(value)
+        let previous = normalize(read(importedKeychainAccount))
+        guard trimmed != previous else { return nil }
+        return write(trimmed, importedKeychainAccount)
+    }
+
+    private static func normalize(_ value: String?) -> String? {
+        value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
     }
 }
 
@@ -50,6 +81,20 @@ public enum CursorUsageSummaryDecoder {
         let start = parseTimestamp(summary.billingCycleStart)
         let end = parseTimestamp(summary.billingCycleEnd)
         let duration = durationMinutes(from: start, to: end)
+
+        if let pool = summary.individualUsage?.plan,
+           pool.autoPercentUsed != nil || pool.apiPercentUsed != nil {
+            func window(_ value: Double?, kind: AccountUsageWindowKind, label: String) throws -> AccountUsageWindow? {
+                guard let value else { return nil }
+                guard value.isFinite, value >= 0 else { throw AccountUsageError.incompatibleFormat }
+                return AccountUsageWindow(kind: kind, usedPercent: Int(min(100, value).rounded()),
+                    windowDurationMinutes: duration, resetsAt: end, label: label)
+            }
+            return try AccountUsageSnapshot(provider: .cursor, planType: summary.membershipType,
+                primary: window(pool.autoPercentUsed, kind: .primary, label: "Cursor Models"),
+                secondary: window(pool.apiPercentUsed, kind: .secondary, label: "Other Models"),
+                lifetimeTokens: nil, latestDailyTokens: nil, fetchedAt: fetchedAt)
+        }
 
         guard let primaryUsed = primaryUsedPercent(from: summary) else {
             throw AccountUsageError.incompatibleFormat
@@ -157,6 +202,8 @@ struct CursorPlanUsageDTO: Decodable {
     var limit: Int?
     var remaining: Int?
     var totalPercentUsed: Double?
+    var autoPercentUsed: Double?
+    var apiPercentUsed: Double?
 }
 
 struct CursorOnDemandUsageDTO: Decodable {
@@ -173,39 +220,46 @@ struct CursorLegacyModelUsageDTO: Decodable {
 
 /// Reads Cursor plan allowance via session Cookie + `usage-summary`.
 /// Cookie may come from a pasted header (#104) or optional browser import (#105).
+///
+/// Cookie source mode is resolved on every `fetch()` (via `cookieMode`), so a
+/// Settings Picker change takes effect on the next refresh without restarting.
 public struct CursorUsageProvider: AccountUsageProviding {
     public static let defaultEndpoint = URL(string: "https://cursor.com/api/usage-summary")!
 
     private let cookie: String?
-    private let cookieMode: CursorCookieSourceMode
+    private let cookieMode: @Sendable () -> CursorCookieSourceMode
     private let cookieImporter: CursorBrowserCookieImporting
+    private let persistImportedCookie: @Sendable (String) -> Void
     private let endpoint: URL
     private let transport: CursorUsageTransport
     private let timeout: TimeInterval
+    private let importTimeout: TimeInterval
 
     public init(
         cookie: String? = nil,
-        cookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode(),
+        cookieMode: @escaping @Sendable () -> CursorCookieSourceMode = { CursorCookieSourceSettings.mode() },
         cookieImporter: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
+        persistImportedCookie: @escaping @Sendable (String) -> Void = { _ = CursorSessionCookieStore.saveImportedIfChanged($0) },
         endpoint: URL = defaultEndpoint,
         transport: CursorUsageTransport = URLSession.shared,
-        timeout: TimeInterval = 15
+        timeout: TimeInterval = 15,
+        importTimeout: TimeInterval = 10
     ) {
         self.cookie = cookie
         self.cookieMode = cookieMode
         self.cookieImporter = cookieImporter
+        self.persistImportedCookie = persistImportedCookie
         self.endpoint = endpoint
         self.transport = transport
         self.timeout = timeout
+        self.importTimeout = importTimeout
     }
 
     public func fetch() async throws -> AccountUsageSnapshot {
-        let cookie = try CursorCookieResolver.resolve(
-            mode: cookieMode,
-            manualCookie: cookie,
-            importer: cookieImporter,
-            allowKeychainPrompt: false
-        )
+        try Task.checkCancellation()
+        let cookie = try await resolveCookieHeader()
+        try Task.checkCancellation()
+
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
         request.timeoutInterval = timeout
@@ -238,5 +292,58 @@ public struct CursorUsageProvider: AccountUsageProviding {
         default:
             throw AccountUsageError.providerUnavailable
         }
+    }
+
+    /// Manual resolve stays on the cooperative pool (Keychain read only).
+    /// Browser import mirrors Grok: blocking SweetCookieKit I/O runs on a
+    /// utility queue behind a continuation, with an import timeout.
+    private func resolveCookieHeader() async throws -> String {
+        switch cookieMode() {
+        case .cursorApp:
+            return try CursorLocalSession.cookieHeader()
+        case .manual:
+            return try CursorCookieResolver.resolve(
+                mode: .manual,
+                manualCookie: cookie,
+                importer: cookieImporter,
+                allowKeychainPrompt: false
+            )
+        case .browserAuto:
+            return try await importBrowserCookieOffPool()
+        }
+    }
+
+    private func importBrowserCookieOffPool() async throws -> String {
+        let importer = cookieImporter
+        let manualOverride = cookie
+        let seconds = importTimeout
+        // A stream terminates its waiter without waiting for blocking browser I/O.
+        // Late results are discarded and never persist a cookie after cancellation.
+        let stream = AsyncThrowingStream<(header: String, imported: Bool), Error> { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                do {
+                    var imported = false
+                    let header = try CursorCookieResolver.resolve(
+                        mode: .browserAuto,
+                        manualCookie: manualOverride,
+                        importer: importer,
+                        allowKeychainPrompt: false,
+                        persistImportedCookie: { _ in imported = true }
+                    )
+                    continuation.yield((header, imported))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + max(0, seconds)) {
+                continuation.finish(throwing: AccountUsageError.timedOut)
+            }
+        }
+        var iterator = stream.makeAsyncIterator()
+        guard let result = try await iterator.next() else { throw CancellationError() }
+        try Task.checkCancellation()
+        if result.imported { persistImportedCookie(result.header) }
+        return result.header
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
@@ -173,20 +173,25 @@ struct CursorLegacyModelUsageDTO: Decodable {
 
 /// Reads Cursor plan allowance via session Cookie + `usage-summary`.
 /// Cookie may come from a pasted header (#104) or optional browser import (#105).
+///
+/// Cookie source mode is resolved on every `fetch()` (via `cookieMode`), so a
+/// Settings Picker change takes effect on the next refresh without restarting.
 public struct CursorUsageProvider: AccountUsageProviding {
     public static let defaultEndpoint = URL(string: "https://cursor.com/api/usage-summary")!
 
     private let cookie: String?
-    private let cookieMode: CursorCookieSourceMode
+    private let cookieMode: @Sendable () -> CursorCookieSourceMode
     private let cookieImporter: CursorBrowserCookieImporting
+    private let persistImportedCookie: @Sendable (String) -> Void
     private let endpoint: URL
     private let transport: CursorUsageTransport
     private let timeout: TimeInterval
 
     public init(
         cookie: String? = nil,
-        cookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode(),
+        cookieMode: @escaping @Sendable () -> CursorCookieSourceMode = { CursorCookieSourceSettings.mode() },
         cookieImporter: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
+        persistImportedCookie: @escaping @Sendable (String) -> Void = { CursorSessionCookieStore.save($0) },
         endpoint: URL = defaultEndpoint,
         transport: CursorUsageTransport = URLSession.shared,
         timeout: TimeInterval = 15
@@ -194,6 +199,7 @@ public struct CursorUsageProvider: AccountUsageProviding {
         self.cookie = cookie
         self.cookieMode = cookieMode
         self.cookieImporter = cookieImporter
+        self.persistImportedCookie = persistImportedCookie
         self.endpoint = endpoint
         self.transport = transport
         self.timeout = timeout
@@ -201,10 +207,11 @@ public struct CursorUsageProvider: AccountUsageProviding {
 
     public func fetch() async throws -> AccountUsageSnapshot {
         let cookie = try CursorCookieResolver.resolve(
-            mode: cookieMode,
+            mode: cookieMode(),
             manualCookie: cookie,
             importer: cookieImporter,
-            allowKeychainPrompt: false
+            allowKeychainPrompt: false,
+            persistImportedCookie: persistImportedCookie
         )
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import VibeBuddyKit
 
 #if canImport(FoundationNetworking)
@@ -16,19 +17,65 @@ extension URLSession: CursorUsageTransport {
     }
 }
 
-/// Keychain account for the pasted Cursor session Cookie header (#104).
+/// Keychain accounts for Cursor session Cookie headers (#104 / #114).
+/// Manual paste and browser-imported cookies stay in separate slots so
+/// `browserAuto` refresh cannot wipe the user's pasted fallback.
 public enum CursorSessionCookieStore {
-    public static let keychainAccount = "cursorSessionCookie"
+    /// Manual paste slot (also the browserAuto fallback).
+    public static let manualKeychainAccount = "cursorSessionCookie"
+    /// Browser-imported slot; written only when the imported value changes.
+    public static let importedKeychainAccount = "cursorSessionCookie.imported"
+    /// Back-compat alias for the manual paste account.
+    public static let keychainAccount = manualKeychainAccount
 
-    public static func load(read: (String) -> String? = KeychainStore.get) -> String? {
-        read(keychainAccount)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .nilIfEmpty
+    public static func loadManual(read: (String) -> String? = { KeychainStore.get($0) }) -> String? {
+        normalize(read(manualKeychainAccount))
     }
 
-    public static func save(_ value: String?, write: (String?, String) -> Void = KeychainStore.set) {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
-        write(trimmed?.nilIfEmpty, keychainAccount)
+    @discardableResult
+    public static func saveManual(
+        _ value: String?,
+        write: (String?, String) -> OSStatus = { KeychainStore.set($0, for: $1) }
+    ) -> OSStatus {
+        write(normalize(value), manualKeychainAccount)
+    }
+
+    public static func loadImported(read: (String) -> String? = { KeychainStore.get($0) }) -> String? {
+        normalize(read(importedKeychainAccount))
+    }
+
+    /// Persists the imported cookie only when it differs from the stored value.
+    /// Returns `nil` when no write was needed; otherwise the Keychain OSStatus.
+    @discardableResult
+    public static func saveImportedIfChanged(
+        _ value: String?,
+        read: (String) -> String? = { KeychainStore.get($0) },
+        write: (String?, String) -> OSStatus = { KeychainStore.set($0, for: $1) }
+    ) -> OSStatus? {
+        let trimmed = normalize(value)
+        let previous = normalize(read(importedKeychainAccount))
+        guard trimmed != previous else { return nil }
+        return write(trimmed, importedKeychainAccount)
+    }
+
+    /// Back-compat: load the manual paste slot.
+    public static func load(read: (String) -> String? = { KeychainStore.get($0) }) -> String? {
+        loadManual(read: read)
+    }
+
+    /// Back-compat: save into the manual paste slot.
+    @discardableResult
+    public static func save(
+        _ value: String?,
+        write: (String?, String) -> OSStatus = { KeychainStore.set($0, for: $1) }
+    ) -> OSStatus {
+        saveManual(value, write: write)
+    }
+
+    private static func normalize(_ value: String?) -> String? {
+        value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
     }
 }
 
@@ -182,6 +229,7 @@ public struct CursorUsageProvider: AccountUsageProviding {
     private let endpoint: URL
     private let transport: CursorUsageTransport
     private let timeout: TimeInterval
+    private let importTimeout: TimeInterval
 
     public init(
         cookie: String? = nil,
@@ -189,7 +237,8 @@ public struct CursorUsageProvider: AccountUsageProviding {
         cookieImporter: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
         endpoint: URL = defaultEndpoint,
         transport: CursorUsageTransport = URLSession.shared,
-        timeout: TimeInterval = 15
+        timeout: TimeInterval = 15,
+        importTimeout: TimeInterval = 10
     ) {
         self.cookie = cookie
         self.cookieMode = cookieMode
@@ -197,15 +246,14 @@ public struct CursorUsageProvider: AccountUsageProviding {
         self.endpoint = endpoint
         self.transport = transport
         self.timeout = timeout
+        self.importTimeout = importTimeout
     }
 
     public func fetch() async throws -> AccountUsageSnapshot {
-        let cookie = try CursorCookieResolver.resolve(
-            mode: cookieMode,
-            manualCookie: cookie,
-            importer: cookieImporter,
-            allowKeychainPrompt: false
-        )
+        try Task.checkCancellation()
+        let cookie = try await resolveCookieHeader()
+        try Task.checkCancellation()
+
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
         request.timeoutInterval = timeout
@@ -237,6 +285,54 @@ public struct CursorUsageProvider: AccountUsageProviding {
             throw AccountUsageError.rateLimited
         default:
             throw AccountUsageError.providerUnavailable
+        }
+    }
+
+    /// Manual resolve stays on the cooperative pool (Keychain read only).
+    /// Browser import mirrors Grok: blocking SweetCookieKit I/O runs on a
+    /// utility queue behind a continuation, with an import timeout.
+    private func resolveCookieHeader() async throws -> String {
+        switch cookieMode {
+        case .manual:
+            return try CursorCookieResolver.resolve(
+                mode: .manual,
+                manualCookie: cookie,
+                importer: cookieImporter,
+                allowKeychainPrompt: false
+            )
+        case .browserAuto:
+            return try await importBrowserCookieOffPool()
+        }
+    }
+
+    private func importBrowserCookieOffPool() async throws -> String {
+        let importer = cookieImporter
+        let manualOverride = cookie
+        let seconds = importTimeout
+        return try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+                    DispatchQueue.global(qos: .utility).async {
+                        continuation.resume(with: Result {
+                            try CursorCookieResolver.resolve(
+                                mode: .browserAuto,
+                                manualCookie: manualOverride,
+                                importer: importer,
+                                allowKeychainPrompt: false
+                            )
+                        })
+                    }
+                }
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw AccountUsageError.timedOut
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next() else {
+                throw AccountUsageError.unknown
+            }
+            return first
         }
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
@@ -365,18 +365,22 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
                 )
             } catch {
                 try Task.checkCancellation()
-                guard Self.allowsLogFallback(after: error) else { throw error }
-                if let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(
+                // Log and proxy are independent: incompatibleFormat must not
+                // read a stale log, but still may try the billing proxy.
+                if Self.allowsLogFallback(after: error),
+                   let snapshot = GrokUsageResponseDecoder.decodeNewestLogRecord(
                     in: logURL,
                     now: Date()
-                ) {
+                   ) {
                     return snapshot
                 }
-                if proxyEnabled, let snapshot = await Self.fetchProxyFallback(
+                if Self.allowsProxyFallback(after: error),
+                   proxyEnabled,
+                   let snapshot = await Self.fetchProxyFallback(
                     authFileURL: authFileURL,
                     endpoint: proxyEndpoint,
                     transport: proxyTransport
-                ) {
+                   ) {
                     return snapshot
                 }
                 throw error
@@ -386,8 +390,9 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
         }
     }
 
-    /// Best-effort proxy: never upgrades a hard auth/format failure from ACP, and
-    /// never invents a reading when the bearer is missing.
+    /// Best-effort proxy: never upgrades a hard auth failure from ACP, and
+    /// never invents a reading when the bearer is missing. Format failures
+    /// (no usable percent) are eligible — that is the billing-proxy case.
     static func fetchProxyFallback(
         authFileURL: URL,
         endpoint: URL,
@@ -419,6 +424,23 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
             switch usage {
             case .providerUnavailable, .timedOut, .offline, .unknown: return true
             case .notLoggedIn, .rateLimited, .incompatibleFormat: return false
+            }
+        default: return true
+        }
+    }
+
+    /// Proxy covers the same unreachable/timeout cases as the log, plus
+    /// `.incompatibleFormat` (ACP answered but with no usable percent). Hard
+    /// auth, rate limits, and cancellation stay terminal.
+    static func allowsProxyFallback(after error: any Error) -> Bool {
+        switch error {
+        case is CancellationError: return false
+        case let usage as AccountUsageError:
+            switch usage {
+            case .providerUnavailable, .timedOut, .offline, .unknown, .incompatibleFormat:
+                return true
+            case .notLoggedIn, .rateLimited:
+                return false
             }
         default: return true
         }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -526,12 +526,27 @@ public actor SessionStore {
         broadcast()
     }
 
+    /// Peer vocabulary shipped in App Store iOS/Watch before Cursor (#111).
+    private static let peerProviderQuotaVocabulary: Set<AccountUsageProvider> = [
+        .codex, .claude, .grok
+    ]
+
+    private static func wireCompatibleProviderQuota(_ quota: [ProviderQuota]) -> [ProviderQuota] {
+        quota.filter { peerProviderQuotaVocabulary.contains($0.provider) }
+    }
+
     /// The one place a runtime snapshot is assembled: sessions and diagnostics
     /// from the reducer, allowance from beside it.
     private func currentSnapshot(now: Date) -> Snapshot {
         var snapshot = reducer.snapshot(now: now, observationDiagnostics: diagnostics(now: now))
         snapshot.sourceID = sourceID
-        snapshot.providerQuota = providerQuota.isEmpty ? nil : providerQuota
+        // Wire gate (#111): omit providers outside the App Store peer vocabulary
+        // (codex/claude/grok) until iOS/Watch with tolerant providerQuota decode
+        // are live. Local Mac UI still collects Cursor via AccountUsageCoordinator;
+        // only the emitted Snapshot is filtered. Remove this gate after that
+        // client ships, then unrestricted Mac emit is safe.
+        let wireQuota = Self.wireCompatibleProviderQuota(providerQuota)
+        snapshot.providerQuota = wireQuota.isEmpty ? nil : wireQuota
         let directories = recentDirectories()
         snapshot.recentDirectories = directories.isEmpty ? nil : directories
         snapshot.sessions = snapshot.sessions.map { session in

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -655,7 +655,7 @@ struct AccountUsageTests {
 
     @Test("Cursor collector without a cookie stays unavailable, never 0%")
     func cursorProviderRequiresCookie() async throws {
-        let provider = CursorUsageProvider(cookie: nil, cookieMode: .manual, transport: MissingCookieTransport())
+        let provider = CursorUsageProvider(cookie: nil, cookieMode: { .manual }, transport: MissingCookieTransport())
         do {
             _ = try await provider.fetch()
             Issue.record("CursorUsageProvider must not succeed without a cookie")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Security
+import SweetCookieKit
 import Testing
 @testable import VibeBuddyMacCore
 
@@ -10,12 +12,14 @@ struct CursorBrowserCookieImporterTests {
             try CursorCookieResolver.resolve(
                 mode: .manual,
                 manualCookie: nil,
+                loadManual: { nil },
                 importer: FailingImporter()
             )
         }
         let header = try! CursorCookieResolver.resolve(
             mode: .manual,
             manualCookie: "WorkosCursorSessionToken=abc",
+            loadManual: { nil },
             importer: FailingImporter()
         )
         #expect(header == "WorkosCursorSessionToken=abc")
@@ -23,20 +27,23 @@ struct CursorBrowserCookieImporterTests {
 
     @Test("browserAuto uses import then falls back to manual paste")
     func browserAutoFallback() throws {
-        var persisted: String?
+        var persisted: [String] = []
         let imported = try CursorCookieResolver.resolve(
             mode: .browserAuto,
             manualCookie: nil,
+            loadManual: { nil },
             importer: ScriptedImporter(header: "WorkosCursorSessionToken=from-browser"),
-            persistImportedCookie: { persisted = $0 }
+            persistImportedCookie: { persisted.append($0) }
         )
         #expect(imported == "WorkosCursorSessionToken=from-browser")
-        #expect(persisted == imported)
+        #expect(persisted == [imported])
 
         let fallback = try CursorCookieResolver.resolve(
             mode: .browserAuto,
             manualCookie: "WorkosCursorSessionToken=pasted",
-            importer: FailingImporter()
+            loadManual: { nil },
+            importer: FailingImporter(),
+            persistImportedCookie: { _ in Issue.record("must not persist on import failure") }
         )
         #expect(fallback == "WorkosCursorSessionToken=pasted")
 
@@ -44,22 +51,139 @@ struct CursorBrowserCookieImporterTests {
             try CursorCookieResolver.resolve(
                 mode: .browserAuto,
                 manualCookie: nil,
+                loadManual: { nil },
                 importer: FailingImporter()
             )
         }
     }
 
+    @Test("dual-slot resolve keeps manual paste across auto-import cycles")
+    func dualSlotManualSurvivesAutoImport() throws {
+        let slots = InMemoryCookieSlots([
+            CursorSessionCookieStore.manualKeychainAccount: "WorkosCursorSessionToken=manual-fallback",
+        ])
+
+        // First auto import lands only in the imported slot.
+        let first = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: ScriptedImporter(header: "WorkosCursorSessionToken=auto-1"),
+            persistImportedCookie: {
+                _ = CursorSessionCookieStore.saveImportedIfChanged($0, read: slots.read, write: slots.write)
+            }
+        )
+        #expect(first == "WorkosCursorSessionToken=auto-1")
+        #expect(slots.values[CursorSessionCookieStore.manualKeychainAccount] == "WorkosCursorSessionToken=manual-fallback")
+        #expect(slots.values[CursorSessionCookieStore.importedKeychainAccount] == "WorkosCursorSessionToken=auto-1")
+
+        // Identical refresh must not rewrite the imported slot.
+        let writesBefore = slots.writeCount
+        _ = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: ScriptedImporter(header: "WorkosCursorSessionToken=auto-1"),
+            persistImportedCookie: {
+                _ = CursorSessionCookieStore.saveImportedIfChanged($0, read: slots.read, write: slots.write)
+            }
+        )
+        #expect(slots.writeCount == writesBefore)
+
+        // Changed import updates imported only; manual still intact for fallback.
+        let second = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: ScriptedImporter(header: "WorkosCursorSessionToken=auto-2"),
+            persistImportedCookie: {
+                _ = CursorSessionCookieStore.saveImportedIfChanged($0, read: slots.read, write: slots.write)
+            }
+        )
+        #expect(second == "WorkosCursorSessionToken=auto-2")
+        #expect(slots.values[CursorSessionCookieStore.manualKeychainAccount] == "WorkosCursorSessionToken=manual-fallback")
+        #expect(slots.values[CursorSessionCookieStore.importedKeychainAccount] == "WorkosCursorSessionToken=auto-2")
+
+        let fallback = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: FailingImporter(),
+            persistImportedCookie: { _ in Issue.record("must not persist on import failure") }
+        )
+        #expect(fallback == "WorkosCursorSessionToken=manual-fallback")
+    }
+
+    @Test("domain match rejects evilcursor.com-style suffix collisions")
+    func domainRejectsEvilCursor() {
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain("cursor.com"))
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain("www.cursor.com"))
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain(".cursor.com"))
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain("authenticator.cursor.sh"))
+        #expect(!CursorBrowserCookieImporter.matchesAllowedDomain("evilcursor.com"))
+        #expect(!CursorBrowserCookieImporter.matchesAllowedDomain("notcursor.com"))
+        #expect(!CursorBrowserCookieImporter.matchesAllowedDomain("cursor.com.evil.example"))
+    }
+
+    @Test("cookieHeader drops poisoned domains and weak cookies")
+    func cookieHeaderFiltersDomainAndRequiresSessionName() {
+        let poisoned = storeGroup(records: [
+            record(domain: "evilcursor.com", name: "WorkosCursorSessionToken", value: "evil"),
+            record(domain: "cursor.com", name: "_ga", value: "analytics-only"),
+        ])
+        #expect(CursorBrowserCookieImporter.cookieHeader(
+            from: [poisoned],
+            requireKnownSessionName: true
+        ) == nil)
+
+        let good = storeGroup(records: [
+            record(domain: "evilcursor.com", name: "WorkosCursorSessionToken", value: "evil"),
+            record(domain: "www.cursor.com", name: "WorkosCursorSessionToken", value: "good"),
+            record(domain: "www.cursor.com", name: "_ga", value: "analytics"),
+        ])
+        let header = CursorBrowserCookieImporter.cookieHeader(
+            from: [good],
+            requireKnownSessionName: true
+        )
+        #expect(header == "WorkosCursorSessionToken=good; _ga=analytics")
+        #expect(!(header?.contains("evil") ?? false))
+
+        let weakOnly = storeGroup(records: [
+            record(domain: "cursor.com", name: "_ga", value: "analytics-only"),
+        ])
+        #expect(CursorBrowserCookieImporter.cookieHeader(
+            from: [weakOnly],
+            requireKnownSessionName: true
+        ) == nil)
+    }
+
     @Test("provider fetch in browserAuto does not crash when import fails")
     func providerSurvivesImportFailure() async {
-        let provider = CursorUsageProvider(
-            cookie: nil,
-            cookieMode: .browserAuto,
-            cookieImporter: FailingImporter(),
-            transport: MissingTransport()
-        )
+        // cookie: "" avoids CursorSessionCookieStore.loadManual() → real Keychain.
         await #expect(throws: AccountUsageError.notLoggedIn) {
+            try await CursorUsageProvider(
+                cookie: "",
+                cookieMode: { .browserAuto },
+                cookieImporter: FailingImporter(),
+                transport: MissingTransport()
+            ).fetch()
+        }
+    }
+
+    @Test("browserAuto import timeout surfaces timedOut")
+    func importTimeout() async {
+        let started = ContinuousClock.now
+        let provider = CursorUsageProvider(
+            cookie: "",
+            cookieMode: { .browserAuto },
+            cookieImporter: SlowImporter(delayNanoseconds: 500_000_000),
+            transport: MissingTransport(),
+            importTimeout: 0.05
+        )
+        await #expect(throws: AccountUsageError.timedOut) {
             try await provider.fetch()
         }
+        #expect(started.duration(to: .now) < .milliseconds(300))
     }
 
     private struct ScriptedImporter: CursorBrowserCookieImporting {
@@ -73,10 +197,66 @@ struct CursorBrowserCookieImporterTests {
         }
     }
 
+    private struct SlowImporter: CursorBrowserCookieImporting {
+        let delayNanoseconds: UInt64
+        func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String {
+            // Sleep past the provider importTimeout, then fail — never returns a
+            // cookie that could be persisted into the user's real Keychain.
+            Thread.sleep(forTimeInterval: Double(delayNanoseconds) / 1_000_000_000)
+            throw AccountUsageError.notLoggedIn
+        }
+    }
+
     private struct MissingTransport: CursorUsageTransport {
         func cursorData(for request: URLRequest) async throws -> (Data, URLResponse) {
             Issue.record("network should not run without a cookie")
             throw URLError(.badURL)
         }
+    }
+
+    private func record(domain: String, name: String, value: String) -> BrowserCookieRecord {
+        BrowserCookieRecord(
+            domain: domain,
+            name: name,
+            path: "/",
+            value: value,
+            expires: nil,
+            isSecure: true,
+            isHTTPOnly: true
+        )
+    }
+
+    private final class InMemoryCookieSlots: @unchecked Sendable {
+        var values: [String: String]
+        var writeCount = 0
+
+        init(_ values: [String: String] = [:]) {
+            self.values = values
+        }
+
+        func read(_ account: String) -> String? { values[account] }
+
+        func write(_ value: String?, _ account: String) -> OSStatus {
+            writeCount += 1
+            if let value, !value.isEmpty {
+                values[account] = value
+            } else {
+                values.removeValue(forKey: account)
+            }
+            return errSecSuccess
+        }
+    }
+
+    private func storeGroup(records: [BrowserCookieRecord]) -> BrowserCookieStoreRecords {
+        BrowserCookieStoreRecords(
+            store: BrowserCookieStore(
+                browser: .chrome,
+                profile: BrowserProfile(id: "test", name: "Test"),
+                kind: .primary,
+                label: "Test",
+                databaseURL: nil
+            ),
+            records: records
+        )
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
@@ -53,7 +53,7 @@ struct CursorBrowserCookieImporterTests {
     func providerSurvivesImportFailure() async {
         let provider = CursorUsageProvider(
             cookie: nil,
-            cookieMode: .browserAuto,
+            cookieMode: { .browserAuto },
             cookieImporter: FailingImporter(),
             transport: MissingTransport()
         )

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorBrowserCookieImporterTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Security
+import SweetCookieKit
 import Testing
 @testable import VibeBuddyMacCore
 
@@ -10,12 +12,14 @@ struct CursorBrowserCookieImporterTests {
             try CursorCookieResolver.resolve(
                 mode: .manual,
                 manualCookie: nil,
+                loadManual: { nil },
                 importer: FailingImporter()
             )
         }
         let header = try! CursorCookieResolver.resolve(
             mode: .manual,
             manualCookie: "WorkosCursorSessionToken=abc",
+            loadManual: { nil },
             importer: FailingImporter()
         )
         #expect(header == "WorkosCursorSessionToken=abc")
@@ -23,20 +27,23 @@ struct CursorBrowserCookieImporterTests {
 
     @Test("browserAuto uses import then falls back to manual paste")
     func browserAutoFallback() throws {
-        var persisted: String?
+        var persisted: [String] = []
         let imported = try CursorCookieResolver.resolve(
             mode: .browserAuto,
             manualCookie: nil,
+            loadManual: { nil },
             importer: ScriptedImporter(header: "WorkosCursorSessionToken=from-browser"),
-            persistImportedCookie: { persisted = $0 }
+            persistImportedCookie: { persisted.append($0) }
         )
         #expect(imported == "WorkosCursorSessionToken=from-browser")
-        #expect(persisted == imported)
+        #expect(persisted == [imported])
 
         let fallback = try CursorCookieResolver.resolve(
             mode: .browserAuto,
             manualCookie: "WorkosCursorSessionToken=pasted",
-            importer: FailingImporter()
+            loadManual: { nil },
+            importer: FailingImporter(),
+            persistImportedCookie: { _ in Issue.record("must not persist on import failure") }
         )
         #expect(fallback == "WorkosCursorSessionToken=pasted")
 
@@ -44,20 +51,135 @@ struct CursorBrowserCookieImporterTests {
             try CursorCookieResolver.resolve(
                 mode: .browserAuto,
                 manualCookie: nil,
+                loadManual: { nil },
                 importer: FailingImporter()
             )
         }
     }
 
+    @Test("dual-slot resolve keeps manual paste across auto-import cycles")
+    func dualSlotManualSurvivesAutoImport() throws {
+        let slots = InMemoryCookieSlots([
+            CursorSessionCookieStore.manualKeychainAccount: "WorkosCursorSessionToken=manual-fallback",
+        ])
+
+        // First auto import lands only in the imported slot.
+        let first = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: ScriptedImporter(header: "WorkosCursorSessionToken=auto-1"),
+            persistImportedCookie: {
+                _ = CursorSessionCookieStore.saveImportedIfChanged($0, read: slots.read, write: slots.write)
+            }
+        )
+        #expect(first == "WorkosCursorSessionToken=auto-1")
+        #expect(slots.values[CursorSessionCookieStore.manualKeychainAccount] == "WorkosCursorSessionToken=manual-fallback")
+        #expect(slots.values[CursorSessionCookieStore.importedKeychainAccount] == "WorkosCursorSessionToken=auto-1")
+
+        // Identical refresh must not rewrite the imported slot.
+        let writesBefore = slots.writeCount
+        _ = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: ScriptedImporter(header: "WorkosCursorSessionToken=auto-1"),
+            persistImportedCookie: {
+                _ = CursorSessionCookieStore.saveImportedIfChanged($0, read: slots.read, write: slots.write)
+            }
+        )
+        #expect(slots.writeCount == writesBefore)
+
+        // Changed import updates imported only; manual still intact for fallback.
+        let second = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: ScriptedImporter(header: "WorkosCursorSessionToken=auto-2"),
+            persistImportedCookie: {
+                _ = CursorSessionCookieStore.saveImportedIfChanged($0, read: slots.read, write: slots.write)
+            }
+        )
+        #expect(second == "WorkosCursorSessionToken=auto-2")
+        #expect(slots.values[CursorSessionCookieStore.manualKeychainAccount] == "WorkosCursorSessionToken=manual-fallback")
+        #expect(slots.values[CursorSessionCookieStore.importedKeychainAccount] == "WorkosCursorSessionToken=auto-2")
+
+        let fallback = try CursorCookieResolver.resolve(
+            mode: .browserAuto,
+            manualCookie: nil,
+            loadManual: { CursorSessionCookieStore.loadManual(read: slots.read) },
+            importer: FailingImporter(),
+            persistImportedCookie: { _ in Issue.record("must not persist on import failure") }
+        )
+        #expect(fallback == "WorkosCursorSessionToken=manual-fallback")
+    }
+
+    @Test("domain match rejects evilcursor.com-style suffix collisions")
+    func domainRejectsEvilCursor() {
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain("cursor.com"))
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain("www.cursor.com"))
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain(".cursor.com"))
+        #expect(CursorBrowserCookieImporter.matchesAllowedDomain("authenticator.cursor.sh"))
+        #expect(!CursorBrowserCookieImporter.matchesAllowedDomain("evilcursor.com"))
+        #expect(!CursorBrowserCookieImporter.matchesAllowedDomain("notcursor.com"))
+        #expect(!CursorBrowserCookieImporter.matchesAllowedDomain("cursor.com.evil.example"))
+    }
+
+    @Test("cookieHeader drops poisoned domains and weak cookies")
+    func cookieHeaderFiltersDomainAndRequiresSessionName() {
+        let poisoned = storeGroup(records: [
+            record(domain: "evilcursor.com", name: "WorkosCursorSessionToken", value: "evil"),
+            record(domain: "cursor.com", name: "_ga", value: "analytics-only"),
+        ])
+        #expect(CursorBrowserCookieImporter.cookieHeader(
+            from: [poisoned],
+            requireKnownSessionName: true
+        ) == nil)
+
+        let good = storeGroup(records: [
+            record(domain: "evilcursor.com", name: "WorkosCursorSessionToken", value: "evil"),
+            record(domain: "www.cursor.com", name: "WorkosCursorSessionToken", value: "good"),
+            record(domain: "www.cursor.com", name: "_ga", value: "analytics"),
+        ])
+        let header = CursorBrowserCookieImporter.cookieHeader(
+            from: [good],
+            requireKnownSessionName: true
+        )
+        #expect(header == "WorkosCursorSessionToken=good; _ga=analytics")
+        #expect(!(header?.contains("evil") ?? false))
+
+        let weakOnly = storeGroup(records: [
+            record(domain: "cursor.com", name: "_ga", value: "analytics-only"),
+        ])
+        #expect(CursorBrowserCookieImporter.cookieHeader(
+            from: [weakOnly],
+            requireKnownSessionName: true
+        ) == nil)
+    }
+
     @Test("provider fetch in browserAuto does not crash when import fails")
     func providerSurvivesImportFailure() async {
-        let provider = CursorUsageProvider(
-            cookie: nil,
-            cookieMode: .browserAuto,
-            cookieImporter: FailingImporter(),
-            transport: MissingTransport()
-        )
+        // cookie: "" avoids CursorSessionCookieStore.loadManual() → real Keychain.
         await #expect(throws: AccountUsageError.notLoggedIn) {
+            try await CursorUsageProvider(
+                cookie: "",
+                cookieMode: .browserAuto,
+                cookieImporter: FailingImporter(),
+                transport: MissingTransport()
+            ).fetch()
+        }
+    }
+
+    @Test("browserAuto import timeout surfaces timedOut")
+    func importTimeout() async {
+        let provider = CursorUsageProvider(
+            cookie: "",
+            cookieMode: .browserAuto,
+            cookieImporter: SlowImporter(delayNanoseconds: 500_000_000),
+            transport: MissingTransport(),
+            importTimeout: 0.05
+        )
+        await #expect(throws: AccountUsageError.timedOut) {
             try await provider.fetch()
         }
     }
@@ -73,10 +195,66 @@ struct CursorBrowserCookieImporterTests {
         }
     }
 
+    private struct SlowImporter: CursorBrowserCookieImporting {
+        let delayNanoseconds: UInt64
+        func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String {
+            // Sleep past the provider importTimeout, then fail — never returns a
+            // cookie that could be persisted into the user's real Keychain.
+            Thread.sleep(forTimeInterval: Double(delayNanoseconds) / 1_000_000_000)
+            throw AccountUsageError.notLoggedIn
+        }
+    }
+
     private struct MissingTransport: CursorUsageTransport {
         func cursorData(for request: URLRequest) async throws -> (Data, URLResponse) {
             Issue.record("network should not run without a cookie")
             throw URLError(.badURL)
         }
+    }
+
+    private func record(domain: String, name: String, value: String) -> BrowserCookieRecord {
+        BrowserCookieRecord(
+            domain: domain,
+            name: name,
+            path: "/",
+            value: value,
+            expires: nil,
+            isSecure: true,
+            isHTTPOnly: true
+        )
+    }
+
+    private final class InMemoryCookieSlots: @unchecked Sendable {
+        var values: [String: String]
+        var writeCount = 0
+
+        init(_ values: [String: String] = [:]) {
+            self.values = values
+        }
+
+        func read(_ account: String) -> String? { values[account] }
+
+        func write(_ value: String?, _ account: String) -> OSStatus {
+            writeCount += 1
+            if let value, !value.isEmpty {
+                values[account] = value
+            } else {
+                values.removeValue(forKey: account)
+            }
+            return errSecSuccess
+        }
+    }
+
+    private func storeGroup(records: [BrowserCookieRecord]) -> BrowserCookieStoreRecords {
+        BrowserCookieStoreRecords(
+            store: BrowserCookieStore(
+                browser: .chrome,
+                profile: BrowserProfile(id: "test", name: "Test"),
+                kind: .primary,
+                label: "Test",
+                databaseURL: nil
+            ),
+            records: records
+        )
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorLocalSessionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorLocalSessionTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import VibeBuddyMacCore
+
+struct CursorLocalSessionTests {
+    private func token(expiration: Double = 1000) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: ["sub": "auth0|user_test", "exp": expiration])
+        let payload = data.base64EncodedString().replacingOccurrences(of: "+", with: "-").replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+        return "eyJhbGciOiJub25lIn0.\(payload).test"
+    }
+    @Test func appSessionUsesReadOnlyDatabase() throws {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        var db: OpaquePointer?
+        #expect(sqlite3_open(path, &db) == SQLITE_OK)
+        let value = try token()
+        #expect(sqlite3_exec(db, "CREATE TABLE ItemTable (key TEXT, value TEXT); INSERT INTO ItemTable VALUES ('cursorAuth/accessToken', '\(value)');", nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+        let before = try Data(contentsOf: URL(fileURLWithPath: path))
+        #expect(try CursorLocalSession.cookieHeader(path: path, now: Date(timeIntervalSince1970: 900)) == "WorkosCursorSessionToken=user_test%3A%3A\(value)")
+        #expect(try Data(contentsOf: URL(fileURLWithPath: path)) == before)
+        #expect(throws: AccountUsageError.notLoggedIn) { try CursorLocalSession.cookieHeader(path: path, now: Date(timeIntervalSince1970: 950)) }
+    }
+    @Test func independentPoolsDoNotUseOnDemandBudget() throws {
+        let json = #"{"individualUsage":{"plan":{"autoPercentUsed":22,"apiPercentUsed":83,"totalPercentUsed":50},"onDemand":{"used":999,"limit":1000}}}"#
+        let snapshot = try CursorUsageSummaryDecoder.decode(Data(json.utf8), fetchedAt: Date())
+        #expect(snapshot.primary?.usedPercent == 22)
+        #expect(snapshot.primary?.label == "Cursor Models")
+        #expect(snapshot.secondary?.usedPercent == 83)
+        #expect(snapshot.secondary?.label == "Other Models")
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorUsageProviderTests.swift
@@ -72,6 +72,51 @@ struct CursorUsageProviderTests {
         #expect(snapshot.primary?.usedPercent == 40)
     }
 
+    @Test("cookie source mode is re-read on each fetch, not frozen at init")
+    func cookieModeRereadEachFetch() async throws {
+        let endpoint = URL(string: "https://cursor.test/api/usage-summary")!
+        let body = try Self.fixture("usage-summary-plan-only")
+        final class FetchProbe: @unchecked Sendable {
+            var mode: CursorCookieSourceMode = .manual
+            var cookiesSeen: [String] = []
+            let lock = NSLock()
+            func noteCookie(_ value: String) {
+                lock.lock(); cookiesSeen.append(value); lock.unlock()
+            }
+            func snapshotCookies() -> [String] {
+                lock.lock(); defer { lock.unlock() }; return cookiesSeen
+            }
+        }
+        let probe = FetchProbe()
+        let transport = ScriptedCursorTransport { request in
+            probe.noteCookie(request.value(forHTTPHeaderField: "Cookie") ?? "")
+            let response = HTTPURLResponse(
+                url: endpoint, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (body, response)
+        }
+        let provider = CursorUsageProvider(
+            cookie: "WorkosCursorSessionToken=manual",
+            cookieMode: { probe.mode },
+            cookieImporter: ScriptedModeImporter(header: "WorkosCursorSessionToken=imported"),
+            persistImportedCookie: { _ in },
+            endpoint: endpoint,
+            transport: transport
+        )
+        _ = try await provider.fetch()
+        probe.mode = .browserAuto
+        _ = try await provider.fetch()
+        #expect(probe.snapshotCookies() == [
+            "WorkosCursorSessionToken=manual",
+            "WorkosCursorSessionToken=imported",
+        ])
+    }
+
+    private struct ScriptedModeImporter: CursorBrowserCookieImporting {
+        let header: String
+        func importSessionCookieHeader(allowKeychainPrompt: Bool) throws -> String { header }
+    }
+
     private struct ScriptedCursorTransport: CursorUsageTransport {
         let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
         func cursorData(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
@@ -474,6 +474,127 @@ struct GrokUsageProviderTests {
     }
 
 
+    @Test("incompatibleFormat ACP still attempts billing proxy without reading the log")
+    func proxyFallbackAfterIncompatibleFormat() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // A fresh log reading that must NOT be used for incompatibleFormat.
+        let logURL = directory.appendingPathComponent("unified.jsonl")
+        try (Self.logLine(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            percent: "72.0"
+        ) + Data("\n".utf8)).write(to: logURL)
+
+        let auth = directory.appendingPathComponent("auth.json")
+        try Data("""
+        {
+          "https://auth.x.ai::openid": {
+            "key": "token-456",
+            "expires_at": "2099-01-01T00:00:00Z"
+          }
+        }
+        """.utf8).write(to: auth)
+
+        // Period present, no usable creditPercent — exactly #106 / #112.
+        let agent = try Self.writeFakeAgent(
+            in: directory,
+            transcript: directory.appendingPathComponent("stdin.txt"),
+            reply: #"{"jsonrpc":"2.0","id":2,"result":{"config":{"currentPeriod":{"start":"2026-08-30T11:36:49Z","end":"2026-09-06T11:36:49Z"},"onDemandCap":{"val":100}}}}"#
+        )
+
+        let endpoint = URL(string: "https://grok.test/v1/billing?format=credits")!
+        let proxyHits = ProxyHitCounter()
+        let transport = ScriptedProxyTransport(handler: { request in
+            proxyHits.increment()
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token-456")
+            let body = Data("""
+            {"config":{"creditUsagePercent":55.0,"currentPeriod":{"start":"2026-08-06T00:00:00Z","end":"2026-08-13T00:00:00Z"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0}},"subscriptionTier":"SuperGrok"}
+            """.utf8)
+            let response = HTTPURLResponse(
+                url: endpoint, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (body, response)
+        })
+
+        let snapshot = try await GrokUsageProvider(
+            executableURL: agent,
+            arguments: [],
+            timeout: 5,
+            logURL: logURL,
+            authFileURL: auth,
+            proxyEndpoint: endpoint,
+            proxyTransport: transport
+        ).fetch()
+
+        #expect(snapshot.provider == .grok)
+        #expect(snapshot.primary?.usedPercent == 55)
+        #expect(snapshot.planType == "SuperGrok")
+        #expect(proxyHits.count == 1)
+        // Log gate stays closed for this error; proxy gate opens.
+        #expect(!GrokUsageProvider.allowsLogFallback(after: AccountUsageError.incompatibleFormat))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.incompatibleFormat))
+    }
+
+    @Test("notLoggedIn skips both log and proxy fallbacks")
+    func notLoggedInSkipsProxy() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory.appendingPathComponent("unified.jsonl")
+        try (Self.logLine(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            percent: "72.0"
+        ) + Data("\n".utf8)).write(to: logURL)
+        let auth = directory.appendingPathComponent("auth.json")
+        try Data("""
+        {"https://auth.x.ai::openid":{"key":"token-789","expires_at":"2099-01-01T00:00:00Z"}}
+        """.utf8).write(to: auth)
+        let agent = try Self.writeFakeAgent(
+            in: directory,
+            transcript: directory.appendingPathComponent("stdin.txt"),
+            reply: #"{"jsonrpc":"2.0","id":2,"error":{"code":-32000,"message":"Authentication required","data":"Run `grok login` to authenticate."}}"#
+        )
+        let endpoint = URL(string: "https://grok.test/v1/billing?format=credits")!
+        let proxyHits = ProxyHitCounter()
+        let transport = ScriptedProxyTransport(handler: { _ in
+            proxyHits.increment()
+            throw URLError(.badServerResponse)
+        })
+
+        await #expect(throws: AccountUsageError.notLoggedIn) {
+            try await GrokUsageProvider(
+                executableURL: agent,
+                arguments: [],
+                timeout: 5,
+                logURL: logURL,
+                authFileURL: auth,
+                proxyEndpoint: endpoint,
+                proxyTransport: transport
+            ).fetch()
+        }
+        #expect(proxyHits.count == 0)
+        #expect(!GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.notLoggedIn))
+        #expect(!GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.rateLimited))
+        #expect(!GrokUsageProvider.allowsProxyFallback(after: CancellationError()))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.providerUnavailable))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.timedOut))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.offline))
+        #expect(GrokUsageProvider.allowsProxyFallback(after: AccountUsageError.unknown))
+    }
+
+    private final class ProxyHitCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+        func increment() {
+            lock.lock(); defer { lock.unlock() }
+            value += 1
+        }
+    }
+
     private struct ScriptedProxyTransport: GrokCreditsProxyTransport {
         let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
         func proxyData(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
@@ -237,6 +237,35 @@ struct ProviderQuotaProjectionTests {
         }
     }
 
+    // MARK: Cursor / Grok billing periods (#113 H3)
+
+    @Test("A Cursor monthly billing window stays in otherWindows and is usable for display")
+    func cursorMonthlyBillingProjectsToOtherWindows() throws {
+        // Mid-cycle relative to usage-summary-plan-only (Aug→Sep 2026 billing window).
+        let observed = ISO8601DateFormatter().date(from: "2026-08-15T12:00:00Z")!
+        let url = try #require(Bundle.module.url(
+            forResource: "usage-summary-plan-only",
+            withExtension: "json",
+            subdirectory: "Fixtures/cursor"
+        ))
+        let data = try Data(contentsOf: url)
+        let snapshot = try CursorUsageSummaryDecoder.decode(data, fetchedAt: observed)
+        let result = ProviderQuota(.available(snapshot, nextRefreshAt: nil), provider: .cursor)
+        #expect(result.provider == .cursor)
+        #expect(result.weeklyRemainingPercent == nil)
+        #expect(result.shortWindowRemainingPercent == nil)
+        #expect(result.otherWindows?.first?.remainingPercent == 60)
+        #expect(result.otherWindows?.first?.durationMinutes == 31 * 24 * 60)
+        #expect(result.observedAt == observed)
+        #expect(result.freshness(now: observed) == .live)
+        #expect(result.unavailableReason == nil)
+        // Watch/home surfaces must not show "Window unavailable" while live.
+        let display = result.displayWindow(preferring: .weekly)
+        #expect(display.remainingPercent == 60)
+        #expect(display.currentRemainingPercent(now: observed) == 60)
+        #expect(display.status(now: observed) == .live)
+    }
+
     // MARK: both providers at once
 
     private func codexState(usedWeekly: Int) -> AccountUsageState {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
@@ -148,9 +148,24 @@ struct SessionStoreTests {
         #expect(after.observationDiagnostics?.health(agent: .codex, source: .rollout) == .healthy)
         #expect(after.observationDiagnostics?.lastObserved(agent: .codex, source: .rollout) == observedAt)
     }
+
+    @Test("wire gate omits cursor from Snapshot while peer vocab remains")
+    func omitsCursorFromWireSnapshot() async {
+        let store = SessionStore(sourceID: "test")
+        await store.setProviderQuota([
+            ProviderQuota(provider: .codex, weeklyRemainingPercent: 70),
+            ProviderQuota(provider: .claude, weeklyRemainingPercent: 40),
+            ProviderQuota(provider: .grok, weeklyRemainingPercent: 55),
+            ProviderQuota(provider: .cursor, weeklyRemainingPercent: 60),
+        ])
+        let snap = await store.snapshot(now: Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(snap.providerQuota?.map(\.provider) == [.codex, .claude, .grok])
+        #expect(snap.providerQuota?.contains { $0.provider == .cursor } != true)
+    }
 }
 
 private extension Array where Element == AgentObservationDiagnostic {
+
     func health(agent: AgentKind, source: ObservationSource) -> ObservationHealth? {
         first(where: { $0.agent == agent })?.sources
             .first(where: { $0.source == source })?.health

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -109,9 +109,10 @@ struct AccountUsageSummaryView: View {
 struct AccountUsageSettings: View {
     @ObservedObject var model: MenuBarModel
     @AppStorage("accountUsageAlertThreshold") private var alertThreshold = 90
-    @State private var cursorCookie: String = CursorSessionCookieStore.load() ?? ""
+    @State private var cursorCookie: String = CursorSessionCookieStore.loadManual() ?? ""
     @State private var cursorCookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode()
     @State private var cursorImportMessage: String?
+    @FocusState private var cursorCookieFocused: Bool
 
     var body: some View {
         Form {
@@ -144,15 +145,19 @@ struct AccountUsageSettings: View {
                 if cursorCookieMode == .manual {
                     SecureField("Cookie header from cursor.com", text: $cursorCookie)
                         .textFieldStyle(.roundedBorder)
-                        .onChange(of: cursorCookie) { _, value in
-                            CursorSessionCookieStore.save(value)
+                        .focused($cursorCookieFocused)
+                        .onSubmit { CursorSessionCookieStore.saveManual(cursorCookie) }
+                        .onChange(of: cursorCookieFocused) { _, focused in
+                            if !focused {
+                                CursorSessionCookieStore.saveManual(cursorCookie)
+                            }
                         }
                     Button("Paste Cookie") {
                         guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
                         let trimmed = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
                         guard !trimmed.isEmpty else { return }
                         cursorCookie = trimmed
-                        CursorSessionCookieStore.save(trimmed)
+                        CursorSessionCookieStore.saveManual(trimmed)
                     }
                     .accessibilityIdentifier("paste-cursorCookie")
                 } else {
@@ -161,8 +166,7 @@ struct AccountUsageSettings: View {
                         do {
                             let header = try CursorBrowserCookieImporter()
                                 .importSessionCookieHeader(allowKeychainPrompt: true)
-                            CursorSessionCookieStore.save(header)
-                            cursorCookie = header
+                            _ = CursorSessionCookieStore.saveImportedIfChanged(header)
                             cursorImportMessage = "Imported a Cursor session cookie from the browser."
                         } catch {
                             cursorImportMessage = "No usable Cursor session found in the browser. Paste a Cookie header, or sign in at cursor.com and try again."
@@ -174,16 +178,20 @@ struct AccountUsageSettings: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    SecureField("Last imported / fallback Cookie", text: $cursorCookie)
+                    SecureField("Manual fallback Cookie", text: $cursorCookie)
                         .textFieldStyle(.roundedBorder)
-                        .onChange(of: cursorCookie) { _, value in
-                            CursorSessionCookieStore.save(value)
+                        .focused($cursorCookieFocused)
+                        .onSubmit { CursorSessionCookieStore.saveManual(cursorCookie) }
+                        .onChange(of: cursorCookieFocused) { _, focused in
+                            if !focused {
+                                CursorSessionCookieStore.saveManual(cursorCookie)
+                            }
                         }
                 }
             } header: {
                 Text("Cursor session")
             } footer: {
-                Text("Paste mode stores the Cookie header in the Keychain. Browser import reads Safari/Chrome/Firefox cookies for cursor.com (may prompt for Keychain or Full Disk Access); refresh uses a non-interactive import and falls back to the saved Cookie.")
+                Text("Paste mode stores the Cookie in a Keychain slot separate from browser import. Browser import reads Safari/Chrome/Firefox cookies for cursor.com (may prompt for Keychain or Full Disk Access); refresh writes the imported slot only when the value changes and falls back to the manual Cookie.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -83,6 +83,7 @@ struct AccountUsageSummaryView: View {
     }
 
     private func windowTitle(_ window: AccountUsageWindow) -> String {
+        if let label = window.label { return label }
         guard let minutes = window.windowDurationMinutes else {
             return window.kind == .primary ? "Primary window" : "Secondary window"
         }
@@ -109,9 +110,10 @@ struct AccountUsageSummaryView: View {
 struct AccountUsageSettings: View {
     @ObservedObject var model: MenuBarModel
     @AppStorage("accountUsageAlertThreshold") private var alertThreshold = 90
-    @State private var cursorCookie: String = CursorSessionCookieStore.load() ?? ""
+    @State private var cursorCookie: String = CursorSessionCookieStore.loadManual() ?? ""
     @State private var cursorCookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode()
     @State private var cursorImportMessage: String?
+    @FocusState private var cursorCookieFocused: Bool
 
     var body: some View {
         Form {
@@ -125,7 +127,7 @@ struct AccountUsageSettings: View {
             } header: {
                 Text("Providers")
             } footer: {
-                Text("Codex reads its official local app-server. Claude runs the official read-only /usage command without session persistence or hooks. Grok asks its own agent process for the billing summary and falls back to the CLI billing proxy with the local login token when needed. Cursor uses a session Cookie you paste from cursor.com (Keychain only). No account IDs or raw responses are logged. Turning a source off leaves session monitoring and notifications running.")
+                Text("Codex reads its official local app-server. Claude runs the official read-only /usage command without session persistence or hooks. Grok asks its own agent process for the billing summary and falls back to the CLI billing proxy with the local login token when needed. Cursor reads its selected local app login or browser/manual Cookie. Local app credentials are never copied to storage. No account IDs or raw responses are logged. Turning a source off leaves session monitoring and notifications running.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -141,32 +143,43 @@ struct AccountUsageSettings: View {
                     CursorCookieSourceSettings.setMode(mode)
                 }
 
-                if cursorCookieMode == .manual {
+                if cursorCookieMode == .cursorApp {
+                    Text("Uses the account signed in to Cursor on this Mac. If the session expires, sign in again in Cursor and refresh.").font(.caption)
+                } else if cursorCookieMode == .manual {
                     SecureField("Cookie header from cursor.com", text: $cursorCookie)
                         .textFieldStyle(.roundedBorder)
-                        .onChange(of: cursorCookie) { _, value in
-                            CursorSessionCookieStore.save(value)
+                        .focused($cursorCookieFocused)
+                        .onSubmit { CursorSessionCookieStore.saveManual(cursorCookie) }
+                        .onChange(of: cursorCookieFocused) { _, focused in
+                            if !focused {
+                                CursorSessionCookieStore.saveManual(cursorCookie)
+                            }
                         }
                     Button("Paste Cookie") {
                         guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
                         let trimmed = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
                         guard !trimmed.isEmpty else { return }
                         cursorCookie = trimmed
-                        CursorSessionCookieStore.save(trimmed)
+                        CursorSessionCookieStore.saveManual(trimmed)
                     }
                     .accessibilityIdentifier("paste-cursorCookie")
                 } else {
                     Button("Import Cookie from browser now") {
                         cursorImportMessage = nil
+                        Task {
                         do {
-                            let header = try CursorBrowserCookieImporter()
-                                .importSessionCookieHeader(allowKeychainPrompt: true)
-                            CursorSessionCookieStore.save(header)
-                            cursorCookie = header
+                            let header = try await Task.detached(priority: .utility) {
+                                try CursorBrowserCookieImporter().importSessionCookieHeader(allowKeychainPrompt: true)
+                            }.value
+                            if let status = CursorSessionCookieStore.saveImportedIfChanged(header), status != 0 {
+                                cursorImportMessage = "Could not save the imported session (Keychain error \(status))."
+                                return
+                            }
                             cursorImportMessage = "Imported a Cursor session cookie from the browser."
                         } catch {
                             cursorImportMessage = "No usable Cursor session found in the browser. Paste a Cookie header, or sign in at cursor.com and try again."
                         }
+                    }
                     }
                     .accessibilityIdentifier("import-cursorCookie")
                     if let cursorImportMessage {
@@ -174,16 +187,20 @@ struct AccountUsageSettings: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    SecureField("Last imported / fallback Cookie", text: $cursorCookie)
+                    SecureField("Manual fallback Cookie", text: $cursorCookie)
                         .textFieldStyle(.roundedBorder)
-                        .onChange(of: cursorCookie) { _, value in
-                            CursorSessionCookieStore.save(value)
+                        .focused($cursorCookieFocused)
+                        .onSubmit { CursorSessionCookieStore.saveManual(cursorCookie) }
+                        .onChange(of: cursorCookieFocused) { _, focused in
+                            if !focused {
+                                CursorSessionCookieStore.saveManual(cursorCookie)
+                            }
                         }
                 }
             } header: {
                 Text("Cursor session")
             } footer: {
-                Text("Paste mode stores the Cookie header in the Keychain. Browser import reads Safari/Chrome/Firefox cookies for cursor.com (may prompt for Keychain or Full Disk Access); refresh uses a non-interactive import and falls back to the saved Cookie.")
+                Text("Paste mode stores the Cookie in a Keychain slot separate from browser import. Browser import reads Safari/Chrome/Firefox cookies for cursor.com (may prompt for Keychain or Full Disk Access); refresh writes the imported slot only when the value changes and falls back to the manual Cookie.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
## Summary
Cursor quota collection now offers an explicit Cursor app login source: it reads the existing local session read-only, rejects expired sessions, and does not copy or refresh its token. Cursor Models and Other Models are shown as separate included-usage pools when supplied by usage-summary; on-demand spending is not substituted for the second pool.

This PR integrates #115, #116 and the corrected #117. Browser-import timeout returns without waiting for blocked I/O, late results do not persist, manual fallback does not overwrite the imported slot, Keychain writes preserve existing values on failure, and domain matching requires a dot boundary. The Mac wire gate remains in place for shipped phone clients.

## Validation
- 60 targeted Mac tests passed, including local-session database reading, expiration and independent pools.
- 28 Kit tests passed, including unknown-provider wire decoding and cached monthly fallback.
- Mac Release and Watch simulator builds passed.
- Stable-signed Mac installation passed health checks; Settings with Cursor app login displayed both live Ultra pools. Watch Cursor transport remains gated.

## Source basis
- https://cursor.com/help/models-and-usage/usage-limits
- https://cursor.com/docs/account/teams/admin-api
- https://github.com/steipete/CodexBar/blob/main/Sources/CodexBarCore/Providers/Cursor/CursorAppAuth.swift
- https://github.com/steipete/CodexBar/blob/main/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift

Fixes #114
