### PR TITLE
fix: integrate voice settings fixes and prepare 1.3.10

### DIFF
--- a/VibeBuddyApp/Sources/SettingsView.swift
+++ b/VibeBuddyApp/Sources/SettingsView.swift
@@ -267,7 +267,23 @@ private struct ProviderSection: View {
     }
     private var effectiveVoice: String {
         let value = voice.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? provider.defaultVoice(VoiceSettings.conversationLanguage) : value
+        return value.isEmpty ? recommendedVoice : value
+    }
+    /// What a blank Voice ID resolves to — the same call the realtime session
+    /// makes, so this screen never advertises a voice the call will not use.
+    private var recommendedVoice: String {
+        VoiceSettings.defaultConversationVoice(provider, VoiceSettings.conversationLanguage)
+    }
+    /// Doubao's summary line names the voice, and the recommended one changes
+    /// with the conversation language (Vivi in Chinese, Tim in English), so the
+    /// name comes from the catalog rather than being written into the sentence.
+    private var recommendedSummary: LocalizedStringKey {
+        guard effectiveModel == provider.defaultModel, effectiveVoice == recommendedVoice else {
+            return "Your custom model or voice is retained. Review Advanced settings before testing."
+        }
+        let name = VoiceCatalog.voices(.conversation, provider)
+            .first { $0.id == recommendedVoice }?.name ?? recommendedVoice
+        return "The recommended model and \(name) voice are ready. Only your realtime API key is required."
     }
     private var configurationValid: Bool {
         let allowed = Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-".utf8)
@@ -331,7 +347,7 @@ private struct ProviderSection: View {
                 }
             } else if provider == .doubao {
                 Text(effectiveModel == provider.defaultModel ? "Doubao realtime voice 3.0 · Recommended" : "Custom realtime model").font(.headline)
-                Text(effectiveModel == provider.defaultModel && effectiveVoice == provider.defaultVoice(.english) ? "The recommended model and Vivi voice are ready. Only your realtime API key is required." : "Your custom model or voice is retained. Review Advanced settings before testing.")
+                Text(recommendedSummary)
                     .font(.caption).foregroundStyle(.secondary)
                 DisclosureGroup("Advanced settings") {
                     customFields

--- a/VibeBuddyApp/project.yml
+++ b/VibeBuddyApp/project.yml
@@ -46,8 +46,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app
-        MARKETING_VERSION: "1.3.9"
-        CURRENT_PROJECT_VERSION: "20"
+        MARKETING_VERSION: "1.3.10"
+        CURRENT_PROJECT_VERSION: "21"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -81,8 +81,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.widget
-        MARKETING_VERSION: "1.3.9"
-        CURRENT_PROJECT_VERSION: "20"
+        MARKETING_VERSION: "1.3.10"
+        CURRENT_PROJECT_VERSION: "21"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "1"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -117,8 +117,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp
         CODE_SIGN_ENTITLEMENTS: Watch/VibeBuddyWatch.entitlements
-        MARKETING_VERSION: "1.3.9"
-        CURRENT_PROJECT_VERSION: "20"
+        MARKETING_VERSION: "1.3.10"
+        CURRENT_PROJECT_VERSION: "21"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2
@@ -145,8 +145,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.app.watchkitapp.widget
-        MARKETING_VERSION: "1.3.9"
-        CURRENT_PROJECT_VERSION: "20"
+        MARKETING_VERSION: "1.3.10"
+        CURRENT_PROJECT_VERSION: "21"
         SWIFT_VERSION: "6.0"
         TARGETED_DEVICE_FAMILY: "4"
         DEVELOPMENT_TEAM: LQAVR62TK2

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -295,17 +295,34 @@ public enum VoiceSettings {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return v.isEmpty ? SpeechSynthesis.support(p).defaultModel : v
     }
-    /// Blank falls back to the catalog's first voice **for the conversation
-    /// language** — a fresh English setup must not be handed a Chinese voice,
-    /// which is the accent bug this catalog exists to fix.
+    /// Blank falls back to a voice that speaks **the conversation language** —
+    /// a fresh English setup must not be handed a Chinese voice, which is the
+    /// accent bug this catalog exists to fix.
     public static func readAloudVoice(_ p: VoiceProvider, language: VoiceLanguage? = nil,
                                       defaults: UserDefaults = .standard) -> String {
         let v = (defaults.string(forKey: readAloudVoiceKey(p)) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard v.isEmpty else { return v }
         let spoken = language ?? conversationLanguage(defaults: defaults)
-        return VoiceCatalog.defaultVoice(.readAloud, p, language: spoken)
-            ?? SpeechSynthesis.support(p).defaultVoice
+        return languageDefault(.readAloud, p, spoken,
+                               curated: SpeechSynthesis.support(p).defaultVoice)
+    }
+
+    /// How a blank voice ID becomes a real one, for either purpose.
+    ///
+    /// The catalog is the authority on **which language a voice speaks**; the
+    /// vendor constant is the authority on **which voice we like**. So keep the
+    /// curated pick whenever it speaks the conversation language — that is how
+    /// Gemini keeps Aoede for Chinese and Puck for English — and only when it
+    /// does not (Doubao's Vivi is Chinese-only) fall to the catalog's first
+    /// voice for that language. A constant the catalog does not list cannot be
+    /// vouched for, so it loses to the catalog too, and is kept only as the
+    /// last resort for a provider with no catalog entries at all.
+    static func languageDefault(_ purpose: VoicePurpose, _ p: VoiceProvider,
+                                _ language: VoiceLanguage, curated: String) -> String {
+        let listed = VoiceCatalog.voices(purpose, p).first { $0.id == curated }
+        if listed?.speaks(language) == true { return curated }
+        return VoiceCatalog.defaultVoice(purpose, p, language: language) ?? curated
     }
 
     public static func readAloudConfiguration(_ p: VoiceProvider,
@@ -372,12 +389,19 @@ public enum VoiceSettings {
         return v.isEmpty ? p.defaultModel : v
     }
 
-    /// The voice ID for a provider, user-editable (blank → a language-appropriate
-    /// default). CN voices carry an accent in English, so the default is chosen
-    /// from the conversation language.
-    public static func voice(_ p: VoiceProvider, _ language: VoiceLanguage) -> String {
-        let v = (UserDefaults.standard.string(forKey: voiceKey(p)) ?? "")
+    /// The language default, independent of any saved custom selection.
+    public static func defaultConversationVoice(_ p: VoiceProvider, _ language: VoiceLanguage) -> String {
+        languageDefault(.conversation, p, language, curated: p.defaultVoice(language))
+    }
+
+    /// The realtime voice ID for a provider, user-editable (blank → a
+    /// language-appropriate default). CN voices carry an accent in English, so
+    /// the default is resolved through the catalog exactly as read-aloud is.
+    public static func voice(_ p: VoiceProvider, _ language: VoiceLanguage,
+                             defaults: UserDefaults = .standard) -> String {
+        let v = (defaults.string(forKey: voiceKey(p)) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return v.isEmpty ? p.defaultVoice(language) : v
+        guard v.isEmpty else { return v }
+        return defaultConversationVoice(p, language)
     }
 }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoiceProvider.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoiceProvider.swift
@@ -48,14 +48,18 @@ public enum VoiceProvider: String, CaseIterable, Sendable {
         }
     }
 
-    /// A natural default voice for the conversation language. Verified voice
-    /// names per provider; the user can override with a free-text Voice ID.
+    /// The voice we pick for this provider when the user has not — taste, not
+    /// language. A vendor whose voices are all multilingual can still branch
+    /// (Gemini), but a vendor whose pick speaks only one language does not
+    /// pretend otherwise: Doubao's Vivi is Chinese, and `VoiceSettings.voice`
+    /// is what swaps it for an English voice when the conversation is English.
+    /// Call that, not this — this is the curated pick, not the resolved one.
     public func defaultVoice(_ language: VoiceLanguage) -> String {
         switch self {
         case .qwen:   return "longanqian"   // Qwen-Audio system voice (multilingual)
         case .openai: return "marin"
         case .gemini: return language == .chinese ? "Aoede" : "Puck"
-        case .doubao: return "zh_female_vv_jupiter_bigtts"
+        case .doubao: return "zh_female_vv_jupiter_bigtts"   // Chinese; English → the catalog
         }
     }
 

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceCatalogTests.swift
@@ -103,6 +103,74 @@ struct VoiceDefaultsInCatalogTests {
     }
 }
 
+@Suite("A fresh conversation voice follows the language")
+struct ConversationDefaultVoiceTests {
+    private func suite() throws -> (UserDefaults, String) {
+        let name = "conversation-voice-\(UUID())"
+        return (try #require(UserDefaults(suiteName: name)), name)
+    }
+
+    @Test func doubaoEnglishNoLongerStartsOnAChineseVoice() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        // The bug: Vivi is Chinese-only, and the vendor constant handed her out
+        // whatever the conversation language was.
+        #expect(VoiceProvider.doubao.defaultVoice(.english) == "zh_female_vv_jupiter_bigtts")
+        let english = VoiceSettings.voice(.doubao, .english, defaults: defaults)
+        #expect(VoiceCatalog.voices(.conversation, .doubao).first { $0.id == english }?.language == .english)
+        #expect(VoiceSettings.voice(.doubao, .chinese, defaults: defaults) == "zh_female_vv_jupiter_bigtts")
+    }
+
+    @Test func aCuratedVoiceThatSpeaksTheLanguageIsKept() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        // Gemini's voices are multilingual, so its own language branch stands —
+        // the catalog corrects the language, it does not overrule the taste.
+        #expect(VoiceSettings.voice(.gemini, .english, defaults: defaults) == "Puck")
+        #expect(VoiceSettings.voice(.gemini, .chinese, defaults: defaults) == "Aoede")
+        #expect(VoiceSettings.voice(.openai, .chinese, defaults: defaults) == "marin")
+        // Qwen's realtime voices are Chinese-only, so English has nothing better.
+        #expect(VoiceSettings.voice(.qwen, .english, defaults: defaults) == "longanqian")
+    }
+
+    @Test func aStoredVoiceOutranksTheLanguage() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        defaults.set("S_MyClonedVoice_42", forKey: VoiceSettings.voiceKey(.doubao))
+        #expect(VoiceSettings.voice(.doubao, .english, defaults: defaults) == "S_MyClonedVoice_42")
+    }
+
+    @Test func everyProviderAndLanguageResolvesToACatalogVoice() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        for provider in VoiceProvider.allCases {
+            for language in [VoiceLanguage.english, .chinese] {
+                let id = VoiceSettings.voice(provider, language, defaults: defaults)
+                let voice = VoiceCatalog.voices(.conversation, provider).first { $0.id == id }
+                #expect(voice != nil, "\(provider) \(language) → \(id)")
+                // And it is never a voice documented as speaking another one.
+                #expect(voice?.speaks(language) == true
+                        || VoiceCatalog.voices(.conversation, provider).allSatisfy { !$0.speaks(language) },
+                        "\(provider) \(language) → \(id)")
+            }
+        }
+    }
+
+    /// The picker's shortlist and the voice the session actually opens with must
+    /// agree, or the row shows one voice and the call speaks another.
+    @Test func theShortlistLeadsWithTheVoiceTheSessionWillUse() throws {
+        let (defaults, name) = try suite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        for provider in VoiceProvider.allCases {
+            for language in [VoiceLanguage.english, .chinese] {
+                let id = VoiceSettings.voice(provider, language, defaults: defaults)
+                #expect(VoiceCatalog.shortlist(.conversation, provider, language: language)
+                    .contains { $0.id == id }, "\(provider) \(language) → \(id)")
+            }
+        }
+    }
+}
+
 @Suite("A fresh read-aloud voice follows the language")
 struct ReadAloudDefaultVoiceTests {
     private func suite() throws -> (UserDefaults, String) {

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -153,7 +153,7 @@ struct VoiceSettingsTab: View {
     }
     private var summarySelection: Binding<String> {
         Binding(get: { summaryProvider?.rawValue ?? "" }, set: { raw in
-            guard let value = VoiceProvider(rawValue: raw), value.supportsCompletionSummaries else { return }
+            guard raw.isEmpty || VoiceProvider(rawValue: raw)?.supportsCompletionSummaries == true else { return }
             summaryChoice = raw
         })
     }
@@ -363,7 +363,7 @@ private struct ConversationFeatureRow: View {
         let voice = voiceID.trimmingCharacters(in: .whitespacesAndNewlines)
         let workspace = workspaceID.trimmingCharacters(in: .whitespacesAndNewlines)
         return .init(provider: provider, model: model.isEmpty ? provider.defaultModel : model,
-                     voice: voice.isEmpty ? provider.defaultVoice(selectedLanguage) : voice,
+                     voice: voice.isEmpty ? VoiceSettings.voice(provider, selectedLanguage) : voice,
                      workspace: workspace.isEmpty ? nil : workspace, international: intl)
     }
     private var detail: String? { provider == nil ? nil : configuration?.failure }
@@ -391,7 +391,8 @@ private struct ConversationFeatureRow: View {
                 if let provider {
                     VoicePicker(label: "Conversation voice", purpose: .conversation, provider: provider,
                                 language: VoiceLanguage(rawValue: language) ?? .english,
-                                fallback: provider.defaultVoice(VoiceLanguage(rawValue: language) ?? .english),
+                                fallback: VoiceSettings.voice(provider,
+                                    VoiceLanguage(rawValue: language) ?? .english),
                                 voiceID: $voiceID)
                 } else { Text(verbatim: "—").foregroundStyle(.secondary) }
             } trailing: {

--- a/VibeBuddyMacApp/project.yml
+++ b/VibeBuddyMacApp/project.yml
@@ -63,8 +63,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibebuddy.mac
-        MARKETING_VERSION: "1.3.9"
-        CURRENT_PROJECT_VERSION: "16"
+        MARKETING_VERSION: "1.3.10"
+        CURRENT_PROJECT_VERSION: "17"
         SWIFT_VERSION: "6.0"
         # Build signs ad-hoc; tools/redeploy-mac.sh re-signs the built .app with a
         # stable local Apple Development identity so Keychain ACLs / TCC grants

--- a/docs/release-notes-1.3.10.md
+++ b/docs/release-notes-1.3.10.md
@@ -1,0 +1,15 @@
+# vibebuddy 1.3.10
+
+- Mac model settings now separate feature choices from provider accounts, with independent conversation, completion-summary and read-aloud configuration.
+- Browse built-in voice catalogs and preview read-aloud voices from Qwen, OpenAI, Gemini and Doubao.
+- Fix clearing the completion-summary provider and keeping following read-aloud settings in sync.
+- Doubao realtime conversation defaults now follow the selected language: Tim for English and Vivi for Chinese. Saved custom voices are preserved, and iPhone settings show the matching recommendation.
+- Fix handling of Doubao speech stream completion.
+
+## 中文
+
+- Mac 模型设置分为功能配置与服务商账号，对话、完成摘要和朗读可分别选择。
+- 提供内置音色目录，支持 Qwen、OpenAI、Gemini 和豆包的朗读试听。
+- 修复摘要服务商无法取消配置，以及跟随摘要的朗读状态同步。
+- 豆包实时对话默认音色跟随语言：英文 Tim、中文 Vivi。保留自定义音色，iPhone 推荐音色说明同步更新。
+- 修复豆包语音流结束帧的处理。


### PR DESCRIPTION
## Changes

Mac completion-summary settings can now be cleared with “Not configured”; read-aloud follows that state unless pinned. Doubao's blank realtime voice resolves to Tim for English and Vivi for Chinese, shared by the Mac picker, connection test, runtime session and iPhone recommendation. Custom voices are preserved.

Integrates the implementation from #143 with the current #144 baseline and corrects the iPhone recommendation check so a custom voice is not labeled as the default. Prepares 1.3.10: Mac build 17 and iOS/Watch build 21.

## Validation

- 30 focused voice catalog/purpose/default tests passed.
- Mac and iOS Simulator builds passed.
- Native Mac settings: summary selection clears; following read-aloud waits; pinned provider stays selected; actual Qwen summary sample succeeds.
- Actual Mac preview synthesis/playback completed for Qwen, OpenAI, Gemini and Doubao.
- Actual Doubao duplex session using resolved English/Chinese defaults returned transcripts and non-silent audio; invalid voice was rejected.
- Native iPhone Simulator settings immediately switch recommendation Tim ↔ Vivi with language.

Physical microphone interruption, human hearing and Watch haptics are not claimed by these checks. Release signing and App Store export are tracked separately.
