### PR TITLE
release: macOS 1.3.6 and iOS/watchOS build 16

### DIFF
--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -47,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "15"
+        CURRENT_PROJECT_VERSION: "16"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "15"
+        CURRENT_PROJECT_VERSION: "16"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -118,7 +118,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
         CODE_SIGN_ENTITLEMENTS: Watch/VibeBuddyWatch.entitlements
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "15"
+        CURRENT_PROJECT_VERSION: "16"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -146,7 +146,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp.widget
         MARKETING_VERSION: "1.3"
-        CURRENT_PROJECT_VERSION: "15"
+        CURRENT_PROJECT_VERSION: "16"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2

--- a/VibeBuddyMacApp/project.yml
+++ b/VibeBuddyMacApp/project.yml
@@ -63,8 +63,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.mac
-        MARKETING_VERSION: "1.3.5"
-        CURRENT_PROJECT_VERSION: "12"
+        MARKETING_VERSION: "1.3.6"
+        CURRENT_PROJECT_VERSION: "13"
         SWIFT_VERSION: "6.0"
         # Build signs ad-hoc; tools/redeploy-mac.sh re-signs the built .app with a
         # stable local Apple Development identity so Keychain ACLs / TCC grants

--- a/docs/release-notes-1.3.6.md
+++ b/docs/release-notes-1.3.6.md
@@ -1,0 +1,8 @@
+# vibebuddy 1.3.6
+
+- Reply to a supported waiting task, steer a running Codex task, or continue an existing Codex task with clearer delivery receipts and protection against stale targets and duplicate requests.
+- View bounded recent dialogue from your Mac on the task detail screen. Reasoning and tool output are excluded, and cached dialogue is cleared when pairing or source changes.
+- Restore ordinary reminders when Mac presence expires, while preserving completion notifications.
+- The companion Watch widget gains time-limited Smart Stack relevance when a followed task needs input.
+
+Companion features require iOS/watchOS 1.3 build 16. Availability on the App Store depends on Apple review. Mac build 13.


### PR DESCRIPTION
Release the integrated task actions, recent dialogue and presence reminders from #126 as macOS 1.3.6 (13), with coordinated iOS/watchOS 1.3 (16). All four mobile targets share version and build numbers.

Version configuration independently reviewed. The new iOS/Watch archive/export and signed device build passed; the Mac app and DMG passed Developer ID signing, notarization and Gatekeeper. Existing functional integration evidence is in docs/qa/retained-work-2026-09-07.md. Release notes distinguish App Store availability from Mac direct distribution.
