### PR TITLE
fix(ios): restore Live Activities and prepare iPhone/Watch 1.3 (12)

### DIFF
--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -171,7 +171,10 @@ final class DashboardStore: ObservableObject {
     }
 
     func start(_ pairing: PairingPayload) {
-        stop()
+        // Reconnecting is not an explicit stop: ActivityKit keeps the current
+        // activity across process death, so the first snapshot must reclaim it.
+        let changedSource = isDemo || (self.pairing != nil && self.pairing != pairing)
+        runTask?.cancel()
         isDemo = false
         self.pairing = pairing
         ConnectionStore.observePairing(pairing)
@@ -182,6 +185,7 @@ final class DashboardStore: ObservableObject {
         relayToWatch([])
         policy = SoundPolicy()                        // fresh connection → suppress the backlog
         runTask = Task { [weak self] in
+            if changedSource { await self?.liveActivity.end() }
             while !Task.isCancelled {
                 guard let self else { return }
                 // Every attempt, not just the first: the Mac may have restarted
@@ -200,10 +204,11 @@ final class DashboardStore: ObservableObject {
         }
     }
 
-    func stop() {
+    @discardableResult
+    func stop() -> Task<Void, Never> {
         runTask?.cancel()
         runTask = nil
-        Task { await liveActivity.end() }
+        return Task { await liveActivity.end() }
     }
 
     func forgetPairing() {

--- a/VibeBuddyApp/Sources/LiveActivityManager.swift
+++ b/VibeBuddyApp/Sources/LiveActivityManager.swift
@@ -10,6 +10,8 @@ import VibeBuddyKit
 final class LiveActivityManager {
     private var activity: Activity<VibeBuddyActivityAttributes>?
     private var tokenObserver: Task<Void, Never>?
+    private var pendingSessions: [AgentSession]?
+    private var reconciliation: Task<Void, Never>?
     /// Reports the activity's APNs push token (hex) whenever it's produced or rotates,
     /// so the Mac can push content-state updates while the app is backgrounded
     /// (dynamic-island/02). Local updates via `update(_:)` still happen regardless.
@@ -18,8 +20,42 @@ final class LiveActivityManager {
     /// Reflect the latest counts. Starts the activity on first non-empty state,
     /// updates it thereafter, and ends it when everything is gone.
     func sync(sessions: [AgentSession]) async {
+        // ActivityKit operations suspend. Serialize them so a reconnect/stop
+        // cannot create an activity while an earlier reconciliation ends it.
+        pendingSessions = sessions
+        if let reconciliation {
+            await reconciliation.value
+            return
+        }
+        let task = Task { @MainActor in
+            while let sessions = self.pendingSessions {
+                self.pendingSessions = nil
+                await self.reconcile(sessions: sessions)
+            }
+            self.reconciliation = nil
+        }
+        reconciliation = task
+        await task.value
+    }
+
+    private func reconcile(sessions: [AgentSession]) async {
         let summary = TaskPresentationSummary(sessions: sessions)
-        guard !summary.isEmpty else { await end(); return }
+        let existing = Activity<VibeBuddyActivityAttributes>.activities
+        let reusable = existing.filter { $0.activityState == .active || $0.activityState == .stale }
+        let retained = summary.isEmpty ? nil : (
+            reusable.first { $0.id == activity?.id } ?? reusable.sorted { $0.id < $1.id }.first)
+        if activity?.id != retained?.id {
+            tokenObserver?.cancel()
+            tokenObserver = nil
+            activity = retained
+            if let retained { observePushToken(retained) }
+        }
+        // Activities survive process death. Reclaim one and dismiss old copies,
+        // including when the first snapshot after relaunch is empty.
+        for old in existing where old.id != retained?.id {
+            await old.end(nil, dismissalPolicy: .immediate)
+        }
+        guard !summary.isEmpty else { return }
         let leading = sessions.leadingPresentationSession
 
         // The island can answer the first pending approval (island-approve/01) —
@@ -63,18 +99,20 @@ final class LiveActivityManager {
 
     private func observePushToken(_ activity: Activity<VibeBuddyActivityAttributes>) {
         tokenObserver?.cancel()
+        if let tokenData = activity.pushToken {
+            onPushToken?(tokenData.map { String(format: "%02x", $0) }.joined())
+        }
         tokenObserver = Task { [weak self] in
             for await tokenData in activity.pushTokenUpdates {
+                guard !Task.isCancelled, let self,
+                      self.activity?.id == activity.id else { return }
                 let hex = tokenData.map { String(format: "%02x", $0) }.joined()
-                self?.onPushToken?(hex)
+                self.onPushToken?(hex)
             }
         }
     }
 
     func end() async {
-        tokenObserver?.cancel(); tokenObserver = nil
-        guard let activity else { return }
-        await activity.end(nil, dismissalPolicy: .immediate)
-        self.activity = nil
+        await sync(sessions: [])
     }
 }

--- a/VibeBuddyApp/Tests/DashboardStoreTests.swift
+++ b/VibeBuddyApp/Tests/DashboardStoreTests.swift
@@ -46,7 +46,7 @@ final class DashboardStoreTests: XCTestCase {
 
         let afterStart = await decisions.acknowledgedSessionIDs
         XCTAssertEqual(afterStart, [])
-        store.stop()
+        await store.stop().value
     }
 
     func testWatchAcknowledgementCarriesExactRoundAndRejectsAnotherSource() async throws {
@@ -76,7 +76,7 @@ final class DashboardStoreTests: XCTestCase {
         }
         let sent = await decisions.completionRequests
         XCTAssertEqual(sent, [CompletionReadRequest(sourceID: "mac-a", sessionID: "task", completionID: "round-1")])
-        store.stop()
+        await store.stop().value
     }
 
     func testPhoneAndWatchReadTheExactWaitWithoutAnsweringIt() async throws {
@@ -89,7 +89,6 @@ final class DashboardStoreTests: XCTestCase {
             streamer: ScriptedStreamer(snapshots: [Snapshot(sessions: [waiting], serverTime: now, sourceID: "mac-a")]),
             notifier: SilentNotifier(), decisionClient: decisions, watchRelay: nil, reportDevice: { _ in })
         store.start(PairingPayload(host: "127.0.0.1", port: 9, token: "test"))
-        defer { store.stop() }
         for _ in 0..<50 where store.allSessions.isEmpty { try await Task.sleep(for: .milliseconds(10)) }
         store.acknowledge("task")
         for _ in 0..<50 {
@@ -107,6 +106,7 @@ final class DashboardStoreTests: XCTestCase {
         let completions = await decisions.completionRequests
         XCTAssertTrue(completions.isEmpty)
         XCTAssertEqual(store.allSessions.first?.status, .needsResponse)
+        await store.stop().value
     }
 
     func testFollowFlipsTheRowAtOnceAndTellsTheMac() async throws {
@@ -134,7 +134,7 @@ final class DashboardStoreTests: XCTestCase {
         let sent = await decisions.attentions
         XCTAssertEqual(sent.map(\.sessionId), ["s"])
         XCTAssertEqual(sent.map(\.level), [.followed])
-        store.stop()
+        await store.stop().value
     }
 
     /// The Mac's device registry can be emptied by a Mac restart while this app
@@ -153,7 +153,7 @@ final class DashboardStoreTests: XCTestCase {
             if reports.count >= 2 { break }
             try await Task.sleep(for: .milliseconds(10))
         }
-        store.stop()
+        await store.stop().value
 
         XCTAssertGreaterThanOrEqual(reports.count, 2)
         XCTAssertEqual(reports.first?.host, "127.0.0.1")

--- a/VibeBuddyApp/Tests/LiveActivityRecoveryTests.swift
+++ b/VibeBuddyApp/Tests/LiveActivityRecoveryTests.swift
@@ -1,0 +1,71 @@
+import ActivityKit
+import XCTest
+import VibeBuddyKit
+@testable import VibeBuddyApp
+
+/// Exercise the real system activity registry, not a mock which loses its state
+/// alongside the manager. Run only on an isolated simulator/test installation.
+@MainActor
+final class LiveActivityRecoveryTests: XCTestCase {
+    func testDashboardStartKeepsSurvivingActivity() async throws {
+        let now = Date()
+        let sessions = [AgentSession(id: "dashboard-recovery", agent: .codex,
+                                    project: "Dashboard Recovery QA", status: .working,
+                                    statusSince: now, updatedAt: now)]
+        let original = try Activity.request(attributes: VibeBuddyActivityAttributes(),
+            content: ActivityContent(state: VibeBuddyActivityAttributes.ContentState(
+                summary: TaskPresentationSummary(sessions: sessions)), staleDate: nil))
+        let store = DashboardStore(
+            streamer: ScriptedStreamer(snapshots: [Snapshot(sessions: sessions, serverTime: now)]),
+            notifier: RecordingNotifier(), decisionClient: NullDecisionClient(),
+            watchRelay: nil, reportDevice: { _ in })
+        store.start(PairingPayload(host: "127.0.0.1", port: 9, token: "test"))
+        let deadline = Date().addingTimeInterval(5)
+        while original.content.state.topProject != "Dashboard Recovery QA", Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        XCTAssertEqual(original.activityState, .active)
+        XCTAssertEqual(original.content.state.topProject, "Dashboard Recovery QA",
+                       "Dashboard.start must preserve and update the original activity")
+        await store.stop().value
+    }
+
+    func testRelaunchReusesActivityAndFreshStopEndsSurvivors() async throws {
+        let now = Date()
+        let sessions = [AgentSession(id: "activity-recovery", agent: .codex,
+                                    project: "Recovery QA", status: .working,
+                                    statusSince: now, updatedAt: now)]
+        let state = VibeBuddyActivityAttributes.ContentState(
+            summary: TaskPresentationSummary(sessions: sessions))
+        let original = try Activity.request(attributes: VibeBuddyActivityAttributes(),
+                                            content: ActivityContent(state: state, staleDate: nil))
+        let duplicate = try Activity.request(attributes: VibeBuddyActivityAttributes(),
+                                             content: ActivityContent(state: state, staleDate: nil))
+        let ids = Set([original.id, duplicate.id])
+
+        let relaunched = LiveActivityManager()
+        await relaunched.sync(sessions: sessions)
+        // update() returns before ActivityKit publishes its new content locally.
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let current = Activity<VibeBuddyActivityAttributes>.activities.filter {
+                $0.activityState == .active || $0.activityState == .stale
+            }
+            if current.count == 1, current.first?.content.state.topProject == "Recovery QA" { break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        let live = Activity<VibeBuddyActivityAttributes>.activities.filter {
+            $0.activityState == .active || $0.activityState == .stale
+        }
+        XCTAssertEqual(live.count, 1)
+        XCTAssertTrue(live.first.map { ids.contains($0.id) } ?? false,
+                      "Relaunch must reuse a surviving activity instead of requesting another")
+        XCTAssertEqual(live.first?.content.state.topProject, "Recovery QA")
+
+        // No in-memory handle exists in this manager, just as after process death.
+        await LiveActivityManager().end()
+        XCTAssertTrue(Activity<VibeBuddyActivityAttributes>.activities.allSatisfy {
+            $0.activityState != .active && $0.activityState != .stale
+        })
+    }
+}

--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -47,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "11"
+        CURRENT_PROJECT_VERSION: "12"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "11"
+        CURRENT_PROJECT_VERSION: "12"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -118,7 +118,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
         CODE_SIGN_ENTITLEMENTS: Watch/VibeBuddyWatch.entitlements
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "11"
+        CURRENT_PROJECT_VERSION: "12"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -146,7 +146,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "11"
+        CURRENT_PROJECT_VERSION: "12"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2

--- a/docs/app-store-submission-1.3.md
+++ b/docs/app-store-submission-1.3.md
@@ -1,5 +1,7 @@
 # VibeBuddy 1.3 — App Store 提交文案包
 
+最新状态（2026-09-07 14:21）：iPhone、watchOS 及两个小组件已统一为 **1.3（12）**，包含实时活动冷启动接管与去重修复。已在一组真实配对 iPhone / Watch 安装并验证任务同步、Watch 表盘组件及灵动岛恢复后更新，详见 [构建 12 验收](qa/ios-1.3-build12.md)。Apple 已接收新构建并显示 **Waiting for Review**；Submission ID：`6da289ac-2278-4925-9e93-6f23bdad3005`。审核通过后自动发布，尚未获批或公开。审核备注已补充 iOS、watchOS、组件及 Mac 的公开源码仓库链接。Mac **1.3.3（10）** 已[公开发布](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3.3)。以下旧状态和内部检查项为历史文案来源，最新验收范围以上述构建 12 记录为准。
+
 截图素材已另备：[三端截图与上传清单](app-store-screenshots/1.3/README.md)。含中英文环境原生实拍；中文未翻译标签及未收录的实际表盘组件见素材清单。
 
 状态（2026-09-06 22:18）：移动版 **1.3（10）** 提交后被 Apple 自动校验退回，邮件明确为 **ITMS-90455**：Watch 包的 `MinimumOSVersion=26.6` 不受支持。已将 Watch 宿主与扩展的最低版本改为 **26.5**，四个移动目标统一升至 **1.3（11）**，已于 22:18 重新提交，Apple 当前为 **Waiting for Review**。Submission ID：`447e220d-5bcb-4344-9335-051f0ee2e891`。Mac **1.3（7）** 已公开在 [GitHub v1.3](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3)。商店 8 张中英文截图来自构建 10；构建 11 只调整系统版本要求及构建号，界面与功能一致，继续使用该组截图。半小时真实体验未在本轮补做；提交审核不代表验收、获批或公开上架。

--- a/docs/qa/ios-1.3-build12.md
+++ b/docs/qa/ios-1.3-build12.md
@@ -29,16 +29,23 @@ The Mac menu entry preference is Mac-only; phone and Watch retain their task sta
   production APNs entitlement passed the archive script checks.
 - Independent Standards/Spec review reported zero findings. `git diff --check` passed.
 
-## Remaining acceptance
+## Real-device build 12 acceptance
 
-Watch developer transport disconnected during installation. The last readable Watch
-installation was 1.3 (9); build 12 installation and real Watch task/complication
-synchronization are not yet verified. Xcode asks for the unlocked Watch near the Mac.
-the acceptance iPhone final-build installation and continued Live Activity state updates remain to
-be checked. The second iPhone is outside this acceptance run and was not modified.
+- Installed archived build 12 on the acceptance iPhone and its Apple Watch without
+  uninstalling or clearing data; device tools and Xcode confirmed Watch 1.3 (12).
+- Watch app screenshot at 14:08 showed five working tasks and real Codex/Claude
+  quota. The connected iPhone dashboard at 14:11 showed the same five working,
+  six completed and one idle projection.
+- Watch face screenshot at 14:13 showed a real followed-task complication and
+  quota complications (Codex 55%, Claude 50%); these were physical-device captures.
+- Terminated iPhone build 12 process at 14:12. One aggregate activity remained;
+  tapping it cold-launched the app, reconnected to the paired Mac and received
+  six working tasks. Final post-recovery Island count observation is pending.
+- The second iPhone was not modified. Wrist haptic perception and background APNs
+  delivery were not exercised by this regression acceptance.
 
 ## Release state
 
-At the live App Store Connect check, 1.3 (11) was Waiting for Review. Build 12 is
-prepared to replace it after acceptance; an upload or successful build must not be
-reported as review approval or public availability.
+At the live App Store Connect check, 1.3 (11) was Waiting for Review. Build 12 upload succeeded at 14:09 and Apple processing completed. It is prepared
+to replace the pending build after acceptance; upload is not review approval or
+public availability.

--- a/docs/qa/ios-1.3-build12.md
+++ b/docs/qa/ios-1.3-build12.md
@@ -40,12 +40,17 @@ The Mac menu entry preference is Mac-only; phone and Watch retain their task sta
   quota complications (Codex 55%, Claude 50%); these were physical-device captures.
 - Terminated iPhone build 12 process at 14:12. One aggregate activity remained;
   tapping it cold-launched the app, reconnected to the paired Mac and received
-  six working tasks. Final post-recovery Island count observation is pending.
+  six working tasks. At 14:16 the single Island count changed from five to four as real tasks
+  changed after recovery. Watch also updated to three working tasks and fresh quota.
 - The second iPhone was not modified. Wrist haptic perception and background APNs
   delivery were not exercised by this regression acceptance.
 
 ## Release state
 
-At the live App Store Connect check, 1.3 (11) was Waiting for Review. Build 12 upload succeeded at 14:09 and Apple processing completed. It is prepared
-to replace the pending build after acceptance; upload is not review approval or
-public availability.
+Build 12 uploaded at 14:09, completed Apple processing, and replaced build 11.
+At 14:21 App Store Connect confirmed submission and **Waiting for Review**.
+Submission ID: `6da289ac-2278-4925-9e93-6f23bdad3005`.
+Build ID: `576acbd6-876a-49ee-89bd-620e885b8451`.
+Release remains automatic after approval; the new version is not yet public.
+Review notes include the public source repository (iOS, watchOS, widgets and Mac),
+the built-in Demo, the tested recovery fix and the public APNs delivery limits.

--- a/docs/qa/ios-1.3-build12.md
+++ b/docs/qa/ios-1.3-build12.md
@@ -1,0 +1,44 @@
+# iOS and watchOS 1.3 (12) acceptance
+
+Date: 2026-09-07. Release candidate includes the Live Activity recovery fix from
+`502defa` (integrated as `06dab57`) and Mac 1.3.3 integration from `4f9ef06`.
+
+## Change
+
+On relaunch, adopt an existing active/stale Live Activity and end extra activities
+instead of creating another aggregate. Serialize reconciliation, end all activities
+when no sessions remain, and resume push-token reporting. Restarting the dashboard
+with the same pairing no longer destroys the existing activity.
+
+All four mobile targets use version 1.3, build 12. Watch minimum OS remains 26.5.
+The Mac menu entry preference is Mac-only; phone and Watch retain their task status.
+
+## Verified
+
+- Native ActivityKit regression run: two Live Activity tests plus five DashboardStore
+  tests passed in the iOS 26.5 simulator (handoff evidence:
+  `/tmp/vibebuddy-live-activity-recovery-verified.log`).
+- the acceptance iPhone received a signed development build containing this fix without uninstall
+  or pairing reset. The device retained its the paired Mac connection and showed real tasks.
+- After terminating the app process, the existing Dynamic Island activity remained.
+  Tapping it reopened the app and its real dashboard; returning Home showed one
+  aggregate activity. This is visible recovery evidence, not a device registry ID
+  count or proof of background APNs delivery. An app-switcher swipe was not verified.
+- The same source was archived as 1.3 (12), with the iPhone widget, Watch app and
+  Watch widget embedded. App Store export succeeded; distribution signatures and
+  production APNs entitlement passed the archive script checks.
+- Independent Standards/Spec review reported zero findings. `git diff --check` passed.
+
+## Remaining acceptance
+
+Watch developer transport disconnected during installation. The last readable Watch
+installation was 1.3 (9); build 12 installation and real Watch task/complication
+synchronization are not yet verified. Xcode asks for the unlocked Watch near the Mac.
+the acceptance iPhone final-build installation and continued Live Activity state updates remain to
+be checked. The second iPhone is outside this acceptance run and was not modified.
+
+## Release state
+
+At the live App Store Connect check, 1.3 (11) was Waiting for Review. Build 12 is
+prepared to replace it after acceptance; an upload or successful build must not be
+reported as review approval or public availability.


### PR DESCRIPTION
Live Activities now reuse an existing activity after the iPhone process restarts, dismiss duplicate activities, and serialize updates with teardown. Reconnecting the same dashboard pairing preserves the activity and resumes push-token reporting.

Packages iPhone, Watch and both widget targets as 1.3 (12). Seven native simulator regression tests passed. The archived build was installed on one paired physical iPhone/Watch: real task and quota updates, Watch complications, and Live Activity recovery without a visible duplicate were observed. Independent Standards/Spec review reported no findings.

Apple processed and accepted build 12 for review on September 7. It replaces build 11, remains Waiting for Review, and will release automatically after approval. Review notes include the public source repository. See docs/qa/ios-1.3-build12.md for evidence and the limits of background-push/haptic acceptance.
