### PR TITLE
Read-aloud speech for OpenAI, Gemini and Doubao

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/DoubaoSpeechSynthesizer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/DoubaoSpeechSynthesizer.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Doubao 语音合成大模型 2.0 over the unidirectional streaming HTTP endpoint.
+///
+/// Auth is the header `X-Api-Key` holding the same key Doubao realtime already
+/// uses, so read-aloud needs no credential of its own — the accounts table
+/// keeps one field per provider. `X-Api-Resource-Id` is a fixed model-version
+/// constant, not a secret. Accounts still on the legacy console need an appid
+/// and access token instead; that is deliberately not offered here, and such a
+/// key simply comes back rejected.
+public struct DoubaoSpeechSynthesizer: SpeechSynthesizer {
+    /// The header value, not a model the user types — Doubao's "model" is the
+    /// resource id, and the voice carries the rest.
+    public static let defaultModel = "seed-tts-2.0"
+    public static let defaultVoice = "zh_female_vv_uranus_bigtts"
+
+    let model: String
+    let voice: String
+
+    public init(model: String = defaultModel, voice: String = defaultVoice) {
+        self.model = model.isEmpty ? Self.defaultModel : model
+        self.voice = voice.isEmpty ? Self.defaultVoice : voice
+    }
+
+    public func synthesize(_ text: String, apiKey: String) async throws -> Data {
+        let text = try SpeechSynthesisHTTP.checkedText(text, apiKey: apiKey)
+        guard let url = URL(string: "https://openspeech.bytedance.com/api/v3/tts/unidirectional") else {
+            throw SpeechSynthesisFailure.configuration
+        }
+        let data = try await SpeechSynthesisHTTP.post(url,
+            headers: ["X-Api-Key": apiKey,
+                      "X-Api-Resource-Id": model,
+                      "X-Api-Request-Id": UUID().uuidString,
+                      "Accept": "application/json"],
+            body: ["req_params": ["text": text, "speaker": voice,
+                                  "audio_params": ["format": "mp3", "sample_rate": 24_000]]])
+        return try Self.audio(from: data)
+    }
+
+    /// The endpoint streams a sequence of JSON objects, one per audio chunk;
+    /// the body therefore holds several concatenated objects, not one.
+    static func audio(from data: Data) throws -> Data {
+        var audio = Data()
+        var sawObject = false
+        for line in String(decoding: data, as: UTF8.self).split(whereSeparator: \.isNewline) {
+            let text = line.trimmingCharacters(in: .whitespaces)
+            guard !text.isEmpty,
+                  let object = (try? JSONSerialization.jsonObject(with: Data(text.utf8))) as? [String: Any]
+            else { continue }
+            sawObject = true
+            if let code = object["code"] as? Int, code != 0 {
+                // Their codes distinguish auth from quota; nothing they said is repeated.
+                throw code == 401 || code == 403 ? SpeechSynthesisFailure.rejected
+                    : code == 429 ? .rateLimited : .transport
+            }
+            guard let encoded = object["data"] as? String, !encoded.isEmpty else { continue }
+            guard let chunk = Data(base64Encoded: encoded, options: .ignoreUnknownCharacters) else {
+                throw SpeechSynthesisFailure.transport
+            }
+            audio.append(chunk)
+            guard audio.count <= SpeechSynthesisHTTP.maximumBytes else { throw SpeechSynthesisFailure.excessiveAudio }
+        }
+        guard sawObject else { throw SpeechSynthesisFailure.transport }
+        guard !audio.isEmpty else { throw SpeechSynthesisFailure.emptyAudio }
+        return audio
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/GeminiSpeechSynthesizer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/GeminiSpeechSynthesizer.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Gemini TTS through `generateContent`'s audio response modality. The audio
+/// comes back as base64 headerless PCM, which no player will open, so it is
+/// wrapped in a WAV container at the rate the response declares.
+public struct GeminiSpeechSynthesizer: SpeechSynthesizer {
+    public static let defaultModel = "gemini-3.1-flash-tts-preview"
+    public static let defaultVoice = "Zephyr"
+    /// What the API documents for `audio/L16` when it names no rate.
+    static let defaultSampleRate = 24_000
+
+    let model: String
+    let voice: String
+
+    public init(model: String = defaultModel, voice: String = defaultVoice) {
+        self.model = model.isEmpty ? Self.defaultModel : model
+        self.voice = voice.isEmpty ? Self.defaultVoice : voice
+    }
+
+    public func synthesize(_ text: String, apiKey: String) async throws -> Data {
+        let text = try SpeechSynthesisHTTP.checkedText(text, apiKey: apiKey)
+        guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent") else {
+            throw SpeechSynthesisFailure.configuration
+        }
+        let data = try await SpeechSynthesisHTTP.post(url,
+            headers: ["x-goog-api-key": apiKey, "Accept": "application/json"],
+            body: ["contents": [["role": "user", "parts": [["text": text]]]],
+                   "generationConfig": [
+                       "candidateCount": 1,
+                       "responseModalities": ["AUDIO"],
+                       "speechConfig": ["voiceConfig": ["prebuiltVoiceConfig": ["voiceName": voice]]],
+                   ]])
+        return try Self.audio(from: data)
+    }
+
+    static func audio(from data: Data) throws -> Data {
+        guard let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            throw SpeechSynthesisFailure.transport
+        }
+        if let feedback = root["promptFeedback"] as? [String: Any], feedback["blockReason"] != nil {
+            throw SpeechSynthesisFailure.rejected
+        }
+        guard let candidates = root["candidates"] as? [[String: Any]], let candidate = candidates.first,
+              let content = candidate["content"] as? [String: Any],
+              let parts = content["parts"] as? [[String: Any]] else { throw SpeechSynthesisFailure.transport }
+        var pcm = Data()
+        var rate = defaultSampleRate
+        for part in parts {
+            guard let inline = part["inlineData"] as? [String: Any] else { continue }
+            guard let encoded = inline["data"] as? String,
+                  let chunk = Data(base64Encoded: encoded, options: .ignoreUnknownCharacters) else {
+                throw SpeechSynthesisFailure.transport
+            }
+            if let mime = inline["mimeType"] as? String, let declared = sampleRate(in: mime) { rate = declared }
+            pcm.append(chunk)
+            guard pcm.count <= SpeechSynthesisHTTP.maximumBytes else { throw SpeechSynthesisFailure.excessiveAudio }
+        }
+        guard !pcm.isEmpty else { throw SpeechSynthesisFailure.emptyAudio }
+        return SpeechSynthesisHTTP.wav(pcm16: pcm, sampleRate: rate)
+    }
+
+    /// `audio/L16;codec=pcm;rate=24000`
+    static func sampleRate(in mimeType: String) -> Int? {
+        for field in mimeType.split(separator: ";") {
+            let parts = field.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2, parts[0].trimmingCharacters(in: .whitespaces) == "rate",
+                  let rate = Int(parts[1].trimmingCharacters(in: .whitespaces)),
+                  (8_000...48_000).contains(rate) else { continue }
+            return rate
+        }
+        return nil
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -256,14 +256,12 @@ public enum VoiceSettings {
     public enum ReadAloudStatus: Equatable, Sendable {
         /// Following summaries, which are unconfigured. Not a reason to use Qwen.
         case waitingForSummaryProvider
-        /// Resolved, but this provider has no `SpeechSynthesizer` yet.
-        case unsupported(VoiceProvider)
         case ready(VoiceProvider)
 
         public var provider: VoiceProvider? {
             switch self {
             case .waitingForSummaryProvider: return nil
-            case .unsupported(let p), .ready(let p): return p
+            case .ready(let p): return p
             }
         }
     }
@@ -282,7 +280,7 @@ public enum VoiceSettings {
     public static func readAloudStatus(defaults: UserDefaults = .standard) -> ReadAloudStatus {
         guard let provider = pinnedReadAloudProvider(defaults: defaults)
                 ?? summaryProvider(defaults: defaults) else { return .waitingForSummaryProvider }
-        return provider.supportsReadAloud ? .ready(provider) : .unsupported(provider)
+        return .ready(provider)
     }
 
     /// Pin read-aloud to one provider, or pass `nil` to follow summaries again.
@@ -290,12 +288,12 @@ public enum VoiceSettings {
         defaults.set(provider?.rawValue ?? "", forKey: readAloudProviderKey)
     }
 
-    /// The read-aloud model / voice for a provider (blank → the provider's own
-    /// default, empty for a provider that cannot speak yet).
+    /// The read-aloud model / voice for a provider; blank falls back to the
+    /// provider's own default.
     public static func readAloudModel(_ p: VoiceProvider, defaults: UserDefaults = .standard) -> String {
         let v = (defaults.string(forKey: readAloudModelKey(p)) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return v.isEmpty ? (SpeechSynthesis.support(p)?.defaultModel ?? "") : v
+        return v.isEmpty ? SpeechSynthesis.support(p).defaultModel : v
     }
     /// Blank falls back to the catalog's first voice **for the conversation
     /// language** — a fresh English setup must not be handed a Chinese voice,
@@ -307,7 +305,7 @@ public enum VoiceSettings {
         guard v.isEmpty else { return v }
         let spoken = language ?? conversationLanguage(defaults: defaults)
         return VoiceCatalog.defaultVoice(.readAloud, p, language: spoken)
-            ?? SpeechSynthesis.support(p)?.defaultVoice ?? ""
+            ?? SpeechSynthesis.support(p).defaultVoice
     }
 
     public static func readAloudConfiguration(_ p: VoiceProvider,

--- a/VibeBuddyKit/Sources/VibeBuddyKit/OpenAISpeechSynthesizer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/OpenAISpeechSynthesizer.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// OpenAI `/v1/audio/speech`. Returns the encoded audio as the response body,
+/// so there is nothing to decode — only the same graded failures.
+public struct OpenAISpeechSynthesizer: SpeechSynthesizer {
+    public static let defaultModel = "gpt-4o-mini-tts"
+    public static let defaultVoice = "marin"
+
+    let model: String
+    let voice: String
+
+    public init(model: String = defaultModel, voice: String = defaultVoice) {
+        self.model = model.isEmpty ? Self.defaultModel : model
+        self.voice = voice.isEmpty ? Self.defaultVoice : voice
+    }
+
+    public func synthesize(_ text: String, apiKey: String) async throws -> Data {
+        let text = try SpeechSynthesisHTTP.checkedText(text, apiKey: apiKey)
+        guard let url = URL(string: "https://api.openai.com/v1/audio/speech") else {
+            throw SpeechSynthesisFailure.configuration
+        }
+        return try await SpeechSynthesisHTTP.post(url,
+            headers: ["Authorization": "Bearer \(apiKey)", "Accept": "audio/mpeg"],
+            body: ["model": model, "voice": voice, "input": text, "response_format": "mp3"])
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesis.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesis.swift
@@ -21,8 +21,34 @@ public struct SpeechSynthesisConfiguration: Sendable, Equatable {
 
 /// Graded so the UI can say something the user can act on without echoing a
 /// provider response, which may carry credentials.
-public enum SpeechSynthesisFailure: String, Error, Sendable {
-    case configuration, rejected, transport, emptyAudio, excessiveAudio
+public enum SpeechSynthesisFailure: String, Error, Sendable, Equatable {
+    /// The request could not even be built — a missing key, model or voice.
+    case configuration
+    /// The provider refused the credential (401/403) or rejected the task.
+    case rejected
+    case rateLimited
+    /// Nothing on the wire: no network, DNS, or a refused connection.
+    case unreachable
+    case timedOut
+    /// Reached the provider, but the exchange did not produce usable audio.
+    case transport
+    case emptyAudio
+    case excessiveAudio
+
+    /// English source text; the app's string tables translate it. Never
+    /// includes anything the provider sent back.
+    public var message: String {
+        switch self {
+        case .configuration: "Check the read-aloud model and voice before speaking."
+        case .rejected: "The provider rejected this API key. Open its account and paste the key again."
+        case .rateLimited: "The provider is rate-limiting this key. Try again in a moment."
+        case .unreachable: "Could not reach the provider. Check your connection."
+        case .timedOut: "The provider did not answer in time."
+        case .transport: "Speech generation failed. Check your read-aloud model, voice and connection."
+        case .emptyAudio: "The provider returned no audio for this text."
+        case .excessiveAudio: "The provider returned more audio than a summary should need."
+        }
+    }
 }
 
 /// Provider-agnostic text-to-speech, shaped like `RealtimeVoiceProvider`
@@ -42,8 +68,9 @@ public enum SpeechSynthesis {
         let make: @Sendable (SpeechSynthesisConfiguration) -> any SpeechSynthesizer
     }
 
-    /// `nil` for a provider with no synthesis implementation yet.
-    public static func support(_ provider: VoiceProvider) -> Support? {
+    /// Every provider speaks, so this is total — there is no "cannot read
+    /// aloud yet" state left for callers to handle.
+    public static func support(_ provider: VoiceProvider) -> Support {
         switch provider {
         case .qwen:
             return Support(defaultModel: QwenSpeechSynthesizer.defaultModel,
@@ -51,12 +78,25 @@ public enum SpeechSynthesis {
                 QwenSpeechSynthesizer(model: $0.model, voice: $0.voice,
                                       workspaceID: $0.qwenWorkspaceID, useIntl: $0.qwenUseIntl)
             }
-        case .openai, .gemini, .doubao:
-            return nil
+        case .openai:
+            return Support(defaultModel: OpenAISpeechSynthesizer.defaultModel,
+                           defaultVoice: OpenAISpeechSynthesizer.defaultVoice) {
+                OpenAISpeechSynthesizer(model: $0.model, voice: $0.voice)
+            }
+        case .gemini:
+            return Support(defaultModel: GeminiSpeechSynthesizer.defaultModel,
+                           defaultVoice: GeminiSpeechSynthesizer.defaultVoice) {
+                GeminiSpeechSynthesizer(model: $0.model, voice: $0.voice)
+            }
+        case .doubao:
+            return Support(defaultModel: DoubaoSpeechSynthesizer.defaultModel,
+                           defaultVoice: DoubaoSpeechSynthesizer.defaultVoice) {
+                DoubaoSpeechSynthesizer(model: $0.model, voice: $0.voice)
+            }
         }
     }
 
-    public static func synthesizer(_ configuration: SpeechSynthesisConfiguration) -> (any SpeechSynthesizer)? {
-        support(configuration.provider)?.make(configuration)
+    public static func synthesizer(_ configuration: SpeechSynthesisConfiguration) -> any SpeechSynthesizer {
+        support(configuration.provider).make(configuration)
     }
 }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesisHTTP.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesisHTTP.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// The wire work every HTTP speech vendor repeats: one bounded POST, no
+/// redirects, no cache, and status/URL errors graded into the shared failure
+/// type. Nothing the provider sends back is ever surfaced verbatim.
+enum SpeechSynthesisHTTP {
+    /// Summaries are two sentences; anything past this is not a summary.
+    static let maximumBytes = 2_000_000
+    static let timeout: TimeInterval = 15
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.urlCache = nil
+        config.httpCookieStorage = nil
+        config.urlCredentialStorage = nil
+        config.httpShouldSetCookies = false
+        config.timeoutIntervalForRequest = timeout
+        config.timeoutIntervalForResource = timeout
+        return URLSession(configuration: config)
+    }
+
+    static func post(_ url: URL, headers: [String: String], body: [String: Any]) async throws -> Data {
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: timeout)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        for (field, value) in headers { request.setValue(value, forHTTPHeaderField: field) }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let session = session()
+        defer { session.invalidateAndCancel() }
+        do {
+            try Task.checkCancellation()
+            // No redirect follow-up: it could disclose the key or bill a second request.
+            let (data, response) = try await session.data(for: request, delegate: NoSpeechRedirect())
+            try Task.checkCancellation()
+            guard let http = response as? HTTPURLResponse else { throw SpeechSynthesisFailure.transport }
+            guard (200..<300).contains(http.statusCode) else {
+                throw switch http.statusCode {
+                case 401, 403: SpeechSynthesisFailure.rejected
+                case 429: SpeechSynthesisFailure.rateLimited
+                default: SpeechSynthesisFailure.transport
+                }
+            }
+            guard !data.isEmpty else { throw SpeechSynthesisFailure.emptyAudio }
+            guard data.count <= maximumBytes else { throw SpeechSynthesisFailure.excessiveAudio }
+            return data
+        } catch let failure as SpeechSynthesisFailure { throw failure }
+          catch is CancellationError { throw CancellationError() }
+          catch let error as URLError {
+            switch error.code {
+            case .cancelled: throw CancellationError()
+            case .timedOut: throw SpeechSynthesisFailure.timedOut
+            case .notConnectedToInternet, .cannotFindHost, .cannotConnectToHost,
+                 .networkConnectionLost, .dnsLookupFailed:
+                throw SpeechSynthesisFailure.unreachable
+            default: throw SpeechSynthesisFailure.transport
+            }
+        } catch { throw SpeechSynthesisFailure.transport }
+    }
+
+    /// A summary is a couple of sentences; refuse anything that is not.
+    static func checkedText(_ text: String, apiKey: String) throws -> String {
+        guard !apiKey.isEmpty else { throw SpeechSynthesisFailure.configuration }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= 180 else { throw SpeechSynthesisFailure.configuration }
+        return trimmed
+    }
+
+    /// Raw PCM needs a container before `AVAudioPlayer` will look at it.
+    static func wav(pcm16: Data, sampleRate: Int, channels: Int = 1) -> Data {
+        var header = Data()
+        func u32(_ value: Int) { withUnsafeBytes(of: UInt32(value).littleEndian) { header.append(contentsOf: $0) } }
+        func u16(_ value: Int) { withUnsafeBytes(of: UInt16(value).littleEndian) { header.append(contentsOf: $0) } }
+        let byteRate = sampleRate * channels * 2
+        header.append(contentsOf: Array("RIFF".utf8)); u32(36 + pcm16.count)
+        header.append(contentsOf: Array("WAVE".utf8))
+        header.append(contentsOf: Array("fmt ".utf8)); u32(16); u16(1); u16(channels)
+        u32(sampleRate); u32(byteRate); u16(channels * 2); u16(16)
+        header.append(contentsOf: Array("data".utf8)); u32(pcm16.count)
+        return header + pcm16
+    }
+}
+
+private final class NoSpeechRedirect: NSObject, URLSessionTaskDelegate, Sendable {
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest) async -> URLRequest? {
+        nil
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoiceProvider.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoiceProvider.swift
@@ -12,11 +12,6 @@ public enum VoiceProvider: String, CaseIterable, Sendable {
     public var supportsCompletionSummaries: Bool { self != .doubao }
     public static var summaryProviders: [Self] { allCases.filter(\.supportsCompletionSummaries) }
 
-    /// Whether this provider can read summaries aloud, i.e. whether it has a
-    /// `SpeechSynthesizer`. Not every realtime provider has one yet.
-    public var supportsReadAloud: Bool { SpeechSynthesis.support(self) != nil }
-    public static var readAloudProviders: [Self] { allCases.filter(\.supportsReadAloud) }
-
     public var display: String {
         switch self {
         case .qwen:   return "Qwen (DashScope)"

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SpeechSynthesisDecodingTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SpeechSynthesisDecodingTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("Speech synthesis response decoding")
+struct SpeechSynthesisDecodingTests {
+    private func base64(_ bytes: [UInt8]) -> String { Data(bytes).base64EncodedString() }
+
+    // MARK: Gemini
+
+    @Test func geminiWrapsHeaderlessPCMSoAPlayerWillOpenIt() throws {
+        let pcm: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8]
+        let body = """
+        {"candidates":[{"content":{"role":"model","parts":[
+          {"inlineData":{"mimeType":"audio/L16;codec=pcm;rate=16000","data":"\(base64(pcm))"}}]}}]}
+        """
+        let audio = try GeminiSpeechSynthesizer.audio(from: Data(body.utf8))
+        #expect(audio.prefix(4).elementsEqual(Array("RIFF".utf8)))
+        #expect(audio.count == 44 + pcm.count)
+        // The rate the response declared, little-endian at the WAV header's offset 24.
+        let rate = audio[24...27].reversed().reduce(0) { $0 << 8 | Int($1) }
+        #expect(rate == 16_000)
+        #expect(Array(audio.suffix(pcm.count)) == pcm)
+    }
+
+    @Test func geminiFallsBackToTheDocumentedRateAndJoinsChunks() throws {
+        let body = """
+        {"candidates":[{"content":{"parts":[
+          {"inlineData":{"mimeType":"audio/L16","data":"\(base64([1, 2]))"}},
+          {"inlineData":{"mimeType":"audio/L16","data":"\(base64([3, 4]))"}}]}}]}
+        """
+        let audio = try GeminiSpeechSynthesizer.audio(from: Data(body.utf8))
+        let rate = audio[24...27].reversed().reduce(0) { $0 << 8 | Int($1) }
+        #expect(rate == GeminiSpeechSynthesizer.defaultSampleRate)
+        #expect(Array(audio.suffix(4)) == [1, 2, 3, 4])
+    }
+
+    @Test func geminiGradesRefusalAndSilence() {
+        #expect(throws: SpeechSynthesisFailure.rejected) {
+            try GeminiSpeechSynthesizer.audio(from: Data(#"{"promptFeedback":{"blockReason":"SAFETY"}}"#.utf8))
+        }
+        #expect(throws: SpeechSynthesisFailure.emptyAudio) {
+            try GeminiSpeechSynthesizer.audio(from: Data(#"{"candidates":[{"content":{"parts":[]}}]}"#.utf8))
+        }
+        #expect(throws: SpeechSynthesisFailure.transport) {
+            try GeminiSpeechSynthesizer.audio(from: Data("not json".utf8))
+        }
+    }
+
+    // MARK: Doubao
+
+    @Test func doubaoJoinsTheStreamedChunks() throws {
+        let body = """
+        {"code":0,"message":"ok","data":"\(base64([9, 9]))"}
+        {"code":0,"message":"ok","data":"\(base64([8, 8]))"}
+        {"code":0,"message":"ok","data":""}
+        """
+        let audio = try DoubaoSpeechSynthesizer.audio(from: Data(body.utf8))
+        #expect(Array(audio) == [9, 9, 8, 8])
+    }
+
+    @Test func doubaoGradesItsOwnCodesWithoutRepeatingThem() {
+        for (code, expected) in [(401, SpeechSynthesisFailure.rejected), (403, .rejected),
+                                 (429, .rateLimited), (55_000_001, .transport)] {
+            #expect(throws: expected) {
+                try DoubaoSpeechSynthesizer.audio(from: Data("{\"code\":\(code),\"message\":\"key leaked here\"}".utf8))
+            }
+        }
+        #expect(throws: SpeechSynthesisFailure.transport) {
+            try DoubaoSpeechSynthesizer.audio(from: Data("<html>gateway</html>".utf8))
+        }
+        #expect(throws: SpeechSynthesisFailure.emptyAudio) {
+            try DoubaoSpeechSynthesizer.audio(from: Data(#"{"code":0,"data":""}"#.utf8))
+        }
+    }
+
+    // MARK: Shared
+
+    @Test func everyFailureSaysSomethingActionableAndNothingBorrowed() {
+        for failure in [SpeechSynthesisFailure.configuration, .rejected, .rateLimited,
+                        .unreachable, .timedOut, .transport, .emptyAudio, .excessiveAudio] {
+            #expect(!failure.message.isEmpty)
+            #expect(failure.message.hasSuffix("."))
+        }
+        #expect(SpeechSynthesisFailure.rejected.message.contains("key"))
+        #expect(SpeechSynthesisFailure.unreachable.message.contains("connection"))
+    }
+
+    @Test func aSummaryIsTwoSentences_notADocumentAndNotEmpty() throws {
+        #expect(throws: SpeechSynthesisFailure.configuration) {
+            _ = try SpeechSynthesisHTTP.checkedText("hello", apiKey: "")
+        }
+        #expect(throws: SpeechSynthesisFailure.configuration) {
+            _ = try SpeechSynthesisHTTP.checkedText("   ", apiKey: "k")
+        }
+        #expect(throws: SpeechSynthesisFailure.configuration) {
+            _ = try SpeechSynthesisHTTP.checkedText(String(repeating: "x", count: 181), apiKey: "k")
+        }
+        let trimmed = try SpeechSynthesisHTTP.checkedText("  spoken  ", apiKey: "k")
+        #expect(trimmed == "spoken")
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
@@ -96,7 +96,7 @@ struct VoiceDefaultsInCatalogTests {
 
     @Test func everySynthesisDefaultIsACatalogVoice() {
         for provider in VoiceProvider.allCases {
-            guard let support = SpeechSynthesis.support(provider) else { continue }
+            let support = SpeechSynthesis.support(provider)
             let ids = Set(VoiceCatalog.voices(.readAloud, provider).map(\.id))
             #expect(ids.contains(support.defaultVoice), "\(provider) → \(support.defaultVoice)")
         }

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoicePurposeSettingsTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoicePurposeSettingsTests.swift
@@ -47,9 +47,9 @@ struct ReadAloudPurposeSettingsTests {
         // Nothing configured anywhere: waiting, not Qwen.
         #expect(VoiceSettings.readAloudStatus(defaults: defaults) == .waitingForSummaryProvider)
         #expect(VoiceSettings.pinnedReadAloudProvider(defaults: defaults) == nil)
-        // A summary provider without a synthesizer is reported, not replaced.
+        // Following means following, whichever vendor summaries picked.
         defaults.set("openai", forKey: VoiceSettings.summaryProviderKey)
-        #expect(VoiceSettings.readAloudStatus(defaults: defaults) == .unsupported(.openai))
+        #expect(VoiceSettings.readAloudStatus(defaults: defaults) == .ready(.openai))
         defaults.set("qwen", forKey: VoiceSettings.summaryProviderKey)
         #expect(VoiceSettings.readAloudStatus(defaults: defaults) == .ready(.qwen))
         // An explicit "follow summaries" and a value this build cannot parse both follow.
@@ -67,7 +67,7 @@ struct ReadAloudPurposeSettingsTests {
         defaults.set("openai", forKey: VoiceSettings.summaryProviderKey)
         #expect(VoiceSettings.readAloudStatus(defaults: defaults) == .ready(.qwen))
         VoiceSettings.selectReadAloudProvider(nil, defaults: defaults)
-        #expect(VoiceSettings.readAloudStatus(defaults: defaults) == .unsupported(.openai))
+        #expect(VoiceSettings.readAloudStatus(defaults: defaults) == .ready(.openai))
     }
 
     @Test func migrationMovesLegacyKeysOnceAndNeverOverwrites() throws {
@@ -94,11 +94,14 @@ struct ReadAloudPurposeSettingsTests {
         #expect(VoiceSettings.readAloudVoice(.qwen, defaults: defaults) == "kept-voice")
     }
 
-    @Test func onlyProvidersWithASynthesizerCanReadAloud() throws {
-        #expect(VoiceProvider.readAloudProviders == [.qwen])
-        #expect(SpeechSynthesis.synthesizer(VoiceSettings.readAloudConfiguration(.qwen)) != nil)
-        for p in VoiceProvider.allCases where !p.supportsReadAloud {
-            #expect(SpeechSynthesis.synthesizer(VoiceSettings.readAloudConfiguration(p)) == nil)
+    @Test func everyProviderCanReadAloud() throws {
+        // Doubao stays out of summaries, but read-aloud is a separate question:
+        // it speaks, so it can be picked here — only never inherited.
+        #expect(!VoiceProvider.summaryProviders.contains(.doubao))
+        for provider in VoiceProvider.allCases {
+            let support = SpeechSynthesis.support(provider)
+            #expect(!support.defaultModel.isEmpty, "\(provider) model")
+            #expect(!support.defaultVoice.isEmpty, "\(provider) voice")
         }
     }
 }

--- a/VibeBuddyMac/Package.resolved
+++ b/VibeBuddyMac/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6cf678b47dfd2641e0d50f7943558007be6bed6daaf8f0fd19f35bdc1e204cfb",
+  "originHash" : "29538e8fbb0ea158ed4b1a31934de89f37cbf6437ee549e11210fc4faea915e9",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -35,15 +35,6 @@
       "state" : {
         "revision" : "89c66b8d6655209268c44f619afcf771d8d83ec9",
         "version" : "2.7.0"
-      }
-    },
-    {
-      "identity" : "sparkle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle",
-      "state" : {
-        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
-        "version" : "2.9.6"
       }
     },
     {

--- a/VibeBuddyMac/Package.resolved
+++ b/VibeBuddyMac/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "29538e8fbb0ea158ed4b1a31934de89f37cbf6437ee549e11210fc4faea915e9",
+  "originHash" : "f6cbd50b9170f9e0ba09677946c7bd7d3d9a23b1e0ffbe8a03646910f30bb8e3",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "89c66b8d6655209268c44f619afcf771d8d83ec9",
         "version" : "2.7.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SpeechSynthesisLiveTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SpeechSynthesisLiveTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+import VibeBuddyKit
+
+/// One real request per vendor, each behind its own environment gate so a
+/// normal test run never spends money or needs a key. Keys come from the
+/// environment and never reach the output — only the byte count does.
+struct SpeechSynthesisLiveTests {
+    private static let line = "Hello, I'm your work companion. The task is complete, and device verification is still pending."
+
+    private static func play(_ synthesizer: any SpeechSynthesizer, key: String, outputVariable: String) async throws {
+        let data = try await synthesizer.synthesize(line, apiKey: key)
+        #expect(data.count > 1000)
+        if let output = ProcessInfo.processInfo.environment[outputVariable] {
+            try data.write(to: URL(fileURLWithPath: output))
+        }
+        print("received audio bytes=\(data.count)")
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["OPENAI_SPEECH_E2E"] == "1"))
+    func openAISpeaks() async throws {
+        let key = try #require(ProcessInfo.processInfo.environment["OPENAI_API_KEY"])
+        try await Self.play(OpenAISpeechSynthesizer(), key: key, outputVariable: "OPENAI_SPEECH_OUTPUT")
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["GEMINI_SPEECH_E2E"] == "1"))
+    func geminiSpeaks() async throws {
+        let key = try #require(ProcessInfo.processInfo.environment["GEMINI_API_KEY"])
+        try await Self.play(GeminiSpeechSynthesizer(), key: key, outputVariable: "GEMINI_SPEECH_OUTPUT")
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["DOUBAO_SPEECH_E2E"] == "1"))
+    func doubaoSpeaks() async throws {
+        let key = try #require(ProcessInfo.processInfo.environment["DOUBAO_API_KEY"])
+        try await Self.play(DoubaoSpeechSynthesizer(), key: key, outputVariable: "DOUBAO_SPEECH_OUTPUT")
+    }
+}

--- a/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -321,8 +321,6 @@
 
 "Read-aloud is waiting for a completion summary provider. Choose one, or pick a read-aloud provider of its own." = "朗读正在等待完成摘要服务商。请先设置摘要服务商，或为朗读单独选择一家。";
 
-"%@ cannot read summaries aloud yet. Choose another read-aloud provider." = "%@ 暂不支持朗读摘要，请另选一家朗读服务商。";
-
 "API key" = "API 密钥";
 
 "Enter a speech synthesis model before previewing." = "试听前请输入语音合成模型。";
@@ -502,3 +500,17 @@
 "Search voices" = "搜索音色";
 
 "No match" = "没有匹配项";
+
+/* Read-aloud synthesis failures — graded, never the provider's own words */
+
+"Check the read-aloud model and voice before speaking." = "朗读前请检查朗读模型和音色。";
+
+"The provider rejected this API key. Open its account and paste the key again." = "服务商拒绝了这把 API Key。请打开对应账号重新粘贴密钥。";
+
+"The provider is rate-limiting this key. Try again in a moment." = "服务商正在限流这把密钥，请稍后再试。";
+
+"The provider did not answer in time." = "服务商未在超时前返回。";
+
+"The provider returned no audio for this text." = "服务商没有为这段文本返回音频。";
+
+"The provider returned more audio than a summary should need." = "服务商返回的音频超出一段摘要应有的长度。";

--- a/VibeBuddyMacApp/Sources/ReadAloud.swift
+++ b/VibeBuddyMacApp/Sources/ReadAloud.swift
@@ -11,7 +11,7 @@ final class ReadAloud: ObservableObject {
     @Published private(set) var status = ""
     @Published private(set) var previewStatus = ""
     enum PreviewResult: Sendable { case completed, cancelled, failed(String) }
-    private let makeSynthesizer: @Sendable (SpeechSynthesisConfiguration) -> (any SpeechSynthesizer)?
+    private let makeSynthesizer: @Sendable (SpeechSynthesisConfiguration) -> any SpeechSynthesizer
     private let automaticKey: @MainActor (VoiceProvider) -> String?
     private var previewTask: Task<PreviewResult, Never>?
     private var previewGeneration = UUID()
@@ -20,7 +20,7 @@ final class ReadAloud: ObservableObject {
     var automaticBusy: Bool { queueBusy }
 
     init(automaticKey: @escaping @MainActor (VoiceProvider) -> String? = { $0.apiKey },
-         makeSynthesizer: @escaping @Sendable (SpeechSynthesisConfiguration) -> (any SpeechSynthesizer)? = SpeechSynthesis.synthesizer) {
+         makeSynthesizer: @escaping @Sendable (SpeechSynthesisConfiguration) -> any SpeechSynthesizer = SpeechSynthesis.synthesizer) {
         self.automaticKey = automaticKey
         self.makeSynthesizer = makeSynthesizer
     }
@@ -55,8 +55,6 @@ final class ReadAloud: ObservableObject {
         switch status {
         case .waitingForSummaryProvider:
             return NSLocalizedString("Read-aloud is waiting for a completion summary provider. Choose one, or pick a read-aloud provider of its own.", comment: "Read-aloud follows an unconfigured summary provider")
-        case .unsupported(let provider):
-            return String(format: NSLocalizedString("%@ cannot read summaries aloud yet. Choose another read-aloud provider.", comment: "Provider has no speech synthesis"), provider.display)
         case .ready:
             return nil
         }
@@ -80,10 +78,8 @@ final class ReadAloud: ObservableObject {
                 guard let key = self.automaticKey(provider), !key.isEmpty else {
                     self.status = String(format: NSLocalizedString("Save your %@ API key first.", comment: "Read-aloud needs a key"), provider.display); return
                 }
-                guard let synthesizer = self.makeSynthesizer(VoiceSettings.readAloudConfiguration(provider)) else {
-                    self.status = Self.unavailability(.unsupported(provider)) ?? ""; return
-                }
                 self.status = "Generating speech…"
+                let synthesizer = self.makeSynthesizer(VoiceSettings.readAloudConfiguration(provider))
                 let data = try await synthesizer.synthesize(text, apiKey: key)
                 guard !Task.isCancelled, self.generation == current, self.canSpeak() else { return }
                 guard await validate(), !Task.isCancelled, self.generation == current, self.canSpeak() else { return }
@@ -101,9 +97,16 @@ final class ReadAloud: ObservableObject {
                 }
                 if self.generation == current { self.status = "Playback complete"; self.player = nil }
             } catch is CancellationError { }
-              catch { if self.generation == current { self.status = "Speech generation failed. Check your read-aloud model, voice and connection." } }
+              catch { if self.generation == current { self.status = Self.copy(for: error) } }
         }
     }
+    /// Graded, actionable, and never the provider's own words — a raw response
+    /// can carry the credential that was sent with it.
+    static func copy(for error: any Error) -> String {
+        NSLocalizedString((error as? SpeechSynthesisFailure ?? .transport).message,
+                          comment: "Speech synthesis failure")
+    }
+
     private func updateBusy() { busy = queueBusy || previewTask != nil }
 
     /// Cancels only the Settings-owned preview; queued automatic speech is untouched.
@@ -119,9 +122,7 @@ final class ReadAloud: ObservableObject {
         guard E2ERunConfiguration.current?.audioEnabled ?? true else { return .cancelled }
         guard !Task.isCancelled else { return .cancelled }
         guard !busy, canSpeak() else { return .failed("Stop the current voice conversation or reading before previewing.") }
-        guard let synthesizer = makeSynthesizer(configuration) else {
-            return .failed(Self.unavailability(.unsupported(configuration.provider)) ?? "")
-        }
+        let synthesizer = makeSynthesizer(configuration)
         let id = UUID()
         previewGeneration = id
         let task = Task { @MainActor [self] in
@@ -143,7 +144,7 @@ final class ReadAloud: ObservableObject {
             } catch is CancellationError { return .cancelled }
               catch {
                 if Task.isCancelled || previewGeneration != id { return .cancelled }
-                return .failed("Speech generation failed. Check your read-aloud model, voice and connection.")
+                return .failed(Self.copy(for: error))
             }
         }
         previewTask = task // Occupy the shared reader before the first suspension.

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -549,7 +549,7 @@ private struct ReadAloudFeatureRow: View {
         _selection = selection
         self.reveal = reveal
         let keyed = status.provider ?? .qwen
-        _modelID = AppStorage(wrappedValue: SpeechSynthesis.support(keyed)?.defaultModel ?? "",
+        _modelID = AppStorage(wrappedValue: SpeechSynthesis.support(keyed).defaultModel,
                               VoiceSettings.readAloudModelKey(keyed))
         // Deliberately empty: a stored voice wins, and everything else is
         // decided by the language-aware fallback below.
@@ -579,14 +579,9 @@ private struct ReadAloudFeatureRow: View {
         if voiceChat.isActive { return NSLocalizedString("Stop the current voice conversation or reading before previewing.", comment: "Read-aloud busy") }
         return nil
     }
-    private var detail: String? {
-        if case .unsupported = status { return ReadAloud.unavailability(status) }
-        return nil
-    }
     private var rowStatus: VoiceFeatureStatus {
         switch status {
         case .waitingForSummaryProvider: return .waitingForSummaries
-        case .unsupported: return .needsAttention
         case .ready(let provider):
             if !credential.configured { return .needsKey(provider) }
             if !summariesEnabled { return .nothingToRead }
@@ -613,16 +608,16 @@ private struct ReadAloudFeatureRow: View {
 
     var body: some View {
         FeatureRow(feature: .readAloud, dependsOnPrevious: true, enabled: $enabled,
-                   status: rowStatus, detail: detail, hint: hint, tests: tests, reveal: reveal) {
+                   status: rowStatus, hint: hint, tests: tests, reveal: reveal) {
           VStack(alignment: .leading, spacing: 6) {
             ControlLine {
                 ProviderPicker(label: "Read-aloud provider", selection: $selection,
-                               options: VoiceProvider.readAloudProviders,
+                               options: VoiceProvider.allCases,
                                leading: ("", followTitle))
             } model: {
                 if case .ready(let provider) = status {
                     IDField(label: "Speech synthesis model",
-                            placeholder: SpeechSynthesis.support(provider)?.defaultModel ?? "",
+                            placeholder: SpeechSynthesis.support(provider).defaultModel,
                             text: $modelID, browse: provider.modelsURL,
                             browseHelp: "Browse available models", identifier: "readAloudModelID")
                 } else { Text(verbatim: "—").foregroundStyle(.secondary) }

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -556,10 +556,20 @@ private struct ReadAloudFeatureRow: View {
         _voiceID = AppStorage(wrappedValue: "", VoiceSettings.readAloudVoiceKey(keyed))
     }
 
+    private var spokenLanguage: VoiceLanguage { VoiceLanguage(rawValue: language) ?? .english }
+    /// What will actually be spoken. A provider picked for the first time has
+    /// nothing stored yet, and the picker shows the language default without
+    /// writing it — so preview and the request must resolve it the same way
+    /// rather than treat "nothing stored" as "no voice".
+    private var effectiveVoice: String {
+        voiceID.isEmpty
+            ? VoiceSettings.readAloudVoice(status.provider ?? .qwen, language: spokenLanguage)
+            : voiceID
+    }
     private var configuration: SpeechSynthesisConfiguration {
         let value = workspace.trimmingCharacters(in: .whitespacesAndNewlines)
         return .init(provider: status.provider ?? .qwen,
-                     model: modelID.trimmingCharacters(in: .whitespacesAndNewlines), voice: voiceID,
+                     model: modelID.trimmingCharacters(in: .whitespacesAndNewlines), voice: effectiveVoice,
                      qwenWorkspaceID: value.isEmpty ? nil : value, qwenUseIntl: intl)
     }
     /// Why preview cannot run — the same order the status pill reports.
@@ -570,7 +580,7 @@ private struct ReadAloudFeatureRow: View {
             return String(format: NSLocalizedString("Save your %@ API key first.", comment: "Read-aloud needs a key"), provider.display)
         }
         if configuration.model.isEmpty { return NSLocalizedString("Enter a speech synthesis model before previewing.", comment: "Read-aloud model missing") }
-        if voiceID.isEmpty { return NSLocalizedString("Enter a voice ID or use the language default.", comment: "Read-aloud voice missing") }
+        if effectiveVoice.isEmpty { return NSLocalizedString("Enter a voice ID or use the language default.", comment: "Read-aloud voice missing") }
         if provider == .qwen {
             let config = CompletionSummaryConfiguration(enabled: true, provider: .qwen, modelID: configuration.model,
                 qwenUseIntl: intl, qwenWorkspaceID: workspace)
@@ -625,8 +635,7 @@ private struct ReadAloudFeatureRow: View {
                 if case .ready(let provider) = status {
                     VoicePicker(label: "Read-aloud voice", purpose: .readAloud, provider: provider,
                                 language: VoiceLanguage(rawValue: language) ?? .english,
-                                fallback: VoiceSettings.readAloudVoice(provider,
-                                    language: VoiceLanguage(rawValue: language) ?? .english),
+                                fallback: VoiceSettings.readAloudVoice(provider, language: spokenLanguage),
                                 voiceID: $voiceID) {
                         Button(action: preview) {
                             Image(systemName: isPreviewing ? "stop.fill" : "play.fill")


### PR DESCRIPTION
Closes #138. Stacked on #141 (#137) — GitHub retargets this to `main` when that merges. With it, the chain that started from "read-aloud is stuck on Qwen" is complete: configure an account once for voice conversation, and read-aloud needs nothing but a provider choice.

## What changed

All four providers speak. Each implements the synthesis protocol introduced by #135, and the player and speech queue gained no per-provider branch — which is what that protocol was for.

- **OpenAI** — `/v1/audio/speech`, `gpt-4o-mini-tts`. The response body *is* the audio, so there is nothing to decode.
- **Gemini** — a TTS model through `generateContent`'s audio response modality. It returns base64 **headerless PCM** (`audio/L16;codec=pcm;rate=24000`), which no player will open, so it is wrapped in a WAV container at the rate the response declares.
- **Doubao** — the unidirectional streaming endpoint returns a **sequence of concatenated JSON objects**, one per audio chunk, not a single object; each carries a base64 fragment to join. Auth is the `X-Api-Key` header holding the same key Doubao realtime already stores, plus the fixed `X-Api-Resource-Id: seed-tts-2.0` constant, so the accounts table still shows one credential field for Doubao and gains no appid or token field. A legacy-console key simply comes back rejected, as the ticket specifies.

**Failures are graded** rather than lumped into one sentence: missing configuration, rejected key, rate limited, unreachable, timed out, empty and oversized audio each say something the user can act on. A provider's own response is never repeated back — it can carry the credential that was sent with it, and there is a test that constructs a Doubao error whose message contains a fake leaked key and asserts it never surfaces.

**Dead code removed rather than kept.** With every provider speaking, `ReadAloudStatus.unsupported`, `VoiceProvider.supportsReadAloud` / `readAloudProviders`, and the optional synthesizer lookup are all unreachable. They are gone, and `SpeechSynthesis.support` is now total.

## Verification

- **Gemini spoke for real.** The environment-gated live smoke test returned 330,284 bytes through the new PCM→WAV path. OpenAI and Doubao skipped as designed — this machine has `GEMINI_API_KEY` but no OpenAI or Doubao speech key, and I did not go looking for one to make a test pass.
- **Three distinct providers at once**, on an isolated Developer-ID-signed build run alongside the installed app: conversation on Gemini, summaries on OpenAI, read-aloud pinned to **Doubao** — which could not speak at all before this ticket — showing `seed-tts-2.0`, "Tim · en_male_tim_uranus_bigtts · US English" and "Show all 26 voices…". Each account row named exactly the feature using it.
- **Player and queue with a fake provider**: all 10 `tools/settings-tests-qa/reader-main.swift` checks pass — preview and automatic reading stay mutually exclusive, a cancelled preview keeps queued automatic work, global stop cancels the queue, nothing speaks after cancel, and no credential, network or audio is used.
- 411 Kit tests pass, including 7 new decoding tests: Gemini's WAV wrapping and declared-rate parsing, its multi-part joining, refusal and silence grading; Doubao's chunk joining, its own error codes graded without repeating them, and an HTML gateway body; plus the input bounds.

The user's preferences were verified unchanged afterwards; every state came from NSUserDefaults argument-domain overrides, which do not persist.

## Not verified

Hearing OpenAI and Doubao speak, for want of keys on this machine. Their request shape follows each vendor's current documentation and their response decoding is covered by tests, but neither has made a real round trip here.