### PR TITLE
Refresh VibeBuddy homepage for Claude Code and Codex workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to VibeBuddy
+
+Thanks for helping make coding-agent workflows easier to follow across Mac,
+iPhone and Apple Watch. Contributions in English or Simplified Chinese are welcome.
+
+## Useful ways to help
+
+- Reproduce a Claude Code or Codex integration issue with the actual agent.
+- Improve English or Chinese UI text and keep the two READMEs consistent.
+- Document a device workflow, especially Watch interactions and reconnects.
+- Fix a focused bug or improve an existing provider adapter.
+- Share a concrete example of how VibeBuddy fits your development workflow.
+
+## Before changing code
+
+Read [AGENTS.md](AGENTS.md) for project rules and
+[getting started](docs/getting-started.md#build-from-source) for local setup.
+Changes to behavior or architecture should also follow the
+[domain guide](docs/agents/domain.md), [CONTEXT.md](CONTEXT.md) and relevant
+[architecture decisions](docs/adr).
+
+For work planning, this project uses local Markdown under `.scratch/<feature>/`,
+as described in the [issue-tracker guide](docs/agents/issue-tracker.md). Those
+local notes are not committed. Send reviewable changes as GitHub pull requests;
+for a substantial proposal, explain the intended behavior before investing in a
+large implementation.
+
+## Make the change easy to review
+
+Keep the diff focused and preserve existing uncommitted work. Explain what the
+user experienced, what changes after the patch, and how you checked it. Include
+the affected agent version and connection type when relevant: Codex CLI, a
+daemon-owned app-server task and a Desktop-origin task are different test cases.
+
+For app or daemon behavior, prefer a real end-to-end check of the affected flow.
+Run relevant existing tests for shared logic and regressions. For documentation,
+check links, images and the rendered page. A screenshot of Demo mode demonstrates
+the interface; a real-device check demonstrates that specific device flow.
+
+In your pull request, include:
+
+- The problem and resulting behavior.
+- The checks performed and their results.
+- Screenshots for visible changes, labelled with their source.
+- Any remaining device, provider or integration limitation.
+
+## Keep private data out of contributions
+
+Use sample tasks for public screenshots and reports. Remove pairing QR codes,
+bearer tokens, API credentials, private project paths and transcript contents.
+Never commit APNs signing keys or provisioning credentials. If a bug depends on
+private data, describe the smallest sanitized reproduction instead.
+
+## License
+
+By submitting a contribution, you agree that it may be distributed under the
+project's [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,214 +1,128 @@
 <div align="center">
 
-<img src="docs/screenshots/app-icon-256.png" width="112" alt="vibebuddy" />
+<img src="docs/screenshots/app-icon-256.png" width="88" alt="vibebuddy's white cat with green ears" />
 
 # vibebuddy
 
-**Claude Code and Codex, connected across iPhone, Apple Watch and Mac.**
-Step away from your desk. Check progress, see what needs you, and handle supported approvals and questions—with a little cat keeping you company.
+### Leave your desk. Keep your agents moving.
 
-[**⬇️ Download for macOS**](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) · [Features](#-features) · [How it works](#-how-it-works) · [Build from source](#️-build--run) · [简体中文](./README.zh-CN.md)
+A native **Mac, iPhone & Apple Watch** companion for **Claude Code and Codex**.<br>See what needs you, respond to supported requests, and hear what got done.
 
-![License](https://img.shields.io/badge/license-MIT-green)
-![Platform](https://img.shields.io/badge/platform-iOS%2017%20%2B%20macOS%2014-blue)
-![Swift](https://img.shields.io/badge/Swift-6.0-orange)
-[![Latest release](https://img.shields.io/github/v/release/semantic-craft/iOS-vibebuddy)](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)
+[**Download for Mac**](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) · [**Get the iPhone app**](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338) · [Get started](#get-started) · [简体中文](README.zh-CN.md)
 
-</div>
+[![Latest Mac release](https://img.shields.io/github/v/release/semantic-craft/iOS-vibebuddy?label=Mac%20release&color=67a86b)](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) [![MIT license](https://img.shields.io/badge/license-MIT-67a86b)](LICENSE) ![Platforms](https://img.shields.io/badge/platforms-macOS%20%C2%B7%20iOS%20%C2%B7%20watchOS-536584) ![Swift 6](https://img.shields.io/badge/Swift-6-F05138)
 
----
+**Free & open source · No VibeBuddy account · No analytics · Bring your own AI key**
 
-## From a status dashboard to a three-device companion
+<img src="docs/app-store-screenshots/1.3/macos/en-US/01-dashboard-approval.jpg" width="960" alt="Mac dashboard showing Claude Code and Codex tasks, a pending file edit, and Approve, Deny and Jump controls" />
 
-**The 1.3 candidate is a major step beyond the original phone dashboard.** The first release focused on session status and local alerts. This update brings deeper Codex integration, Watch complications and a more consistent companion experience.
-
-| Upgrade | What it means for you |
-|---|---|
-| **Updated agent integrations** | Improved task, permission and question handling for Claude Code and Codex. See the capability limits below. |
-| **Deeper Codex integration** | Observe Desktop and CLI tasks; answer questions, send follow-up instructions and start tasks through supported connections. |
-| **New Apple Watch complications** | Followed tasks in a rectangular slot; Claude, Codex or combined remaining quota in a circular slot, with five display styles. |
-| **Refreshed icons and interactions** | A shared cat identity and agent icons across devices, a simpler phone connection menu and clearer task states. |
-| **Updated macOS UI** | Menu-bar status, notch glance and task cards, with improved dashboard reopening and glance position recovery. |
-
-> These are current-source and 1.3 candidate features, pending release and device acceptance. The latest public Mac download is currently 1.1. Update the Mac companion when the new release is available. Watch refresh timing is system-controlled; quota depends on available provider data.
-
-## New here? Start with your Mac
-
-1. **[Download the free Mac companion](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)**. Under Assets, choose the DMG and drag the app into Applications. Requires Apple Silicon and macOS 14 or later.
-2. **Open “Pair a phone” in the Mac menu bar**, with your iPhone and Mac on the same local network.
-3. **Tap “Scan to pair” on iPhone** and scan the Mac's QR code. Follow Setup in the Mac settings to connect your agent.
-4. **Just exploring?** Tap “See the demo (no Mac needed)” on the iPhone connection screen. Live tasks require a reachable paired Mac.
-
-Apple Watch also requires a paired iPhone. See Download below for current iPhone availability; the new App Store listing is being prepared.
-
----
-
-## 🐱 The 30-second pitch
-
-You kick off three Claude Code sessions, switch to Codex for a fourth, walk away to make coffee — and now you have no idea which agent is stuck waiting on you, which is still grinding, and which already finished and is sitting idle.
-
-**vibebuddy** is a tiny menu-bar cat on your Mac plus a companion app on your iPhone. It watches every coding-agent session and answers the only three questions that matter:
-
-> ### 🟠 Needs response · 🔵 Working · 🟢 Done
-
-No more walking back to the desk to find a session has been blocked on a permission prompt for ten minutes. Your phone buzzes, you review the diff preview, and you tap **Approve** — or you tap the cat and **say "approve it."**
-
-<div align="center">
-
-<img src="docs/screenshots/mac/dashboard.png" width="840" alt="vibebuddy Mac menu-bar app — three-pane dashboard: status sidebar, session list with the voice pet, and a remote-approval detail" />
-
-<sub><b>The Mac menu-bar app</b> — every session in three buckets, the voice pet, and a remote-approval detail pane.</sub>
-
-<br><br>
-
-<img src="docs/screenshots/mac/glance.png" width="360" alt="vibebuddy notch glance — the cat and the one count that matters, either side of the notch" />
-<img src="docs/screenshots/mac/glance-card.png" width="360" alt="an approval card unfolded under the notch with Approve / Deny / Jump" />
-
-<sub><b>Notch glance</b> — lives beside the notch like a Dynamic Island: nothing when idle, the cat + the count that matters when not, hover to expand, and approvals drop down as cards you answer in place.</sub>
-
-<br><br>
-
-<img src="docs/app-store-screenshots/6.9/01-dashboard.png" width="280" alt="vibebuddy iPhone dashboard with an inline diff and Approve/Deny buttons" />
-
-<sub><b>On your iPhone</b> — tap a session for the inline diff and Approve / Deny.</sub>
+<sub>Real app, sample tasks: the 1.3 demo dashboard. Screenshots illustrate the interface, not live agent results.</sub>
 
 </div>
 
-<div align="center">
+## A little less checking. A lot more doing.
 
-<img src="docs/screenshots/app-icon.png" width="640" alt="vibebuddy app icon on macOS, iPhone and Apple Watch — a white kitten with green ears and eyes on slate blue" />
+Start a refactor in Claude Code and a test run in Codex. VibeBuddy brings both into one view. While your Mac stays running and reachable, you can check a question on your phone, follow a task on your wrist, or ask the voice companion for an update.
 
-<sub><b>One icon, three platforms</b> — the same kitten on your Mac, iPhone and Apple Watch, masked by each system.</sub>
+| See what matters | Keep work moving | Hear the outcome |
+| --- | --- | --- |
+| **One task view.** Needs response, Working and Done, with project, model, current activity and available usage data. | **Approve and reply.** Review a command or bounded diff preview, answer a question, or continue a supported Codex task. | **Voice and summaries.** Ask for current task status, read a concise completion summary, or enable read-aloud on Mac. |
 
-</div>
+## Three screens. One companion.
 
-> **The app icon** is a white kitten with green ears and eyes on muted slate blue — one soft silhouette, three colors, still readable at 16 px. It was designed with the [ip-as-logo](https://github.com/s1dashu/ip-as-logo-skill) skill and picked from six generated candidates; the same 1024 px artwork ships on macOS, iOS and watchOS.
->
-> The **in-app buddy is the same cat, drawn in code** from one shared geometry on iPhone, Apple Watch, the Dynamic Island, the Mac dashboard, the notch glance and the menu bar. Its mood (ears, eyes, mouth) and small reactions change with the sessions; on compact surfaces (menu bar, collapsed glance, Dynamic Island, Watch header) it shrinks to the head alone, the menu bar shows it as a monochrome template silhouette, and only iPhone and the Mac animate it. All screenshots above are **Demo mode** (sample data) — no real session data.
+<table>
+<tr>
+<th>Review on iPhone</th>
+<th>Open the task details</th>
+<th>Glance at your wrist</th>
+</tr>
+<tr>
+<td align="center" valign="top"><img src="docs/app-store-screenshots/1.3/ios/en-US/01-dashboard.jpg" width="270" alt="iPhone demo dashboard with Claude edit approval and a question" /></td>
+<td align="center" valign="top"><img src="docs/app-store-screenshots/1.3/ios/en-US/02-codex-task.jpg" width="270" alt="iPhone demo Codex task detail with model, context usage, notification preferences and Reply" /></td>
+<td align="center" valign="top"><img src="docs/app-store-screenshots/1.3/watchos/en-US/02-quota.jpg" width="208" alt="Apple Watch demo showing Codex weekly and short-window remaining quota" /><br><br>Followed tasks<br>Quick answers<br>Completion summaries<br>Quota at a glance</td>
+</tr>
+</table>
 
----
+<sub>Captured from the actual 1.3 apps in Demo mode. Watch image shows the in-app quota page. <a href="docs/app-store-screenshots/1.3/README.md">Screenshot provenance</a>.</sub>
 
-## ✨ Features
+- **On Mac:** a searchable menu-bar activity feed, full dashboard, notch Glance and jump back to the originating terminal or app.
+- **On iPhone:** task details, recent dialogue, supported approvals and replies, Live Activity and Dynamic Island counts.
+- **On Apple Watch:** followed tasks, quick answers, completion summaries, task and quota complications, and Smart Stack relevance. A paired iPhone is required; watchOS controls background refresh.
 
-### 🎙️ Talk to your agents — voice companion
-Voice is off by default. Select a provider, enter your own API key, accept the data disclosure, and grant microphone access before explicitly starting a conversation. Ask about task status or respond to supported requests. Audio and selected task context go directly to your chosen provider (OpenAI, Google Gemini, Alibaba DashScope / Qwen, or Volcengine / Doubao); provider fees may apply. Available actions depend on the connection and request. The dashboard and button approvals work without voice.
+## New in the 1.3 series
 
-### 📊 The three-bucket dashboard
-Every session grouped into **Needs response / Working / Done**, each row showing project · branch · model · live token & context-window usage · the tool the agent is currently running · and a peek at its most recent output. Priority is honest: `needs response` always outranks `working`.
+| Feature | What changed |
+| --- | --- |
+| **Talk to your tasks** | [1.3.11](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3.11) adds GPT-Live 1 with a separately configurable task reasoning model. OpenAI, Gemini, Qwen and Doubao share task-status and supported action tools. |
+| **Get a useful completion update** | Optional AI summaries focus on results, blockers and next steps. Mac read-aloud has its own provider, model and voice, with voice previews. [Model settings](docs/release-notes-1.3.10.md). |
+| **Continue the conversation** | Reply to supported waits, steer a running Codex turn or continue an existing task. Recent dialogue and delivery receipts help you see what was sent. [Task interaction](docs/release-notes-1.3.6.md). |
+| **Keep the Mac close at hand** | Search and filter the menu feed, open task details, and use an explicitly opened QR pairing window. [Mac companion update](docs/release-notes-1.3.9.md). |
+| **Bring more of your workflow along** | Watch quick answers and task controls; optional Grok Bot observation; Claude, Codex, Grok and Cursor account usage where provider data is available. [Watch update](docs/release-notes-1.3.8.md) · [Grok Bot](docs/release-notes-1.3.7.md). |
 
-### ✅ Remote approvals
-When an agent asks to run a command or edit a file, review the command or **diff preview** in the phone dashboard. Diff previews show up to eight lines per side; inspect the full change on the Mac when more context is needed. **Approve / Deny** from the dashboard or a lock-screen notification (Approve requires unlocking); answerable question notifications offer text input. **Always allow this** / **Allow all this session** remain in the dashboard, not notification buttons. A read-only wait tells you to respond in the Mac's native prompt. Actions require pairing and a reachable Mac.
+Mac releases and iPhone/Watch App Store updates ship independently. Newer features need an updated client on the device using them. Check the [Mac releases](https://github.com/semantic-craft/iOS-vibebuddy/releases) and [App Store listing](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338) for current versions and availability.
 
-### 🔔 Notifications, Live Activity & Dynamic Island
-Approval and question banners request **Time Sensitive** delivery when their final delivery level includes sound; Quiet makes them ordinary silent banners. Other categories remain ordinary. Your category switches and system notification / Focus settings still apply. ActivityKit puts live counts on the **Lock Screen and Dynamic Island**, updated while the app is foregrounded or connected.
+## Built around Claude Code and Codex
 
-The current source supports APNs notifications with the iPhone app closed when the Mac sender is running, APNs signing is configured for the iPhone build, the phone has registered, and notifications are allowed. This is not yet a public-download setup promise: the distribution approach awaits [DEC-APNS](docs/adr/0013-apns-key-delivery.md), and lock-screen / Focus / Watch delivery still needs device acceptance. Responding requires a reachable paired Mac; away from that network, return to it before acting (an existing Tailscale connection is an advanced option).
+VibeBuddy connects to the agents you already run. Available controls follow the actual connection and pending request.
 
-### 🤖 Three existing adapters; Cursor is planned
-The first-class roadmap covers **Claude Code, Codex, Grok, and Cursor**: three-state tracking and remote approval are the required baseline; quota and jump support are best effort. Claude Code, Codex and Grok have adapters today; **Cursor is planned and is not yet supported**. Device acceptance remains a separate gate for each agent. **Qwen, Kimi, OpenCode, and Antigravity** adapters are community-tier, unverified, and fail-open. See the [hook setup guide](docs/multi-cli-hook-setup.md) for agent-specific setup.
+| Connection | Available integration | Where the boundary is |
+| --- | --- | --- |
+| **Claude Code** | Lifecycle hooks, task state, usage, permission decisions and answers to supported questions. | Remote responses need the approval hooks. When the native prompt owns the interaction, respond on Mac. |
+| **Codex CLI / connected app-server** | Task state, usage, supported approvals and questions; create, continue, steer and stop tasks through a connected app-server. | Task control requires the connected server to own the task and expose the required turn/request. MCP elicitation is read-only. |
+| **Codex Desktop** | Observe local task progress and completions; jump back to the app. | Desktop may own a separate app-server. Native Desktop approval coverage is incomplete; use the Mac prompt when no answerable request is available. |
+| **Grok Build / Grok Bot** | Build CLI hooks and mode-dependent approvals; optional Bot observation and quota. | Bot is read-only. Build approvals depend on its permission mode. |
+| **Cursor** | Account usage from supported login sources, including Cursor CLI login. | Quota integration is available; task tracking and remote approval are not yet supported. |
 
-### 📷 QR pairing, zero typing
-The Mac shows a QR encoding `host:port` + a bearer token. The phone scans it once — no manual IP entry. (The same QR can carry a Tailscale `100.x` address later, with no code change.)
+See the [Codex integration contract](docs/codex-integration.md) and [agent hook setup](docs/multi-cli-hook-setup.md). Qwen, Kimi, OpenCode and Antigravity coding-agent adapters are experimental community integrations; their verification is separate from Qwen's supported voice-provider integration.
 
-### 🖥️ Native Mac menu-bar app
-A fixed menu-bar launcher with optional task status (off by default), a macOS notch glance for live counts and alerts, **jump-to-terminal** (open the right session with one click), launch-at-login, and a LAN bearer token persisted in the owner-only (`0600`) file `~/Library/Application Support/vibebuddy/token`. ⏎ / ⌘F dashboard shortcuts included. v1.1 uses a signed Sparkle update feed; original v1.0 users need a one-time manual installation.
+## Get started
 
-### 🔒 Local-first & private by design
-vibebuddy talks **directly** between your Mac and your phone over your own network. Session data **never** touches a vibebuddy server — there is no vibebuddy cloud, no account, no analytics, no tracking. Daemon routes are bearer-token gated. When APNs is configured, notification payloads (including titles and bodies) pass through Apple's push service. (The optional voice companion sends microphone audio and selected session context only to the provider *you* chose, with *your* key, when you turn it on.)
+1. **Install the Mac companion.** [Download the latest DMG](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest), drag the app into Applications, and launch it. The distributed Mac app requires Apple Silicon and macOS 14+.
+2. **Connect your coding agent.** Open Setup in Mac settings and follow the agent-specific instructions. [Manual setup](docs/getting-started.md#connect-an-agent) is also available.
+3. **Add your iPhone.** Install [VibeBuddy: Agent Monitor](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338), choose **Pair a phone** on Mac, then **Scan to pair** on iPhone. Start on the same trusted local network. iPhone requires iOS 17+; the current Watch companion requires watchOS 26.5+.
+4. **Try a task.** Run a short task in Claude Code or Codex. Check its state, open its details, and follow it until completion. Enable voice or summaries separately if you want them.
 
-### 🌏 Bilingual + Demo mode
-Full English and Simplified-Chinese UI on both apps. Plus a **Demo mode** that loads the whole interface with sample data — explore sample tasks with no Mac required.
+**Just looking?** The iPhone connection screen includes **See the demo (no Mac needed)**. Mac works on its own, too. App Store availability varies by region; [build from source](docs/getting-started.md#build-from-source) if needed.
 
----
+### Voice is optional
 
-## ⬇️ Download
+Choose **OpenAI, Google Gemini, Alibaba Qwen or Volcengine Doubao**, add your own API credential in the app, review the disclosure and explicitly start a call. Ask “Which task needs me?” or give a clear response to an answerable request. Voice conversation, completion summaries and Mac read-aloud are configured independently. Provider charges apply; task monitoring and button approvals need no AI API key.
 
-### macOS app
-**[Download the latest Mac Companion →](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)** · Apple Silicon · macOS 14+
+### Notifications follow your setup
 
-The v1.1 DMG is Developer ID signed and notarized. Open it and drag **VibeBuddyMacApp** to **Applications**. No quarantine-removal command is needed.
+Live Activity and Dynamic Island counts update while the phone is connected. Closed-app push requires a running Mac, matching APNs signing configuration, a registered phone and notification permission. **Public downloads do not yet include turnkey closed-app push setup**; see the [APNs setup](docs/apns-setup.md) and [distribution decision](docs/adr/0013-apns-key-delivery.md). Actions always require a reachable paired Mac. Focus, notification settings and watchOS scheduling affect what appears.
 
-**Updating from v1.0:** install v1.1 manually once. The original v1.0 shipped with an invalid update URL, so it cannot discover this release automatically. v1.1 uses the published Sparkle feed for future releases. The installed source build and the GitHub release are separate: use the latest release asset for the supported download.
+## Your Mac is the hub
 
-### iPhone app
-Build it from source for now — see [Build & run](#️-build--run). Install on your own iPhone; there is no public iPhone download.
-
----
-
-## 🧠 How it works
-
-```
-Claude Code / Codex / Qwen / … ──hooks──▶ vibebuddy (macOS menu-bar app)
-                                          • reduce hooks → needsResponse / working / done
-                                          • parse JSONL transcript → model / tokens / summary
-                                          • serve over LAN  (HTTP /snapshot, WebSocket /ws)
-                                                  │  scan QR to pair (host:port + token)
-                                                  ▼
-                                          vibebuddy (iPhone, SwiftUI)
-                                          • 3-bucket dashboard + Live Activity
-                                          • notify + remote approve + voice companion
-                  shared VibeBuddyKit — one Codable wire model, written once
-```
-
-The hard part — *detecting* session state — is solved by **hooks** that each agent CLI fires on its lifecycle events (`UserPromptSubmit`, `PreToolUse`, `Notification`, `Stop`, …). vibebuddy reduces them to the three states and broadcasts a token-gated snapshot. The hooks **fail open**: if vibebuddy isn't running, your agents are completely unaffected.
-
----
-
-## 🛠️ Build & run
-
-Deployment targets: **iOS 17 / macOS 14**. The 1.2 candidate is built with **Xcode 26.6**. Xcode 27 work is deferred until a later update.
-
-| Path | What |
-|------|------|
-| `VibeBuddyKit/` | Shared Codable wire model (SwiftPM) |
-| `VibeBuddyMac/` | macOS core lib + `vibebuddyd` headless CLI (SwiftPM) |
-| `VibeBuddyMacApp/` | macOS menu-bar app (xcodegen) — owner-only LAN-token file, launch-at-login, Sparkle |
-| `VibeBuddyApp/` | iOS app (xcodegen) |
-| `docs/planning/` | overview, PRD, architecture, roadmap, prior-art |
-
-**Mac side (menu-bar app):**
-```bash
-cd VibeBuddyMacApp && xcodegen generate
-open VibeBuddyMacApp.xcodeproj   # build & run (⌘R)
-```
-A menu-bar-only app: live counts, a "Pair a phone" QR, and launch-at-login; the Mac daemon's `TokenStore` keeps the LAN token in the owner-only file `~/Library/Application Support/vibebuddy/token`. (`vibebuddyd` in `VibeBuddyMac/` is the headless equivalent: `swift run vibebuddyd`.) Choose **Pair a phone** to allow a new registration for two minutes; merely launching the Mac app does not enable pairing. For the headless daemon, use `swift run vibebuddyd --pair` for that same two-minute window. Saved phones reconnect normally; forgetting phones closes the window and survives a restart.
-
-**iOS app:**
-```bash
-cd VibeBuddyApp && xcodegen generate
-open VibeBuddyApp.xcodeproj   # run on a Simulator/device
-```
-Pair by scanning the QR, or enter host/port/token manually. On iOS, `ConnectionStore` persists the pairing payload in `UserDefaults`. (Simulator: use `127.0.0.1` and the token from `~/Library/Application Support/vibebuddy/token`.)
-
-**Hooks (feed real agent sessions):**
-```bash
-python3 hooks/install-claude-hooks.py --dry-run    # preview
-python3 hooks/install-claude-hooks.py --install    # back up + install
-python3 hooks/install-claude-hooks.py --uninstall  # revert
-```
-Installs fail-open `curl` POSTs for each lifecycle event. See [`docs/multi-cli-hook-setup.md`](docs/multi-cli-hook-setup.md) for every supported CLI.
-
-**Tests:**
-```bash
-cd VibeBuddyKit && swift test     # wire-model tests
-cd VibeBuddyMac && swift test     # daemon / reducer / transcript tests
+```mermaid
+flowchart LR
+    A[Claude Code and agent CLI hooks] --> M[VibeBuddy on your Mac]
+    C[Codex rollouts and connected app-server] <--> M
+    M <-->|Paired local connection| P[iPhone]
+    P <-->|WatchConnectivity| W[Apple Watch]
+    M -. Optional AI features .-> V[Your chosen AI provider]
+    P -. Optional voice .-> V
 ```
 
----
+There is **no VibeBuddy cloud, account or analytics service**. Mac and phone communicate over your network with bearer-token authentication. Optional AI features send the required audio or task text directly to the provider you choose; configured push notifications pass through Apple. Voice credentials are stored in Keychain. [Privacy policy](docs/privacy-policy.md).
 
-## 💡 Inspired by
+## Open source, all the way down
 
-vibebuddy stands on the shoulders of two clever projects that first proved you can *detect* coding-agent state from hooks and a transcript tail — we re-pointed that idea at a phone (and added two-way voice). We **studied their architecture and wrote our own Swift**; no code was copied.
+The Mac app, iPhone app, Watch companion, daemon, shared Swift models and agent hooks are all in this MIT-licensed repository. The integrations and their limits are documented so other developers can inspect, reproduce and improve them.
 
-- **[op7418/m5-paper-buddy](https://github.com/op7418/m5-paper-buddy)** — showed your agent's RUNNING / WAITING status on an **M5Paper e-ink gadget** via transcript-tail JSONL parsing and fail-open hook `curl`. vibebuddy borrows the detection concept and moves the display from a desk gadget to your pocket.
-- **[Octane0411/open-vibe-island](https://github.com/Octane0411/open-vibe-island)** — a source-agnostic `SessionState` reducer across 10+ agents, surfaced in the **macOS menu bar / notch**. It shaped vibebuddy's multi-agent model and Mac-side glance.
+| Explore | Start here |
+| --- | --- |
+| Build and run | [Developer setup](docs/getting-started.md#build-from-source) |
+| Shared models and voice adapters | [VibeBuddyKit](VibeBuddyKit/Sources/VibeBuddyKit) |
+| Agent observation and local server | [VibeBuddyMacCore](VibeBuddyMac/Sources/VibeBuddyMacCore) |
+| Native apps | [Mac](VibeBuddyMacApp/Sources) · [iPhone](VibeBuddyApp/Sources) · [Watch](VibeBuddyApp/Watch) |
+| Protocol checks and design decisions | [Codex probes](tools/codex-integration/README.md) · [Architecture decisions](docs/adr) |
+| Maintenance history | [Releases](https://github.com/semantic-craft/iOS-vibebuddy/releases) · [Merged pull requests](https://github.com/semantic-craft/iOS-vibebuddy/pulls?q=is%3Apr+is%3Amerged) |
 
----
+**Contributions are welcome.** Reproduce an integration issue, improve a translation, document a device workflow or submit a focused fix. Start with [CONTRIBUTING.md](CONTRIBUTING.md). If VibeBuddy helps your workflow, a star or a concrete account of how you use it helps others discover the project.
 
-## 📍 Status
+## Acknowledgements
 
-The Mac v1.1 source includes Codex Desktop 0.153.3 monitoring, bounded UTF-8 rollout handling, graceful daemon shutdown, observation diagnostics and Watch companion support. Mac, iPhone and Apple Watch have been installed locally; real phone approvals, recovery and phone-to-Watch state relay were verified. Full wrist approval, notification perception, voice and accessibility acceptance remain user follow-ups. App Store availability is separate from the Mac GitHub release. See the [latest Mac release](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) and [roadmap](docs/planning/roadmap.md).
+[m5-paper-buddy](https://github.com/op7418/m5-paper-buddy) inspired the hook-and-transcript approach to agent status; [open-vibe-island](https://github.com/Octane0411/open-vibe-island) informed the multi-agent model and Mac Glance. VibeBuddy's Swift implementation was written independently. The app icon was developed with the [ip-as-logo skill](https://github.com/s1dashu/ip-as-logo-skill); the in-app cat is drawn in shared Swift code.
 
-## 📄 License
-
-[MIT](./LICENSE) © 2026 Xianwei Zhang
+[MIT](LICENSE) © 2026 Xianwei Zhang. An independent community project; not affiliated with or endorsed by Anthropic, OpenAI or Apple.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,214 +1,128 @@
 <div align="center">
 
-<img src="docs/screenshots/app-icon-256.png" width="112" alt="vibebuddy" />
+<img src="docs/screenshots/app-icon-256.png" width="88" alt="vibebuddy 的绿耳白猫" />
 
 # vibebuddy
 
-**Claude Code 与 Codex 的 iPhone、Apple Watch 和 Mac 伴侣。**
-离开电脑，也能看进度、查看需要回应的任务，并处理支持的批准与提问。让小猫帮你盯着任务，把注意力留给生活。
+### 离开书桌，也能接着推进任务。
 
-[**⬇️ 下载 macOS 版**](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) · [功能](#-功能) · [工作原理](#-工作原理) · [从源码构建](#️-构建与运行) · [English](./README.md)
+为 **Claude Code 和 Codex** 打造的 **Mac、iPhone 与 Apple Watch** 原生伴侣。<br>看看谁需要你，回应可远程处理的请求，听听任务完成了什么。
 
-![License](https://img.shields.io/badge/license-MIT-green)
-![Platform](https://img.shields.io/badge/platform-iOS%2017%20%2B%20macOS%2014-blue)
-![Swift](https://img.shields.io/badge/Swift-6.0-orange)
-[![Latest release](https://img.shields.io/github/v/release/semantic-craft/iOS-vibebuddy)](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)
+[**下载 Mac 版**](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) · [**获取 iPhone 版**](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338) · [开始使用](#开始使用) · [English](README.md)
 
-</div>
+[![最新 Mac 版本](https://img.shields.io/github/v/release/semantic-craft/iOS-vibebuddy?label=Mac%20release&color=67a86b)](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) [![MIT 许可](https://img.shields.io/badge/license-MIT-67a86b)](LICENSE) ![平台](https://img.shields.io/badge/platforms-macOS%20%C2%B7%20iOS%20%C2%B7%20watchOS-536584) ![Swift 6](https://img.shields.io/badge/Swift-6-F05138)
 
----
+**免费开源 · 无需 VibeBuddy 账号 · 无行为分析 · AI 功能使用自己的密钥**
 
-## 从初版看状态，到三端协作
+<img src="docs/app-store-screenshots/1.3/macos/zh-Hans/01-dashboard-approval.jpg" width="960" alt="Mac 任务看板：Claude Code、Codex 任务与文件编辑审批" />
 
-**1.3 候选版，是一次从手机看板到桌面、口袋与手腕的重大升级。** 初版以会话状态和本地提醒为核心；新版把 Codex 深度集成、手表小组件与统一交互带到日常使用中。
-
-| 升级 | 对你有什么用 |
-|---|---|
-| **Agent 适配持续升级** | 围绕 Claude Code 与 Codex 的任务、权限请求和提问完善接入；支持情况见下方适配说明。 |
-| **Codex 深度集成** | 覆盖 Desktop 与 CLI 的状态观测，并在支持的连接中处理提问、追加指令和发起任务。 |
-| **新增 Apple Watch 表盘小组件** | 矩形“关注任务”看任务状态；圆形“额度”查看 Claude、Codex 或两者的剩余额度，提供五种显示样式。 |
-| **图标与交互全面焕新** | 三端统一小猫形象与 Agent 图标；手机配对连接菜单更简洁，任务状态更易辨认。 |
-| **macOS UI 更新** | 菜单栏、刘海概览与任务卡片协同呈现，改善仪表盘重新打开及概览位置恢复。 |
-
-> 此处介绍当前源码与 1.3 候选功能，尚不代表公开发布或完成真机验收。GitHub 最新公开 Mac 包目前为 1.1；新版发布后，请同步更新 Mac 伴侣。表盘刷新由系统调度，额度取决于来源提供的数据。
-
-## 第一次使用，从这里开始
-
-1. **在 Mac 下载并安装 [Mac 版伴侣](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)**：打开 Release 的 Assets，下载 DMG，将应用拖入“应用程序”。需要 Apple Silicon Mac、macOS 14 或更高版本。
-2. **在 Mac 菜单栏打开“配对手机”**，让 iPhone 与 Mac 连接同一局域网。
-3. **在 iPhone 点“扫码配对”**，扫描 Mac 显示的二维码。随后按 Mac 设置中的 Setup 指引接入 Agent。
-4. **先体验也可以**：iPhone 连接页点“查看演示（无需 Mac）”，浏览示例任务；真实任务需要已配对且可连接的 Mac。
-
-真实任务数据主要来自你自己的 Mac；请保持 Mac 伴侣运行、网络可连接。Apple Watch 功能还需要配对的 iPhone。iPhone 当前获取方式见下方“下载”；App Store 新版文案正在准备中。
-
----
-
-## 🐱 30 秒介绍
-
-你同时开了三个 Claude Code 会话，又切到 Codex 跑第四个，转身去倒了杯咖啡——回来已经分不清：哪个 agent 卡着在等你确认，哪个还在埋头干活，哪个早就跑完在那儿空等。
-
-**vibebuddy** = Mac 菜单栏里的一只小猫 + iPhone 上的伴侣 App。它盯着每一个编程 agent 会话，只回答最关键的三个问题：
-
-> ### 🟠 需要回应 · 🔵 进行中 · 🟢 已完成
-
-再也不用走回电脑前，才发现某个会话已经卡在权限确认上十分钟了。手机一震，你查看 diff 预览，点一下**批准**——或者点一下那只猫，**直接说一句"批准"**。
-
-<div align="center">
-
-<img src="docs/screenshots/mac/dashboard-zh.png" width="840" alt="vibebuddy Mac 菜单栏应用——三栏仪表盘：状态侧栏、带语音宠物的会话列表、远程批准详情" />
-
-<sub><b>Mac 菜单栏应用</b>——所有会话分三栏、语音宠物，以及远程批准详情面板。</sub>
-
-<br><br>
-
-<img src="docs/screenshots/mac/glance.png" width="360" alt="vibebuddy 刘海概览——小猫和最要紧的一个计数分列刘海两侧" />
-<img src="docs/screenshots/mac/glance-card.png" width="360" alt="从刘海下方展开的审批卡片，带批准 / 拒绝 / 跳转" />
-
-<sub><b>刘海概览</b>——像灵动岛一样贴着刘海：空闲时什么都不显示，有事时小猫 + 最要紧的计数分列两侧，悬停展开，审批直接以卡片从刘海下方掉出来就地处理。</sub>
-
-<br><br>
-
-<img src="docs/app-store-screenshots/6.9/01-dashboard.png" width="280" alt="vibebuddy iPhone 仪表盘，含内联 diff 与 批准/拒绝 按钮" />
-
-<sub><b>在你的 iPhone 上</b>——点开一个会话，看内联 diff 并 批准 / 拒绝。</sub>
+<sub>真实 App 的 1.3 演示界面，使用样例任务。截图展示界面，不代表真实 Agent 的运行结果。</sub>
 
 </div>
 
-<div align="center">
+## 少来回查看，多做自己的事。
 
-<img src="docs/screenshots/app-icon.png" width="640" alt="vibebuddy 应用图标在 macOS、iPhone 与 Apple Watch 上的样子——石板蓝底上一只绿耳朵绿眼睛的小白猫" />
+让 Claude Code 改代码，让 Codex 跑测试，VibeBuddy 把它们放进同一个视图。只要 Mac 保持运行、网络可达，你就能在手机上处理问题，在手表上关注任务，或者开口询问最新进展。
 
-<sub><b>一个图标，三个平台</b>——同一只小猫出现在 Mac、iPhone 和 Apple Watch 上，由各系统套上自己的遮罩。</sub>
+| 看清当前情况 | 接着推进任务 | 了解完成结果 |
+| --- | --- | --- |
+| **统一任务视图。** 需要回应、进行中、已完成；查看项目、模型、当前活动与可获取的用量信息。 | **审批与回复。** 查看命令或有限行数的差异预览，回答问题，继续支持远程控制的 Codex 任务。 | **语音与摘要。** 询问当前任务状态，阅读简明的完成摘要，也可在 Mac 上开启朗读。 |
 
-</div>
+## 三块屏幕，同一个小伙伴。
 
-> **应用图标**是一只绿耳朵、绿眼睛的小白猫，趴在柔和的石板蓝底上——一个柔软的剪影、三种颜色，缩到 16 px 仍能认出来。它用 [ip-as-logo](https://github.com/s1dashu/ip-as-logo-skill) 技能设计，从六张生成候选中选出；同一张 1024 px 原图同时用于 macOS、iOS 和 watchOS。
->
-> App 里的 **buddy 就是同一只猫，纯代码绘制**，iPhone、Apple Watch、灵动岛、Mac 仪表盘、刘海概览和菜单栏共用一套几何。心情（耳朵、眼睛、嘴巴）和小动作随会话变化；在紧凑位置（菜单栏、收起的刘海概览、灵动岛、手表标题栏）只画头部，菜单栏里是单色模板剪影，只有 iPhone 和 Mac 上会动。以上截图均为**演示模式**（示例数据），不含任何真实会话数据。
+<table>
+<tr>
+<th>在 iPhone 上处理请求</th>
+<th>打开任务详情</th>
+<th>抬腕查看额度</th>
+</tr>
+<tr>
+<td align="center" valign="top"><img src="docs/app-store-screenshots/1.3/ios/zh-Hans/01-dashboard.jpg" width="270" alt="iPhone 演示看板中的 Claude 编辑审批与问题" /></td>
+<td align="center" valign="top"><img src="docs/app-store-screenshots/1.3/ios/zh-Hans/02-codex-task.jpg" width="270" alt="iPhone 演示中的 Codex 任务详情、上下文用量与回复入口" /></td>
+<td align="center" valign="top"><img src="docs/app-store-screenshots/1.3/watchos/zh-Hans/02-quota.jpg" width="208" alt="Apple Watch 演示中的 Codex 周额度与短窗口剩余额度" /><br><br>关注中的任务<br>快捷回答<br>完成摘要<br>剩余额度</td>
+</tr>
+</table>
 
----
+<sub>以上均来自实际运行的 1.3 App 演示模式。Watch 图片为 App 内额度页。<a href="docs/app-store-screenshots/1.3/README.md">截图来源说明</a>。</sub>
 
-## ✨ 功能
+- **Mac：** 可搜索的菜单栏活动列表、完整任务看板、刘海 Glance，以及返回原终端或应用的快捷入口。
+- **iPhone：** 任务详情、近期对话、支持的审批与回复、实时活动和灵动岛计数。
+- **Apple Watch：** 关注任务、快捷回答、完成摘要、任务与额度表盘组件，以及智能叠放相关性提示。需要配对的 iPhone，后台刷新由 watchOS 调度。
 
-### 🎙️ 和你的 agent 对话——语音伴侣
-语音伙伴默认关闭。选择服务商、填写自己的 API key、接受数据用途说明并授予麦克风权限后，可主动开始语音交流，询问任务状态或处理支持的请求。音频与所选任务上下文直接发送至所选服务商（OpenAI、Google Gemini、阿里云百炼 / 通义千问或火山引擎 / 豆包），可能产生服务商费用。可执行操作取决于连接与请求支持情况；不启用语音也能使用任务看板和按钮批准。
+## 1.3 系列带来了什么
 
-### 📊 三栏仪表盘
-每个会话按 **需要回应 / 进行中 / 已完成** 分组，每行显示 项目 · 分支 · 模型 · 实时 token 与上下文窗口占用 · 当前正在执行的工具 · 最近输出的预览。优先级很诚实：`需要回应` 永远盖过 `进行中`。
+| 新功能 | 具体变化 |
+| --- | --- |
+| **开口询问任务** | [1.3.11](https://github.com/semantic-craft/iOS-vibebuddy/releases/tag/v1.3.11) 接入 GPT-Live 1，可独立配置任务推理模型。OpenAI、Gemini、千问与豆包共用任务状态查询和受支持的操作工具。 |
+| **听懂完成结果** | 可选 AI 摘要聚焦结果、阻塞与下一步。Mac 朗读可分别选择服务商、模型和音色，并先试听。[模型设置更新](docs/release-notes-1.3.10.md)。 |
+| **继续已有对话** | 回答可处理的等待请求，为运行中的 Codex 任务补充指令，或继续已有任务；查看近期对话与发送回执。[任务交互更新](docs/release-notes-1.3.6.md)。 |
+| **随手找到 Mac 上的任务** | 搜索和筛选菜单栏活动，打开任务详情，通过主动开启的二维码配对窗口连接手机。[Mac 伴侣更新](docs/release-notes-1.3.9.md)。 |
+| **带上更多工作信息** | Watch 快捷回答与任务控制、可选 Grok Bot 观测，以及在服务商数据可用时查看 Claude、Codex、Grok、Cursor 账户额度。[Watch 更新](docs/release-notes-1.3.8.md) · [Grok Bot](docs/release-notes-1.3.7.md)。 |
 
-### ✅ 远程批准
-当 agent 请求执行命令或修改文件时，可在手机仪表盘查看命令或 **diff 预览**。diff 每侧最多显示八行；需要更多上下文时，请到 Mac 查看完整改动。可在仪表盘或锁屏通知中**批准 / 拒绝**（批准需要解锁），可远程作答的问题通知提供文本输入。**总是允许这一条** / **本次会话全部允许**仅在仪表盘提供，不是通知按钮。只读等待会提示到 Mac 原生对话框处理。操作要求已配对且 Mac 可达。
+Mac 版本与 iPhone／Watch 的 App Store 更新分别发布，新功能需要相应设备安装更新后的客户端。当前版本和可用情况以 [Mac Releases](https://github.com/semantic-craft/iOS-vibebuddy/releases) 和 [App Store 页面](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338)为准。
 
-### 🔔 通知、实时活动与灵动岛
-审批和问题横幅在最终投递级别带声音时请求 **Time Sensitive（时效性通知）**；Quiet 会将它们降为普通静音横幅，其余类别使用普通级别。类别开关及系统通知／专注模式设置仍然生效。ActivityKit 将实时计数显示在**锁屏和灵动岛**上，并在 App 位于前台或保持连接时更新。
+## 围绕 Claude Code 与 Codex 的实际工作流
 
-当前源码支持关闭 iPhone App 后通过 APNs 接收通知，条件是 Mac 发送端正在运行、APNs 签名与 iPhone 构建匹配、手机已注册且允许通知。这尚不是公开下载后开箱即用的承诺：分发方案仍待 [DEC-APNS](docs/adr/0013-apns-key-delivery.md)，锁屏／专注模式／Watch 送达仍需真机验收。回应要求已配对的 Mac 可达；离开该网络时应回到同一网络后处理（已有 Tailscale 连接可作为进阶方案）。
+VibeBuddy 连接你已经在用的 Agent。能否操作，取决于当前连接方式和具体请求。
 
-### 🤖 三家现有适配，Cursor 计划中，以及社区适配器
-一等支持路线图覆盖 **Claude Code、Codex、Grok、Cursor**：三态追踪与远程审批是必需能力，配额和跳转尽力支持。Claude Code、Codex、Grok 已有适配器；**Cursor 仍在计划中，尚未支持**。每家仍需分别完成真机验收。**Qwen、Kimi、OpenCode、Antigravity** 为社区级适配器，未验证、失败即放行。各家的接线方法见 [hook 配置指南](docs/multi-cli-hook-setup.md)。
+| 连接方式 | 已有集成 | 能力范围 |
+| --- | --- | --- |
+| **Claude Code** | 生命周期 hooks、任务状态、用量、权限决定与受支持的问题回答。 | 远程回应需要安装审批 hooks；交互由原生提示处理时，回到 Mac 回应。 |
+| **Codex CLI／已连接的 app-server** | 任务状态、额度、受支持的审批与问题；通过已连接的 app-server 新建、继续、补充指令和停止任务。 | 连接的服务必须拥有该任务，并能识别相应轮次或请求；MCP elicitation 目前只读。 |
+| **Codex Desktop** | 观测本地任务进展和完成结果，跳回应用。 | Desktop 可能使用独立 app-server；原生审批覆盖不完整，没有可回应请求时需使用 Mac 提示。 |
+| **Grok Build／Grok Bot** | Build CLI hooks 与依权限模式提供的审批；可选 Bot 观测和额度。 | Bot 只读；Build 的审批效果取决于权限模式。 |
+| **Cursor** | 从支持的登录来源读取账户额度，包括 Cursor CLI 登录。 | 已支持额度；尚不支持任务追踪和远程审批。 |
 
-### 📷 扫码配对，零输入
-Mac 显示一个编码了 `host:port` + bearer token 的二维码。手机扫一次即可——无需手动输 IP。（同一个二维码以后可以承载 Tailscale `100.x` 地址，无需改代码。）
+详见 [Codex 集成契约](docs/codex-integration.md)和 [Agent hook 配置](docs/multi-cli-hook-setup.md)。Qwen、Kimi、OpenCode、Antigravity 编码 Agent 适配器属于实验性社区集成；其验证状态与已支持的千问语音服务不同。
 
-### 🖥️ 原生 Mac 菜单栏应用
-固定菜单栏入口（可选状态点和数量，默认关闭）、负责实时状态与提醒的 macOS 刘海概览、**跳转到终端**（一键打开对应会话）、开机自启，以及持久化在仅所有者可读写（`0600`）文件 `~/Library/Application Support/vibebuddy/token` 中的局域网 bearer token。还有 ⏎ / ⌘F 仪表盘快捷键。v1.1 使用带签名的 Sparkle 更新源；原 v1.0 用户需要先手动安装一次新版。
+## 开始使用
 
-### 🔒 本地优先，隐私至上
-vibebuddy 在你的 Mac 与手机之间**直接**通过你自己的网络通信。会话数据**绝不**经过 vibebuddy 服务器——没有 vibebuddy 云、没有账号、没有埋点、没有追踪。守护进程路由由 bearer token 把关。配置 APNs 后，通知负载（包括标题和正文）会经过 Apple 推送服务。（可选语音伙伴只会在你开启后，把麦克风音频和所选会话上下文发往*你选择*的服务商，并使用*你自己*的 key。）
+1. **安装 Mac 伴侣。** [下载最新 DMG](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)，将 App 拖入“应用程序”并打开。发布的 Mac 版需要 Apple Silicon 与 macOS 14+。
+2. **接入编码 Agent。** 在 Mac 设置的 Setup 中按对应 Agent 的说明配置，也可查看[手动配置指南](docs/getting-started.md#connect-an-agent)。
+3. **连接 iPhone。** 安装 [VibeBuddy: Agent Monitor](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338)，在 Mac 选择“配对手机”，在 iPhone 选择“扫码配对”。首次在同一可信局域网操作。iPhone 需要 iOS 17+，当前 Watch 伴侣需要 watchOS 26.5+。
+4. **跑一个任务。** 在 Claude Code 或 Codex 发起简短任务，查看状态、打开详情并关注至完成。语音和摘要可按需单独开启。
 
-### 🌏 双语 + 演示模式
-两端 App 都支持完整的中英文界面。还有一个**演示模式**，用示例数据加载整个界面——无需 Mac 即可浏览示例任务。
+**想先看看界面？** iPhone 连接页有“查看演示（无需 Mac）”，Mac 也可独立使用。上述 App Store 链接指向美国商店，是否可下载取决于账号地区；也可[自行编译](docs/getting-started.md#build-from-source)。
 
----
+### 语音按需开启
 
-## ⬇️ 下载
+选择 **OpenAI、Google Gemini、阿里千问或火山引擎豆包**，在 App 内填写自己的 API 凭据、阅读告知后主动开始通话。可以询问“哪个任务需要我？”，也可以明确回答当前可处理的请求。实时对话、完成摘要和 Mac 朗读分别配置。服务商可能收费；任务看板和按钮审批不需要 AI API 密钥。
 
-### macOS 应用
-**[下载最新版 Mac Companion →](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)** · Apple Silicon · macOS 14+
+### 通知取决于实际配置
 
-v1.1 DMG 已使用 Developer ID 签名并完成公证。打开后把 **VibeBuddyMacApp** 拖入**应用程序**，无需执行移除隔离属性的命令。
+手机连接期间会更新实时活动与灵动岛计数。App 关闭后的推送需要 Mac 持续运行、匹配的 APNs 签名配置、已注册的手机及通知权限。**公开下载目前尚未提供开箱即用的闭应用推送配置**，见 [APNs 配置](docs/apns-setup.md)和[分发决策](docs/adr/0013-apns-key-delivery.md)。操作始终需要已配对且网络可达的 Mac；专注模式、通知设置及 watchOS 调度会影响实际呈现。
 
-**从 v1.0 更新：**请手动安装一次 v1.1。原 v1.0 内置更新地址无效，不能自动发现本次更新；v1.1 使用正式 Sparkle 更新源接收后续版本。源码构建和 GitHub 发布包是不同交付物，需要直接安装时请使用上方最新版 Release 资产。
+## 你的 Mac 是连接中心
 
-### iPhone 应用
-目前请从源码构建——见 [构建与运行](#️-构建与运行)。装到你自己的 iPhone 上即可；没有公开的 iPhone 下载。
-
----
-
-## 🧠 工作原理
-
-```
-Claude Code / Codex / Qwen / … ──hooks──▶ vibebuddy（macOS 菜单栏应用）
-                                          • 把 hooks 归约为 needsResponse / working / done
-                                          • 解析 JSONL transcript → 模型 / tokens / 摘要
-                                          • 在局域网上提供服务（HTTP /snapshot、WebSocket /ws）
-                                                  │  扫码配对（host:port + token）
-                                                  ▼
-                                          vibebuddy（iPhone，SwiftUI）
-                                          • 三栏仪表盘 + 实时活动
-                                          • 通知 + 远程批准 + 语音伴侣
-                  共享 VibeBuddyKit —— 唯一一套 Codable 线缆模型，只写一次
-```
-
-最难的部分——*检测*会话状态——由每个 agent CLI 在其生命周期事件（`UserPromptSubmit`、`PreToolUse`、`Notification`、`Stop` …）上触发的 **hooks** 解决。vibebuddy 把它们归约为三种状态，再广播一份受 token 保护的快照。这些 hook **失败即放行**：vibebuddy 没运行时，你的 agent 完全不受影响。
-
----
-
-## 🛠️ 构建与运行
-
-部署目标：**iOS 17 / macOS 14**。1.2 候选使用 **Xcode 26.6** 构建；Xcode 27 工作暂缓，留待后续更新。
-
-| 路径 | 内容 |
-|------|------|
-| `VibeBuddyKit/` | 共享 Codable 线缆模型（SwiftPM） |
-| `VibeBuddyMac/` | macOS 核心库 + `vibebuddyd` 无头 CLI（SwiftPM） |
-| `VibeBuddyMacApp/` | macOS 菜单栏应用（xcodegen）—— 仅所有者可读写的局域网 token 文件、开机自启、Sparkle |
-| `VibeBuddyApp/` | iOS 应用（xcodegen） |
-| `docs/planning/` | 概览、PRD、架构、路线图、先行研究 |
-
-**Mac 端（菜单栏应用）：**
-```bash
-cd VibeBuddyMacApp && xcodegen generate
-open VibeBuddyMacApp.xcodeproj   # 构建并运行（⌘R）
-```
-一个纯菜单栏应用：实时计数、"配对手机"二维码、开机自启；Mac 守护进程的 `TokenStore` 把局域网 token 保存在仅所有者可读写的文件 `~/Library/Application Support/vibebuddy/token` 中。（`VibeBuddyMac/` 里的 `vibebuddyd` 是无头等价物：`swift run vibebuddyd`。）
-
-**iOS 应用：**
-```bash
-cd VibeBuddyApp && xcodegen generate
-open VibeBuddyApp.xcodeproj   # 在模拟器/真机上运行
-```
-扫码配对，或手动输入 host/port/token。在 iOS 上，`ConnectionStore` 把配对 payload 持久化到 `UserDefaults`。（模拟器：用 `127.0.0.1` 和 `~/Library/Application Support/vibebuddy/token` 里的 token。）
-
-**Hooks（接入真实 agent 会话）：**
-```bash
-python3 hooks/install-claude-hooks.py --dry-run    # 预览改动
-python3 hooks/install-claude-hooks.py --install    # 备份并安装
-python3 hooks/install-claude-hooks.py --uninstall  # 还原
-```
-为每个生命周期事件安装失败即放行的 `curl` POST。所有受支持的 CLI 见 [`docs/multi-cli-hook-setup.md`](docs/multi-cli-hook-setup.md)。
-
-**测试：**
-```bash
-cd VibeBuddyKit && swift test     # 线缆模型测试
-cd VibeBuddyMac && swift test     # 守护进程 / 归约器 / transcript 测试
+```mermaid
+flowchart LR
+    A[Claude Code 与 Agent CLI hooks] --> M[Mac 上的 VibeBuddy]
+    C[Codex 本地记录与已连接的 app-server] <--> M
+    M <-->|配对后的本地连接| P[iPhone]
+    P <-->|WatchConnectivity| W[Apple Watch]
+    M -. 可选 AI 功能 .-> V[你选择的 AI 服务商]
+    P -. 可选语音 .-> V
 ```
 
----
+**没有 VibeBuddy 云端、账号或行为分析服务。** Mac 与手机通过自己的网络通信，使用 bearer token 验证身份。可选 AI 功能把所需音频或任务文本直接发送到你选择的服务商；配置后的推送通知经由 Apple。语音凭据保存在 Keychain。详见[隐私政策](docs/privacy-policy.md)。
 
-## 💡 灵感来源
+## 完整开源，欢迎一起改进
 
-vibebuddy 站在两个聪明项目的肩膀上——它们最早证明了可以从 hooks 和 transcript 尾部*检测*编程 agent 的状态，我们把这个想法重新指向了手机（并加上了双向语音）。我们**研究了它们的架构、自己写了 Swift**；没有复制任何代码。
+Mac App、iPhone App、Watch 伴侣、守护进程、共享 Swift 模型和 Agent hooks 均在本仓库，以 MIT 许可开放。集成方式及能力范围有对应文档，便于开发者检查、复现和改进。
 
-- **[op7418/m5-paper-buddy](https://github.com/op7418/m5-paper-buddy)** —— 通过解析 transcript 尾部的 JSONL 和失败即放行的 hook `curl`，把 agent 的 RUNNING / WAITING 状态显示在 **M5Paper 墨水屏小工具**上。vibebuddy 借用了它的检测理念，把显示从桌面小工具搬进了你的口袋。
-- **[Octane0411/open-vibe-island](https://github.com/Octane0411/open-vibe-island)** —— 一个跨 10+ agent 的、与来源无关的 `SessionState` 归约器，呈现在 **macOS 菜单栏 / 刘海**上。它塑造了 vibebuddy 的多 agent 模型和 Mac 端概览。
+| 想了解什么 | 从这里开始 |
+| --- | --- |
+| 编译与运行 | [开发环境配置](docs/getting-started.md#build-from-source) |
+| 共享模型与语音适配器 | [VibeBuddyKit](VibeBuddyKit/Sources/VibeBuddyKit) |
+| Agent 观测与本地服务 | [VibeBuddyMacCore](VibeBuddyMac/Sources/VibeBuddyMacCore) |
+| 原生客户端 | [Mac](VibeBuddyMacApp/Sources) · [iPhone](VibeBuddyApp/Sources) · [Watch](VibeBuddyApp/Watch) |
+| 协议检查与设计决策 | [Codex 探针](tools/codex-integration/README.md) · [架构决策](docs/adr) |
+| 维护记录 | [发布历史](https://github.com/semantic-craft/iOS-vibebuddy/releases) · [已合并 PR](https://github.com/semantic-craft/iOS-vibebuddy/pulls?q=is%3Apr+is%3Amerged) |
 
----
+**欢迎贡献。** 复现集成问题、改进翻译、记录设备使用流程，或提交范围明确的修复，都很有帮助。详见 [CONTRIBUTING.md](CONTRIBUTING.md)。如果 VibeBuddy 帮到了你，欢迎点 Star，或分享具体的使用方式，让更多人发现它。
 
-## 📍 状态
+## 致谢
 
-Mac v1.1 源码已包含 Codex Desktop 0.153.3 观测、UTF-8 截断处理、守护进程正常退出、观测诊断和 Watch 伴侣支持。Mac、iPhone、Apple Watch 已在本地安装，真实手机审批、恢复及手机到手表的状态传递已验证。完整腕上审批、通知感知、语音与可访问性体验仍留待实际使用确认。App Store 上架与 Mac GitHub 发布分别推进。见[最新 Mac Release](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)和[路线图](docs/planning/roadmap.md)。
+[m5-paper-buddy](https://github.com/op7418/m5-paper-buddy) 启发了通过 hook 与对话记录观测任务状态的思路；[open-vibe-island](https://github.com/Octane0411/open-vibe-island) 为多 Agent 模型与 Mac Glance 提供了参考。VibeBuddy 的 Swift 实现为独立编写。App 图标借助 [ip-as-logo skill](https://github.com/s1dashu/ip-as-logo-skill)设计，App 内的小猫由共享 Swift 代码绘制。
 
-## 📄 许可
-
-[MIT](./LICENSE) © 2026 Xianwei Zhang
+[MIT](LICENSE) © 2026 Xianwei Zhang。独立社区项目，与 Anthropic、OpenAI 或 Apple 无隶属或背书关系。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,141 @@
+# Getting started with VibeBuddy
+
+VibeBuddy's Mac app observes your coding agents and connects to the optional
+iPhone and Apple Watch companions. [Back to the homepage](../README.md).
+
+## Install and pair
+
+1. Download the DMG from [GitHub Releases](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest).
+   The distributed Mac build requires Apple Silicon and macOS 14 or later.
+2. Drag the app into Applications and open it. The menu-bar cat opens the
+   activity feed; Dashboard and Settings are available from its footer.
+3. Install [VibeBuddy: Agent Monitor for iPhone](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338)
+   where available. iOS 17+ is required. The current Watch companion requires a
+   paired iPhone and watchOS 26.5+.
+4. Put Mac and iPhone on the same trusted local network. Choose **Pair a phone**
+   on Mac, then **Scan to pair** on iPhone. New phone registration is allowed for
+   two minutes; open the pairing window again if it expires.
+
+Keep the Mac running and reachable for live tasks and actions. Existing paired
+phones reconnect without opening a new pairing window. The Mac can be used
+alone; iPhone Demo mode can be explored without pairing.
+
+The local connection uses HTTP/WebSocket with bearer authentication, not built-in
+TLS. Use a trusted LAN or a protected private network; do not expose port 9876
+directly to the public internet. Treat the pairing QR as a credential.
+
+## Connect an agent
+
+Start with Setup in the Mac app's settings. For manual installation, clone this
+repository and run the appropriate installer from its root while VibeBuddy is
+running. Python 3 and the agent CLI are required.
+
+### Claude Code
+
+```bash
+python3 hooks/install-claude-hooks.py --dry-run
+python3 hooks/install-claude-hooks.py --install
+```
+
+To enable supported permission decisions and question replies, also run:
+
+```bash
+python3 hooks/install-claude-hooks.py --approval
+```
+
+Start a fresh Claude Code session and submit a short task. When a supported
+permission or question arrives, VibeBuddy shows its available controls. If the
+request belongs to the native Mac prompt, the companion directs you there.
+
+### Codex
+
+```bash
+python3 hooks/install-codex-hooks.py --install
+python3 hooks/install-codex-hooks.py --approval
+```
+
+In a fresh Codex CLI session, review and trust the installed hooks through
+`/hooks`. The approval option is needed only for remote permission decisions.
+Follow the Mac setup instructions for the app-server connection used by task
+creation, continuation and steering.
+
+Codex Desktop can run a separate app-server. Local task observation does not
+establish permission coverage or task-control access. Read the
+[Codex integration contract](codex-integration.md) for the current boundary and
+[probe instructions](../tools/codex-integration/README.md) for diagnostics.
+
+### Other agents and removal
+
+See [multi-agent hook setup](multi-cli-hook-setup.md) for Grok Build and
+experimental adapters. Cursor currently supplies account usage, not task control.
+Each Claude/Codex installer accepts `--uninstall` to remove its managed entries.
+Keep this checkout at its installed path while file-based hooks refer to it.
+
+## Optional AI and notifications
+
+Voice conversation, completion summaries and Mac read-aloud each have their own
+settings. Add your provider credential in the app's native settings, select the
+feature's provider/model, and use the connection or voice preview controls. These
+configuration checks do not replace trying an actual call. Monitoring and button
+approvals work without AI credentials.
+
+Closed-app push is a separate setup: the Mac needs APNs credentials matching the
+iPhone app's signing team, bundle and environment. Public downloads do not yet
+provide a turnkey path. Do not use a different team's APNs key with the App Store
+binary. See [APNs setup](apns-setup.md) and the
+[distribution decision](adr/0013-apns-key-delivery.md).
+
+## Build from source
+
+Use **Xcode 26.6**, **Swift 6** and **XcodeGen** for the current project. App
+deployment targets are macOS 14, iOS 17 and watchOS 26.5. Package minimums may be
+lower than app minimums. Install XcodeGen with `brew install xcodegen` if needed.
+
+```bash
+git clone https://github.com/semantic-craft/iOS-vibebuddy.git
+cd iOS-vibebuddy
+```
+
+Generate and open the Mac project from the repository root:
+
+```bash
+xcodegen generate --spec VibeBuddyMacApp/project.yml
+open VibeBuddyMacApp/VibeBuddyMacApp.xcodeproj
+```
+
+Choose the `VibeBuddyMacApp` scheme, select your signing team if needed, then
+build and run. For iPhone and Watch:
+
+```bash
+xcodegen generate --spec VibeBuddyApp/project.yml
+open VibeBuddyApp/VibeBuddyApp.xcodeproj
+```
+
+Choose the `VibeBuddyApp` scheme and a simulator or your device. For a device
+build, select your own signing team and unique bundle identifiers for the app
+and its extensions; configure capabilities for that team. Release scripts are
+maintainer tooling and are not required for a local build.
+
+The headless Mac daemon is an alternative to the menu-bar app. Run one server
+at a time on the default port:
+
+```bash
+swift run --package-path VibeBuddyMac vibebuddyd --pair
+```
+
+`--pair` opens the same two-minute registration window. Use the daemon's pairing
+instructions; never share its token in an issue or screenshot.
+
+## Check a change
+
+For shared logic or server changes, the existing package tests are:
+
+```bash
+swift test --package-path VibeBuddyKit
+swift test --package-path VibeBuddyMac
+```
+
+For app behavior, build the affected app and exercise that flow with actual agent
+data. Record whether the check used Demo mode, a simulator, an isolated Mac app or
+physical devices. Documentation-only changes need link and rendering checks, not
+an app build. See [contributing](../CONTRIBUTING.md).

--- a/docs/multi-cli-hook-setup.md
+++ b/docs/multi-cli-hook-setup.md
@@ -145,8 +145,11 @@ therefore replaces just that group with a blocking `hooks/approval-hook.sh codex
 `{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"|"deny"}}}`,
 and a phone decision is final. Silence (no phone answer in 25s) falls back to
 Codex's own prompt. `apply_patch` is decided as `Edit`, with a `file_path` from
-the patch when it names one file. **Codex Desktop never runs `hooks.json`**, so
-this covers the CLI only.
+the patch when it names one file. This describes the CLI approval path.
+Desktop lifecycle/tool hooks arrived in the 0.153.4 acceptance, but the tested
+native escalation did not produce an answerable approval card. Hook delivery
+does not establish Desktop approval coverage; see the
+[Codex integration contract](codex-integration.md).
 
 ### Grok Build (`~/.grok/hooks/vibebuddy.json`)
 


### PR DESCRIPTION
The repository homepage still described a 1.3 candidate, linked an obsolete Mac release story, and said there was no public iPhone download. Rebuild both READMEs around the shipped companion experience: real demo screenshots, current download links, voice and completion summaries, Codex task workflows, Watch features, and an explicit integration capability table.

Add a contributor guide and a practical installation/build guide, and align the old Codex hook note with the documented Desktop acceptance results. Preserve the APNs public-distribution and Desktop approval limits.

Validation: checked 112 links/image references and local anchors; rendered all four new/rewritten documents through GitHub's Markdown API; inspected the homepage layout in a browser; ran both documented XcodeGen generation commands successfully; git diff --check passed. Documentation only; no app behavior or release artifacts changed.
