### PR TITLE
feat: add read-only Copilot CLI session history

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -336,3 +336,11 @@ code, and tests — don't drift to synonyms.
   they implement the pending/decision protocol.
 
 Mac presence suppresses ordinary cues only while the verdict is current; leaving restores one still-open wait reminder without making the card remotely answerable.
+
+- **Copilot history** — Wake-compatible read-only conversations from
+  `~/.copilot/session-store.db` (`sessions` + `turns`). The scanner checks the
+  database and WAL every five seconds and reads private temporary copies.
+  History rows bypass SessionReducer, carry `historyOnly: true`, and use the
+  existing quiet `.done` wire value with no completion identity or unread flag.
+  They do not establish live status or generate completion notices; clients
+  label them History. RecentOutput carries a bounded dialogue slice.

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -419,6 +419,8 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     public let id: String
     public let agent: AgentKind
     public var project: String
+    /// Read-only stored conversation; no live task state is known.
+    public var historyOnly: Bool? = nil
     public var branch: String?
     public var model: String?
     public var status: SessionStatus

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ObservationDiagnosticPresentation.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ObservationDiagnosticPresentation.swift
@@ -18,6 +18,8 @@ public extension ObservationSourceDiagnostic {
     var diagnosticTitle: String {
         if isOptionalStatusLineNotConfigured { return "Status line information not enabled" }
         return switch reasonCode {
+        case "copilotHistoryOnly": "Read-only history"
+        case "copilotHistoryUnreadable": "Copilot history unavailable"
         case "awaitingActivity": source == .hook ? "Configured, awaiting first activity" : "Awaiting activity"
         case "versionUnverified": "Version \(sourceVersion ?? "unknown") not yet verified"
         case "invalidSourceData": "Invalid source data"
@@ -31,6 +33,10 @@ public extension ObservationSourceDiagnostic {
             return "Optional Claude status line information is not enabled. Hook and Transcript monitoring can continue."
         }
         switch reasonCode {
+        case "copilotHistoryOnly":
+            return "Stored Copilot CLI conversations. Live task status is unavailable."
+        case "copilotHistoryUnreadable":
+            return "Copilot history could not be refreshed. Existing rows may be outdated; reading will retry automatically."
         case "awaitingActivity":
             return source == .transcript
                 ? "No transcript has been read since this launch. Transcript reading starts when a Hook reports session activity."

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
@@ -174,6 +174,7 @@ public struct AgentObservationDiagnostic: Codable, Sendable, Equatable, Identifi
 public extension AgentSession {
     /// Compact copy shared by the Mac and iOS session rows.
     var observationDescription: String? {
+        if historyOnly == true { return "Stored conversation · live status unavailable" }
         guard let observations, !observations.isEmpty else { return nil }
         let sorted = observations.sorted { $0.source < $1.source }
         let sources = sorted.map(\.source.displayName).joined(separator: " + ")

--- a/VibeBuddyKit/Sources/VibeBuddyKit/TaskPresentation.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/TaskPresentation.swift
@@ -103,6 +103,8 @@ public struct TaskStatusColorToken: Codable, Sendable, Hashable {
 }
 
 public extension AgentSession {
+    var statusLabel: String { historyOnly == true ? "History · read only" : presentationState.label }
+
     var presentationState: TaskPresentationState {
         TaskPresentationState.project(
             status: status,

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ToolActivity.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ToolActivity.swift
@@ -12,6 +12,7 @@ public enum ToolActivity {
     /// session. Unlike a prose transcript summary, this always tells the user
     /// whether the agent is active, blocked, or ready.
     public static func label(for session: AgentSession) -> String {
+        if session.historyOnly == true { return "History · read only" }
         switch session.status {
         case .needsResponse:
             return session.waitKind == .permission ? "Needs approval" : "Needs input"

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoicePrompt.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoicePrompt.swift
@@ -93,7 +93,8 @@ public enum VoicePrompt {
     public static func sessionContext(_ sessions: [AgentSession]) -> String {
         let rows: [[String: Any]] = sessions.prefix(40).map { s in
             ["project": s.project, "title": String((s.name ?? s.project).prefix(200)),
-             "agent": s.agent.shortName, "status": s.status.rawValue,
+             "agent": s.agent.shortName, "status": s.historyOnly == true ? "unknown" : s.status.rawValue,
+             "historyOnly": s.historyOnly == true,
              "updatedAt": s.updatedAt.ISO8601Format(), "statusSince": s.statusSince.ISO8601Format(),
              "failed": s.isStuck, "summary": s.status == .done ? String((s.displaySummary ?? "").prefix(1600)) : "",
              "activeTool": s.status == .working ? (s.activeTool ?? "") : "",
@@ -105,8 +106,8 @@ public enum VoicePrompt {
             "scopeCount": sessions.count, "truncated": sessions.count > rows.count,
             "needsResponseCount": sessions.filter { $0.status == .needsResponse }.count,
             "runningCount": sessions.filter { $0.status == .working }.count,
-            "endedWithoutResultCount": sessions.filter { $0.status == .done && ($0.displaySummary ?? "").isEmpty }.count,
-            "note": "Current application snapshot. Only done tasks include summaries; earlier-turn summaries are omitted from running/waiting tasks. Summaries are bounded and not independent verification."], options: [.sortedKeys])
+            "endedWithoutResultCount": sessions.filter { $0.historyOnly != true && $0.status == .done && ($0.displaySummary ?? "").isEmpty }.count,
+            "note": "Current application snapshot. History-only rows are stored conversations with unknown live status; their summaries do not prove completion. Only done tasks include summaries; earlier-turn summaries are omitted from running/waiting tasks. Summaries are bounded and not independent verification."], options: [.sortedKeys])
         return data.map { String(decoding: $0, as: UTF8.self) } ?? "No readable session state."
     }
 
@@ -128,6 +129,7 @@ public enum VoicePrompt {
         for s in sessions {
             let status: String
             switch s.status {
+            case _ where s.historyOnly == true: status = "stored history; live status unknown; read only"
             case .needsResponse: status = s.waitKind == .permission ? "waiting for approval" : "waiting for your answer"
             case .working:       status = s.isStuck ? "stuck" : "working"
             case .done:          status = s.isStuck ? "failed" : "done"

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CopilotSessionReader.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CopilotSessionReader.swift
@@ -1,0 +1,139 @@
+import Foundation
+import SQLite3
+import VibeBuddyKit
+
+/// Wake-compatible Copilot CLI history. No lifecycle events or remote actions.
+/// Reads a private snapshot so even SQLite WAL/SHM bookkeeping never writes to
+/// Copilot's directory. A changed source during copying is retried next poll.
+public struct CopilotSessionReader: Sendable {
+    public let database: URL
+    private var stamp: [String]?
+    public init(database: URL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".copilot/session-store.db")) { self.database = database }
+
+    public struct Record: Equatable, Sendable {
+        public var session: AgentSession
+        public var output: RecentOutput
+    }
+    public enum ReadError: Error { case unreadable, changedDuringRead }
+
+    /// nil means unchanged; an empty array means a successfully read empty store.
+    public mutating func refresh() throws -> [Record]? {
+        let before = signature()
+        guard before != stamp else { return nil }
+        stamp = nil // failed reads must be retried, including return to a prior signature
+        guard FileManager.default.fileExists(atPath: database.path) else {
+            stamp = before
+            return []
+        }
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebuddy-copilot-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false,
+                                               attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let copy = directory.appendingPathComponent("history.sqlite")
+        for suffix in ["", "-wal"] {
+            let source = URL(fileURLWithPath: database.path + suffix)
+            if FileManager.default.fileExists(atPath: source.path) {
+                try FileManager.default.copyItem(at: source, to: URL(fileURLWithPath: copy.path + suffix))
+            }
+        }
+        guard signature() == before else { throw ReadError.changedDuringRead }
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(copy.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            sqlite3_close(db)
+            throw ReadError.unreadable
+        }
+        defer { sqlite3_close(db) }
+        sqlite3_busy_timeout(db, 250)
+        var statement: OpaquePointer?
+        let sql = """
+            SELECT s.id, s.cwd, s.branch, s.summary, s.created_at, s.updated_at,
+                   (SELECT substr(t.user_message,1,220) FROM turns t
+                    WHERE t.session_id=s.id AND trim(COALESCE(t.user_message,''))<>''
+                    ORDER BY t.turn_index LIMIT 1)
+            FROM sessions s WHERE EXISTS (SELECT 1 FROM turns t WHERE t.session_id=s.id)
+            ORDER BY s.updated_at DESC, s.id
+            """
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw ReadError.unreadable
+        }
+        defer { sqlite3_finalize(statement) }
+        var records: [Record] = []
+        var step = sqlite3_step(statement)
+        while step == SQLITE_ROW {
+            let nativeID = text(statement, 0)
+            if !nativeID.isEmpty {
+                let id = "copilot:\(nativeID)"
+                let updated = date(text(statement, 5)) ?? date(text(statement, 4)) ?? .distantPast
+                let summary = String(text(statement, 3).trimmingCharacters(in: .whitespacesAndNewlines).prefix(220))
+                var session = AgentSession(id: id, agent: .copilot, project: text(statement, 1),
+                    branch: optional(text(statement, 2)), status: .done,
+                    summary: optional(summary),
+                    name: optional(summary) ?? optional(text(statement, 6)),
+                    statusSince: updated, updatedAt: updated)
+                // .done is the existing wire representation for a quiet row;
+                // historyOnly makes clear that no live status was established.
+                session.historyOnly = true
+                records.append(Record(session: session,
+                    output: try output(db: db, nativeID: nativeID, id: id, updated: updated)))
+            }
+            step = sqlite3_step(statement)
+        }
+        guard step == SQLITE_DONE else { throw ReadError.unreadable }
+        stamp = before
+        return records
+    }
+
+    private func output(db: OpaquePointer?, nativeID: String, id: String, updated: Date) throws -> RecentOutput {
+        var statement: OpaquePointer?
+        // Fetch one extra turn to report truncation, bounding text in SQLite.
+        let sql = "SELECT substr(user_message,1,601), substr(assistant_response,1,601) FROM turns WHERE session_id=? ORDER BY turn_index DESC LIMIT 7"
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { throw ReadError.unreadable }
+        defer { sqlite3_finalize(statement) }
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        guard sqlite3_bind_text(statement, 1, nativeID, -1, transient) == SQLITE_OK else { throw ReadError.unreadable }
+        var turns: [[RecentOutputEntry]] = []
+        var truncated = false
+        var step = sqlite3_step(statement)
+        while step == SQLITE_ROW {
+            var entries: [RecentOutputEntry] = []
+            for (column, role) in [(Int32(0), "user"), (Int32(1), "assistant")] {
+                let value = text(statement, column)
+                if value.count > 600 { truncated = true }
+                if !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    entries.append(.init(role: role, text: String(value.prefix(600))))
+                }
+            }
+            turns.append(entries)
+            step = sqlite3_step(statement)
+        }
+        guard step == SQLITE_DONE else { throw ReadError.unreadable }
+        let entries = turns.reversed().flatMap { $0 }
+        return RecentOutput(sessionId: id, source: .transcript, updatedAt: updated,
+            truncated: truncated || turns.count > 6 || entries.count > 12,
+            entries: Array(entries.suffix(12)))
+    }
+
+    private func signature() -> [String] {
+        ["", "-wal"].map { suffix in
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: database.path + suffix) else { return "missing" }
+            return "\(attrs[.systemFileNumber] ?? ""):\(attrs[.size] ?? ""):\((attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0)"
+        }
+    }
+    private func text(_ statement: OpaquePointer?, _ column: Int32) -> String {
+        sqlite3_column_text(statement, column).map { String(cString: $0) } ?? ""
+    }
+    private func optional(_ text: String) -> String? { text.isEmpty ? nil : text }
+    private func date(_ value: String) -> Date? {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = iso.date(from: value) { return date }
+        if let date = ISO8601DateFormatter().date(from: value) { return date }
+        let sql = DateFormatter()
+        sql.locale = Locale(identifier: "en_US_POSIX")
+        sql.timeZone = TimeZone(secondsFromGMT: 0)
+        sql.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return sql.date(from: value)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -7,6 +7,29 @@ import VibeBuddyKit
 public actor SessionStore {
     private static let diagnosticStaleAfter: TimeInterval = 10 * 60
     private var reducer = SessionReducer()
+    private var copilotReader: CopilotSessionReader
+    private var copilotReadFailed = false
+    private var copilotHistory: [String: CopilotSessionReader.Record] = [:]
+
+    /// History bypasses the lifecycle reducer: imports never earn completion cues.
+    public func refreshCopilotHistory() {
+        do {
+            guard let records = try copilotReader.refresh() else { return }
+            let next = Dictionary(records.map { ($0.session.id, $0) }, uniquingKeysWith: { _, last in last })
+            let recovered = copilotReadFailed
+            copilotReadFailed = false
+            guard next != copilotHistory || recovered else { return }
+            copilotHistory = next
+            broadcast()
+        } catch {
+            if !copilotReadFailed {
+                copilotReadFailed = true
+                broadcast()
+            }
+            // Retain readable history through a transient lock or incompatible schema.
+            // A failed read never advances the scanner signature; the next poll retries.
+        }
+    }
     private var noticeLedger: CompletionNoticeLedger?
     private var noticeEnabled: (@Sendable () -> Bool)?
     private var noticeHandler: (@Sendable (AgentSession) async -> String?)?
@@ -121,8 +144,10 @@ public actor SessionStore {
         attentionURL: URL? = nil,
         missedURL: URL? = nil,
         grokHome: URL? = nil,
+        copilotDatabase: URL? = nil,
         now: Date = Date()
     ) {
+        self.copilotReader = copilotDatabase.map { CopilotSessionReader(database: $0) } ?? CopilotSessionReader()
         self.sourceID = sourceID
         self.staleAfter = staleAfter
         self.diagnosticsHome = diagnosticsHome
@@ -697,6 +722,17 @@ public actor SessionStore {
     /// from the reducer, allowance from beside it.
     private func currentSnapshot(now: Date) -> Snapshot {
         var snapshot = reducer.snapshot(now: now, observationDiagnostics: diagnostics(now: now))
+        snapshot.sessions += copilotHistory.values.map(\.session).sorted {
+            $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt > $1.updatedAt
+        }
+        if copilotReadFailed || !copilotHistory.isEmpty {
+            var diagnostics = snapshot.observationDiagnostics ?? []
+            diagnostics.removeAll { $0.agent == .copilot }
+            diagnostics.append(.init(agent: .copilot, sources: [.init(source: .transcript,
+                health: copilotReadFailed ? .sourceUnreadable : .healthy,
+                reasonCode: copilotReadFailed ? "copilotHistoryUnreadable" : "copilotHistoryOnly")]))
+            snapshot.observationDiagnostics = diagnostics
+        }
         snapshot.sourceID = sourceID
         snapshot.providerQuota = providerQuota.isEmpty ? nil : providerQuota
         let directories = recentDirectories()
@@ -763,6 +799,19 @@ public actor SessionStore {
         rolloutPath: String? = nil,
         appServerItems: [[String: Any]]? = nil
     ) -> RecentOutput {
+        if let record = copilotHistory[sessionID] {
+            if copilotReadFailed {
+                return .unavailable(sessionId: sessionID, reason: .unreadable,
+                    source: .transcript, updatedAt: record.output.updatedAt)
+            }
+            let entries = record.output.entries.suffix(max(0, min(limit, 12)))
+            let clipped = entries.map { RecentOutputEntry(role: $0.role,
+                text: String($0.text.prefix(max(0, min(perEntryLimit, 600))))) }
+            return RecentOutput(sessionId: sessionID, source: .transcript,
+                updatedAt: record.output.updatedAt,
+                truncated: record.output.truncated || entries.count < record.output.entries.count
+                    || zip(entries, clipped).contains { $0.text != $1.text }, entries: clipped)
+        }
         guard let session = reducer.sessions[sessionID] else {
             return .unavailable(sessionId: sessionID, reason: .unknownSession)
         }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -153,6 +153,14 @@ public struct VibeBuddyServer: Sendable {
     }
 
     public func runService() async throws {
+        await store.refreshCopilotHistory()
+        let historyTask = Task {
+            while !Task.isCancelled {
+                do { try await Task.sleep(for: .seconds(5)) } catch { break }
+                await store.refreshCopilotHistory()
+            }
+        }
+        defer { historyTask.cancel() }
         let monitorTask = codexRolloutMonitor.map { monitor in
             Task { await monitor.run(store: store) }
         }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CopilotHistoryTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CopilotHistoryTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SQLite3
+import Testing
+import Hummingbird
+import HummingbirdTesting
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+@Suite("Copilot read-only history")
+struct CopilotHistoryTests {
+    @Test("WAL updates, empty sessions, bounded dialogue and quiet snapshot round-trip")
+    func history() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let database = root.appendingPathComponent("session-store.db")
+        var db: OpaquePointer?
+        #expect(sqlite3_open(database.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        func execute(_ sql: String) throws {
+            guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+                throw CopilotSessionReader.ReadError.unreadable
+            }
+        }
+        try execute("""
+            PRAGMA journal_mode=WAL;
+            PRAGMA wal_autocheckpoint=0;
+            CREATE TABLE sessions(id TEXT PRIMARY KEY,cwd TEXT,branch TEXT,summary TEXT,created_at TEXT,updated_at TEXT);
+            CREATE TABLE turns(id INTEGER PRIMARY KEY,session_id TEXT,turn_index INTEGER,user_message TEXT,assistant_response TEXT,timestamp TEXT);
+            INSERT INTO sessions VALUES('s','/tmp/copilot-project','main',NULL,'2026-09-12 01:00:00','2026-09-12 01:01:00');
+            INSERT INTO sessions VALUES('empty','/tmp/empty',NULL,NULL,NULL,NULL);
+            INSERT INTO turns VALUES(1,'s',0,'Inspect this project','Initial reply','2026-09-12 01:01:00');
+            """)
+        let original = try Data(contentsOf: database)
+        let store = SessionStore(copilotDatabase: database)
+        await store.refreshCopilotHistory()
+        let snapshot = await store.snapshot(now: Date())
+        let session = try #require(snapshot.sessions.first)
+        #expect(snapshot.sessions.count == 1)
+        #expect(session.id == "copilot:s")
+        #expect(session.name == "Inspect this project")
+        #expect(session.branch == "main")
+        #expect(session.historyOnly == true)
+        #expect(session.presentationState == .idle)
+        #expect(!session.hasUnreadCompletion && session.completionID == nil)
+        #expect(!SessionActionSupport.resolve(for: session).isAvailable)
+        #expect(!session.canJump)
+        #expect(ToolActivity.label(for: session) == "History · read only")
+        #expect(VoicePrompt.sessionContext([session]).contains("\"status\":\"unknown\""))
+        #expect(VoicePrompt.systemPrompt(sessions: [session]).contains("live status unknown"))
+        let decoded = try JSONDecoder().decode(Snapshot.self, from: JSONEncoder().encode(snapshot))
+        #expect(decoded.sessions.first?.historyOnly == true)
+        let output = await store.recentOutput(sessionID: session.id)
+        #expect(output.entries.map(\.text) == ["Inspect this project", "Initial reply"])
+        #expect(try Data(contentsOf: database) == original)
+        // Writes stay in WAL; the main database does not change.
+        try execute("UPDATE turns SET assistant_response='Changed reply' WHERE id=1")
+        await store.refreshCopilotHistory()
+        #expect(await store.recentOutput(sessionID: session.id).entries.last?.text == "Changed reply")
+        #expect(try Data(contentsOf: database) == original)
+        // Reproduce same-size rewrites in one second; Date descriptions lose
+        // these fractions, so this locks down the scanner signature regression.
+        try execute("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;")
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 1_800_000_000.1)], ofItemAtPath: database.path)
+        await store.refreshCopilotHistory()
+        let size = try FileManager.default.attributesOfItem(atPath: database.path)[.size] as? NSNumber
+        try execute("UPDATE turns SET assistant_response='Another reply' WHERE id=1")
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 1_800_000_000.9)], ofItemAtPath: database.path)
+        #expect(try FileManager.default.attributesOfItem(atPath: database.path)[.size] as? NSNumber == size)
+        await store.refreshCopilotHistory()
+        #expect(await store.recentOutput(sessionID: session.id).entries.last?.text == "Another reply")
+        for index in 1...8 {
+            try execute("INSERT INTO turns VALUES(\(index+1),'s',\(index),'Question \(index)','\(String(repeating: "x", count: 650))',NULL)")
+        }
+        await store.refreshCopilotHistory()
+        let bounded = await store.recentOutput(sessionID: session.id)
+        #expect(bounded.truncated && bounded.entries.count == 12)
+        #expect(bounded.entries.allSatisfy { $0.text.count <= 600 })
+        await store.sweep(now: Date().addingTimeInterval(24*3600))
+        #expect(await store.snapshot(now: Date()).sessions.count == 1)
+        let server = VibeBuddyServer(store: store, token: "copilot-test-token")
+        try await server.buildApplication().test(.live) { client in
+            try await client.execute(uri: "/recent-output?sessionId=copilot:s", method: .get,
+                headers: [.authorization: "Bearer copilot-test-token"]) { response in
+                #expect(response.status == .ok)
+                let wire = try JSONDecoder().decode(RecentOutput.self, from: Data(buffer: response.body))
+                #expect(wire.entries == bounded.entries)
+            }
+        }
+        try execute("DELETE FROM turns")
+        await store.refreshCopilotHistory()
+        #expect(await store.snapshot(now: Date()).sessions.isEmpty)
+    }
+
+    @Test("Missing store is empty; incompatible schema can recover")
+    func recovery() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let db = root.appendingPathComponent("session-store.db")
+        var reader = CopilotSessionReader(database: db)
+        #expect(try reader.refresh() == [])
+        try Data("bad database".utf8).write(to: db)
+        #expect(throws: (any Error).self) { try reader.refresh() }
+        try FileManager.default.removeItem(at: db)
+        #expect(try reader.refresh() == [])
+    }
+}

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -401,7 +401,7 @@ private struct DetailCard: View {
             }
             HStack(spacing: 6) {
                 Image(systemName: session.presentationState.symbolName).font(.system(size: 10, weight: .bold))
-                Text(session.presentationState.label)
+                Text(session.statusLabel)
             }
             .font(MacTheme.font(12, .heavy))
             .foregroundStyle(MacTheme.status(session.presentationState))

--- a/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
+++ b/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
@@ -867,9 +867,9 @@ struct MenuContent: View {
         }
         .buttonStyle(.plain)
         .onHover { hoveredSessionID = $0 ? session.id : nil }
-        .help("\(session.displayTitle)\n\(session.agent.displayName) · \(session.presentationState.label)\n\(session.summary ?? "")")
+        .help("\(session.displayTitle)\n\(session.agent.displayName) · \(session.statusLabel)\n\(session.summary ?? "")")
         .accessibilityLabel(Text(verbatim: session.displayTitle))
-        .accessibilityValue(Text(verbatim: session.summary ?? session.presentationState.label))
+        .accessibilityValue(Text(verbatim: session.summary ?? session.statusLabel))
         .accessibilityHint("Jump to this session")
     }
 
@@ -880,7 +880,7 @@ struct MenuContent: View {
             .font(MacTheme.font(12.5, .semibold))
             .foregroundColor(MacTheme.ink)
         let detail = session.summary.flatMap { $0.isEmpty ? nil : Text(verbatim: $0) }
-            ?? Text(LocalizedStringKey(session.presentationState.label))
+            ?? Text(LocalizedStringKey(session.statusLabel))
         return title + Text(verbatim: "  ")
             + detail.font(MacTheme.font(12.5)).foregroundColor(MacTheme.ink2)
     }

--- a/docs/multi-cli-hook-setup.md
+++ b/docs/multi-cli-hook-setup.md
@@ -36,7 +36,7 @@ The CLI pipes its event JSON on stdin. VibeBuddy reads `hook_event_name`,
 | Kimi | `kimi` | `~/.kimi/config.toml` | TOML hooks | ⚠️ template |
 | Antigravity (Gemini) | `antigravity` | `~/.gemini/antigravity-cli/hooks.json` | JSON `command` hooks | blocked: `agy` 1.0.5 loads but skips execution |
 | Grok Build | `grok` | `~/.grok/hooks/vibebuddy.json` | JSON `command` hooks (camelCase envelope) | ✅ tested (1.0.13) |
-| GitHub Copilot | `copilot` | — | observe mode (no hooks) | ⚠️ partial |
+| GitHub Copilot CLI | `copilot` | `~/.copilot/session-store.db` | read-only session history | history only |
 
 ✅ = wired and exercised. ⚠️ template = the source routing + display are done in
 the app; the config snippet below needs validation against the installed CLI.
@@ -63,8 +63,15 @@ workspace.
 
 Other hook-compatible CLIs (OpenCode, Qwen) follow the same shape with
 `agent=<their source>`. Kimi uses its TOML hook table; Antigravity uses
-a Gemini plugin that shells out to the same curl. Copilot has no hook surface
-yet — it appears once a future watcher observes it.
+a Gemini plugin that shells out to the same curl. Copilot CLI is integrated
+through its local history database, following [Wake's adapter](https://github.com/iAmCorey/Wake/blob/main/crates/wake-core/src/adapters/copilot.rs).
+The Mac reads sessions with turns, their project/branch/title, and the latest
+12 dialogue entries (600 characters each). It checks database and WAL changes
+every five seconds, using a private temporary copy and never changing Copilot files.
+Rows are marked **History · read only**; no live task state, completion alert,
+remote approval, reply, resume, or quota is inferred. A CLI installation with no
+stored turns contributes no rows. Full-history indexing is not part of this
+bounded dashboard integration.
 
 #### Remote approval (`--approval`)
 
@@ -256,4 +263,4 @@ e.g. `# vibebuddy: managed, do not remove`, and uninstall does
 - [ ] `--install/--uninstall` that detects installed CLIs and writes/strips
       marked hooks (Claude/Codex first, then the templates above)
 - [ ] Per-CLI event-shape validation against the real tools
-- [ ] Copilot observe-mode watcher
+- [x] Copilot CLI read-only history (Wake database format; no lifecycle monitoring)


### PR DESCRIPTION
Copilot CLI conversations now appear as read-only history by reading its local `session-store.db`, following Wake's sessions/turns format. The Mac checks database and WAL changes every five seconds and shows project, branch, title and bounded recent dialogue without modifying Copilot files.

History bypasses lifecycle reduction: it does not create completion alerts, infer live status or enable remote actions. UI and voice context identify stored history explicitly; failed reads retain existing rows with an unavailable-source diagnostic and retry automatically.

Validation: Mac app and daemon builds passed; 8 focused Mac tests and 61 Kit tests passed. An isolated daemon exercised automatic import, HTTP dialogue reads and WAL refresh against a private copy of the real schema with sample turns; the original database hash was unchanged. The local real database contains no turns, so a real nonempty Copilot conversation remains unverified. The patch was reapplied without conflicts to current main; its patch ID is unchanged. Builds/tests preceded that reapplication.
