### PR TITLE
macOS 1.3.3: optional menu-bar task status

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,11 @@ code, and tests — don't drift to synonyms.
   shown under the housing with its actions (Approve / Deny / Jump), timed by
   `GlanceCardQueue`. While the glance is on screen the card *replaces* the
   macOS banner for session cues; hidden glance → banner as before.
+- **Menu-bar entry** — a fixed cat icon that opens the menu for Dashboard and
+  Settings. "Show task status in menu bar" optionally adds a state dot and the
+  primary state count; it is off by default. The Glance owns ambient status and
+  actionable alerts. Both surfaces are enabled by
+  default and can be hidden independently.
 - **Pairing** — linking a phone to a Mac over the LAN by scanning a QR that
   encodes `host:port` + a **bearer token**.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The first-class roadmap covers **Claude Code, Codex, Grok, and Cursor**: three-s
 The Mac shows a QR encoding `host:port` + a bearer token. The phone scans it once — no manual IP entry. (The same QR can carry a Tailscale `100.x` address later, with no code change.)
 
 ### 🖥️ Native Mac menu-bar app
-A `MenuBarExtra` glance with live counts, a macOS notch glance, **jump-to-terminal** (open the right session with one click), launch-at-login, and a LAN bearer token persisted in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`. ⏎ / ⌘F dashboard shortcuts included. v1.1 uses a signed Sparkle update feed; original v1.0 users need a one-time manual installation.
+A fixed menu-bar launcher with optional task status (off by default), a macOS notch glance for live counts and alerts, **jump-to-terminal** (open the right session with one click), launch-at-login, and a LAN bearer token persisted in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`. ⏎ / ⌘F dashboard shortcuts included. v1.1 uses a signed Sparkle update feed; original v1.0 users need a one-time manual installation.
 
 ### 🔒 Local-first & private by design
 vibebuddy talks **directly** between your Mac and your phone over your own network. Session data **never** touches a vibebuddy server — there is no vibebuddy cloud, no account, no analytics, no tracking. Daemon routes are bearer-token gated. When APNs is configured, notification payloads (including titles and bodies) pass through Apple's push service. (The optional voice companion sends microphone audio and selected session context only to the provider *you* chose, with *your* key, when you turn it on.)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -111,7 +111,7 @@
 Mac 显示一个编码了 `host:port` + bearer token 的二维码。手机扫一次即可——无需手动输 IP。（同一个二维码以后可以承载 Tailscale `100.x` 地址，无需改代码。）
 
 ### 🖥️ 原生 Mac 菜单栏应用
-`MenuBarExtra` 实时计数概览、macOS 刘海概览、**跳转到终端**（一键打开对应会话）、开机自启，以及持久化在仅所有者可读写（`0600`）文件 `~/Library/Application Support/vibebuddy/token` 中的局域网 bearer token。还有 ⏎ / ⌘F 仪表盘快捷键。v1.1 使用带签名的 Sparkle 更新源；原 v1.0 用户需要先手动安装一次新版。
+固定菜单栏入口（可选状态点和数量，默认关闭）、负责实时状态与提醒的 macOS 刘海概览、**跳转到终端**（一键打开对应会话）、开机自启，以及持久化在仅所有者可读写（`0600`）文件 `~/Library/Application Support/vibebuddy/token` 中的局域网 bearer token。还有 ⏎ / ⌘F 仪表盘快捷键。v1.1 使用带签名的 Sparkle 更新源；原 v1.0 用户需要先手动安装一次新版。
 
 ### 🔒 本地优先，隐私至上
 vibebuddy 在你的 Mac 与手机之间**直接**通过你自己的网络通信。会话数据**绝不**经过 vibebuddy 服务器——没有 vibebuddy 云、没有账号、没有埋点、没有追踪。守护进程路由由 bearer token 把关。配置 APNs 后，通知负载（包括标题和正文）会经过 Apple 推送服务。（可选语音伙伴只会在你开启后，把麦克风音频和所选会话上下文发往*你选择*的服务商，并使用*你自己*的 key。）

--- a/VibeBuddyMacApp/Sources/SettingsView.swift
+++ b/VibeBuddyMacApp/Sources/SettingsView.swift
@@ -321,6 +321,7 @@ private extension LifecycleJournalEntry {
 private struct GeneralSettings: View {
     @ObservedObject var model: MenuBarModel
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
+    @AppStorage("showMenuBarTaskStatus") private var showMenuBarTaskStatus = false
     @State private var showHideIconNote = false
 
     var body: some View {
@@ -331,6 +332,14 @@ private struct GeneralSettings: View {
             Toggle("Show icon in menu bar", isOn: Binding(
                 get: { showMenuBarIcon },
                 set: { on in showMenuBarIcon = on; if !on { showHideIconNote = true } }))
+            Text("A fixed shortcut to the Dashboard and Settings. Live status and alerts appear in the Glance.")
+                .font(.caption).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Toggle("Show task status in menu bar", isOn: $showMenuBarTaskStatus)
+                .disabled(!showMenuBarIcon)
+            Text("Add a status dot and the primary task count beside the cat icon.")
+                .font(.caption).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             if showHideIconNote {
                 Text("Hidden. You can still open the Dashboard with \(model.openDashboardHotkey.displayString) — it has a Settings button.")
                     .font(.caption).foregroundStyle(.secondary)

--- a/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
+++ b/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
@@ -192,32 +192,33 @@ enum MenuBarGlyph {
     }()
 }
 
-/// Presentation only; hiding the label cannot disconnect app commands.
+/// A stable launcher; task status is opt-in to avoid repeating the Glance.
+/// Hiding the label cannot disconnect app commands.
 struct MenuBarLabel: View {
     @ObservedObject var model: MenuBarModel
+    @AppStorage("showMenuBarTaskStatus") private var showTaskStatus = false
 
     var body: some View {
         let state = model.presentationSummary.primaryState
         let count = model.presentationSummary.count(for: state)
         HStack(spacing: 3) {
-            // A stable cat-head mark (matches the pet + app icon), monochrome so
-            // the system tints it for light/dark. State shows as a badge + count,
-            // not a shape change, so the silhouette stays recognizable.
             CatHeadIcon()
                 .frame(width: 17, height: 17)
                 .overlay(alignment: .topTrailing) {
-                    if state != .unassigned {
+                    if showTaskStatus && state != .unassigned {
                         TaskStatusIndicator(state, size: 6)
                             .offset(x: 1.5, y: -0.5)
                     }
                 }
-            if state == .error || state == .requiresInput {
+            if showTaskStatus && count > 0 {
                 Text("\(count)")
                     .font(.system(size: 12, weight: .semibold).monospacedDigit())
-                    .accessibilityLabel("\(count) \(state.label)")
             }
         }
-
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(showTaskStatus && count > 0
+            ? "VibeBuddy, \(count) \(state.label)" : "VibeBuddy")
+        .help("Open VibeBuddy menu")
     }
 }
 

--- a/VibeBuddyMacApp/project.yml
+++ b/VibeBuddyMacApp/project.yml
@@ -63,8 +63,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.mac
-        MARKETING_VERSION: "1.3.2"
-        CURRENT_PROJECT_VERSION: "9"
+        MARKETING_VERSION: "1.3.3"
+        CURRENT_PROJECT_VERSION: "10"
         SWIFT_VERSION: "6.0"
         # Build signs ad-hoc; tools/redeploy-mac.sh re-signs the built .app with a
         # stable local Apple Development identity so Keychain ACLs / TCC grants

--- a/docs/adr/0011-glance-follows-dynamic-island-grammar.md
+++ b/docs/adr/0011-glance-follows-dynamic-island-grammar.md
@@ -56,3 +56,15 @@ chose **A (invisible island) + D (event cards)**.
   (delivery is still recorded as a local delivery).
 - `GlanceMode` and the measure-and-reframe window code are gone. QA on a
   notchless Mac uses `VIBEBUDDY_FAKE_NOTCH=185x32`.
+
+## Amendment (2026-09-07): fixed menu-bar entry
+
+The menu-bar icon is a stable cat mark opening the Dashboard/Settings menu,
+with no state or count by default. General Settings offers an independent
+"Show task status in menu bar" switch (default off) that adds the primary
+state's dot and count. The Glance owns ambient status, counts and
+actionable alerts so the two persistent surfaces do not repeat that summary.
+Both remain enabled by default, with independent visibility switches. Hiding
+the Glance keeps the existing macOS notification path; it does not add status
+back to the menu-bar icon automatically. The task-status preference is independent
+of Glance visibility. Details inside the opened menu remain available.

--- a/docs/qa/mac-1.3.3.md
+++ b/docs/qa/mac-1.3.3.md
@@ -1,0 +1,28 @@
+# macOS 1.3.3 acceptance — 2026-09-07
+
+Source: f7daa73, based on 87c6a84 (PR #120 / 1.3.2). This document and final release-note signing statement do not change executable source.
+
+## Passed
+
+- MacCore: 732 Swift Testing tests; Kit: 307 Swift Testing tests plus 27 XCTest tests. This includes Cursor CLI timeout/cancellation and Grok recovery regressions.
+- Independent read-only review: no blocking Standards or Spec findings; no confirmed unused source in the changed area. Removed obsolete always-on status behavior; no compatibility preference keys added.
+- Release build, Developer ID signature, hardened runtime, app and DMG notarization/stapling, and Gatekeeper assessment.
+- Ran the signed release executable as the primary app with actual Claude/Codex sessions and existing provider logins, without demo data. Health returned ok; the authenticated snapshot contained real Codex and Claude sessions.
+- CUA verified General settings: icon on, new task-status switch off by default; toggles on/off. Hiding the icon disables the status control. Glance can be hidden independently.
+- Quit and restarted the signed release: task-status on and Glance off persisted independently, health recovered, and live provider data refreshed. Restored icon on, task-status off, Glance on afterwards.
+- Actual 13:34 UI: Codex 40%; Claude 1% short / 50% week; Grok 0%; Cursor Models 38% / Other Models 98%. All refreshed, no stale marker at that observation. Percentages are time-specific live readings, not fixed expected values.
+- Launching a second release instance returned to the existing dashboard, exited, and left exactly one app process plus healthy service.
+- Read-only DMG mount: inner executable SHA-256 matched the exercised signed executable; nested signature verified.
+
+## Verification limits
+
+- CUA exposed app windows and settings but not system status items. The menu glyph pixels and a real camera-notch layout were not visually verified; default/conditional rendering was reviewed in source. This is not a claim of exhaustive visual E2E.
+- No real approval was generated solely for this test; unchanged notification routing is covered by existing regression tests, not a new human-perception acceptance.
+- No iPhone/Watch build, voice interaction, or Sparkle replacement installation was performed. They are outside the changed behavior. The existing installed 1.3.2 was restarted after candidate E2E; /Applications was not replaced.
+
+## Artifact
+
+DMG SHA-256: b1e5ca851620003d9d163a6f8e996a9ae2f3d85c75379f5db3a83887ec6b3015
+Executable SHA-256: e751f6e2e84c2e102bd657ecec62ac916d0c8237794c4e1be79a697a7a4c2d5a
+App notary submission: e8d9c126-8b8d-4230-a863-9269b72f7792 (Accepted)
+DMG notary submission: dc44fbe8-f6bd-4aee-a532-63a15222d27e (Accepted)

--- a/docs/release-notes-1.3.3.md
+++ b/docs/release-notes-1.3.3.md
@@ -6,5 +6,5 @@ The menu bar now stays quiet by default: a fixed cat icon opens the menu, while 
 - Menu-bar visibility and Glance visibility remain independent. Hiding the Glance keeps the existing macOS notification path.
 - Includes the Cursor CLI login support from 1.3.2 and the Grok quota recovery fixes from 1.3.1. Cursor Models and Other Models remain separate.
 
-Mac companion version 1.3.3 (10), for Apple Silicon Macs running macOS 14 or later.
+Mac companion version 1.3.3 (10), for Apple Silicon Macs running macOS 14 or later. The app and DMG are Developer ID signed and notarized by Apple.
 This release updates only the Mac companion; it does not publish an iPhone or Watch build or change their quota transport compatibility gates.

--- a/docs/release-notes-1.3.3.md
+++ b/docs/release-notes-1.3.3.md
@@ -1,0 +1,10 @@
+# VibeBuddy 1.3.3 — macOS
+
+The menu bar now stays quiet by default: a fixed cat icon opens the menu, while the Glance shows live task status and actionable alerts.
+
+- Settings → General → **Show task status in menu bar** optionally adds a status dot and the primary task count. It is off by default and persists across restarts.
+- Menu-bar visibility and Glance visibility remain independent. Hiding the Glance keeps the existing macOS notification path.
+- Includes the Cursor CLI login support from 1.3.2 and the Grok quota recovery fixes from 1.3.1. Cursor Models and Other Models remain separate.
+
+Mac companion version 1.3.3 (10), for Apple Silicon Macs running macOS 14 or later.
+This release updates only the Mac companion; it does not publish an iPhone or Watch build or change their quota transport compatibility gates.


### PR DESCRIPTION
The menu bar now defaults to a fixed cat launcher. General Settings adds **Show task status in menu bar**, off by default, to enable the primary-state dot and count together. Glance visibility stays independent. Includes the already merged Cursor CLI quota and Grok recovery fixes in macOS 1.3.3 (10).

Validation: MacCore 732 tests; Kit 307 Swift Testing + 27 XCTest tests; independent review; signed Release build; Apple notarization and Gatekeeper checks for app and DMG. Exercised actual Claude/Codex sessions, fresh provider quotas, settings toggles and persistence, restart recovery and single-instance handling. DMG executable matches the exercised executable.

CUA could not expose system status items, so menu-bar pixels and physical-notch layout were not visually accepted. No new phone/Watch, voice, notification-perception or Sparkle installation acceptance is claimed. See docs/qa/mac-1.3.3.md. No unused source was found in the changed area; generated dependency/build artifacts are excluded.
