### PR TITLE
Present all five integrations in the VibeBuddy product overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,8 @@ iPhone and Apple Watch. Contributions in English or Simplified Chinese are welco
 
 ## Useful ways to help
 
-- Reproduce a Claude Code or Codex integration issue with the actual agent.
+- Reproduce a Claude Code, Codex or Grok Build issue with the actual agent, or
+  improve Grok Bot observation and Cursor account-usage integration.
 - Improve English or Chinese UI text and keep the two READMEs consistent.
 - Document a device workflow, especially Watch interactions and reconnects.
 - Fix a focused bug or improve an existing provider adapter.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Leave your desk. Keep your agents moving.
 
-A native **Mac, iPhone & Apple Watch** companion for **Claude Code and Codex**.<br>See what needs you, respond to supported requests, and hear what got done.
+A native **Mac, iPhone & Apple Watch** companion for your AI workflow.<br>**Claude Code · Codex · Grok Build · Grok Bot · Cursor**<br>Follow tasks, review supported requests, and keep account usage in view.
 
 [**Download for Mac**](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) · [**Get the iPhone app**](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338) · [Get started](#get-started) · [简体中文](README.zh-CN.md)
 
@@ -22,7 +22,7 @@ A native **Mac, iPhone & Apple Watch** companion for **Claude Code and Codex**.<
 
 ## A little less checking. A lot more doing.
 
-Start a refactor in Claude Code and a test run in Codex. VibeBuddy brings both into one view. While your Mac stays running and reachable, you can check a question on your phone, follow a task on your wrist, or ask the voice companion for an update.
+Start a refactor in Claude Code, a test run in Codex and a build in Grok Build. Check a Grok Bot result and your remaining Cursor allowance from the same companion. While your Mac stays running and reachable, you can check a question on your phone, follow a task on your wrist, or ask the voice companion for an update.
 
 | See what matters | Keep work moving | Hear the outcome |
 | --- | --- | --- |
@@ -57,11 +57,13 @@ Start a refactor in Claude Code and a test run in Codex. VibeBuddy brings both i
 | **Get a useful completion update** | Optional AI summaries focus on results, blockers and next steps. Mac read-aloud has its own provider, model and voice, with voice previews. [Model settings](docs/release-notes-1.3.10.md). |
 | **Continue the conversation** | Reply to supported waits, steer a running Codex turn or continue an existing task. Recent dialogue and delivery receipts help you see what was sent. [Task interaction](docs/release-notes-1.3.6.md). |
 | **Keep the Mac close at hand** | Search and filter the menu feed, open task details, and use an explicitly opened QR pairing window. [Mac companion update](docs/release-notes-1.3.9.md). |
-| **Bring more of your workflow along** | Watch quick answers and task controls; optional Grok Bot observation; Claude, Codex, Grok and Cursor account usage where provider data is available. [Watch update](docs/release-notes-1.3.8.md) · [Grok Bot](docs/release-notes-1.3.7.md). |
+| **Follow work on your wrist** | Watch quick answers, task controls and completion summaries keep followed tasks close at hand. [Watch update](docs/release-notes-1.3.8.md). |
+| **Follow Grok Build and Grok Bot** | Track Build CLI tasks, account usage and mode-dependent approval requests. Enable read-only Bot observation, summaries of verified ordinary completions and its separate account quota. [Grok Build setup](docs/getting-started.md#grok-build) · [Grok Bot update](docs/release-notes-1.3.7.md). |
+| **Keep Cursor usage in view** | Read allowance from an existing Cursor app or Cursor CLI login, with separate **Cursor Models** and **Other Models** pools. [Cursor CLI support](docs/release-notes-1.3.2.md). |
 
 Mac releases and iPhone/Watch App Store updates ship independently. Newer features need an updated client on the device using them. Check the [Mac releases](https://github.com/semantic-craft/iOS-vibebuddy/releases) and [App Store listing](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338) for current versions and availability.
 
-## Built around Claude Code and Codex
+## Your tools, connected
 
 VibeBuddy connects to the agents you already run. Available controls follow the actual connection and pending request.
 
@@ -70,8 +72,9 @@ VibeBuddy connects to the agents you already run. Available controls follow the 
 | **Claude Code** | Lifecycle hooks, task state, usage, permission decisions and answers to supported questions. | Remote responses need the approval hooks. When the native prompt owns the interaction, respond on Mac. |
 | **Codex CLI / connected app-server** | Task state, usage, supported approvals and questions; create, continue, steer and stop tasks through a connected app-server. | Task control requires the connected server to own the task and expose the required turn/request. MCP elicitation is read-only. |
 | **Codex Desktop** | Observe local task progress and completions; jump back to the app. | Desktop may own a separate app-server. Native Desktop approval coverage is incomplete; use the Mac prompt when no answerable request is available. |
-| **Grok Build / Grok Bot** | Build CLI hooks and mode-dependent approvals; optional Bot observation and quota. | Bot is read-only. Build approvals depend on its permission mode. |
-| **Cursor** | Account usage from supported login sources, including Cursor CLI login. | Quota integration is available; task tracking and remote approval are not yet supported. |
+| **Grok Build** | CLI lifecycle hooks, task state, account usage and configured approval gates. | Whether a remote approval resolves the native prompt depends on Grok's permission mode. |
+| **Grok Bot** | Optional read-only task observation, summaries of verified ordinary completions and separate account usage. | Replies and approvals stay in the official app. Question continuations, automated tasks and turns spanning a disconnect are not yet supported. |
+| **Cursor** | Account usage from supported login sources, including the Cursor app and Cursor CLI, with separate **Cursor Models** and **Other Models** pools. | Quota integration is available; task tracking and remote approval are not yet supported. |
 
 See the [Codex integration contract](docs/codex-integration.md) and [agent hook setup](docs/multi-cli-hook-setup.md). Qwen, Kimi, OpenCode and Antigravity coding-agent adapters are experimental community integrations; their verification is separate from Qwen's supported voice-provider integration.
 
@@ -80,7 +83,7 @@ See the [Codex integration contract](docs/codex-integration.md) and [agent hook 
 1. **Install the Mac companion.** [Download the latest DMG](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest), drag the app into Applications, and launch it. The distributed Mac app requires Apple Silicon and macOS 14+.
 2. **Connect your coding agent.** Open Setup in Mac settings and follow the agent-specific instructions. [Manual setup](docs/getting-started.md#connect-an-agent) is also available.
 3. **Add your iPhone.** Install [VibeBuddy: Agent Monitor](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338), choose **Pair a phone** on Mac, then **Scan to pair** on iPhone. Start on the same trusted local network. iPhone requires iOS 17+; the current Watch companion requires watchOS 26.5+.
-4. **Try a task.** Run a short task in Claude Code or Codex. Check its state, open its details, and follow it until completion. Enable voice or summaries separately if you want them.
+4. **Try your workflow.** Run a short task in Claude Code, Codex or Grok Build and follow it until completion. You can also [enable Grok Bot observation](docs/getting-started.md#grok-bot) or [connect Cursor usage](docs/getting-started.md#cursor). Enable voice or summaries separately if you want them.
 
 **Just looking?** The iPhone connection screen includes **See the demo (no Mac needed)**. Mac works on its own, too. App Store availability varies by region; [build from source](docs/getting-started.md#build-from-source) if needed.
 
@@ -96,8 +99,10 @@ Live Activity and Dynamic Island counts update while the phone is connected. Clo
 
 ```mermaid
 flowchart LR
-    A[Claude Code and agent CLI hooks] --> M[VibeBuddy on your Mac]
+    A[Claude Code and Grok Build hooks] --> M[VibeBuddy on your Mac]
     C[Codex rollouts and connected app-server] <--> M
+    B[Grok Bot observation] --> M
+    U[Account usage including Cursor] --> M
     M <-->|Paired local connection| P[iPhone]
     P <-->|WatchConnectivity| W[Apple Watch]
     M -. Optional AI features .-> V[Your chosen AI provider]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 ### 离开书桌，也能接着推进任务。
 
-为 **Claude Code 和 Codex** 打造的 **Mac、iPhone 与 Apple Watch** 原生伴侣。<br>看看谁需要你，回应可远程处理的请求，听听任务完成了什么。
+陪你使用 AI 工具的 **Mac、iPhone 与 Apple Watch** 原生伴侣。<br>**Claude Code · Codex · Grok Build · Grok Bot · Cursor**<br>关注任务进展，回应可处理的请求，随时查看账户额度。
 
 [**下载 Mac 版**](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest) · [**获取 iPhone 版**](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338) · [开始使用](#开始使用) · [English](README.md)
 
@@ -22,7 +22,7 @@
 
 ## 少来回查看，多做自己的事。
 
-让 Claude Code 改代码，让 Codex 跑测试，VibeBuddy 把它们放进同一个视图。只要 Mac 保持运行、网络可达，你就能在手机上处理问题，在手表上关注任务，或者开口询问最新进展。
+让 Claude Code 改代码、Codex 跑测试、Grok Build 执行构建，也能在同一个伴侣中查看 Grok Bot 的结果与 Cursor 剩余额度。只要 Mac 保持运行、网络可达，你就能在手机上处理问题，在手表上关注任务，或者开口询问最新进展。
 
 | 看清当前情况 | 接着推进任务 | 了解完成结果 |
 | --- | --- | --- |
@@ -57,11 +57,13 @@
 | **听懂完成结果** | 可选 AI 摘要聚焦结果、阻塞与下一步。Mac 朗读可分别选择服务商、模型和音色，并先试听。[模型设置更新](docs/release-notes-1.3.10.md)。 |
 | **继续已有对话** | 回答可处理的等待请求，为运行中的 Codex 任务补充指令，或继续已有任务；查看近期对话与发送回执。[任务交互更新](docs/release-notes-1.3.6.md)。 |
 | **随手找到 Mac 上的任务** | 搜索和筛选菜单栏活动，打开任务详情，通过主动开启的二维码配对窗口连接手机。[Mac 伴侣更新](docs/release-notes-1.3.9.md)。 |
-| **带上更多工作信息** | Watch 快捷回答与任务控制、可选 Grok Bot 观测，以及在服务商数据可用时查看 Claude、Codex、Grok、Cursor 账户额度。[Watch 更新](docs/release-notes-1.3.8.md) · [Grok Bot](docs/release-notes-1.3.7.md)。 |
+| **抬腕关注任务** | Watch 快捷回答、任务控制与完成摘要，方便随时查看关注中的任务。[Watch 更新](docs/release-notes-1.3.8.md)。 |
+| **关注 Grok Build 与 Grok Bot** | 追踪 Build CLI 任务、账户额度与依权限模式提供的审批请求；可开启 Bot 只读观测、可核实的普通对话完成摘要与独立账户额度。[Grok Build 配置](docs/getting-started.md#grok-build) · [Grok Bot 更新](docs/release-notes-1.3.7.md)。 |
+| **查看 Cursor 剩余额度** | 使用已有 Cursor App 或 Cursor CLI 登录，分别显示 **Cursor Models** 与 **Other Models** 两个额度池。[Cursor CLI 支持](docs/release-notes-1.3.2.md)。 |
 
 Mac 版本与 iPhone／Watch 的 App Store 更新分别发布，新功能需要相应设备安装更新后的客户端。当前版本和可用情况以 [Mac Releases](https://github.com/semantic-craft/iOS-vibebuddy/releases) 和 [App Store 页面](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338)为准。
 
-## 围绕 Claude Code 与 Codex 的实际工作流
+## 常用工具与支持能力
 
 VibeBuddy 连接你已经在用的 Agent。能否操作，取决于当前连接方式和具体请求。
 
@@ -70,8 +72,9 @@ VibeBuddy 连接你已经在用的 Agent。能否操作，取决于当前连接�
 | **Claude Code** | 生命周期 hooks、任务状态、用量、权限决定与受支持的问题回答。 | 远程回应需要安装审批 hooks；交互由原生提示处理时，回到 Mac 回应。 |
 | **Codex CLI／已连接的 app-server** | 任务状态、额度、受支持的审批与问题；通过已连接的 app-server 新建、继续、补充指令和停止任务。 | 连接的服务必须拥有该任务，并能识别相应轮次或请求；MCP elicitation 目前只读。 |
 | **Codex Desktop** | 观测本地任务进展和完成结果，跳回应用。 | Desktop 可能使用独立 app-server；原生审批覆盖不完整，没有可回应请求时需使用 Mac 提示。 |
-| **Grok Build／Grok Bot** | Build CLI hooks 与依权限模式提供的审批；可选 Bot 观测和额度。 | Bot 只读；Build 的审批效果取决于权限模式。 |
-| **Cursor** | 从支持的登录来源读取账户额度，包括 Cursor CLI 登录。 | 已支持额度；尚不支持任务追踪和远程审批。 |
+| **Grok Build** | CLI 生命周期 hooks、任务状态、账户额度与配置后的审批通道。 | 远程批准能否解除原生提示，取决于 Grok 的权限模式。 |
+| **Grok Bot** | 可选的只读任务观测、可核实的普通对话完成摘要与独立账户额度。 | 回复和审批在官方 App 中处理；问题续接、自动化任务及跨断线轮次尚未支持。 |
+| **Cursor** | 从支持的登录来源读取账户额度，包括 Cursor App 与 Cursor CLI，分别显示 **Cursor Models** 和 **Other Models**。 | 已支持额度；尚不支持任务追踪和远程审批。 |
 
 详见 [Codex 集成契约](docs/codex-integration.md)和 [Agent hook 配置](docs/multi-cli-hook-setup.md)。Qwen、Kimi、OpenCode、Antigravity 编码 Agent 适配器属于实验性社区集成；其验证状态与已支持的千问语音服务不同。
 
@@ -80,7 +83,7 @@ VibeBuddy 连接你已经在用的 Agent。能否操作，取决于当前连接�
 1. **安装 Mac 伴侣。** [下载最新 DMG](https://github.com/semantic-craft/iOS-vibebuddy/releases/latest)，将 App 拖入“应用程序”并打开。发布的 Mac 版需要 Apple Silicon 与 macOS 14+。
 2. **接入编码 Agent。** 在 Mac 设置的 Setup 中按对应 Agent 的说明配置，也可查看[手动配置指南](docs/getting-started.md#connect-an-agent)。
 3. **连接 iPhone。** 安装 [VibeBuddy: Agent Monitor](https://apps.apple.com/us/app/vibebuddy-agent-monitor/id6777469338)，在 Mac 选择“配对手机”，在 iPhone 选择“扫码配对”。首次在同一可信局域网操作。iPhone 需要 iOS 17+，当前 Watch 伴侣需要 watchOS 26.5+。
-4. **跑一个任务。** 在 Claude Code 或 Codex 发起简短任务，查看状态、打开详情并关注至完成。语音和摘要可按需单独开启。
+4. **试试你的工作流。** 在 Claude Code、Codex 或 Grok Build 发起简短任务并关注至完成，也可[开启 Grok Bot 观测](docs/getting-started.md#grok-bot)或[接入 Cursor 额度](docs/getting-started.md#cursor)。语音和摘要可按需单独开启。
 
 **想先看看界面？** iPhone 连接页有“查看演示（无需 Mac）”，Mac 也可独立使用。上述 App Store 链接指向美国商店，是否可下载取决于账号地区；也可[自行编译](docs/getting-started.md#build-from-source)。
 
@@ -96,8 +99,10 @@ VibeBuddy 连接你已经在用的 Agent。能否操作，取决于当前连接�
 
 ```mermaid
 flowchart LR
-    A[Claude Code 与 Agent CLI hooks] --> M[Mac 上的 VibeBuddy]
+    A[Claude Code 与 Grok Build hooks] --> M[Mac 上的 VibeBuddy]
     C[Codex 本地记录与已连接的 app-server] <--> M
+    B[Grok Bot 观测] --> M
+    U[账户额度与 Cursor 用量] --> M
     M <-->|配对后的本地连接| P[iPhone]
     P <-->|WatchConnectivity| W[Apple Watch]
     M -. 可选 AI 功能 .-> V[你选择的 AI 服务商]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,8 @@
 # Getting started with VibeBuddy
 
-VibeBuddy's Mac app observes your coding agents and connects to the optional
-iPhone and Apple Watch companions. [Back to the homepage](../README.md).
+VibeBuddy's Mac app tracks Claude Code, Codex and Grok Build tasks, optionally
+observes Grok Bot, and reads Cursor account usage. Add the iPhone and Apple Watch
+companions to bring those views with you. [Back to the homepage](../README.md).
 
 ## Install and pair
 
@@ -64,11 +65,45 @@ establish permission coverage or task-control access. Read the
 [Codex integration contract](codex-integration.md) for the current boundary and
 [probe instructions](../tools/codex-integration/README.md) for diagnostics.
 
-### Other agents and removal
+### Grok Build
 
-See [multi-agent hook setup](multi-cli-hook-setup.md) for Grok Build and
-experimental adapters. Cursor currently supplies account usage, not task control.
-Each Claude/Codex installer accepts `--uninstall` to remove its managed entries.
+```bash
+python3 hooks/install-grok-hooks.py --dry-run
+python3 hooks/install-grok-hooks.py --install
+```
+
+Reload Grok's hooks with `/hooks` then `r`, or start a fresh session. The optional
+`--approval` installer flag adds the blocking approval gate. Grok's permission
+mode determines whether a phone approval also resolves the native prompt; read
+the [Grok Build setup details](multi-cli-hook-setup.md#grok-build-grokhooksvibebuddyjson)
+before enabling it. Task observation and account usage do not require that gate.
+
+### Grok Bot
+
+Sign in through the official Grok Bot app, then enable **Observe Grok Bot tasks**
+in VibeBuddy's Mac settings. The observer is off by default. Its read-only view
+supports task status, verified ordinary completions and optional completion
+summaries/read-aloud; replies and approvals stay in Grok Bot. Question
+continuations, automated tasks and turns spanning a disconnect are not yet
+supported, so check those results in the official app.
+
+For its separate quota, use the **Grok Bot** section in Usage settings. If access
+is needed, use **Authorize Grok Bot account access…** there, then enable collection
+and refresh. Renew expired login in Grok Bot itself.
+
+### Cursor
+
+In Mac **Settings → Usage → Login source**, choose the existing Cursor app or
+**Cursor CLI login**. The CLI path uses the account signed in through
+`cursor-agent login` and does not require the Cursor desktop app. Refresh usage
+to see **Cursor Models** and **Other Models** as separate pools. Available values
+depend on the selected account and provider response. This is account-usage
+integration; Cursor task tracking and remote approval are not yet supported.
+
+### Experimental adapters and removal
+
+See [multi-agent hook setup](multi-cli-hook-setup.md) for experimental adapters.
+The Claude, Codex and Grok installers accept `--uninstall` to remove managed entries.
 Keep this checkout at its installed path while file-based hooks refer to it.
 
 ## Optional AI and notifications


### PR DESCRIPTION
Present Claude Code, Codex, Grok Build, Grok Bot and Cursor together in both homepage introductions. Give Grok Build, Grok Bot and Cursor distinct feature descriptions and capability rows, with setup sections and diagram inputs that match their actual integrations: Build task tracking and mode-dependent approvals, Bot read-only observation and verified completion summaries, and Cursor account usage with separate allowance pools.

Validation: checked local links, anchors and image references in all four edited documents; rendered them through GitHub Markdown; verified each homepage names all five tools in its introduction. Documentation only; no application behavior changed.
