### PR TITLE
fix(quota): recover Grok usage and prepare macOS 1.3.1

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
@@ -38,6 +38,16 @@ public struct AccountUsageSnapshot: Codable, Equatable, Sendable {
     public var lifetimeTokens: Int?
     public var latestDailyTokens: Int?
     public var fetchedAt: Date
+    /// Billing metadata remains available when the provider withholds usage.
+    public var periodStart: Date?
+    public var periodEnd: Date?
+    /// Set when the sample itself came from a provider's local cache/log.
+    public var isCached: Bool?
+
+    /// Extra Grok spend is not the shared subscription allowance.
+    public var quotaWindows: [AccountUsageWindow] {
+        provider == .grok ? [primary].compactMap { $0 } : windows
+    }
 
     public var windows: [AccountUsageWindow] {
         [primary, secondary].compactMap { $0 }
@@ -50,7 +60,9 @@ public struct AccountUsageSnapshot: Codable, Equatable, Sendable {
         secondary: AccountUsageWindow?,
         lifetimeTokens: Int?,
         latestDailyTokens: Int?,
-        fetchedAt: Date
+        fetchedAt: Date,
+        periodStart: Date? = nil,
+        periodEnd: Date? = nil
     ) {
         self.provider = provider
         self.planType = planType
@@ -58,7 +70,18 @@ public struct AccountUsageSnapshot: Codable, Equatable, Sendable {
         self.secondary = secondary
         self.lifetimeTokens = lifetimeTokens
         self.latestDailyTokens = latestDailyTokens
+        self.periodStart = periodStart
+        self.periodEnd = periodEnd
         self.fetchedAt = fetchedAt
+    }
+
+    /// Grok's last period is not a reading of its new allowance.
+    public func excludingExpiredGrokWindows(at now: Date) -> Self {
+        guard provider == .grok else { return self }
+        var result = self
+        if let end = primary?.resetsAt, end <= now { result.primary = nil }
+        if let end = secondary?.resetsAt, end <= now { result.secondary = nil }
+        return result
     }
 
 }
@@ -151,8 +174,9 @@ public struct AccountUsageState: Equatable, Sendable {
         AccountUsageState(
             collectionEnabled: true,
             snapshot: snapshot,
-            isStale: false,
-            unavailableReason: nil,
+            isStale: snapshot.isCached == true,
+            unavailableReason: snapshot.provider == .grok && snapshot.primary == nil
+                ? .unknown : (snapshot.isCached == true ? .cachedData : nil),
             lastAttemptAt: snapshot.fetchedAt,
             nextRefreshAt: nextRefreshAt
         )
@@ -395,7 +419,7 @@ public actor AccountUsageCollector {
         let cached = await cache.load()
         guard isEnabled, generation == currentGeneration else { return state }
         if let snapshot = cached {
-            state = .stale(snapshot, reason: .cachedData, lastAttemptAt: nil, nextRefreshAt: now)
+            state = .stale(snapshot.excludingExpiredGrokWindows(at: now), reason: .cachedData, lastAttemptAt: nil, nextRefreshAt: now)
         } else {
             state = .unavailable(.notYetLoaded, lastAttemptAt: nil, nextRefreshAt: now)
         }
@@ -413,7 +437,7 @@ public actor AccountUsageCollector {
         let cachePermit = cacheCommitGate.permit(generation: currentGeneration)
 
         do {
-            let snapshot = try await provider.fetch()
+            let snapshot = try await provider.fetch().excludingExpiredGrokWindows(at: now)
             guard isEnabled, generation == currentGeneration else { return state }
             failureCount = 0
             state = .available(snapshot, nextRefreshAt: now.addingTimeInterval(refreshInterval))
@@ -431,7 +455,7 @@ public actor AccountUsageCollector {
             let delay = min(baseBackoff * pow(2, Double(exponent)), maxBackoff)
             let retryAt = now.addingTimeInterval(delay)
             if let lastKnownGood = state.snapshot {
-                state = .stale(lastKnownGood, reason: reason, lastAttemptAt: now, nextRefreshAt: retryAt)
+                state = .stale(lastKnownGood.excludingExpiredGrokWindows(at: now), reason: reason, lastAttemptAt: now, nextRefreshAt: retryAt)
             } else {
                 state = .unavailable(reason, lastAttemptAt: now, nextRefreshAt: retryAt)
             }
@@ -495,7 +519,7 @@ public struct AccountUsageAlertMonitor: Sendable {
         guard thresholdPercent > 0 else { return [] }
         guard state.collectionEnabled, !state.isStale, let snapshot = state.snapshot else { return [] }
 
-        let currentKeys = Dictionary(uniqueKeysWithValues: snapshot.windows.map {
+        let currentKeys = Dictionary(uniqueKeysWithValues: snapshot.quotaWindows.map {
             ($0.kind, Self.key(provider: snapshot.provider, window: $0))
         })
         for (kind, currentKey) in currentKeys {
@@ -510,7 +534,7 @@ public struct AccountUsageAlertMonitor: Sendable {
 
         if !didObserveFreshSnapshot {
             didObserveFreshSnapshot = true
-            for window in snapshot.windows {
+            for window in snapshot.quotaWindows {
                 let key = Self.key(provider: snapshot.provider, window: window)
                 observedWindowKeys.insert(key)
                 if window.usedPercent >= thresholdPercent {
@@ -521,7 +545,7 @@ public struct AccountUsageAlertMonitor: Sendable {
         }
 
         var alerts: [AccountUsageWindow] = []
-        for window in snapshot.windows {
+        for window in snapshot.quotaWindows {
             let key = Self.key(provider: snapshot.provider, window: window)
             guard observedWindowKeys.contains(key) else {
                 observedWindowKeys.insert(key)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokCreditsProxy.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokCreditsProxy.swift
@@ -20,6 +20,16 @@ extension URLSession: GrokCreditsProxyTransport {
 /// CodexBar documents (MIT). Reimplemented against the public HTTP shape; we do
 /// not vendor CodexBar's UI stack.
 public enum GrokCreditsProxyClient {
+    /// Bound the whole transfer, not just idle time between response bytes.
+    public static let session: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 6
+        configuration.timeoutIntervalForResource = 6
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieStorage = nil
+        return URLSession(configuration: configuration)
+    }()
+
     public static let defaultEndpoint = URL(
         string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
     )!
@@ -33,6 +43,8 @@ public enum GrokCreditsProxyClient {
     ) async throws -> Data {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
+        request.httpShouldHandleCookies = false
+        request.cachePolicy = .reloadIgnoringLocalCacheData
         request.timeoutInterval = timeout
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("xai-grok-cli", forHTTPHeaderField: "x-xai-token-auth")

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
@@ -47,11 +47,13 @@ public enum GrokUsageResponseDecoder {
               let timestamp = parseTimestamp(record.ts) else {
             throw AccountUsageError.incompatibleFormat
         }
-        return try snapshot(
+        var reading = try snapshot(
             config: context.config,
             tier: context.subscriptionTier,
             fetchedAt: timestamp
         )
+        reading.isCached = true
+        return reading
     }
 
     /// Returns the newest credits record in the tail of a unified log, or nil
@@ -75,8 +77,8 @@ public enum GrokUsageResponseDecoder {
     }
 
     /// Decodes `GET …/v1/billing?format=credits` (CodexBar CLI-proxy shape).
-    /// Primary comes from `creditUsagePercent` when present; otherwise from a
-    /// positive on-demand cap/used pair. Period-only answers are not usable.
+    /// Included usage and extra usage remain separate. A complete billing
+    /// period without included usage is a valid unknown reading.
     public static func decode(proxyCreditsResponse: Data, fetchedAt: Date) throws -> AccountUsageSnapshot {
         let envelope: ProxyCreditsEnvelopeDTO
         do {
@@ -84,35 +86,9 @@ public enum GrokUsageResponseDecoder {
         } catch {
             throw AccountUsageError.incompatibleFormat
         }
-        let config = envelope.config
-        let tier = config?.subscriptionTier ?? envelope.subscriptionTier
-        if config?.creditPercent != nil {
-            return try snapshot(config: config, tier: tier, fetchedAt: fetchedAt)
-        }
-        // On-demand-only proxy answers still fill the single Grok primary window.
-        guard let config,
-              let cap = config.onDemandCap?.val, cap > 0 else {
-            throw AccountUsageError.incompatibleFormat
-        }
-        let used = config.onDemandUsedValue ?? 0
-        let percent = min(100, max(0, used / cap * 100))
-        guard percent.isFinite else { throw AccountUsageError.incompatibleFormat }
-        let start = parseTimestamp(config.periodStart)
-        let resetsAt = parseTimestamp(config.periodEnd)
-        return AccountUsageSnapshot(
-            provider: .grok,
-            planType: tier.flatMap { $0.isEmpty ? nil : $0 },
-            primary: AccountUsageWindow(
-                kind: .primary,
-                usedPercent: Int(percent.rounded()),
-                windowDurationMinutes: duration(from: start, to: resetsAt),
-                resetsAt: resetsAt
-            ),
-            secondary: nil,
-            lifetimeTokens: nil,
-            latestDailyTokens: nil,
-            fetchedAt: fetchedAt
-        )
+        return try snapshot(config: envelope.config,
+                            tier: envelope.config?.subscriptionTier ?? envelope.subscriptionTier,
+                            fetchedAt: fetchedAt)
     }
 
     private static func snapshot(
@@ -125,16 +101,19 @@ public enum GrokUsageResponseDecoder {
         let resetsAt = parseTimestamp(config.periodEnd)
         let durationMinutes = duration(from: start, to: resetsAt)
 
-        guard let creditPercent = config.creditPercent else {
-            throw AccountUsageError.incompatibleFormat
-        }
-        guard creditPercent.isFinite, (0...100).contains(creditPercent) else {
-            throw AccountUsageError.incompatibleFormat
+        let creditPercent = config.creditPercent
+        if let creditPercent {
+            guard creditPercent.isFinite, (0...100).contains(creditPercent) else {
+                throw AccountUsageError.incompatibleFormat
+            }
+        } else {
+            guard let start, let resetsAt, start < resetsAt else {
+                throw AccountUsageError.incompatibleFormat
+            }
         }
 
         var onDemand: AccountUsageWindow?
-        if let cap = config.onDemandCap?.val, cap > 0 {
-            let used = config.onDemandUsedValue ?? 0
+        if let cap = config.onDemandCap?.val, cap > 0, let used = config.onDemandUsedValue {
             let percent = min(100, max(0, used / cap * 100))
             guard percent.isFinite else { throw AccountUsageError.incompatibleFormat }
             onDemand = AccountUsageWindow(
@@ -148,16 +127,18 @@ public enum GrokUsageResponseDecoder {
         return AccountUsageSnapshot(
             provider: .grok,
             planType: tier.flatMap { $0.isEmpty ? nil : $0 },
-            primary: AccountUsageWindow(
+            primary: creditPercent.map { AccountUsageWindow(
                 kind: .primary,
-                usedPercent: Int(creditPercent.rounded()),
+                usedPercent: Int($0.rounded()),
                 windowDurationMinutes: durationMinutes,
                 resetsAt: resetsAt
-            ),
+            ) },
             secondary: onDemand,
             lifetimeTokens: nil,
             latestDailyTokens: nil,
-            fetchedAt: fetchedAt
+            fetchedAt: fetchedAt,
+            periodStart: start,
+            periodEnd: resetsAt
         )
     }
 
@@ -314,6 +295,7 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
     private let proxyEndpoint: URL
     private let proxyTransport: GrokCreditsProxyTransport
     private let proxyEnabled: Bool
+    private let now: @Sendable () -> Date
 
     public init(
         executableURL: URL? = nil,
@@ -322,8 +304,9 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
         logURL: URL? = nil,
         authFileURL: URL? = nil,
         proxyEndpoint: URL = GrokCreditsProxyClient.defaultEndpoint,
-        proxyTransport: GrokCreditsProxyTransport = URLSession.shared,
-        proxyEnabled: Bool = true
+        proxyTransport: GrokCreditsProxyTransport = GrokCreditsProxyClient.session,
+        proxyEnabled: Bool = true,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.executableURL = executableURL ?? Self.resolveGrokExecutable()
         self.arguments = arguments
@@ -333,10 +316,12 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
         self.proxyEndpoint = proxyEndpoint
         self.proxyTransport = proxyTransport
         self.proxyEnabled = proxyEnabled
+        self.now = now
     }
 
     public func fetch() async throws -> AccountUsageSnapshot {
         try Task.checkCancellation()
+        let token = proxyEnabled ? GrokCLIAuthToken.loadAccessToken(from: authFileURL) : nil
         let client = GrokACPClient()
         let executableURL = executableURL
         let arguments = arguments
@@ -359,10 +344,11 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
                     }
                 }
                 try Task.checkCancellation()
-                return try GrokUsageResponseDecoder.decode(
-                    billingResponse: response,
-                    fetchedAt: Date()
-                )
+                let snapshot = try GrokUsageResponseDecoder.decode(billingResponse: response, fetchedAt: now())
+                // ACP owns authentication. Never merge if it refreshed/switched the
+                // captured credential during this request.
+                guard proxyEnabled, token == GrokCLIAuthToken.loadAccessToken(from: authFileURL) else { return snapshot }
+                return try await recoverUnknown(snapshot, token: token)
             } catch {
                 try Task.checkCancellation()
                 guard Self.allowsLogFallback(after: error) else { throw error }
@@ -372,12 +358,13 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
                 ) {
                     return snapshot
                 }
-                if proxyEnabled, let snapshot = await Self.fetchProxyFallback(
-                    authFileURL: authFileURL,
+                if proxyEnabled, let snapshot = try await Self.fetchProxyFallback(
+                    token: token,
                     endpoint: proxyEndpoint,
-                    transport: proxyTransport
+                    transport: proxyTransport,
+                    now: now()
                 ) {
-                    return snapshot
+                    return try await recoverUnknown(snapshot, token: token)
                 }
                 throw error
             }
@@ -386,15 +373,35 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
         }
     }
 
+    private func recoverUnknown(_ snapshot: AccountUsageSnapshot, token: String?) async throws -> AccountUsageSnapshot {
+        guard snapshot.primary == nil, let token else { return snapshot }
+        do {
+            let reading = try await GrokWebCredits.fetch(token: token, transport: proxyTransport, now: now())
+            guard let start = snapshot.periodStart, let end = snapshot.periodEnd,
+                  abs(start.timeIntervalSince(reading.start)) < 1,
+                  abs(end.timeIntervalSince(reading.end)) < 1 else { return snapshot }
+            var recovered = snapshot
+            recovered.primary = AccountUsageWindow(kind: .primary,
+                usedPercent: Int(reading.percent.rounded()),
+                windowDurationMinutes: Int((end.timeIntervalSince(start) / 60).rounded()), resetsAt: end)
+            return recovered
+        } catch {
+            try Task.checkCancellation()
+            if error is CancellationError { throw error }
+            if let urlError = error as? URLError, urlError.code == .cancelled { throw error }
+            return snapshot
+        }
+    }
+
     /// Best-effort proxy: never upgrades a hard auth/format failure from ACP, and
     /// never invents a reading when the bearer is missing.
     static func fetchProxyFallback(
-        authFileURL: URL,
+        token: String?,
         endpoint: URL,
         transport: GrokCreditsProxyTransport,
         now: Date = Date()
-    ) async -> AccountUsageSnapshot? {
-        guard let token = GrokCLIAuthToken.loadAccessToken(from: authFileURL, now: now) else {
+    ) async throws -> AccountUsageSnapshot? {
+        guard let token else {
             return nil
         }
         do {
@@ -403,8 +410,11 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
                 endpoint: endpoint,
                 transport: transport
             )
+            try Task.checkCancellation()
             return try GrokUsageResponseDecoder.decode(proxyCreditsResponse: data, fetchedAt: now)
         } catch {
+            try Task.checkCancellation()
+            if error is CancellationError || (error as? URLError)?.code == .cancelled { throw error }
             return nil
         }
     }
@@ -415,6 +425,7 @@ public final class GrokUsageProvider: AccountUsageProviding, Sendable {
     static func allowsLogFallback(after error: any Error) -> Bool {
         switch error {
         case is CancellationError: return false
+        case let url as URLError where url.code == .cancelled: return false
         case let usage as AccountUsageError:
             switch usage {
             case .providerUnavailable, .timedOut, .offline, .unknown: return true

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokWebCredits.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokWebCredits.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+/// The narrow billing schema published by grok.com's web client. No cookie import.
+/// Descriptor: cdn.grok.com/_next/static/chunks/32g78bk5hhe1q.js (2026-09-07).
+public enum GrokWebCredits {
+    public static let endpoint = URL(string: "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig")!
+
+    public struct Reading: Sendable {
+        public let percent: Double
+        public let start: Date
+        public let end: Date
+        public let isImplicitZero: Bool
+    }
+
+    static func fetch(token: String, transport: GrokCreditsProxyTransport, now: Date) async throws -> Reading {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.httpShouldHandleCookies = false
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.httpBody = Data(repeating: 0, count: 5)
+        request.timeoutInterval = 6
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("https://grok.com", forHTTPHeaderField: "Origin")
+        request.setValue("https://grok.com/?_s=usage", forHTTPHeaderField: "Referer")
+        request.setValue("application/grpc-web+proto", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "x-grpc-web")
+        request.setValue("connect-es/2.1.1", forHTTPHeaderField: "x-user-agent")
+        request.setValue("VibeBuddy", forHTTPHeaderField: "User-Agent")
+        let (data, response) = try await transport.proxyData(for: request)
+        try Task.checkCancellation()
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw AccountUsageError.providerUnavailable
+        }
+        if let status = http.value(forHTTPHeaderField: "grpc-status"), status != "0" {
+            throw AccountUsageError.providerUnavailable
+        }
+        return try decode(data, now: now)
+    }
+
+    /// Requires a complete current period even for a published percentage, so
+    /// historical values cannot be attached to a newer ACP billing period.
+    public static func decode(_ data: Data, now: Date) throws -> Reading {
+        guard !data.isEmpty, data.count <= 1_048_576 else { throw AccountUsageError.incompatibleFormat }
+        var payload = data
+        if data.first == 0 || data.first == 0x80 {
+            var cursor = Cursor(data)
+            var message: Data?
+            var trailersSeen = false
+            while !cursor.atEnd {
+                let flags = try cursor.byte()
+                let lengthBytes = try cursor.bytes(4)
+                let length = lengthBytes.reduce(0) { ($0 << 8) | Int($1) }
+                let body = try cursor.bytes(length)
+                if flags == 0, message == nil, !trailersSeen { message = body }
+                else if flags == 0x80, !trailersSeen {
+                    trailersSeen = true
+                    guard let text = String(data: body, encoding: .utf8) else { throw AccountUsageError.incompatibleFormat }
+                    let statuses = text.components(separatedBy: "\r\n").filter { $0.lowercased().hasPrefix("grpc-status:") }
+                    guard statuses.count == 1,
+                          statuses[0].split(separator: ":", maxSplits: 1).last?.trimmingCharacters(in: .whitespaces) == "0" else {
+                        throw AccountUsageError.providerUnavailable
+                    }
+                } else { throw AccountUsageError.incompatibleFormat }
+            }
+            guard let message, trailersSeen else { throw AccountUsageError.incompatibleFormat }
+            payload = message
+        }
+        let response = try Message(payload)
+        let config = try Message(response.requiredBytes(1))
+        try config.validate(.config)
+        let period = try Message(config.requiredBytes(8))
+        let type = try period.integer(1)
+        guard type == 1 || type == 2 else { throw AccountUsageError.incompatibleFormat }
+        let start = try timestamp(period.requiredBytes(2))
+        let end = try timestamp(period.requiredBytes(3))
+        guard start <= now, now < end else { throw AccountUsageError.incompatibleFormat }
+        let percent = try config.float(1)
+        // A product breakdown without its total does not establish zero.
+        guard percent != nil || config.fields[7] == nil else { throw AccountUsageError.incompatibleFormat }
+        guard percent.map({ $0.isFinite && (0...100).contains($0) }) ?? true else {
+            throw AccountUsageError.incompatibleFormat
+        }
+        // proto3 implicit scalar presence: default zero is omitted. Only this
+        // validated active-period protobuf contract supplies an implicit zero.
+        return Reading(percent: percent ?? 0, start: start, end: end, isImplicitZero: percent == nil)
+    }
+
+    private static func timestamp(_ data: Data) throws -> Date {
+        let message = try Message(data)
+        guard let seconds = try message.integer(1), seconds <= 253_402_300_799 else {
+            throw AccountUsageError.incompatibleFormat
+        }
+        let nanos = try message.integer(2) ?? 0
+        guard nanos < 1_000_000_000 else { throw AccountUsageError.incompatibleFormat }
+        return Date(timeIntervalSince1970: Double(seconds) + Double(nanos) / 1e9)
+    }
+
+    private enum Schema { case config, period, timestamp, cent, history, product, cycle }
+
+    private enum Value {
+        case integer(UInt64), bytes(Data), float(Double), fixed64
+    }
+
+    /// Unknown fields are skipped as opaque wire values, never scanned for a
+    /// percentage. Duplicate queried singular fields and wrong wire types fail.
+    private struct Message {
+        var fields: [UInt64: [Value]] = [:]
+        init(_ data: Data) throws {
+            var cursor = Cursor(data)
+            while !cursor.atEnd {
+                let tag = try cursor.varint()
+                let field = tag >> 3
+                guard field > 0, field <= 536_870_911 else { throw AccountUsageError.incompatibleFormat }
+                let value: Value
+                switch tag & 7 {
+                case 0: value = .integer(try cursor.varint())
+                case 1: _ = try cursor.bytes(8); value = .fixed64
+                case 2:
+                    let count = try cursor.varint()
+                    guard count <= UInt64(data.count) else { throw AccountUsageError.incompatibleFormat }
+                    value = .bytes(try cursor.bytes(Int(count)))
+                case 5:
+                    let bytes = try cursor.bytes(4)
+                    let bits = bytes.enumerated().reduce(UInt32(0)) { $0 | (UInt32($1.element) << ($1.offset * 8)) }
+                    value = .float(Double(Float(bitPattern: bits)))
+                default: throw AccountUsageError.incompatibleFormat
+                }
+                fields[field, default: []].append(value)
+            }
+        }
+        func validate(_ schema: Schema) throws {
+            let children: [UInt64: Schema]
+            let integers: Set<UInt64>
+            let floats: Set<UInt64>
+            let repeated: Set<UInt64>
+            switch schema {
+            case .config:
+                children = [2: .cent, 3: .cent, 4: .timestamp, 5: .timestamp,
+                            6: .history, 7: .product, 8: .period, 12: .cent]
+                integers = [11, 13]; floats = [1]; repeated = [6, 7]
+            case .period:
+                children = [2: .timestamp, 3: .timestamp]; integers = [1]; floats = []; repeated = []
+            case .history:
+                children = [1: .cycle, 2: .cent, 3: .period]; integers = []; floats = []; repeated = []
+            case .product:
+                children = [:]; integers = [1]; floats = [2]; repeated = []
+            case .cent:
+                children = [:]; integers = [1]; floats = []; repeated = []
+            case .timestamp, .cycle:
+                children = [:]; integers = [1, 2]; floats = []; repeated = []
+            }
+            for (field, values) in fields {
+                let known = children[field] != nil || integers.contains(field) || floats.contains(field)
+                guard !known || repeated.contains(field) || values.count == 1 else {
+                    throw AccountUsageError.incompatibleFormat
+                }
+                for value in values {
+                    if let child = children[field] {
+                        guard case let .bytes(data) = value else { throw AccountUsageError.incompatibleFormat }
+                        try Message(data).validate(child)
+                    } else if integers.contains(field) {
+                        guard case .integer = value else { throw AccountUsageError.incompatibleFormat }
+                    } else if floats.contains(field) {
+                        guard case .float = value else { throw AccountUsageError.incompatibleFormat }
+                    }
+                }
+            }
+        }
+        func single(_ field: UInt64) throws -> Value? {
+            guard let values = fields[field] else { return nil }
+            guard values.count == 1 else { throw AccountUsageError.incompatibleFormat }
+            return values[0]
+        }
+        func requiredBytes(_ field: UInt64) throws -> Data {
+            guard case let .bytes(data) = try single(field) else { throw AccountUsageError.incompatibleFormat }
+            return data
+        }
+        func integer(_ field: UInt64) throws -> UInt64? {
+            guard let value = try single(field) else { return nil }
+            guard case let .integer(number) = value else { throw AccountUsageError.incompatibleFormat }
+            return number
+        }
+        func float(_ field: UInt64) throws -> Double? {
+            guard let value = try single(field) else { return nil }
+            guard case let .float(number) = value else { throw AccountUsageError.incompatibleFormat }
+            return number
+        }
+    }
+
+    private struct Cursor {
+        let data: [UInt8]
+        var index = 0
+        init(_ data: Data) { self.data = Array(data) }
+        var atEnd: Bool { index == data.count }
+        mutating func byte() throws -> UInt8 {
+            guard index < data.count else { throw AccountUsageError.incompatibleFormat }
+            defer { index += 1 }
+            return data[index]
+        }
+        mutating func bytes(_ count: Int) throws -> Data {
+            guard count >= 0, count <= data.count - index else { throw AccountUsageError.incompatibleFormat }
+            defer { index += count }
+            return Data(data[index..<index + count])
+        }
+        mutating func varint() throws -> UInt64 {
+            var value: UInt64 = 0
+            for offset in 0..<10 {
+                let next = try byte()
+                guard offset < 9 || next <= 1 else { throw AccountUsageError.incompatibleFormat }
+                value |= UInt64(next & 0x7f) << (offset * 7)
+                if next & 0x80 == 0 { return value }
+            }
+            throw AccountUsageError.incompatibleFormat
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ProviderQuotaProjection.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ProviderQuotaProjection.swift
@@ -26,17 +26,17 @@ public extension ProviderQuota {
             self = .unavailable(provider, reason: AccountUsageUnavailableReason.collectionDisabled.displayText(provider: provider))
             return
         }
-        guard let snapshot = state.snapshot else {
+        guard let snapshot = state.snapshot?.excludingExpiredGrokWindows(at: Date()) else {
             self = .unavailable(provider,
                 reason: (state.unavailableReason ?? .notYetLoaded).displayText(provider: provider))
             return
         }
-        let weekly = snapshot.windows.first { $0.windowDurationMinutes == 10080 }
-        let short = snapshot.windows.filter {
+        let weekly = snapshot.quotaWindows.first { $0.windowDurationMinutes == 10080 }
+        let short = snapshot.quotaWindows.filter {
             guard let minutes = $0.windowDurationMinutes else { return false }
             return minutes > 0 && minutes < 1440
         }.max { ($0.windowDurationMinutes ?? 0) < ($1.windowDurationMinutes ?? 0) }
-        let others = snapshot.windows.filter {
+        let others = snapshot.quotaWindows.filter {
             guard let minutes = $0.windowDurationMinutes else { return true }
             return minutes != 10080 && !(minutes > 0 && minutes < 1440)
         }.map {
@@ -55,7 +55,7 @@ public extension ProviderQuota {
                   otherWindows: others.isEmpty ? nil : others,
                   observedAt: usable ? snapshot.fetchedAt : nil,
                   unavailableReason: state.unavailableReason?.displayText(provider: provider)
-                    ?? (usable ? nil : AccountUsageUnavailableReason.incompatibleFormat.displayText(provider: provider)),
+                    ?? (usable ? nil : (provider == .grok ? AccountUsageUnavailableReason.unknown : .incompatibleFormat).displayText(provider: provider)),
                   isCached: state.isStale)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -268,6 +268,20 @@ struct AccountUsageTests {
         #expect(quota.shortWindowRemainingPercent == nil)
     }
 
+    @Test("expired Grok cache never becomes the current weekly quota after restart")
+    func expiredGrokCache() async {
+        var old = sampleSnapshot(percent: 53)
+        old.provider = .grok
+        old.primary?.resetsAt = now.addingTimeInterval(-60)
+        let collector = AccountUsageCollector(provider: ScriptedUsageProvider([.failure(.offline)]),
+            cache: MemoryUsageCache(old), enabled: true)
+        let boot = await collector.bootstrap(now: now)
+        #expect(boot.snapshot?.primary == nil)
+        let failed = await collector.refresh(now: now)
+        #expect(failed.snapshot?.primary == nil)
+        #expect(failed.snapshot?.fetchedAt == old.fetchedAt)
+    }
+
     @Test("successful refresh is cached as the last known good value")
     func successfulRefreshCaches() async {
         let snapshot = sampleSnapshot(percent: 55)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
@@ -7,6 +7,65 @@ import Testing
 struct GrokUsageProviderTests {
     private let now = Date(timeIntervalSince1970: 1_788_314_400)
 
+    @Test("a valid period-only bill preserves the plan without inventing usage")
+    func periodOnlyBill() throws {
+        let body = Data(#"{"result":{"subscription_tier":"SuperGrok Heavy","config":{"currentPeriod":{"start":"2026-09-06T11:36:49Z","end":"2026-09-13T11:36:49Z"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0}}}}"#.utf8)
+        let snapshot = try GrokUsageResponseDecoder.decode(billingResponse: body, fetchedAt: now)
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.planType == "SuperGrok Heavy")
+        #expect(AccountUsageState.available(snapshot, nextRefreshAt: nil).unavailableReason == .unknown)
+    }
+
+    @Test("period-only billing recovers usage or preserves unknown without swallowing cancellation",
+          arguments: ["success", "offline", "cancelled", "task-cancelled"])
+    func recoverPeriodOnlyBill(outcome: String) async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let reply = #"{"jsonrpc":"2.0","id":2,"result":{"subscription_tier":"SuperGrok Heavy","config":{"currentPeriod":{"start":"2026-09-06T11:36:49Z","end":"2026-09-13T11:36:49Z"}}}}"#
+        let executable = try Self.writeFakeAgent(in: directory, transcript: directory.appendingPathComponent("requests"), reply: reply)
+        let auth = directory.appendingPathComponent("auth.json")
+        try Data(#"{"https://auth.x.ai::openid":{"key":"test-token","expires_at":"2099-01-01T00:00:00Z"}}"#.utf8).write(to: auth)
+        let transport = ScriptedProxyTransport { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+            #expect(request.value(forHTTPHeaderField: "Cookie") == nil)
+            if outcome == "offline" { throw URLError(.notConnectedToInternet) }
+            if outcome == "cancelled" { throw URLError(.cancelled) }
+            if outcome == "task-cancelled" { throw CancellationError() }
+            // Declared GrokCreditsConfig fields: percent 42.5, active weekly period.
+            let hex = "0a190d00002a4242120802120608d1a0f5d4061a0608d1959ad506"
+            let bytes = stride(from: 0, to: hex.count, by: 2).map { offset -> UInt8 in
+                let start = hex.index(hex.startIndex, offsetBy: offset)
+                return UInt8(hex[start..<hex.index(start, offsetBy: 2)], radix: 16)!
+            }
+            return (Data(bytes), HTTPURLResponse(url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: ["grpc-status": "0"])!)
+        }
+        let provider = GrokUsageProvider(executableURL: executable,
+            logURL: directory.appendingPathComponent("absent"), authFileURL: auth,
+            proxyTransport: transport, now: { Date(timeIntervalSince1970: 1_788_750_000) })
+        if outcome == "task-cancelled" {
+            await #expect(throws: CancellationError.self) { try await provider.fetch() }
+            return
+        }
+        if outcome == "cancelled" {
+            await #expect(throws: URLError(.cancelled)) { try await provider.fetch() }
+            return
+        }
+        let snapshot = try await provider.fetch()
+        #expect(snapshot.primary?.usedPercent == (outcome == "success" ? 43 : nil))
+        #expect(snapshot.planType == "SuperGrok Heavy")
+        #expect(Self.matches(snapshot.periodEnd, "2026-09-13T11:36:49Z"))
+    }
+
+    @Test("a log fallback keeps its sampled time and remains cached")
+    func logRemainsCached() throws {
+        let snapshot = try GrokUsageResponseDecoder.decode(unifiedLogLine: Self.logLine())
+        let state = AccountUsageState.available(snapshot, nextRefreshAt: nil)
+        #expect(state.isStale)
+        #expect(state.unavailableReason == .cachedData)
+        #expect(abs(snapshot.fetchedAt.timeIntervalSince1970 - 1_788_395_550.702) < 0.001)
+    }
+
     // MARK: - Decoding
 
     @Test("credits config maps the weekly window, reset time, and tier")
@@ -241,7 +300,7 @@ struct GrokUsageProviderTests {
                 "vibebuddy-test", pidFile.path,
             ],
             timeout: 0.2,
-            logURL: directory.appendingPathComponent("absent.jsonl")
+            logURL: directory.appendingPathComponent("absent.jsonl"), proxyEnabled: false
         )
 
         let started = ContinuousClock.now
@@ -342,7 +401,7 @@ struct GrokUsageProviderTests {
         #expect(snapshot.primary?.usedPercent != 0 || snapshot.primary != nil)
     }
 
-    @Test("proxy on-demand-only answers still fill the single Grok primary window")
+    @Test("extra usage never becomes the included Grok allowance")
     func proxyOnDemandOnlyPrimary() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_100)
         let body = Data("""
@@ -350,13 +409,14 @@ struct GrokUsageProviderTests {
           "config": {
             "onDemandCap": { "val": 1000.0 },
             "onDemandUsed": { "val": 250.0 },
+            "billingPeriodStart": "2026-08-06T00:00:00Z",
             "billingPeriodEnd": "2026-08-13T00:00:00Z"
           }
         }
         """.utf8)
         let snapshot = try GrokUsageResponseDecoder.decode(proxyCreditsResponse: body, fetchedAt: now)
-        #expect(snapshot.primary?.usedPercent == 25)
-        #expect(snapshot.secondary == nil)
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.secondary?.usedPercent == 25)
         #expect(snapshot.fetchedAt == now)
     }
 

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokWebCreditsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokWebCreditsTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import VibeBuddyMacCore
+
+@Suite("Grok web credits contract")
+struct GrokWebCreditsTests {
+    // Descriptor-derived active weekly period, no percentage field. Same shape
+    // observed on 2026-09-07; no credentials or account identifiers.
+    static let zero = hex("0a1442120802120608d1a0f5d4061a0608d1959ad506")
+    let now = Date(timeIntervalSince1970: 1_788_750_000)
+
+    @Test("a missing gRPC completion trailer cannot manufacture zero usage")
+    func requiresCompletion() {
+        let incomplete = Data([0, 0, 0, 0, UInt8(Self.zero.count)]) + Self.zero
+        #expect(throws: (any Error).self) { try GrokWebCredits.decode(incomplete, now: now) }
+    }
+
+    @Test("only a complete active protobuf period can supply an implicit zero")
+    func implicitZeroContract() throws {
+        let reading = try GrokWebCredits.decode(Self.zero, now: now)
+        #expect(reading.percent == 0)
+        #expect(reading.isImplicitZero)
+        #expect(throws: (any Error).self) {
+            try GrokWebCredits.decode(Self.zero, now: Date(timeIntervalSince1970: 1_789_300_000))
+        }
+        // Malformed declared onDemandCap submessage after a valid period.
+        let corrupt = Self.hex("0a1742120802120608d1a0f5d4061a0608d1959ad506120180")
+        #expect(throws: (any Error).self) { try GrokWebCredits.decode(corrupt, now: now) }
+        #expect(throws: (any Error).self) { try GrokWebCredits.decode(Self.zero + Data([0]), now: now) }
+    }
+
+    static func hex(_ string: String) -> Data {
+        Data(stride(from: 0, to: string.count, by: 2).map { offset in
+            let start = string.index(string.startIndex, offsetBy: offset)
+            return UInt8(string[start..<string.index(start, offsetBy: 2)], radix: 16)!
+        })
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
@@ -25,6 +25,21 @@ struct ProviderQuotaProjectionTests {
         ProviderQuota(state, provider: .codex)
     }
 
+    @Test("unknown Grok included allowance cannot become extra-usage quota or an alert")
+    func grokExtraUsageIsSeparate() {
+        var bill = snapshot(primary: nil, secondary: window(.secondary, used: 95, minutes: 10080))
+        bill.provider = .grok
+        let state = AccountUsageState.available(bill, nextRefreshAt: nil)
+        let result = ProviderQuota(state, provider: .grok)
+        #expect(result.weeklyRemainingPercent == nil)
+        #expect(result.otherWindows == nil)
+        var monitor = AccountUsageAlertMonitor()
+        var baseline = bill
+        baseline.secondary?.usedPercent = 10
+        _ = monitor.newlyCrossed(in: .available(baseline, nextRefreshAt: nil), thresholdPercent: 90)
+        #expect(monitor.newlyCrossed(in: state, thresholdPercent: 90).isEmpty)
+    }
+
     // MARK: normalization
 
     @Test("Consumed becomes remaining exactly once")

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -10,10 +10,21 @@ struct AccountUsageSummaryView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 7 : 10) {
-            if let snapshot = state.snapshot {
+            if let snapshot = state.snapshot?.excludingExpiredGrokWindows(at: Date()) {
+                if provider == .grok, snapshot.primary == nil {
+                    if state.unavailableReason != .unknown {
+                        Text("Usage is temporarily unavailable").foregroundStyle(.secondary)
+                    }
+                    if let end = snapshot.periodEnd {
+                        Text("Period ends \(end.formatted(date: .abbreviated, time: .shortened))")
+                            .font(.caption2).foregroundStyle(.secondary)
+                    }
+                }
                 if snapshot.windows.isEmpty {
-                    Label("No quota windows supplied", systemImage: "gauge.with.dots.needle.0percent")
-                        .foregroundStyle(.secondary)
+                    if provider != .grok {
+                        Label("No quota windows supplied", systemImage: "gauge.with.dots.needle.0percent")
+                            .foregroundStyle(.secondary)
+                    }
                 } else {
                     ForEach(snapshot.windows) { window in
                         windowRow(window)
@@ -83,6 +94,7 @@ struct AccountUsageSummaryView: View {
     }
 
     private func windowTitle(_ window: AccountUsageWindow) -> String {
+        if provider == .grok, window.kind == .secondary { return "Extra usage" }
         guard let minutes = window.windowDurationMinutes else {
             return window.kind == .primary ? "Primary window" : "Secondary window"
         }

--- a/VibeBuddyMacApp/project.yml
+++ b/VibeBuddyMacApp/project.yml
@@ -63,8 +63,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.mac
-        MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "7"
+        MARKETING_VERSION: "1.3.1"
+        CURRENT_PROJECT_VERSION: "8"
         SWIFT_VERSION: "6.0"
         # Build signs ad-hoc; tools/redeploy-mac.sh re-signs the built .app with a
         # stable local Apple Development identity so Keychain ACLs / TCC grants

--- a/docs/release-notes-1.3.1.md
+++ b/docs/release-notes-1.3.1.md
@@ -1,0 +1,11 @@
+# VibeBuddy 1.3.1 — macOS
+
+This update fixes Grok and Cursor account usage reporting.
+
+- Grok usage recovers when the CLI returns a billing period without a percentage. Missing data is shown as unavailable, and an expired weekly reading no longer appears as the current quota.
+- Cursor can use the existing Cursor app login. Cursor Models and Other Models remain separate included-usage pools; extra spending is not substituted for either pool.
+- Browser-cookie import handles timeouts and manual fallback correctly, preserves existing Keychain values on failed writes, and matches cookie domains precisely.
+
+Mac companion version 1.3.1 (8), for Apple Silicon Macs running macOS 14 or later. The download is Developer ID signed and notarized by Apple.
+
+This release updates the Mac companion only. Existing iPhone and Watch compatibility gates remain in place, including the Cursor quota transport gate for shipped phone clients. It does not publish a new iPhone or Watch build. Public downloads do not include APNs provider credentials.


### PR DESCRIPTION
Grok now recovers subscription usage from the same account when the CLI returns only a billing period, preserves unknown usage without fabricating JSON zeroes, and stops displaying expired quota windows. Cached log readings remain stale, extra spending is excluded from subscription alerts, and cancellation propagates through fallback requests.

This branch integrates the already-merged Cursor quota fixes in #118 and prepares macOS 1.3.1 (8). Cursor app login, independent included pools, cookie handling, and the shipped-phone compatibility gate are preserved. No iPhone/Watch release is included.

Validation: 177 focused Mac tests and 26 shared-model/wire tests passed after integration. Grok live account recovery and actual usage-view rendering passed locally. The macOS 1.3.1 (8) release build passed Developer ID signing, Apple notarization and stapling for both app and DMG, Gatekeeper assessment, and Sparkle appcast signing. The uploaded GitHub asset SHA-256 matches the verified local DMG.
