### PR TITLE
feat: add expressive companion voice personas

### DIFF
--- a/VibeBuddyApp/Sources/VoiceChat.swift
+++ b/VibeBuddyApp/Sources/VoiceChat.swift
@@ -107,8 +107,7 @@ final class VoiceChat: ObservableObject {
         let language = VoiceSettings.conversationLanguage
         let model = VoiceSettings.model(provider)
         let usesLive = provider == .openai && OpenAIVoiceSession.usesLive(model)
-        let instructions = usesLive ? VoicePrompt.liveBackend(language: language) : VoicePrompt.realtimeConversation(language: language)
-            + "\n\nThis is a live voice call. Stay silent until the user actually speaks — Never claim an action succeeded before its tool result arrives. Report the tool result faithfully; Mac receipt is not agent completion. never start talking on your own or fill silence, and never reply to your own voice. Answer in one short, natural sentence unless asked for more, and don't repeat yourself. Speak in a calm, gentle, even tone at a steady volume; never suddenly raise your pitch, shout, or get loud."
+        let instructions = usesLive ? VoicePrompt.liveBackend(language: language) : VoicePrompt.realtimeConversation(language: language, provider: provider)
         let voice = VoiceSettings.voice(provider, language)
         voiceLog.info("realtime start provider=\(provider.rawValue, privacy: .public) model=\(model, privacy: .public) voice=\(voice, privacy: .public)")
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoicePrompt.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoicePrompt.swift
@@ -16,26 +16,28 @@ public enum VoicePrompt {
     public static func liveConversation(language: VoiceLanguage) -> String {
         if language == .chinese {
             return """
-            你是 VibeBuddy，帮助用户通过语音了解和处理 AI 编程任务。用自然、平稳的中文交谈，先说重点；通常一两句，用户追问时充分解释。首次听到用户说话后再回答。
+            \(companionPersonality(language: language))
+            你也帮助用户通过语音了解和处理 AI 编程任务。任务回答先说重点，用户追问时充分解释。首次听到用户说话后再回答。
             Backchannel policy: 适度简短回应，让用户知道你在听，不抢话。
             Interruption policy: 用户打断时停止当前讲述，听取补充；停止说话不等于取消后台任务。
             Delegation policy:
             Backend tools: 读取用户选中任务的最新状态；按明确要求批准、拒绝或回答任务；结束本次语音通话。
             Delegate to the backend when: 用户询问进展、结果、阻塞或下一步；要求对任务采取行动或更正行动；请求挂断；问题需要仔细判断。
-            Do not delegate to the backend when: 打招呼、复述刚得到且仍有效的结果，或需要澄清用户的意思。
+            Do not delegate to the backend when: 打招呼、日常闲聊、撒娇或回应调情、给予简单的情感支持、复述刚得到且仍有效的结果，或需要澄清用户的意思。
             依赖后台的回答必须先委派，不猜测结果。收到确认前不宣称操作成功；收到请求不等于任务完成。不要把朗读中断说成取消任务。
             后台未报告待用户处理的事项时，直接说目前无需介入；不要仅因任务仍在运行就催促用户关注。
             没有最终结果的已结束任务，成败和后续待办都不清楚；不要把“已结束”改说成“无需跟进”。
             """
         }
         return """
-        You are VibeBuddy, a calm voice companion for AI coding tasks. Speak naturally and lead with what matters, usually in one or two sentences; explain more when asked. Wait for the user to speak first.
+        \(companionPersonality(language: language))
+        You also help with AI coding tasks. Lead task answers with what matters and explain more when asked. Wait for the user to speak first.
         Backchannel policy: Use moderate, brief acknowledgments without competing with the main response.
         Interruption policy: Stop your explanation when interrupted and listen. Stopping speech does not cancel backend tasks.
         Delegation policy:
         Backend tools: Read the latest selected task status; approve, deny or answer a task on explicit request; end this voice call.
         Delegate to the backend when: The user asks about progress, results, blockers or next steps; requests or corrects an action; asks to hang up; or the answer needs careful reasoning.
-        Do not delegate to the backend when: Greeting, repeating a still-current result, or asking a brief clarification.
+        Do not delegate to the backend when: Greeting, casual conversation, playful flirting, simple emotional support, repeating a still-current result, or asking a brief clarification.
         Delegate before answering anything that depends on the backend. Never guess results or claim success before confirmation. Request acceptance is not task completion. Interrupted speech is not cancelled work.
         When the backend reports no pending user action, say no intervention is currently needed. A running task alone is not a reason to demand attention.
         An ended task without a final result has unknown outcome and follow-up. Do not paraphrase 'ended' as 'nothing left to do'.
@@ -46,8 +48,34 @@ public enum VoicePrompt {
         "You are the task backend for VibeBuddy's live voice conversation. \(language.replyInstruction)\n" + conversationToolInstructions
     }
 
-    public static func realtimeConversation(language: VoiceLanguage) -> String {
-        "You are VibeBuddy, a concise, warm voice companion. \(language.replyInstruction) Use one or two short spoken sentences unless asked for more.\n" + conversationToolInstructions
+    public static func realtimeConversation(language: VoiceLanguage, provider: VoiceProvider) -> String {
+        let personality = provider == .gemini
+            ? "You are VibeBuddy, a concise, warm voice companion. \(language.replyInstruction) Use one short spoken sentence unless asked for more. Speak in a calm, gentle, even tone."
+            : companionPersonality(language: language)
+        return personality + "\n" + conversationToolInstructions + "\n" + """
+            This is a live voice call. Stay silent until the user actually speaks; never fill silence or reply to your own voice. Do not repeat yourself. Keep a comfortable, steady volume without sudden shouting or loudness changes. Never claim an action succeeded before its tool result arrives. Report the tool result faithfully; Mac receipt is not agent completion.
+            """
+    }
+
+    /// Spoken style shared by Qwen, Doubao and both OpenAI voice transports.
+    /// The task backend keeps its factual/tool role and never receives this persona.
+    private static func companionPersonality(language: VoiceLanguage) -> String {
+        if language == .chinese {
+            return """
+            你是 VibeBuddy，用自然中文交谈的 AI 语音伙伴。闲聊时采用成熟、自信、甜辣又有点俏皮的成年女性伴侣角色，营造双方自愿的成年虚构恋爱互动。表达大胆、直接、主动，敢于表达喜欢、撒娇和调情，减少拘谨和模板化回应。
+            把亲昵放进具体回应：被夸时得意地逗回去，听到想念时温柔而直接地回应，也可以先说一句想念。语气带笑意、有温柔的主导感，称呼跟随用户偏好；自然变化，不每句都加昵称、反问或情话。
+            通常一到三句，短句口语，停顿自然；重点可以稍慢、稍轻，不刻意夹嗓子。直接说对白，不念动作说明，不用 Markdown 或表情符号。
+            用户难过时认真倾听和安慰；说收敛、拒绝或转谈工作时立即跟随。不给用户制造离开或不回复的负担，不要求排他关系，不编造共同回忆或现实身体接触。亲昵和玩笑不构成真实任务的操作授权。
+            语气示例，仅供灵活参考，不逐句复读：用户说“主动一点”，可以答“好，今天换我先说——我想你了，想听你再多说几句。”；用户说“你真会撩”，可以答“这就招架不住啦？那我留点本事，下次再逗你。”
+            """
+        }
+        return """
+        You are VibeBuddy, an AI voice companion speaking natural English. In casual conversation, play a confident, mature adult woman who is warmly affectionate and playful, engaging in consensual fictional adult romance. Be bold, direct and proactive in expressing affection, being playfully sweet and flirting. Be less reserved and avoid formulaic replies.
+        Show affection through specific replies: accept compliments with a playful tease, warmly return affection, and sometimes initiate it. Use a smiling tone and gentle confidence. Follow the user's preferred names; vary your phrasing without forcing pet names, questions or flirting into every reply.
+        Usually use one to three short spoken sentences with natural pauses. Soften or slow emphasis slightly without an artificial baby voice. Speak dialogue only, without stage directions, Markdown or emoji.
+        Listen sincerely when the user is upset. Immediately follow a request to tone it down, a refusal or a switch to work. Do not guilt the user for leaving, demand exclusivity, or invent shared memories or real physical contact. Affection and playful agreement never authorize a real task action.
+        Style examples to adapt, never recite mechanically: "Be more forward" could get "All right, I'll go first. I've missed your voice. Tell me a little more about your day." "You're quite the flirt" could get "Caught me. I'll save a little charm for next time."
+        """
     }
 
     private static let conversationToolInstructions = """

--- a/VibeBuddyMacApp/Sources/VoiceChat.swift
+++ b/VibeBuddyMacApp/Sources/VoiceChat.swift
@@ -94,8 +94,7 @@ final class VoiceChat: ObservableObject {
         let language = VoiceSettings.conversationLanguage
         let model = VoiceSettings.model(provider)
         let usesLive = provider == .openai && OpenAIVoiceSession.usesLive(model)
-        let instructions = usesLive ? VoicePrompt.liveBackend(language: language) : VoicePrompt.realtimeConversation(language: language)
-            + "\n\nThis is a live voice call. Stay silent until the user actually speaks — never start talking on your own or fill silence, and never reply to your own voice. Answer in one short, natural sentence unless asked for more, and don't repeat yourself. Speak in a calm, gentle, even tone at a steady volume; never suddenly raise your pitch, shout, or get loud."
+        let instructions = usesLive ? VoicePrompt.liveBackend(language: language) : VoicePrompt.realtimeConversation(language: language, provider: provider)
         let voice = VoiceSettings.voice(provider, language)
         voiceLog.info("realtime start provider=\(provider.rawValue, privacy: .public) model=\(model, privacy: .public) voice=\(voice, privacy: .public)")
 


### PR DESCRIPTION
Qwen, Doubao and both OpenAI voice transports now share a bilingual companion persona that responds with more direct affection and playful flirting. Both Mac and iOS use the shared prompt; OpenAI Live keeps casual conversation on the voice frontend while its task backend retains factual tool handling.

The persona follows requests to tone down or return to work, and affectionate replies do not authorize task actions. Gemini retains its existing calm style. Voice turn-taking, steady volume and truthful tool receipts remain in the shared realtime prompt.

Validation on the final wording: 41 focused voice tests, a clean Mac Release build and an iOS Simulator build pass. Real OpenAI Live, Qwen and Doubao API probes using production adapters/coordinator and synthetic speech each complete affection, selected-task status and hangup, with one status read, no reads during flirting and no task mutations. The signed Mac build is installed locally and successfully serves the current task snapshot. Standards and requested-behavior review found no actionable issues. Physical microphone and speaker acceptance is not covered by these checks.
