### PR TITLE
fix: a fresh Doubao realtime voice follows the conversation language

### DIFF
--- a/VibeBuddyApp/Sources/SettingsView.swift
+++ b/VibeBuddyApp/Sources/SettingsView.swift
@@ -267,7 +267,23 @@ private struct ProviderSection: View {
     }
     private var effectiveVoice: String {
         let value = voice.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? provider.defaultVoice(VoiceSettings.conversationLanguage) : value
+        return value.isEmpty ? recommendedVoice : value
+    }
+    /// What a blank Voice ID resolves to — the same call the realtime session
+    /// makes, so this screen never advertises a voice the call will not use.
+    private var recommendedVoice: String {
+        VoiceSettings.voice(provider, VoiceSettings.conversationLanguage)
+    }
+    /// Doubao's summary line names the voice, and the recommended one changes
+    /// with the conversation language (Vivi in Chinese, Tim in English), so the
+    /// name comes from the catalog rather than being written into the sentence.
+    private var recommendedSummary: LocalizedStringKey {
+        guard effectiveModel == provider.defaultModel, effectiveVoice == recommendedVoice else {
+            return "Your custom model or voice is retained. Review Advanced settings before testing."
+        }
+        let name = VoiceCatalog.voices(.conversation, provider)
+            .first { $0.id == recommendedVoice }?.name ?? recommendedVoice
+        return "The recommended model and \(name) voice are ready. Only your realtime API key is required."
     }
     private var configurationValid: Bool {
         let allowed = Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-".utf8)
@@ -331,7 +347,7 @@ private struct ProviderSection: View {
                 }
             } else if provider == .doubao {
                 Text(effectiveModel == provider.defaultModel ? "Doubao realtime voice 3.0 · Recommended" : "Custom realtime model").font(.headline)
-                Text(effectiveModel == provider.defaultModel && effectiveVoice == provider.defaultVoice(.english) ? "The recommended model and Vivi voice are ready. Only your realtime API key is required." : "Your custom model or voice is retained. Review Advanced settings before testing.")
+                Text(recommendedSummary)
                     .font(.caption).foregroundStyle(.secondary)
                 DisclosureGroup("Advanced settings") {
                     customFields

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -297,17 +297,34 @@ public enum VoiceSettings {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return v.isEmpty ? (SpeechSynthesis.support(p)?.defaultModel ?? "") : v
     }
-    /// Blank falls back to the catalog's first voice **for the conversation
-    /// language** — a fresh English setup must not be handed a Chinese voice,
-    /// which is the accent bug this catalog exists to fix.
+    /// Blank falls back to a voice that speaks **the conversation language** —
+    /// a fresh English setup must not be handed a Chinese voice, which is the
+    /// accent bug this catalog exists to fix.
     public static func readAloudVoice(_ p: VoiceProvider, language: VoiceLanguage? = nil,
                                       defaults: UserDefaults = .standard) -> String {
         let v = (defaults.string(forKey: readAloudVoiceKey(p)) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard v.isEmpty else { return v }
         let spoken = language ?? conversationLanguage(defaults: defaults)
-        return VoiceCatalog.defaultVoice(.readAloud, p, language: spoken)
-            ?? SpeechSynthesis.support(p)?.defaultVoice ?? ""
+        return languageDefault(.readAloud, p, spoken,
+                               curated: SpeechSynthesis.support(p)?.defaultVoice ?? "")
+    }
+
+    /// How a blank voice ID becomes a real one, for either purpose.
+    ///
+    /// The catalog is the authority on **which language a voice speaks**; the
+    /// vendor constant is the authority on **which voice we like**. So keep the
+    /// curated pick whenever it speaks the conversation language — that is how
+    /// Gemini keeps Aoede for Chinese and Puck for English — and only when it
+    /// does not (Doubao's Vivi is Chinese-only) fall to the catalog's first
+    /// voice for that language. A constant the catalog does not list cannot be
+    /// vouched for, so it loses to the catalog too, and is kept only as the
+    /// last resort for a provider with no catalog entries at all.
+    static func languageDefault(_ purpose: VoicePurpose, _ p: VoiceProvider,
+                                _ language: VoiceLanguage, curated: String) -> String {
+        let listed = VoiceCatalog.voices(purpose, p).first { $0.id == curated }
+        if listed?.speaks(language) == true { return curated }
+        return VoiceCatalog.defaultVoice(purpose, p, language: language) ?? curated
     }
 
     public static func readAloudConfiguration(_ p: VoiceProvider,
@@ -374,12 +391,14 @@ public enum VoiceSettings {
         return v.isEmpty ? p.defaultModel : v
     }
 
-    /// The voice ID for a provider, user-editable (blank → a language-appropriate
-    /// default). CN voices carry an accent in English, so the default is chosen
-    /// from the conversation language.
-    public static func voice(_ p: VoiceProvider, _ language: VoiceLanguage) -> String {
-        let v = (UserDefaults.standard.string(forKey: voiceKey(p)) ?? "")
+    /// The realtime voice ID for a provider, user-editable (blank → a
+    /// language-appropriate default). CN voices carry an accent in English, so
+    /// the default is resolved through the catalog exactly as read-aloud is.
+    public static func voice(_ p: VoiceProvider, _ language: VoiceLanguage,
+                             defaults: UserDefaults = .standard) -> String {
+        let v = (defaults.string(forKey: voiceKey(p)) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return v.isEmpty ? p.defaultVoice(language) : v
+        guard v.isEmpty else { return v }
+        return languageDefault(.conversation, p, language, curated: p.defaultVoice(language))
     }
 }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoiceProvider.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoiceProvider.swift
@@ -53,14 +53,18 @@ public enum VoiceProvider: String, CaseIterable, Sendable {
         }
     }
 
-    /// A natural default voice for the conversation language. Verified voice
-    /// names per provider; the user can override with a free-text Voice ID.
+    /// The voice we pick for this provider when the user has not — taste, not
+    /// language. A vendor whose voices are all multilingual can still branch
+    /// (Gemini), but a vendor whose pick speaks only one language does not
+    /// pretend otherwise: Doubao's Vivi is Chinese, and `VoiceSettings.voice`
+    /// is what swaps it for an English voice when the conversation is English.
+    /// Call that, not this — this is the curated pick, not the resolved one.
     public func defaultVoice(_ language: VoiceLanguage) -> String {
         switch self {
         case .qwen:   return "longanqian"   // Qwen-Audio system voice (multilingual)
         case .openai: return "marin"
         case .gemini: return language == .chinese ? "Aoede" : "Puck"
-        case .doubao: return "zh_female_vv_jupiter_bigtts"
+        case .doubao: return "zh_female_vv_jupiter_bigtts"   // Chinese; English → the catalog
         }
     }
 

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
@@ -103,6 +103,74 @@ struct VoiceDefaultsInCatalogTests {
     }
 }
 
+@Suite("A fresh conversation voice follows the language")
+struct ConversationDefaultVoiceTests {
+    private func suite() throws -> (UserDefaults, String) {
+        let name = "conversation-voice-\(UUID())"
+        return (try #require(UserDefaults(suiteName: name)), name)
+    }
+
+    @Test func doubaoEnglishNoLongerStartsOnAChineseVoice() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        // The bug: Vivi is Chinese-only, and the vendor constant handed her out
+        // whatever the conversation language was.
+        #expect(VoiceProvider.doubao.defaultVoice(.english) == "zh_female_vv_jupiter_bigtts")
+        let english = VoiceSettings.voice(.doubao, .english, defaults: defaults)
+        #expect(VoiceCatalog.voices(.conversation, .doubao).first { $0.id == english }?.language == .english)
+        #expect(VoiceSettings.voice(.doubao, .chinese, defaults: defaults) == "zh_female_vv_jupiter_bigtts")
+    }
+
+    @Test func aCuratedVoiceThatSpeaksTheLanguageIsKept() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        // Gemini's voices are multilingual, so its own language branch stands —
+        // the catalog corrects the language, it does not overrule the taste.
+        #expect(VoiceSettings.voice(.gemini, .english, defaults: defaults) == "Puck")
+        #expect(VoiceSettings.voice(.gemini, .chinese, defaults: defaults) == "Aoede")
+        #expect(VoiceSettings.voice(.openai, .chinese, defaults: defaults) == "marin")
+        // Qwen's realtime voices are Chinese-only, so English has nothing better.
+        #expect(VoiceSettings.voice(.qwen, .english, defaults: defaults) == "longanqian")
+    }
+
+    @Test func aStoredVoiceOutranksTheLanguage() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        defaults.set("S_MyClonedVoice_42", forKey: VoiceSettings.voiceKey(.doubao))
+        #expect(VoiceSettings.voice(.doubao, .english, defaults: defaults) == "S_MyClonedVoice_42")
+    }
+
+    @Test func everyProviderAndLanguageResolvesToACatalogVoice() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        for provider in VoiceProvider.allCases {
+            for language in [VoiceLanguage.english, .chinese] {
+                let id = VoiceSettings.voice(provider, language, defaults: defaults)
+                let voice = VoiceCatalog.voices(.conversation, provider).first { $0.id == id }
+                #expect(voice != nil, "\(provider) \(language) → \(id)")
+                // And it is never a voice documented as speaking another one.
+                #expect(voice?.speaks(language) == true
+                        || VoiceCatalog.voices(.conversation, provider).allSatisfy { !$0.speaks(language) },
+                        "\(provider) \(language) → \(id)")
+            }
+        }
+    }
+
+    /// The picker's shortlist and the voice the session actually opens with must
+    /// agree, or the row shows one voice and the call speaks another.
+    @Test func theShortlistLeadsWithTheVoiceTheSessionWillUse() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        for provider in VoiceProvider.allCases {
+            for language in [VoiceLanguage.english, .chinese] {
+                let id = VoiceSettings.voice(provider, language, defaults: defaults)
+                #expect(VoiceCatalog.shortlist(.conversation, provider, language: language)
+                    .contains { $0.id == id }, "\(provider) \(language) → \(id)")
+            }
+        }
+    }
+}
+
 @Suite("A fresh read-aloud voice follows the language")
 struct ReadAloudDefaultVoiceTests {
     private func suite() throws -> (UserDefaults, String) {

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -363,7 +363,7 @@ private struct ConversationFeatureRow: View {
         let voice = voiceID.trimmingCharacters(in: .whitespacesAndNewlines)
         let workspace = workspaceID.trimmingCharacters(in: .whitespacesAndNewlines)
         return .init(provider: provider, model: model.isEmpty ? provider.defaultModel : model,
-                     voice: voice.isEmpty ? provider.defaultVoice(selectedLanguage) : voice,
+                     voice: voice.isEmpty ? VoiceSettings.voice(provider, selectedLanguage) : voice,
                      workspace: workspace.isEmpty ? nil : workspace, international: intl)
     }
     private var detail: String? { provider == nil ? nil : configuration?.failure }
@@ -391,7 +391,8 @@ private struct ConversationFeatureRow: View {
                 if let provider {
                     VoicePicker(label: "Conversation voice", purpose: .conversation, provider: provider,
                                 language: VoiceLanguage(rawValue: language) ?? .english,
-                                fallback: provider.defaultVoice(VoiceLanguage(rawValue: language) ?? .english),
+                                fallback: VoiceSettings.voice(provider,
+                                    VoiceLanguage(rawValue: language) ?? .english),
                                 voiceID: $voiceID)
                 } else { Text(verbatim: "—").foregroundStyle(.secondary) }
             } trailing: {


### PR DESCRIPTION
## The defect

`VoiceProvider.defaultVoice(_:)` ignores the language for Doubao — it always returns `zh_female_vv_jupiter_bigtts` (Vivi, Chinese). Doubao's realtime catalog also ships three English voices (`en_male_tim_uranus_bigtts`, `en_female_dacey_uranus_bigtts`, `en_female_stokie_uranus_bigtts`), so with the conversation language set to English the voice-conversation row offered a shortlist of those three while the *selected* default stayed Vivi. Same accent defect #135–#138 fixed for read-aloud, one row over.

## The fix

`VoiceSettings.voice` now resolves a blank voice ID the way `VoiceSettings.readAloudVoice` does. Both go through one shared rule:

> The catalog is the authority on **which language a voice speaks**; the vendor constant is the authority on **which voice we like**. Keep the curated pick whenever it speaks the conversation language, and only when it does not, take the catalog's first voice for that language.

Straight catalog-first would have worked for Doubao but flattened Gemini — its voices are documented multilingual, so a catalog lookup cannot express "Aoede for Chinese, Puck for English", and Gemini's default would have silently become Zephyr. The rule above keeps that branch, which the read-aloud side never had to preserve.

`VoiceProvider.defaultVoice` stays as the curated pick and now has exactly one production caller. Its doc comment says so, so the next voice added to the catalog doesn't reopen this gap.

## Behavior change (migration note)

**One default moves: Doubao + English.** An existing Doubao user who never picked a voice and has English selected gets Tim instead of Vivi on their next call. Nothing is rewritten in `UserDefaults` — a stored voice ID still wins, so anyone who chose a voice is untouched.

Everything else resolves to the same ID as before:

| | before | after |
|---|---|---|
| Doubao · English | Vivi (Chinese) | **Tim** |
| Doubao · Chinese | Vivi | Vivi |
| Gemini · English / Chinese | Puck / Aoede | Puck / Aoede |
| Qwen · English / Chinese | longanqian | longanqian |
| OpenAI · either | marin | marin |
| read-aloud, all providers | — | unchanged |

## Other callers

All three call sites the ticket flagged now read the same resolver, so the picker's selection, the connection test and the realtime session cannot disagree:

- `VoiceChat` (iOS + Mac) already called `VoiceSettings.voice` — it picks the fix up for free.
- `ConversationFeatureRow.configuration` (the Mac **Test** button) tested Vivi while an English call would have spoken Tim. Now it tests what the session will use.
- The Mac `VoicePicker` fallback, which is what made the mismatch visible.
- The iPhone Doubao section named "Vivi" in prose and compared against a hard-coded `.english`. It now names the voice from the catalog and follows the actual conversation language.

## Verification

- `swift test` in `VibeBuddyKit`: **409 tests pass**, including `everyRealtimeDefaultIsACatalogVoice` (the ticket's constraint that every runtime default is a catalog voice) and the whole read-aloud suite unchanged.
- New `ConversationDefaultVoiceTests` mirrors `ReadAloudDefaultVoiceTests`: Doubao English is now an English catalog voice, Gemini/OpenAI/Qwen keep their curated picks, a stored ID still outranks the language, and — the invariant the bug violated — the resolved voice is always in the shortlist the picker shows.
- Isolated builds only: Mac app and iOS app both build clean from a scratch derived-data path. No `tools/redeploy-mac.sh`; the shared `/Applications` install and its preferences were not touched.
- Real end-to-end acceptance on an iPhone 17 Pro simulator (own defaults, provider/language injected through the argument domain): Doubao + English reads "The recommended model and **Tim** voice are ready", Doubao + 中文 reads "**Vivi**".