### PR TITLE
docs: record 1.3.5 release and build 15 submission

### DIFF
--- a/docs/app-store-submission-1.3.md
+++ b/docs/app-store-submission-1.3.md
@@ -1,6 +1,8 @@
 # VibeBuddy 1.3 — App Store 提交文案包
 
-最新状态（2026-09-07 14:21）：iPhone、watchOS 及两个小组件已统一为 **1.3（12）**，包含实时活动冷启动接管与去重修复。已在一组真实配对 iPhone / Watch 安装并验证任务同步、Watch 表盘组件及灵动岛恢复后更新，详见 [构建 12 验收](qa/ios-1.3-build12.md)。Apple 已接收新构建并显示 **Waiting for Review**；Submission ID：`6da289ac-2278-4925-9e93-6f23bdad3005`。审核通过后自动发布，尚未获批或公开。审核备注已补充 iOS、watchOS、组件及 Mac 的公开源码仓库链接。Mac **1.3.3（10）** 已[公开发布](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3.3)。以下旧状态和内部检查项为历史文案来源，最新验收范围以上述构建 12 记录为准。
+最新状态（2026-09-07 18:22）：iPhone、watchOS 及两个小组件已统一为 **1.3（15）**，已替换构建 12 并重新提交。Apple 显示 **Waiting for Review**；Submission ID：`a2ba9729-ce00-456a-9c81-059b1d8e4adb`，Build ID：`a9efed21-a27f-4e0a-987b-d6ce2aff67b4`。审核通过后自动发布，尚未获批或公开。中英文更新说明及审核备注已更新。Mac **1.3.5（12）** 已[公开发布](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3.5)、完成公证并替换本机应用；Sparkle 更新源已生效。五张跨端协同工单通过 [PR #124](https://github.com/semantic-craft/iOS-vibebuddy/pull/124) 合并。按用户要求完成必要实机 E2E，包含手机完成摘要及已读回传、真实三端额度传输和 Watch 双额度池显示，详见[验收记录](qa/cross-device-1.3.5.md)。以下内容保留为历史来源。
+
+历史状态（2026-09-07 14:21）：iPhone、watchOS 及两个小组件已统一为 **1.3（12）**，包含实时活动冷启动接管与去重修复。已在一组真实配对 iPhone / Watch 安装并验证任务同步、Watch 表盘组件及灵动岛恢复后更新，详见 [构建 12 验收](qa/ios-1.3-build12.md)。Apple 已接收新构建并显示 **Waiting for Review**；Submission ID：`6da289ac-2278-4925-9e93-6f23bdad3005`。审核通过后自动发布，尚未获批或公开。审核备注已补充 iOS、watchOS、组件及 Mac 的公开源码仓库链接。Mac **1.3.3（10）** 已[公开发布](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3.3)。以下旧状态和内部检查项为历史文案来源，最新验收范围以上述构建 12 记录为准。
 
 截图素材已另备：[三端截图与上传清单](app-store-screenshots/1.3/README.md)。含中英文环境原生实拍；中文未翻译标签及未收录的实际表盘组件见素材清单。
 

--- a/docs/qa/cross-device-1.3.5.md
+++ b/docs/qa/cross-device-1.3.5.md
@@ -10,7 +10,7 @@
 - The running Mac's approval endpoint held a harmless synthetic permission probe, delivered deny, then rejected a duplicate decision with HTTP 409. No command or file modification was performed. This checks the live service receipt path; the phone action client and voice awaiting behavior are covered by the prior focused native tests.
 - A physical Watch screenshot showed updated Codex 13% / Claude 49%, matching the running Mac. This demonstrates the actual relay and complication refresh.
 - Prior combined checks: Kit 316 Swift Testing plus 27 XCTest; Mac 763 tests; iPhone 48 tests plus a focused 12-test rerun. Independent review passed. The main integration produces exactly the same tree as the tested implementation, so no duplicate full test run was needed.
-- Mac app and DMG notarization completed successfully. Mobile 1.3 (15), differing from installed 14 only in build metadata, archived and exported for App Store Connect.
+- Mac app and DMG notarization completed successfully. The final mobile 1.3 (15), including the Watch layout correction below, archived, exported and uploaded successfully.
 
 ## Final essential E2E
 
@@ -23,3 +23,10 @@ Phone quota rendering was covered by the focused native checks; the separate pho
 This minimal E2E does not claim a new background-APNs matrix, every failure/deadline path, perceived wrist haptics, or a new microphone audio round-trip. Existing unit and protocol coverage remains in place; those broader checks were not requested for this release.
 
 Private device captures and bounded probe outputs are retained locally under `.scratch/cross-device-coordination-audit/acceptance/release135/` and are not published with unrelated screen content.
+
+## Release receipt
+
+- PR #124 merged as `9e0a324e77cddd5ca488772c500a952b5cb65191`; its tree matches the tested release commit.
+- Mac v1.3.5 is public on GitHub. Installed 1.3.5 (12) passed `spctl` as Notarized Developer ID. Live Sparkle feed advertises build 12 and its published DMG; previous 1.3.4 URLs remain valid.
+- DMG SHA-256: `25f5e50db367b6e5911a276b61053bac2405a2ad2da5492b03600e50176275fe`, matching the GitHub asset digest.
+- At 18:22 Asia/Shanghai, App Store Connect accepted iOS/Watch 1.3 (15): Waiting for Review, submission `a2ba9729-ce00-456a-9c81-059b1d8e4adb`, build `a9efed21-a27f-4e0a-987b-d6ce2aff67b4`. Automatic release after approval remains selected. This is submission, not App Store approval or public availability.


### PR DESCRIPTION
Record the public, notarized Mac 1.3.5 release and the installed iPhone/Watch build 15. App Store Connect confirms build 15 is Waiting for Review with automatic release after approval. Link the essential physical-device acceptance evidence and preserve the limits of the checks performed. Documentation only; diff and references checked.