### PR TITLE
Doubao's stream-finished frame is not a failure

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/DoubaoSpeechSynthesizer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/DoubaoSpeechSynthesizer.swift
@@ -37,6 +37,20 @@ public struct DoubaoSpeechSynthesizer: SpeechSynthesizer {
         return try Self.audio(from: data)
     }
 
+    /// Every frame carries a status: `0` on each audio chunk and `20000000`
+    /// ("OK") on the terminal one that closes the stream. The whole 2xxxxxxx
+    /// family is status rather than failure — the realtime API uses 20000002
+    /// the same way — so only codes outside it end the read. Their codes
+    /// distinguish auth from quota; nothing they said is ever repeated back.
+    static func failure(for code: Int) -> SpeechSynthesisFailure? {
+        switch code {
+        case 0, 20_000_000..<30_000_000: nil
+        case 401, 403: .rejected
+        case 429: .rateLimited
+        default: .transport
+        }
+    }
+
     /// The endpoint streams a sequence of JSON objects, one per audio chunk;
     /// the body therefore holds several concatenated objects, not one.
     static func audio(from data: Data) throws -> Data {
@@ -48,11 +62,7 @@ public struct DoubaoSpeechSynthesizer: SpeechSynthesizer {
                   let object = (try? JSONSerialization.jsonObject(with: Data(text.utf8))) as? [String: Any]
             else { continue }
             sawObject = true
-            if let code = object["code"] as? Int, code != 0 {
-                // Their codes distinguish auth from quota; nothing they said is repeated.
-                throw code == 401 || code == 403 ? SpeechSynthesisFailure.rejected
-                    : code == 429 ? .rateLimited : .transport
-            }
+            if let code = object["code"] as? Int, let failure = Self.failure(for: code) { throw failure }
             guard let encoded = object["data"] as? String, !encoded.isEmpty else { continue }
             guard let chunk = Data(base64Encoded: encoded, options: .ignoreUnknownCharacters) else {
                 throw SpeechSynthesisFailure.transport

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SpeechSynthesisDecodingTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SpeechSynthesisDecodingTests.swift
@@ -59,6 +59,20 @@ struct SpeechSynthesisDecodingTests {
         #expect(Array(audio) == [9, 9, 8, 8])
     }
 
+    @Test func doubaoTreatsTheTerminalStatusFrameAsTheEndOfTheStream() throws {
+        // The stream closes with code 20000000 "OK" after the audio; reading it
+        // as an error threw away a complete recording.
+        let body = """
+        {"code":0,"message":"","data":"\(base64([1, 2]))"}
+        {"code":0,"message":"","data":"\(base64([3, 4]))","sentence":{"words":[]}}
+        {"code":20000000,"message":"OK","data":""}
+        """
+        #expect(Array(try DoubaoSpeechSynthesizer.audio(from: Data(body.utf8))) == [1, 2, 3, 4])
+        #expect(DoubaoSpeechSynthesizer.failure(for: 20_000_000) == nil)
+        #expect(DoubaoSpeechSynthesizer.failure(for: 20_000_002) == nil)
+        #expect(DoubaoSpeechSynthesizer.failure(for: 0) == nil)
+    }
+
     @Test func doubaoGradesItsOwnCodesWithoutRepeatingThem() {
         for (code, expected) in [(401, SpeechSynthesisFailure.rejected), (403, .rejected),
                                  (429, .rateLimited), (55_000_001, .transport)] {


### PR DESCRIPTION
Follow-up to #138, found by verifying what that PR could not: Doubao read-aloud never produced a sound.

## What was wrong

Everything about the request was right. The service answered `200`, seventeen base64 chunks arrived, every one decoded to MP3 — and then the terminal frame came with `code: 20000000, message: "OK"`, which is how the stream closes. Treating any non-zero `code` as an error threw away a complete recording and reported *"Speech generation failed. Check your read-aloud model, voice and connection"* — model, voice and connection all being fine.

The whole `2xxxxxxx` family is status rather than failure; the realtime API uses `20000002` the same way for a user's exit intent. Only codes outside it now end the read, with `401`/`403` still rejection and `429` still rate limiting.

## Verification

Driven through the app's own read-aloud preview on an isolated Developer-ID-signed build, so the keys stay in the Keychain and never pass through a shell:

| provider | before | after |
|---|---|---|
| Doubao | Speech generation failed | playback completed |
| OpenAI | — | playback completed |
| Gemini | — | playback completed |
| Qwen | playback completed | playback completed |

**This also closes #138's "not verified" note.** That PR said OpenAI and Doubao had never made a real round trip "for want of keys on this machine" — wrong: the keys were in the Keychain all along, and the app reads them itself. The shell environment lacking `OPENAI_API_KEY` said nothing about what the app could do. Driving the app's own preview button is the instrument; the environment-gated test target is only for CI.

412 Kit tests pass, including a new one that a stream ending in `20000000 "OK"` still yields its audio.

## Also found, deliberately not fixed here

**The Doubao conversation catalog is narrower than the endpoint accepts.** Handshaking through the app's Test button, the full-duplex endpoint (`/api/v3/duplex/realtime/dialogue`) accepted every voice tried from both families — `zh_female_vv_jupiter_bigtts`, `en_male_tim_uranus_bigtts`, `zh_female_vv_uranus_bigtts`, `ICL_uranus_en_male_ethan_tob`, `zh_female_sajiaoxuemei_uranus_bigtts`, `zh_male_wennuanahu_uranus_bigtts` — while a deliberately bogus ID was rejected, which is what makes those confirmations meaningful. The vendor's own voice-list page is titled 「豆包语音合成模型2.0、S2S-O2.0、S2S-全双工」, i.e. one shared 2.0 table. So conversation could offer the same 26 voices read-aloud does instead of 7. Additive, and a separate change.

**`ReadAloud.copy(for:)` maps every non-`SpeechSynthesisFailure` error to `.transport`**, so an `AVAudioPlayer` failure would also say "check your model, voice and connection". It sent me down the wrong path during this investigation before the logs corrected me.