### PR TITLE
Support Cursor CLI quota login; release macOS 1.3.2

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorBrowserCookieImporter.swift
@@ -9,6 +9,7 @@ import FoundationNetworking
 /// Where Cursor session cookies come from on the Mac (#105).
 public enum CursorCookieSourceMode: String, CaseIterable, Sendable, Identifiable {
     case cursorApp
+    case cursorCLI
     case manual
     case browserAuto
 
@@ -17,6 +18,7 @@ public enum CursorCookieSourceMode: String, CaseIterable, Sendable, Identifiable
     public var displayName: String {
         switch self {
         case .cursorApp: return "Cursor app login"
+        case .cursorCLI: return "Cursor CLI login"
         case .manual: return "Paste Cookie"
         case .browserAuto: return "Import from browser"
         }
@@ -156,12 +158,13 @@ public enum CursorCookieResolver {
             _ = CursorSessionCookieStore.saveImportedIfChanged($0)
         }
     ) throws -> String {
-        let manual = (manualCookie ?? loadManual())?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
         switch mode {
+        case .cursorCLI:
+            return try CursorLocalSession.cookieHeader(token: CursorCLISession.readAccessToken(supervisor: POSIXCommandSupervisor()), now: Date())
         case .cursorApp:
             return try CursorLocalSession.cookieHeader()
         case .manual:
+            let manual = (manualCookie ?? loadManual())?.trimmingCharacters(in: .whitespacesAndNewlines)
             guard let manual, !manual.isEmpty else { throw AccountUsageError.notLoggedIn }
             return manual
         case .browserAuto:
@@ -173,6 +176,7 @@ public enum CursorCookieResolver {
                 return imported
             } catch {
                 // Independent manual slot — never the imported account (#114 M1).
+                let manual = (manualCookie ?? loadManual())?.trimmingCharacters(in: .whitespacesAndNewlines)
                 if let manual, !manual.isEmpty { return manual }
                 throw (error as? AccountUsageError) ?? AccountUsageError.notLoggedIn
             }
@@ -245,6 +249,49 @@ public enum CursorLocalSession {
         guard let token = String(data: data, encoding: utf16 ? .utf16LittleEndian : .utf8), !token.isEmpty else {
             throw AccountUsageError.notLoggedIn
         }
+        return token
+    }
+}
+
+/// Reads the CLI Keychain item through Apple's helper, as ai-usage-dashboard does.
+/// A supervised process bounds legacy Keychain prompts that can block SecItemCopyMatching.
+public enum CursorCLISession {
+    public static func loadAccessToken() async throws -> String {
+        let supervisor = try POSIXCommandSupervisor()
+        return try await withTaskCancellationHandler {
+            let token: String = try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .utility).async {
+                    continuation.resume(with: Result { try readAccessToken(supervisor: supervisor) })
+                }
+            }
+            try Task.checkCancellation()
+            return token
+        } onCancel: {
+            supervisor.cancel()
+        }
+    }
+
+    static func readAccessToken(supervisor: POSIXCommandSupervisor) throws -> String {
+        let result: POSIXCommandResult
+        do {
+            result = try supervisor.run(executableURL: URL(fileURLWithPath: "/usr/bin/security"),
+                arguments: ["find-generic-password", "-a", "cursor-user", "-s", "cursor-access-token", "-w"],
+                environment: ["PATH": "/usr/bin:/bin"], timeout: 8, outputLimit: 64 * 1024)
+        } catch POSIXCommandError.timedOut {
+            throw AccountUsageError.timedOut
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw AccountUsageError.unknown
+        }
+        // security returns 44 for errSecItemNotFound. Never include its output in errors.
+        if result.waitStatus == (44 << 8) { throw AccountUsageError.notLoggedIn }
+        guard result.exitedSuccessfully else { throw AccountUsageError.unknown }
+        guard let value = String(data: result.standardOutput, encoding: .utf8) else {
+            throw AccountUsageError.notLoggedIn
+        }
+        let token = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { throw AccountUsageError.notLoggedIn }
         return token
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
@@ -227,6 +227,7 @@ public struct CursorUsageProvider: AccountUsageProviding {
     public static let defaultEndpoint = URL(string: "https://cursor.com/api/usage-summary")!
 
     private let cookie: String?
+    private let cliAccessToken: @Sendable () async throws -> String
     private let cookieMode: @Sendable () -> CursorCookieSourceMode
     private let cookieImporter: CursorBrowserCookieImporting
     private let persistImportedCookie: @Sendable (String) -> Void
@@ -238,6 +239,7 @@ public struct CursorUsageProvider: AccountUsageProviding {
     public init(
         cookie: String? = nil,
         cookieMode: @escaping @Sendable () -> CursorCookieSourceMode = { CursorCookieSourceSettings.mode() },
+        cliAccessToken: @escaping @Sendable () async throws -> String = { try await CursorCLISession.loadAccessToken() },
         cookieImporter: CursorBrowserCookieImporting = CursorBrowserCookieImporter(),
         persistImportedCookie: @escaping @Sendable (String) -> Void = { _ = CursorSessionCookieStore.saveImportedIfChanged($0) },
         endpoint: URL = defaultEndpoint,
@@ -245,6 +247,7 @@ public struct CursorUsageProvider: AccountUsageProviding {
         timeout: TimeInterval = 15,
         importTimeout: TimeInterval = 10
     ) {
+        self.cliAccessToken = cliAccessToken
         self.cookie = cookie
         self.cookieMode = cookieMode
         self.cookieImporter = cookieImporter
@@ -299,6 +302,8 @@ public struct CursorUsageProvider: AccountUsageProviding {
     /// utility queue behind a continuation, with an import timeout.
     private func resolveCookieHeader() async throws -> String {
         switch cookieMode() {
+        case .cursorCLI:
+            return try CursorLocalSession.cookieHeader(token: await cliAccessToken(), now: Date())
         case .cursorApp:
             return try CursorLocalSession.cookieHeader()
         case .manual:

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorUsageProviderTests.swift
@@ -4,6 +4,49 @@ import Testing
 
 @Suite("Cursor usage adapter")
 struct CursorUsageProviderTests {
+    @Test("CLI login fetches both pools without desktop or browser authentication")
+    func cliOnlyFetch() async throws {
+        let payload = Data(#"{"sub":"auth0|user_cli","exp":4102444800}"#.utf8).base64EncodedString().replacingOccurrences(of: "=", with: "")
+        let token = "e30.\(payload).test"
+        let transport = ScriptedCursorTransport { request in
+            #expect(request.value(forHTTPHeaderField: "Cookie") == "WorkosCursorSessionToken=user_cli%3A%3A\(token)")
+            let body = Data(#"{"individualUsage":{"plan":{"autoPercentUsed":38,"apiPercentUsed":98}}}"#.utf8)
+            return (body, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let snapshot = try await CursorUsageProvider(
+            cookie: "WorkosCursorSessionToken=other-account",
+            cookieMode: { .cursorCLI },
+            cliAccessToken: { token },
+            transport: transport
+        ).fetch()
+        #expect(snapshot.primary?.usedPercent == 38)
+        #expect(snapshot.secondary?.usedPercent == 98)
+    }
+
+    @Test("Unavailable CLI credentials never use a saved cookie from another account",
+          arguments: [AccountUsageError.notLoggedIn, .unknown])
+    func cliCredentialFailure(_ error: AccountUsageError) async throws {
+        let transport = ScriptedCursorTransport { _ in
+            Issue.record("Must not send a request after CLI credential failure")
+            throw AccountUsageError.unknown
+        }
+        let provider = CursorUsageProvider(cookie: "WorkosCursorSessionToken=other-account",
+            cookieMode: { .cursorCLI }, cliAccessToken: { throw error }, transport: transport)
+        await #expect(throws: error) { try await provider.fetch() }
+    }
+
+    @Test("Expired CLI login never reaches the usage endpoint")
+    func expiredCLI() async throws {
+        let payload = Data(#"{"sub":"auth0|user_cli","exp":1000}"#.utf8).base64EncodedString().replacingOccurrences(of: "=", with: "")
+        let transport = ScriptedCursorTransport { _ in
+            Issue.record("Must not send an expired CLI token")
+            throw AccountUsageError.unknown
+        }
+        let provider = CursorUsageProvider(cookieMode: { .cursorCLI },
+            cliAccessToken: { "e30.\(payload).test" }, transport: transport)
+        await #expect(throws: AccountUsageError.notLoggedIn) { try await provider.fetch() }
+    }
+
     @Test("plan-only usage-summary maps to primary used % and reset")
     func planOnlyFixture() throws {
         let data = try Self.fixture("usage-summary-plan-only")

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -139,14 +139,14 @@ struct AccountUsageSettings: View {
             } header: {
                 Text("Providers")
             } footer: {
-                Text("Codex reads its official local app-server. Claude runs the official read-only /usage command without session persistence or hooks. Grok asks its own agent process for the billing summary and falls back to the CLI billing proxy with the local login token when needed. Cursor reads its selected local app login or browser/manual Cookie. Local app credentials are never copied to storage. No account IDs or raw responses are logged. Turning a source off leaves session monitoring and notifications running.")
+                Text("Codex reads its official local app-server. Claude runs the official read-only /usage command without session persistence or hooks. Grok asks its own agent process for the billing summary and falls back to the CLI billing proxy with the local login token when needed. Cursor reads its selected CLI login, local app login, or browser/manual Cookie. Local login credentials are never copied to storage. No account IDs or raw responses are logged. Turning a source off leaves session monitoring and notifications running.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Section {
-                Picker("Cookie source", selection: $cursorCookieMode) {
+                Picker("Login source", selection: $cursorCookieMode) {
                     ForEach(CursorCookieSourceMode.allCases) { mode in
                         Text(mode.displayName).tag(mode)
                     }
@@ -155,7 +155,9 @@ struct AccountUsageSettings: View {
                     CursorCookieSourceSettings.setMode(mode)
                 }
 
-                if cursorCookieMode == .cursorApp {
+                if cursorCookieMode == .cursorCLI {
+                    Text("Uses only Cursor CLI login; the desktop app is not required. Run cursor-agent login if signed out or expired. If Keychain access is unavailable, unlock the login Keychain or select another login source.").font(.caption)
+                } else if cursorCookieMode == .cursorApp {
                     Text("Uses the account signed in to Cursor on this Mac. If the session expires, sign in again in Cursor and refresh.").font(.caption)
                 } else if cursorCookieMode == .manual {
                     SecureField("Cookie header from cursor.com", text: $cursorCookie)

--- a/VibeBuddyMacApp/project.yml
+++ b/VibeBuddyMacApp/project.yml
@@ -63,8 +63,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.mac
-        MARKETING_VERSION: "1.3.1"
-        CURRENT_PROJECT_VERSION: "8"
+        MARKETING_VERSION: "1.3.2"
+        CURRENT_PROJECT_VERSION: "9"
         SWIFT_VERSION: "6.0"
         # Build signs ad-hoc; tools/redeploy-mac.sh re-signs the built .app with a
         # stable local Apple Development identity so Keychain ACLs / TCC grants

--- a/docs/release-notes-1.3.2.md
+++ b/docs/release-notes-1.3.2.md
@@ -1,0 +1,11 @@
+# VibeBuddy 1.3.2 — macOS
+
+Cursor usage now supports the official Cursor CLI login without requiring the Cursor desktop app.
+
+- Select **Cursor CLI login** in Settings → Usage → Login source to use the account signed in through `cursor-agent login`.
+- Cursor Models and Other Models retain their separate usage percentages and billing reset date.
+- CLI credential reads have an eight-second timeout and support cancellation. Missing or expired CLI credentials do not fall back to another account. Credentials are never refreshed, copied to storage, or logged.
+
+Mac companion version 1.3.2 (9), for Apple Silicon Macs running macOS 14 or later. The download is Developer ID signed and notarized by Apple.
+
+This release updates only the Mac companion; it does not publish an iPhone or Watch build or change their quota transport compatibility gates.


### PR DESCRIPTION
Cursor quota refresh previously failed after removing the desktop app when no browser session was available. Adds an explicit Cursor CLI login source using the CLI's existing Keychain access token, while retaining the separate Cursor Models and Other Models pools.

Uses a bounded system security helper rather than a blocking native Keychain call; no credential refresh, persistence, or fallback to another account. Prepares macOS 1.3.2 (9).

Validation: 20 related tests passed; full macOS build passed; independent review found no blockers. On the actual Mac with Cursor.app and its login database absent, the signed test app refreshed both pools to 38% / 98% using only CLI login, clearing the stale state. Expiry and read-failure isolation are covered by automated tests.
