### PR TITLE
Voice catalog with a tiered picker

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -297,10 +297,17 @@ public enum VoiceSettings {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return v.isEmpty ? (SpeechSynthesis.support(p)?.defaultModel ?? "") : v
     }
-    public static func readAloudVoice(_ p: VoiceProvider, defaults: UserDefaults = .standard) -> String {
+    /// Blank falls back to the catalog's first voice **for the conversation
+    /// language** — a fresh English setup must not be handed a Chinese voice,
+    /// which is the accent bug this catalog exists to fix.
+    public static func readAloudVoice(_ p: VoiceProvider, language: VoiceLanguage? = nil,
+                                      defaults: UserDefaults = .standard) -> String {
         let v = (defaults.string(forKey: readAloudVoiceKey(p)) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return v.isEmpty ? (SpeechSynthesis.support(p)?.defaultVoice ?? "") : v
+        guard v.isEmpty else { return v }
+        let spoken = language ?? conversationLanguage(defaults: defaults)
+        return VoiceCatalog.defaultVoice(.readAloud, p, language: spoken)
+            ?? SpeechSynthesis.support(p)?.defaultVoice ?? ""
     }
 
     public static func readAloudConfiguration(_ p: VoiceProvider,
@@ -310,6 +317,11 @@ public enum VoiceSettings {
         return SpeechSynthesisConfiguration(provider: p,
             model: readAloudModel(p, defaults: defaults), voice: readAloudVoice(p, defaults: defaults),
             qwenWorkspaceID: workspace.isEmpty ? nil : workspace, qwenUseIntl: defaults.bool(forKey: regionIntlKey))
+    }
+
+    /// The shared conversation language, from an injectable store.
+    public static func conversationLanguage(defaults: UserDefaults = .standard) -> VoiceLanguage {
+        VoiceLanguage(rawValue: defaults.string(forKey: conversationLanguageKey) ?? "") ?? .english
     }
 
     /// Move the Qwen-only read-aloud model / voice onto the per-provider keys.

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoiceCatalog.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoiceCatalog.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// What a voice is offered for. The same vendor ships a different set for a
+/// realtime conversation than for one-shot speech, so a catalog keyed by
+/// provider alone would be wrong.
+public enum VoicePurpose: String, Sendable, CaseIterable {
+    case conversation, readAloud
+}
+
+/// One voice as its vendor documents it.
+public struct CatalogVoice: Sendable, Equatable, Identifiable {
+    /// The vendor's own voice ID — what goes on the wire.
+    public let id: String
+    public let name: String
+    /// One line of character, as the vendor describes it. May be empty.
+    public let trait: String
+    /// `nil` when the vendor documents the voice as multilingual.
+    public let language: VoiceLanguage?
+    /// The vendor's own grouping, shown as the section header.
+    public let category: String
+    /// In the vendor's own recommended tier — their signal, not our taste.
+    public let isCore: Bool
+
+    public init(_ id: String, _ name: String, _ trait: String = "",
+                language: VoiceLanguage? = nil, category: String, core: Bool = false) {
+        self.id = id
+        self.name = name
+        self.trait = trait
+        self.language = language
+        self.category = category
+        self.isCore = core
+    }
+
+    /// True for the conversation language, and for a multilingual voice always.
+    public func speaks(_ language: VoiceLanguage) -> Bool {
+        self.language == nil || self.language == language
+    }
+    /// "Mary · Warm British" — the ID only when it carries no separate name.
+    public var label: String {
+        let lead = name == id ? name : "\(name) · \(id)"
+        return trait.isEmpty ? lead : "\(lead) · \(trait)"
+    }
+}
+
+/// One of the vendor's own sections of its voice list.
+public struct VoiceGroup: Sendable, Equatable, Identifiable {
+    public let category: String
+    public let voices: [CatalogVoice]
+    public var id: String { category }
+}
+
+public enum VoiceCatalog {
+    /// Past this many, a dropdown stops being a way to choose and the control
+    /// becomes a shortlist plus a searchable list of everything.
+    public static let tierLimit = 15
+
+    public static func voices(_ purpose: VoicePurpose, _ provider: VoiceProvider) -> [CatalogVoice] {
+        catalog[Key(purpose, provider)] ?? []
+    }
+
+    public static func isTiered(_ purpose: VoicePurpose, _ provider: VoiceProvider) -> Bool {
+        voices(purpose, provider).count > tierLimit
+    }
+
+    /// What the dropdown offers. A short catalog lists everything in the
+    /// conversation language; a long one lists the vendor's recommended tier.
+    /// Neither may come back empty because of the language filter — an empty
+    /// dropdown is worse than one in the wrong language.
+    public static func shortlist(_ purpose: VoicePurpose, _ provider: VoiceProvider,
+                                 language: VoiceLanguage) -> [CatalogVoice] {
+        let all = voices(purpose, provider)
+        guard !all.isEmpty else { return [] }
+        guard all.count > tierLimit else {
+            let matched = all.filter { $0.speaks(language) }
+            return matched.isEmpty ? all : matched
+        }
+        let core = all.filter { $0.isCore && $0.speaks(language) }
+        return core.isEmpty ? all.filter(\.isCore) : core
+    }
+
+    /// The vendor's groups, in the order the vendor documents them.
+    public static func grouped(_ voices: [CatalogVoice]) -> [VoiceGroup] {
+        var order: [String] = []
+        var groups: [String: [CatalogVoice]] = [:]
+        for voice in voices {
+            if groups[voice.category] == nil { order.append(voice.category) }
+            groups[voice.category, default: []].append(voice)
+        }
+        return order.map { VoiceGroup(category: $0, voices: groups[$0]!) }
+    }
+
+    /// Free-text search over everything a row shows, for the full-list panel.
+    public static func search(_ query: String, in voices: [CatalogVoice]) -> [CatalogVoice] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return voices }
+        return voices.filter {
+            "\($0.id) \($0.name) \($0.trait) \($0.category)".lowercased().contains(needle)
+        }
+    }
+
+    /// The default voice for a purpose: the first the shortlist offers.
+    public static func defaultVoice(_ purpose: VoicePurpose, _ provider: VoiceProvider,
+                                    language: VoiceLanguage) -> String? {
+        shortlist(purpose, provider, language: language).first?.id
+    }
+
+    struct Key: Hashable {
+        let purpose: VoicePurpose
+        let provider: VoiceProvider
+        init(_ purpose: VoicePurpose, _ provider: VoiceProvider) {
+            self.purpose = purpose
+            self.provider = provider
+        }
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoiceCatalogData.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoiceCatalogData.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Voices as each vendor documents them, fetched 2026-09-09:
+///
+/// - Qwen — help.aliyun.com Model Studio, Qwen-Audio realtime voices and the
+///   `qwen-audio-3.0-tts-flash` voice list.
+/// - OpenAI — developers.openai.com: the realtime voices, and the longer
+///   `/v1/audio/speech` list that adds `fable`, `nova` and `onyx`.
+/// - Gemini — ai.google.dev speech generation (the 30-voice table) plus the
+///   Live API capabilities guide, which states that native-audio models
+///   "support any of the voices available for our Text-to-Speech (TTS)
+///   models". Conversation and read-aloud therefore share the set, and the
+///   shortlist is the eight the table lists first.
+/// - Doubao — docs.volcengine.com/docs/6561/1257544, the 语音合成大模型 2.0
+///   table (`_uranus_bigtts` / `ICL_uranus_`, the only voices `seed-tts-2.0`
+///   accepts) for read-aloud, and docs/6561/1594356 for the realtime O2.0
+///   voices, which are a different set (`_jupiter_bigtts`).
+///
+/// Voices the vendor tags as platform IP (Volcengine's 抖音同款 / 剪映同款 /
+/// 豆包同款 / 番茄小说同款 / 猫箱同款 — 佩奇猪, 四郎, 擎苍, 直率英子 and the
+/// rest) are **not written here at all**, rather than collected and filtered:
+/// we do not want to ship a licensing question, and Volcengine retires them
+/// (a batch went on 2026-06-30). Custom voice ID covers anything absent —
+/// cloned voices, newly released ones, and these.
+extension VoiceCatalog {
+    static let catalog: [Key: [CatalogVoice]] = [
+        // MARK: Qwen
+
+        Key(.conversation, .qwen): [
+            .init("longanqian", "龙安茜", "Default system voice", language: .chinese, category: "系统音色", core: true),
+            .init("longanlingxin", "龙安灵心", "Warm, confiding", language: .chinese, category: "系统音色", core: true),
+            .init("longanlingxi", "龙安灵希", "Sweet, cheerful", language: .chinese, category: "系统音色", core: true),
+            .init("longanxiaoxin", "龙安小昕", "Friendly, lively", language: .chinese, category: "系统音色", core: true),
+            .init("longanlufeng", "龙安鲁风", "Bright, outgoing", language: .chinese, category: "系统音色", core: true),
+        ],
+        Key(.readAloud, .qwen): [
+            .init("longanfengyue", "龙安风悦", "Natural and warm", language: .chinese, category: "社交陪伴", core: true),
+            .init("longanyuanfei", "龙安元妃", "Proud, imperial", language: .chinese, category: "社交陪伴", core: true),
+            .init("longanlingxi", "龙安灵希", "Sweet, cheerful", language: .chinese, category: "社交陪伴", core: true),
+            .init("longanxiaoxin", "龙安小昕", "Friendly, lively", language: .chinese, category: "社交陪伴", core: true),
+            .init("longanhuan_v3.6", "龙安欢", "Bright and easy", language: .chinese, category: "社交陪伴", core: true),
+            // The reason this ticket exists: an English summary read by a
+            // Chinese voice. These three are the vendor's English tier.
+            .init("loongmary", "Mary", "Warm British", language: .english, category: "语音助手", core: true),
+            .init("loongeva_v3.6", "Eva", "Bright American", language: .english, category: "语音助手", core: true),
+            .init("loongjohn", "John", "Steady, friendly American", language: .english, category: "语音助手", core: true),
+            .init("longjielidou_v3.6", "龙杰力豆", "Innocent boy", language: .chinese, category: "儿童陪伴"),
+            .init("longpaopao_v3.6", "龙泡泡", "Soft and cute", language: .chinese, category: "儿童陪伴"),
+            .init("longhuohuo_v3.6", "龙火火", "Mischievous boy", language: .chinese, category: "角色音"),
+            .init("longchuanshu_v3.6", "龙川叔", "Sichuan-accented uncle", language: .chinese, category: "角色音"),
+        ],
+
+        // MARK: OpenAI — realtime is ten, speech is thirteen.
+
+        Key(.conversation, .openai): openAI([
+            "marin", "cedar", "alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse",
+        ], category: "Realtime voices"),
+        Key(.readAloud, .openai): openAI([
+            "marin", "cedar", "alloy", "ash", "ballad", "coral", "echo",
+            "fable", "nova", "onyx", "sage", "shimmer", "verse",
+        ], category: "Speech voices"),
+
+        // MARK: Gemini — one documented set, shared by both purposes.
+
+        Key(.conversation, .gemini): geminiVoices,
+        Key(.readAloud, .gemini): geminiVoices,
+
+        // MARK: Doubao — realtime O2.0 and TTS 2.0 are different families.
+
+        Key(.conversation, .doubao): [
+            .init("zh_female_vv_jupiter_bigtts", "Vivi", "Lively, eager to share", language: .chinese, category: "精品音色", core: true),
+            .init("zh_female_xiaohe_jupiter_bigtts", "小何", "Sweet, Taiwanese accent", language: .chinese, category: "精品音色", core: true),
+            .init("zh_male_yunzhou_jupiter_bigtts", "云舟", "Crisp and steady", language: .chinese, category: "精品音色", core: true),
+            .init("zh_male_xiaotian_jupiter_bigtts", "小天", "Crisp, magnetic", language: .chinese, category: "精品音色", core: true),
+            .init("en_male_tim_uranus_bigtts", "Tim", "US English", language: .english, category: "多语种", core: true),
+            .init("en_female_dacey_uranus_bigtts", "Dacey", "US English", language: .english, category: "多语种", core: true),
+            .init("en_female_stokie_uranus_bigtts", "Stokie", "US English", language: .english, category: "多语种", core: true),
+        ],
+        Key(.readAloud, .doubao): [
+            .init("zh_female_vv_uranus_bigtts", "Vivi 2.0", "Emotional range, ASMR", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_xiaohe_uranus_bigtts", "小何 2.0", "Emotional range, ASMR", language: .chinese, category: "通用场景", core: true),
+            .init("zh_male_m191_uranus_bigtts", "云舟 2.0", "Emotional range, ASMR", language: .chinese, category: "通用场景", core: true),
+            .init("zh_male_taocheng_uranus_bigtts", "小天 2.0", "Crisp, magnetic", language: .chinese, category: "通用场景", core: true),
+            .init("zh_male_liufei_uranus_bigtts", "刘飞 2.0", "Steady narrator", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_qingxinnvsheng_uranus_bigtts", "清新女声 2.0", "Fresh, clear", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_tianmeixiaoyuan_uranus_bigtts", "甜美小源 2.0", "Sweet", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_tianmeitaozi_uranus_bigtts", "甜美桃子 2.0", "Sweet", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_sophie_uranus_bigtts", "魅力苏菲 2.0", "Charming", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_linjianvhai_uranus_bigtts", "邻家女孩 2.0", "Girl next door", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_meilinvyou_uranus_bigtts", "魅力女友 2.0", "Charming", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_qiaopinv_uranus_bigtts", "俏皮女声 2.0", "Playful", language: .chinese, category: "通用场景", core: true),
+            .init("zh_female_shuangkuaisisi_uranus_bigtts", "爽快思思 2.0", "Brisk", language: .chinese, category: "通用场景", core: true),
+            .init("zh_male_wennuanahu_uranus_bigtts", "温暖阿虎 2.0", "Warm, conversational", language: .chinese, category: "语音闲聊", core: true),
+            .init("en_male_tim_uranus_bigtts", "Tim", "US English", language: .english, category: "多语种", core: true),
+            .init("en_female_dacey_uranus_bigtts", "Dacey", "US English", language: .english, category: "多语种", core: true),
+            .init("en_female_stokie_uranus_bigtts", "Stokie", "US English", language: .english, category: "多语种", core: true),
+            .init("ICL_uranus_en_female_charlie_tob", "Charlie 2.0", "US English", language: .english, category: "多语种"),
+            .init("ICL_uranus_en_male_ethan_tob", "Ethan 2.0", "Australian English", language: .english, category: "多语种"),
+            .init("ICL_uranus_en_male_alastor_tob", "Alastor 2.0", "British English", language: .english, category: "多语种"),
+            .init("ICL_uranus_en_male_noah_tob", "Noah 2.0", "US English", language: .english, category: "多语种"),
+            .init("zh_female_cancan_uranus_bigtts", "知性灿灿 2.0", "Composed", language: .chinese, category: "角色扮演"),
+            .init("zh_female_sajiaoxuemei_uranus_bigtts", "撒娇学妹 2.0", "Coy", language: .chinese, category: "角色扮演"),
+            .init("zh_female_kefunvsheng_uranus_bigtts", "暖阳女声 2.0", "Customer service", language: .chinese, category: "客服场景"),
+            .init("zh_female_xiaoxue_uranus_bigtts", "儿童绘本 2.0", "Picture books", language: .chinese, category: "有声阅读"),
+            .init("zh_female_jitangnv_uranus_bigtts", "鸡汤女 2.0", "Inspirational narration", language: .chinese, category: "视频配音"),
+        ],
+    ]
+
+    /// OpenAI documents no per-voice language, and recommends `marin`/`cedar`.
+    private static func openAI(_ ids: [String], category: String) -> [CatalogVoice] {
+        ids.map {
+            .init($0, $0, ($0 == "marin" || $0 == "cedar") ? "Recommended by OpenAI" : "",
+                  category: category, core: true)
+        }
+    }
+
+    /// The 30-voice table, multilingual by documentation. The eight the table
+    /// lists first are the shortlist; the rest sit behind "show all".
+    private static let geminiVoices: [CatalogVoice] = {
+        let leading = [("Zephyr", "Bright"), ("Puck", "Upbeat"), ("Charon", "Informative"),
+                       ("Kore", "Firm"), ("Fenrir", "Excitable"), ("Leda", "Youthful"),
+                       ("Orus", "Firm"), ("Aoede", "Breezy")]
+        let rest = [("Callirrhoe", "Easy-going"), ("Autonoe", "Bright"), ("Enceladus", "Breathy"),
+                    ("Iapetus", "Clear"), ("Umbriel", "Easy-going"), ("Algieba", "Smooth"),
+                    ("Despina", "Smooth"), ("Erinome", "Clear"), ("Algenib", "Gravelly"),
+                    ("Rasalgethi", "Informative"), ("Laomedeia", "Upbeat"), ("Achernar", "Soft"),
+                    ("Alnilam", "Firm"), ("Schedar", "Even"), ("Gacrux", "Mature"),
+                    ("Pulcherrima", "Forward"), ("Achird", "Friendly"), ("Zubenelgenubi", "Casual"),
+                    ("Vindemiatrix", "Gentle"), ("Sadachbia", "Lively"), ("Sadaltager", "Knowledgeable"),
+                    ("Sulafat", "Warm")]
+        return leading.map { CatalogVoice($0.0, $0.0, $0.1, category: "Prebuilt voices", core: true) }
+            + rest.map { CatalogVoice($0.0, $0.0, $0.1, category: "More voices") }
+    }()
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
@@ -102,3 +102,44 @@ struct VoiceDefaultsInCatalogTests {
         }
     }
 }
+
+@Suite("A fresh read-aloud voice follows the language")
+struct ReadAloudDefaultVoiceTests {
+    private func suite() throws -> (UserDefaults, String) {
+        let name = "read-aloud-voice-\(UUID())"
+        return (try #require(UserDefaults(suiteName: name)), name)
+    }
+
+    @Test func englishNeverStartsOnAChineseVoice() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        // Nothing stored: the language decides, not the vendor's constant.
+        defaults.set(VoiceLanguage.english.rawValue, forKey: VoiceSettings.conversationLanguageKey)
+        let english = VoiceSettings.readAloudVoice(.qwen, defaults: defaults)
+        #expect(VoiceCatalog.voices(.readAloud, .qwen).first { $0.id == english }?.language == .english)
+        defaults.set(VoiceLanguage.chinese.rawValue, forKey: VoiceSettings.conversationLanguageKey)
+        let chinese = VoiceSettings.readAloudVoice(.qwen, defaults: defaults)
+        #expect(VoiceCatalog.voices(.readAloud, .qwen).first { $0.id == chinese }?.language == .chinese)
+        #expect(english != chinese)
+    }
+
+    @Test func aStoredVoiceOutranksTheLanguage() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        defaults.set(VoiceLanguage.english.rawValue, forKey: VoiceSettings.conversationLanguageKey)
+        defaults.set("S_MyClonedVoice_42", forKey: VoiceSettings.readAloudVoiceKey(.qwen))
+        #expect(VoiceSettings.readAloudVoice(.qwen, defaults: defaults) == "S_MyClonedVoice_42")
+    }
+
+    @Test func everyProviderAndLanguageResolvesToACatalogVoice() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        for provider in VoiceProvider.allCases {
+            for language in [VoiceLanguage.english, .chinese] {
+                let id = VoiceSettings.readAloudVoice(provider, language: language, defaults: defaults)
+                #expect(VoiceCatalog.voices(.readAloud, provider).contains { $0.id == id },
+                        "\(provider) \(language) → \(id)")
+            }
+        }
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("Voice catalog and its tier rule")
+struct VoiceCatalogTests {
+    @Test func eachPurposeHasItsOwnSetForTheSameVendor() {
+        // OpenAI's speech list adds three voices its realtime list does not have.
+        let talk = Set(VoiceCatalog.voices(.conversation, .openai).map(\.id))
+        let read = Set(VoiceCatalog.voices(.readAloud, .openai).map(\.id))
+        #expect(talk.count == 10)
+        #expect(read.count == 13)
+        #expect(read.subtracting(talk) == ["fable", "nova", "onyx"])
+        // Doubao's realtime and TTS families do not even share ID shapes.
+        #expect(VoiceCatalog.voices(.conversation, .doubao).contains { $0.id.contains("_jupiter_") })
+        #expect(!VoiceCatalog.voices(.readAloud, .doubao).contains { $0.id.contains("_jupiter_") })
+        // Every (purpose, provider) is populated.
+        for purpose in VoicePurpose.allCases {
+            for provider in VoiceProvider.allCases {
+                #expect(!VoiceCatalog.voices(purpose, provider).isEmpty, "\(purpose) \(provider)")
+            }
+        }
+    }
+
+    @Test func tierRuleTurnsOnJustAboveTheLimit() {
+        // Qwen read-aloud sits below the limit; Doubao and Gemini above it.
+        #expect(VoiceCatalog.voices(.readAloud, .qwen).count <= VoiceCatalog.tierLimit)
+        #expect(!VoiceCatalog.isTiered(.readAloud, .qwen))
+        #expect(VoiceCatalog.voices(.readAloud, .doubao).count > VoiceCatalog.tierLimit)
+        #expect(VoiceCatalog.isTiered(.readAloud, .doubao))
+        #expect(VoiceCatalog.isTiered(.readAloud, .gemini))
+        // Below the limit the dropdown holds everything in the language;
+        // above it, only the vendor's own recommended tier.
+        let qwen = VoiceCatalog.shortlist(.readAloud, .qwen, language: .chinese)
+        #expect(qwen.count == VoiceCatalog.voices(.readAloud, .qwen).filter { $0.speaks(.chinese) }.count)
+        let doubao = VoiceCatalog.shortlist(.readAloud, .doubao, language: .chinese)
+        #expect(doubao.allSatisfy { $0.isCore })
+        #expect(doubao.count < VoiceCatalog.voices(.readAloud, .doubao).count)
+    }
+
+    @Test func theLanguageFilterNeverEmptiesTheList() {
+        // Qwen's realtime voices are all Chinese, so English has nothing to match.
+        #expect(VoiceCatalog.voices(.conversation, .qwen).allSatisfy { $0.language == .chinese })
+        let english = VoiceCatalog.shortlist(.conversation, .qwen, language: .english)
+        #expect(english.count == VoiceCatalog.voices(.conversation, .qwen).count)
+        // And no (purpose, provider, language) combination comes back empty.
+        for purpose in VoicePurpose.allCases {
+            for provider in VoiceProvider.allCases {
+                for language in [VoiceLanguage.english, .chinese] {
+                    #expect(!VoiceCatalog.shortlist(purpose, provider, language: language).isEmpty,
+                            "\(purpose) \(provider) \(language)")
+                }
+            }
+        }
+    }
+
+    @Test func qwenEnglishReadAloudVoicesAreOfferedInEnglish() {
+        let english = VoiceCatalog.shortlist(.readAloud, .qwen, language: .english)
+        #expect(english.map(\.id) == ["loongmary", "loongeva_v3.6", "loongjohn"])
+        // The hard-coded trio this replaces was Chinese-only, which is the bug.
+        #expect(english.allSatisfy { $0.language == .english })
+    }
+
+    @Test func platformIPVoicesAreAbsentFromTheCatalog() {
+        // Volcengine's 抖音同款 / 剪映同款 / 豆包同款 / 番茄小说同款 tier.
+        let tagged = ["zh_female_peiqi_uranus_bigtts", "zh_male_silang_uranus_bigtts",
+                      "zh_male_qingcang_uranus_bigtts", "zh_female_zhishuaiyingzi_uranus_bigtts"]
+        let everything = VoicePurpose.allCases.flatMap { purpose in
+            VoiceProvider.allCases.flatMap { VoiceCatalog.voices(purpose, $0) }
+        }
+        for id in tagged { #expect(!everything.contains { $0.id == id }, "\(id)") }
+    }
+
+    @Test func groupingKeepsTheVendorsOrderAndSearchLooksEverywhere() {
+        let doubao = VoiceCatalog.voices(.readAloud, .doubao)
+        let groups = VoiceCatalog.grouped(doubao)
+        #expect(groups.first?.category == "通用场景")
+        #expect(groups.map(\.voices).reduce(0) { $0 + $1.count } == doubao.count)
+        #expect(VoiceCatalog.search("british", in: VoiceCatalog.voices(.readAloud, .qwen)).map(\.id) == ["loongmary"])
+        #expect(VoiceCatalog.search("  ", in: doubao).count == doubao.count)
+        #expect(VoiceCatalog.search("no such voice", in: doubao).isEmpty)
+    }
+}
+
+@Suite("Runtime defaults exist in the catalog")
+struct VoiceDefaultsInCatalogTests {
+    @Test func everyRealtimeDefaultIsACatalogVoice() {
+        for provider in VoiceProvider.allCases {
+            let ids = Set(VoiceCatalog.voices(.conversation, provider).map(\.id))
+            for language in [VoiceLanguage.english, .chinese] {
+                let fallback = provider.defaultVoice(language)
+                #expect(ids.contains(fallback), "\(provider) \(language) → \(fallback)")
+            }
+        }
+    }
+
+    @Test func everySynthesisDefaultIsACatalogVoice() {
+        for provider in VoiceProvider.allCases {
+            guard let support = SpeechSynthesis.support(provider) else { continue }
+            let ids = Set(VoiceCatalog.voices(.readAloud, provider).map(\.id))
+            #expect(ids.contains(support.defaultVoice), "\(provider) → \(support.defaultVoice)")
+        }
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoicePurposeSettingsTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoicePurposeSettingsTests.swift
@@ -76,7 +76,9 @@ struct ReadAloudPurposeSettingsTests {
         // Absent legacy keys: no side effect, and the provider default still applies.
         VoiceSettings.migrateLegacyReadAloudKeys(defaults: defaults)
         #expect(defaults.object(forKey: VoiceSettings.readAloudModelKey(.qwen)) == nil)
-        #expect(VoiceSettings.readAloudVoice(.qwen, defaults: defaults) == QwenSpeechSynthesizer.defaultVoice)
+        // No legacy key and nothing stored: the language decides, not a constant.
+        #expect(VoiceSettings.readAloudVoice(.qwen, language: .chinese, defaults: defaults)
+                == QwenSpeechSynthesizer.defaultVoice)
 
         defaults.set("custom-model", forKey: VoiceSettings.legacyReadAloudModelKey)
         defaults.set("longanlingxi", forKey: VoiceSettings.legacyReadAloudVoiceKey)

--- a/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -147,7 +147,6 @@
 "Get an API key" = "获取 API 密钥";
 "Model ID — editable, type any model" = "模型 ID——可编辑，可输入任意模型";
 "Browse available models" = "浏览可用模型";
-"Browse available voices" = "浏览可用音色";
 "Find your workspace ID" = "查找业务空间 ID";
 "Use Singapore (international) region" = "使用新加坡（国际）地域";
 "Paste your %@ key" = "粘贴你的 %@ 密钥";
@@ -249,9 +248,6 @@
 "Playback complete" = "播放完成";
 "Speech generation failed. Check your read-aloud model, voice and connection." = "语音合成失败，请检查朗读模型、音色和网络";
 "Speech synthesis model" = "语音合成模型";
-"Longan Fengyue · Warm and natural" = "龙安风悦 · 自然亲切";
-"Longan Lingxi · Sweet and cheerful" = "龙安灵希 · 可爱甜美";
-"Longan Yuanfei · Female character voice" = "龙安元妃 · 角色女声";
 "Stop" = "停止";
 "Hello, I’m your work companion. The task is complete, and device verification is still pending." = "你好，我是你的工作伙伴。任务已完成，设备验证仍待进行。";
 "Read-aloud voice" = "朗读音色";
@@ -482,3 +478,27 @@
 "Optional. When set, Qwen connects through the workspace endpoint." = "可选。填写后 Qwen 将通过工作空间专属接入点连接。";
 
 "Shared by all three features, and it decides which voice each provider defaults to." = "三个功能共用，并决定每家服务商默认使用哪个音色。";
+
+/* Voice catalog picker */
+
+"Conversation voice" = "对话音色";
+
+"Custom voice ID…" = "自定义音色 ID…";
+
+"Custom voice ID" = "自定义音色 ID";
+
+"voice ID from the provider’s docs" = "服务商文档里的音色 ID";
+
+"Back to the list" = "返回列表";
+
+"Show all %lld voices…" = "查看全部 %lld 个音色…";
+
+"%lld voices from %@" = "共 %lld 个音色 · %@";
+
+"Search" = "搜索";
+
+"Search %lld voices…" = "搜索 %lld 个音色…";
+
+"Search voices" = "搜索音色";
+
+"No match" = "没有匹配项";

--- a/VibeBuddyMacApp/Sources/VoicePicker.swift
+++ b/VibeBuddyMacApp/Sources/VoicePicker.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+import VibeBuddyKit
+
+/// Choosing a voice from the built-in catalog. Short catalogs are a plain
+/// dropdown; long ones show the vendor's recommended tier with a searchable
+/// panel behind it. Custom voice ID is always the last way out, for cloned and
+/// newly released voices the catalog cannot know about.
+struct VoicePicker<Trailing: View>: View {
+    /// Names this row's voice for VoiceOver, since two rows both have one.
+    let label: LocalizedStringKey
+    let purpose: VoicePurpose
+    let provider: VoiceProvider
+    let language: VoiceLanguage
+    /// What the runtime uses when nothing is stored. The picker must show the
+    /// same voice the provider would actually speak with, not its own guess.
+    let fallback: String
+    @Binding var voiceID: String
+    @ViewBuilder let trailing: Trailing
+
+    @State private var custom = false
+    @State private var showingAll = false
+    @State private var query = ""
+
+    /// Picked from the dropdown, never a voice ID.
+    private static var customTag: String { "\u{1}custom" }
+
+    private var all: [CatalogVoice] { VoiceCatalog.voices(purpose, provider) }
+    private var shortlist: [CatalogVoice] { VoiceCatalog.shortlist(purpose, provider, language: language) }
+    /// A blank stored value shows what the runtime would use, falling back to
+    /// the catalog's first when a provider has no default of its own. Nothing
+    /// is written until the user picks.
+    private var effectiveID: String {
+        if !voiceID.isEmpty { return voiceID }
+        if !fallback.isEmpty { return fallback }
+        return VoiceCatalog.defaultVoice(purpose, provider, language: language) ?? ""
+    }
+    private var selection: Binding<String> {
+        Binding(get: { effectiveID }, set: { picked in
+            if picked == Self.customTag { custom = true } else { voiceID = picked }
+        })
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if custom {
+                HStack(spacing: 6) {
+                    TextField("Voice ID", text: $voiceID, prompt: Text("voice ID from the provider’s docs"))
+                        .labelsHidden().textFieldStyle(.roundedBorder)
+                        .font(.caption.monospaced()).autocorrectionDisabled()
+                        .accessibilityLabel(label)
+                        .accessibilityIdentifier("customVoiceID")
+                    trailing
+                }
+                Button("Back to the list") {
+                    custom = false
+                    if !all.contains(where: { $0.id == voiceID }) { voiceID = "" }
+                }
+                .buttonStyle(.link).font(.caption)
+            } else {
+                HStack(spacing: 6) {
+                    Picker(label, selection: selection) {
+                        ForEach(VoiceCatalog.grouped(shortlist)) { group in
+                            Section(group.category) {
+                                ForEach(group.voices) { Text(verbatim: $0.label).tag($0.id) }
+                            }
+                        }
+                        // A voice chosen from the full list, or kept from an
+                        // earlier language, still needs a tag of its own.
+                        if !effectiveID.isEmpty, !shortlist.contains(where: { $0.id == effectiveID }) {
+                            Text(verbatim: all.first { $0.id == effectiveID }?.label ?? effectiveID)
+                                .tag(effectiveID)
+                        }
+                        Divider()
+                        Text("Custom voice ID…").tag(Self.customTag)
+                    }
+                    .labelsHidden().accessibilityLabel(label)
+                    trailing
+                }
+                if VoiceCatalog.isTiered(purpose, provider) {
+                    Button("Show all \(all.count) voices…") { query = ""; showingAll = true }
+                        .buttonStyle(.link).font(.caption)
+                        .popover(isPresented: $showingAll, arrowEdge: .bottom) { fullList }
+                } else {
+                    Text("\(shortlist.count) voices from \(provider.display)")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var fullList: some View {
+        let matches = VoiceCatalog.search(query, in: all)
+        return VStack(alignment: .leading, spacing: 8) {
+            TextField("Search", text: $query, prompt: Text("Search \(all.count) voices…"))
+                .textFieldStyle(.roundedBorder).labelsHidden()
+                .accessibilityLabel("Search voices")
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2, pinnedViews: .sectionHeaders) {
+                    if matches.isEmpty {
+                        Text("No match").font(.caption).foregroundStyle(.secondary).padding(.vertical, 6)
+                    }
+                    ForEach(VoiceCatalog.grouped(matches)) { group in
+                        Section {
+                            ForEach(group.voices) { voice in
+                                Button {
+                                    voiceID = voice.id
+                                    showingAll = false
+                                } label: {
+                                    HStack(spacing: 6) {
+                                        Text(verbatim: voice.name)
+                                        Text(verbatim: voice.trait.isEmpty ? voice.id : voice.trait)
+                                            .foregroundStyle(.secondary)
+                                        Spacer(minLength: 0)
+                                        if voice.id == effectiveID {
+                                            Image(systemName: "checkmark").foregroundStyle(.tint)
+                                        }
+                                    }
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        } header: {
+                            HStack {
+                                Text(verbatim: group.category)
+                                Spacer(minLength: 0)
+                                Text(verbatim: "\(group.voices.count)")
+                            }
+                            .font(.caption.bold()).foregroundStyle(.secondary)
+                            .padding(.vertical, 2).background(.background)
+                        }
+                    }
+                }
+                .font(.callout)
+            }
+            .frame(width: 320, height: 260)
+        }
+        .padding(12)
+    }
+}
+
+extension VoicePicker where Trailing == EmptyView {
+    init(label: LocalizedStringKey, purpose: VoicePurpose, provider: VoiceProvider,
+         language: VoiceLanguage, fallback: String, voiceID: Binding<String>) {
+        self.init(label: label, purpose: purpose, provider: provider, language: language,
+                  fallback: fallback, voiceID: voiceID) { EmptyView() }
+    }
+}

--- a/VibeBuddyMacApp/Sources/VoicePicker.swift
+++ b/VibeBuddyMacApp/Sources/VoicePicker.swift
@@ -51,10 +51,9 @@ struct VoicePicker<Trailing: View>: View {
                         .accessibilityIdentifier("customVoiceID")
                     trailing
                 }
-                Button("Back to the list") {
-                    custom = false
-                    if !all.contains(where: { $0.id == voiceID }) { voiceID = "" }
-                }
+                // The list keeps a row for an off-catalog value, so returning to
+                // it must not discard the ID the user just typed.
+                Button("Back to the list") { custom = false }
                 .buttonStyle(.link).font(.caption)
             } else {
                 HStack(spacing: 6) {

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -551,8 +551,9 @@ private struct ReadAloudFeatureRow: View {
         let keyed = status.provider ?? .qwen
         _modelID = AppStorage(wrappedValue: SpeechSynthesis.support(keyed)?.defaultModel ?? "",
                               VoiceSettings.readAloudModelKey(keyed))
-        _voiceID = AppStorage(wrappedValue: SpeechSynthesis.support(keyed)?.defaultVoice ?? "",
-                              VoiceSettings.readAloudVoiceKey(keyed))
+        // Deliberately empty: a stored voice wins, and everything else is
+        // decided by the language-aware fallback below.
+        _voiceID = AppStorage(wrappedValue: "", VoiceSettings.readAloudVoiceKey(keyed))
     }
 
     private var configuration: SpeechSynthesisConfiguration {
@@ -629,7 +630,8 @@ private struct ReadAloudFeatureRow: View {
                 if case .ready(let provider) = status {
                     VoicePicker(label: "Read-aloud voice", purpose: .readAloud, provider: provider,
                                 language: VoiceLanguage(rawValue: language) ?? .english,
-                                fallback: SpeechSynthesis.support(provider)?.defaultVoice ?? "",
+                                fallback: VoiceSettings.readAloudVoice(provider,
+                                    language: VoiceLanguage(rawValue: language) ?? .english),
                                 voiceID: $voiceID) {
                         Button(action: preview) {
                             Image(systemName: isPreviewing ? "stop.fill" : "play.fill")

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -266,10 +266,14 @@ private struct ControlLine<P: View, M: View, V: View, T: View>: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
-            provider.frame(maxWidth: .infinity).layoutPriority(1)
-            model.frame(maxWidth: .infinity).layoutPriority(1)
-            voice.frame(maxWidth: .infinity).layoutPriority(2)
-            trailing
+            // Minimums, not just proportions: the voice cell carries the widest
+            // text and without them it squeezes the other two into slivers. The
+            // row's own action keeps its full width so it cannot be clipped off
+            // the right edge.
+            provider.frame(minWidth: 120, maxWidth: .infinity)
+            model.frame(minWidth: 120, maxWidth: .infinity)
+            voice.frame(minWidth: 170, maxWidth: .infinity).layoutPriority(1)
+            trailing.fixedSize().layoutPriority(3)
         }
     }
 }

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -385,9 +385,10 @@ private struct ConversationFeatureRow: View {
                 } else { Text(verbatim: "—").foregroundStyle(.secondary) }
             } voice: {
                 if let provider {
-                    IDField(label: "Voice ID", placeholder: provider.defaultVoice(VoiceLanguage(rawValue: language) ?? .english),
-                            text: $voiceID, browse: provider.voicesURL, browseHelp: "Browse available voices",
-                            identifier: "voiceID")
+                    VoicePicker(label: "Conversation voice", purpose: .conversation, provider: provider,
+                                language: VoiceLanguage(rawValue: language) ?? .english,
+                                fallback: provider.defaultVoice(VoiceLanguage(rawValue: language) ?? .english),
+                                voiceID: $voiceID)
                 } else { Text(verbatim: "—").foregroundStyle(.secondary) }
             } trailing: {
                 Button("Test", action: test)
@@ -525,6 +526,7 @@ private struct ReadAloudFeatureRow: View {
     let reveal: (VoiceProvider) -> Void
     @AppStorage(ReadAloud.enabledKey) private var enabled = false
     @AppStorage(CompletionSummaryConfiguration.enabledKey) private var summariesEnabled = false
+    @AppStorage(VoiceSettings.conversationLanguageKey) private var language = VoiceLanguage.english.rawValue
     @AppStorage(VoiceSettings.regionIntlKey) private var intl = false
     @AppStorage(VoiceSettings.qwenWorkspaceIDKey) private var workspace = ""
     @AppStorage private var modelID: String
@@ -620,18 +622,11 @@ private struct ReadAloudFeatureRow: View {
                             browseHelp: "Browse available models", identifier: "readAloudModelID")
                 } else { Text(verbatim: "—").foregroundStyle(.secondary) }
             } voice: {
-                if case .ready = status {
-                    HStack(spacing: 6) {
-                        // Qwen's own TTS voices; the per-provider voice catalogue replaces this picker.
-                        Picker("Read-aloud voice", selection: $voiceID) {
-                            Text("Longan Fengyue · Warm and natural").tag("longanfengyue")
-                            Text("Longan Lingxi · Sweet and cheerful").tag("longanlingxi")
-                            Text("Longan Yuanfei · Female character voice").tag("longanyuanfei")
-                            if !["longanfengyue", "longanlingxi", "longanyuanfei"].contains(voiceID) {
-                                Text(verbatim: voiceID).tag(voiceID)
-                            }
-                        }
-                        .labelsHidden().accessibilityLabel("Read-aloud voice")
+                if case .ready(let provider) = status {
+                    VoicePicker(label: "Read-aloud voice", purpose: .readAloud, provider: provider,
+                                language: VoiceLanguage(rawValue: language) ?? .english,
+                                fallback: SpeechSynthesis.support(provider)?.defaultVoice ?? "",
+                                voiceID: $voiceID) {
                         Button(action: preview) {
                             Image(systemName: isPreviewing ? "stop.fill" : "play.fill")
                         }


### PR DESCRIPTION
Closes #137. Stacked on #140 (#136), which is stacked on #139 (#135) — GitHub retargets each as the one below it merges.

## What changed

Voices were a free-text ID for conversation and three hard-coded Chinese options for read-aloud. Both are now a pick from a built-in catalog keyed by **(purpose, provider)** — not by provider, because the same vendor ships different voices for the two purposes. OpenAI's speech list adds `fable`, `nova` and `onyx` to its realtime ten; Doubao's realtime and TTS families do not even share ID shapes (`_jupiter_` vs `_uranus_`).

One rule decides the control's shape. At or below fifteen the dropdown lists everything in the conversation language, grouped by the vendor's own categories; above it, only the vendor's own recommended tier, with a searchable panel behind "Show all N voices…". The language filter never empties the list — Qwen's realtime voices are all Chinese, so in English the dropdown falls back to the full five. Custom voice ID is always the last entry.

**The defect this fixes:** `qwen-audio-3.0-tts-flash` ships three English voices and all three hard-coded options were Chinese, so English summaries were read with an accent. In English those three are now the list.

Voices the vendor tags as platform IP are not written into the catalog at all rather than collected and filtered — Volcengine retires them (a batch went on 2026-06-30) and we would rather not ship a licensing question. Custom voice ID covers them along with cloned and newly released voices.

## The two lists the ticket asked to verify

**Gemini — the recorded eight were wrong.** The Live API capabilities guide states that native-audio models "support any of the voices available for our Text-to-Speech (TTS) models", so conversation and read-aloud share the documented set of 30, and the shortlist is the eight that table lists first — the vendor's own signal, as the ticket asks. Sources: [Live API capabilities](https://ai.google.dev/gemini-api/docs/live-api/capabilities), [speech generation](https://ai.google.dev/gemini-api/docs/speech-generation).

**Doubao — 26 voices, and the count is honest.** Taken from [docs.volcengine.com/docs/6561/1257544](https://docs.volcengine.com/docs/6561/1257544), restricted to the 语音合成大模型 2.0 rows (`_uranus_bigtts` / `ICL_uranus_`), which are the only voices `seed-tts-2.0` accepts. The prototype's list mixed in `BV***_streaming` IDs; those are 1.0 / small-model voices the 2.0 resource rejects, and they are gone. The 130+ figure in the ticket counts 1.0 and cloned voices, and that page returns only a navigation shell to a fetcher, so the full tail could not be verified row by row. Shipping a list I cannot cite would be worse than shipping a shorter one I can: "Show all 26 voices…" is what the app actually offers, and Custom voice ID reaches the rest. The IP exclusion maps onto that table's 特殊标签 column — 佩奇猪, 四郎, 擎苍, 直率英子 and the like are absent.

The realtime Doubao set comes from [docs/6561/1594356](https://docs.volcengine.com/docs/6561/1594356) (the O2.0 精品音色 plus its three English voices).

## Verification

Isolated build run alongside the installed app; the user's preferences were verified unchanged afterwards, and every state came from NSUserDefaults argument-domain overrides, which do not persist.

- **Chinese**: Qwen conversation "5 voices", Qwen read-aloud "9 voices" (12 in the catalog, 9 Chinese).
- **English**: Qwen read-aloud "3 voices" — the three English ones. Qwen conversation still offers all five, which is the language filter falling back rather than emptying.
- **Tiered**: Gemini conversation shows "Show all 30 voices…"; the panel opens with a search field, "Prebuilt voices 8" and "More voices 22", each voice with its documented trait.
- **An off-catalog ID keeps its row**: with `S_MyClonedVoice_42` stored, the picker shows it selected while the shortlist below still reads "3 voices from Qwen (DashScope)" — the same binding the Custom voice ID field writes.
- **Fresh install, no keys** (a copy with its own bundle id, so its Keychain and preferences are both empty): all three rows show the clickable "No API key yet · Add it", Test/Sample/▶ correctly disabled, accounts listing which features use each provider.
- 401 Kit tests pass, 8 of them new: the two purposes genuinely differing, the 15/16 boundary, the language fallback, Qwen's English trio, the absence of IP-tagged IDs, grouping order and search, and that every runtime default is a catalog voice so the picker can never show a selection with no row.

The live look also caught a layout defect twice: the voice cell's width squeezed the provider and model controls into slivers, and then the row's action clipped off the right edge. Both fixed and re-checked at the default 820pt window and a widened one.

## Not verified

Entering Custom voice ID **through the menu** and returning via "Back to the list". That needs a click on a SwiftUI menu item, which the accessibility API here cannot enumerate, and permission to drive the isolated copy was declined. Its target state is verified above; the transition itself is the one manual check left.