### PR TITLE
Name iPhone and Watch apps Vibebuddy

### DIFF
--- a/VibeBuddyApp/WatchWidget/Info.plist
+++ b/VibeBuddyApp/WatchWidget/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>vibebuddy</string>
+	<string>Vibebuddy</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -26,7 +26,7 @@ targets:
     info:
       path: Sources/Info.plist
       properties:
-        CFBundleDisplayName: vibebuddy
+        CFBundleDisplayName: Vibebuddy
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchScreen: {}
@@ -73,7 +73,7 @@ targets:
     info:
       path: Widget/Info.plist
       properties:
-        CFBundleDisplayName: vibebuddy
+        CFBundleDisplayName: Vibebuddy
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         NSExtension:
@@ -101,7 +101,7 @@ targets:
     info:
       path: Watch/Info.plist
       properties:
-        CFBundleDisplayName: vibebuddy
+        CFBundleDisplayName: Vibebuddy
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         WKApplication: true
@@ -137,7 +137,7 @@ targets:
     info:
       path: WatchWidget/Info.plist
       properties:
-        CFBundleDisplayName: vibebuddy
+        CFBundleDisplayName: Vibebuddy
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         NSExtension:


### PR DESCRIPTION
Set the exact display name Vibebuddy for the iPhone app, Watch app and their widget extensions as requested. Keep bundle identifiers, URL schemes and companion links unchanged. XcodeGen output and independent review confirm all four display names; no localization overrides exist. Mobile archive is being rebuilt for distribution.