### PR TITLE
feat: add Mac session history workbench

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryResumePolicy.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryResumePolicy.swift
@@ -6,7 +6,7 @@ public enum HistoryResumePolicy {
     public static func liveSession(for history: SessionHistorySession, in sessions: [AgentSession]) -> AgentSession? {
         guard history.projectPath.hasPrefix("/"), !history.nativeSessionID.isEmpty else { return nil }
         let matches = sessions.filter {
-            $0.historyOnly != true && $0.id == history.nativeSessionID &&
+            $0.id == history.nativeSessionID &&
             $0.agent == (history.agent == .claude ? .claudeCode : .codex) &&
             $0.terminalRef?.cwd == history.projectPath
         }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryResumePolicy.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryResumePolicy.swift
@@ -1,0 +1,30 @@
+import Foundation
+import VibeBuddyKit
+
+/// Archive metadata never grants live control or starts a process.
+public enum HistoryResumePolicy {
+    public static func liveSession(for history: SessionHistorySession, in sessions: [AgentSession]) -> AgentSession? {
+        guard history.projectPath.hasPrefix("/"), !history.nativeSessionID.isEmpty else { return nil }
+        let matches = sessions.filter {
+            $0.historyOnly != true && $0.id == history.nativeSessionID &&
+            $0.agent == (history.agent == .claude ? .claudeCode : .codex) &&
+            $0.terminalRef?.cwd == history.projectPath
+        }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    /// A command for explicit copying only. Codex archive records currently do
+    /// not establish CLI versus Desktop provenance, so they have no command.
+    public static func command(for history: SessionHistorySession, directoryExists: Bool) -> String? {
+        guard history.agent == .claude, history.isAvailable, directoryExists,
+              UUID(uuidString: history.nativeSessionID) != nil,
+              history.projectPath.hasPrefix("/"),
+              !history.projectPath.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) })
+        else { return nil }
+        return "cd -- \(quote(history.projectPath)) && claude --resume \(quote(history.nativeSessionID))"
+    }
+
+    private static func quote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryModels.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryModels.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public enum SessionHistoryAgent: String, Codable, Sendable, CaseIterable {
+    case claude, codex
+    public var displayName: String { self == .claude ? "Claude Code" : "Codex" }
+}
+public enum SessionHistoryRole: String, Codable, Sendable { case user, assistant, tool, system }
+public struct SessionHistoryMessage: Identifiable, Codable, Sendable, Equatable {
+    public var id: String
+    public var role: SessionHistoryRole
+    public var text: String
+    public var timestamp: Date?
+    public var toolName: String?
+    public init(id: String, role: SessionHistoryRole, text: String, timestamp: Date? = nil, toolName: String? = nil) {
+        self.id = id; self.role = role; self.text = text; self.timestamp = timestamp; self.toolName = toolName
+    }
+}
+public struct SessionHistorySession: Identifiable, Codable, Sendable, Equatable {
+    public var id: String
+    public var nativeSessionID: String
+    public var agent: SessionHistoryAgent
+    public var projectPath: String
+    public var title: String
+    public var sourcePath: String
+    public var updatedAt: Date
+    /// Empty in repository snapshots; use repository.session(id:) for the selected transcript.
+    public var messages: [SessionHistoryMessage]
+    /// Indexed readable message count, independent of whether content is loaded.
+    public var messageCount: Int
+    public var warnings: [String]
+    public var isFavorite: Bool
+    public var isAvailable: Bool
+    public init(id: String, nativeSessionID: String, agent: SessionHistoryAgent, projectPath: String, title: String, sourcePath: String, updatedAt: Date, messages: [SessionHistoryMessage], warnings: [String] = [], isFavorite: Bool = false, isAvailable: Bool = true) {
+        self.id = id; self.nativeSessionID = nativeSessionID; self.agent = agent; self.projectPath = projectPath
+        self.title = title; self.sourcePath = sourcePath; self.updatedAt = updatedAt; self.messages = messages; self.messageCount = messages.count
+        self.warnings = warnings; self.isFavorite = isFavorite; self.isAvailable = isAvailable
+    }
+}
+public struct SessionHistorySnapshot: Sendable {
+    public var sessions: [SessionHistorySession]
+    public var issues: [String]
+    public var refreshedAt: Date?
+    public init(sessions: [SessionHistorySession] = [], issues: [String] = [], refreshedAt: Date? = nil) {
+        self.sessions = sessions; self.issues = issues; self.refreshedAt = refreshedAt
+    }
+}
+public struct SessionHistorySearchResult: Identifiable, Sendable {
+    public var sessionID: String
+    public var messageID: String
+    public var excerpt: String
+    public var id: String { sessionID + "|" + messageID }
+}
+public enum SessionHistoryExport {
+    public static func markdown(session: SessionHistorySession) -> String {
+        var output = "# \(session.title)\n\nAgent: \(session.agent.displayName)\n\nSession: \(session.nativeSessionID)\n\nProject: \(session.projectPath)\n\nSource: \(session.sourcePath)\n\n"
+        if !session.isAvailable { output += "> Source unavailable; cached history.\n\n" }
+        for warning in session.warnings { output += "> \(warning)\n\n" }
+        for message in session.messages {
+            output += "## \(message.role.rawValue.capitalized)\(message.toolName.map { " — " + $0 } ?? "")\n\n"
+            if message.role == .tool {
+                let fence = String(repeating: "`", count: max(3, message.text.split(whereSeparator: { $0 != "`" }).map(\.count).max().map { $0 + 1 } ?? 3))
+                output += fence + "text\n" + message.text + "\n" + fence + "\n\n"
+            } else { output += message.text + "\n\n" }
+        }
+        return output
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryParser.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryParser.swift
@@ -1,0 +1,143 @@
+import Foundation
+import CryptoKit
+
+/// Reads only the transcript selected by the repository. Never invokes an agent.
+enum SessionHistoryParser {
+    static let byteLimit = 32 * 1024 * 1024
+    static func read(url: URL, agent: SessionHistoryAgent, updatedAt: Date) throws -> SessionHistorySession {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: byteLimit + 1) ?? Data()
+        var warnings: [String] = []
+        var content = data
+        if content.count > byteLimit {
+            content = content.prefix(byteLimit)
+            if let end = content.lastIndex(of: 10) { content = content.prefix(through: end) }
+            warnings.append("Partial history: source exceeds the 32 MiB reading limit.")
+        }
+        let iso = ISO8601DateFormatter()
+        let fractional = ISO8601DateFormatter(); fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var nativeID = url.deletingPathExtension().lastPathComponent
+        var cwd = ""
+        var messages: [SessionHistoryMessage] = []
+        var fallback: [SessionHistoryMessage] = []
+        var seen = Set<String>()
+        var order: [String: Int] = [:]
+        var occurrences: [String: Int] = [:]
+        var malformed = 0
+        var omitted = 0
+        func stamp(_ value: Any?) -> Date? { guard let text = value as? String else { return nil }; return fractional.date(from: text) ?? iso.date(from: text) }
+        func string(_ value: Any?) -> String {
+            if let text = value as? String { return text }
+            guard let value, JSONSerialization.isValidJSONObject(value), let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]), let text = String(data: data, encoding: .utf8) else { return "" }
+            return text
+        }
+        func textBlocks(_ value: Any?) -> String {
+            if let text = value as? String { return text }
+            return (value as? [[String: Any]] ?? []).compactMap { block in
+                if let text = block["text"] as? String { return text }
+                if ["image", "input_image"].contains(block["type"] as? String ?? "") { omitted += 1; return "[Image attachment not rendered]" }
+                return nil
+            }.joined(separator: "\n\n")
+        }
+        for (lineNumber, line) in content.split(separator: 10).enumerated() {
+            guard let root = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any] else { malformed += 1; continue }
+            if agent == .claude, root["isSidechain"] as? Bool == true { omitted += 1; continue }
+            let date = stamp(root["timestamp"])
+            let type = root["type"] as? String ?? ""
+            if let path = root["cwd"] as? String { cwd = path }
+            if agent == .claude, let id = root["sessionId"] as? String { nativeID = id }
+            func append(_ role: SessionHistoryRole, _ text: String, _ suffix: String, _ tool: String? = nil, fallbackOnly: Bool = false) {
+                guard !text.isEmpty else { return }
+                let material = role.rawValue + "\u{0}" + (tool ?? "") + "\u{0}" + suffix + "\u{0}" + text
+                let digest = SHA256.hash(data: Data(material.utf8)).map { String(format: "%02x", $0) }.joined()
+                let key: String
+                if let uuid = root["uuid"] as? String {
+                    key = uuid + ":" + suffix + ":" + digest
+                } else {
+                    let ordinal = occurrences[digest, default: 0]
+                    occurrences[digest] = ordinal + 1
+                    key = "content:" + digest + ":" + String(ordinal)
+                }
+                guard seen.insert(key).inserted else { return }
+                let bounded = String(text.prefix(128 * 1024))
+                if bounded.count < text.count { omitted += 1 }
+                order[key] = lineNumber
+                let message = SessionHistoryMessage(id: key, role: role, text: bounded, timestamp: date, toolName: tool)
+                if fallbackOnly { fallback.append(message) } else { messages.append(message) }
+            }
+            if agent == .claude {
+                guard let body = root["message"] as? [String: Any], let role = SessionHistoryRole(rawValue: body["role"] as? String ?? type) else { continue }
+                if let blocks = body["content"] as? [[String: Any]] {
+                    for (index, block) in blocks.enumerated() {
+                        switch block["type"] as? String {
+                        case "text": append(role, block["text"] as? String ?? "", "\(index)")
+                        case "tool_use": append(.tool, string(block["input"]), "\(index)", block["name"] as? String)
+                        case "tool_result": append(.tool, textBlocks(block["content"]), "\(index)", "Result")
+                        case "thinking", "redacted_thinking": omitted += 1
+                        case "image": append(role, "[Image attachment not rendered]", "\(index)"); omitted += 1
+                        default: omitted += 1
+                        }
+                    }
+                } else { append(role, textBlocks(body["content"]), "0") }
+            } else if let body = root["payload"] as? [String: Any] {
+                if type == "session_meta" {
+                    nativeID = body["id"] as? String ?? nativeID
+                    cwd = body["cwd"] as? String ?? cwd
+                } else if type == "turn_context", cwd.isEmpty { cwd = body["cwd"] as? String ?? cwd }
+                else if type == "response_item" {
+                    switch body["type"] as? String {
+                    case "message":
+                        if let role = SessionHistoryRole(rawValue: body["role"] as? String ?? "") {
+                            if body["channel"] as? String == "analysis" { omitted += 1 }
+                            else { append(role, textBlocks(body["content"]), "message") }
+                        }
+                    case "function_call", "custom_tool_call", "local_shell_call", "mcp_tool_call":
+                        append(.tool, string(body["arguments"] ?? body["input"] ?? body["action"] ?? "[Tool call]"), "call", body["name"] as? String ?? "Tool")
+                    case "function_call_output", "custom_tool_call_output": append(.tool, string(body["output"]), "output", "Result")
+                    case "reasoning": omitted += 1
+                    default: omitted += 1
+                    }
+                } else if type == "event_msg" {
+                    let event = body["type"] as? String
+                    if event == "user_message" || event == "agent_message" {
+                        append(event == "user_message" ? .user : .assistant, body["message"] as? String ?? "", "event", fallbackOnly: true)
+                    }
+                }
+            }
+        }
+        // Pair only neighboring semantic messages. A global text count can consume
+        // an older, event-only "continue" when a later turn has a canonical mirror.
+        if !fallback.isEmpty {
+            var paired = Set<String>()
+            let eventIDs = Set(fallback.map(\.id))
+            let semantic = (messages + fallback).filter { $0.role == .user || $0.role == .assistant }
+                .sorted { order[$0.id, default: 0] < order[$1.id, default: 0] }
+            for (index, canonical) in semantic.enumerated() where !eventIDs.contains(canonical.id) {
+                let canonicalLine = order[canonical.id, default: 0]
+                let candidates = [index - 1, index + 1].compactMap { neighbor -> SessionHistoryMessage? in
+                    guard semantic.indices.contains(neighbor) else { return nil }
+                    let event = semantic[neighbor]
+                    guard eventIDs.contains(event.id), !paired.contains(event.id), event.role == canonical.role, event.text == canonical.text else { return nil }
+                    let eventLine = order[event.id, default: 0]
+                    if let a = canonical.timestamp, let b = event.timestamp {
+                        guard abs(a.timeIntervalSince(b)) <= 5 else { return nil }
+                    } else if abs(eventLine - canonicalLine) > 12 { return nil }
+                    return event
+                }
+                if candidates.count == 2,
+                   abs(order[candidates[0].id, default: 0] - canonicalLine) == abs(order[candidates[1].id, default: 0] - canonicalLine) { continue }
+                if let mirror = candidates.min(by: {
+                    abs(order[$0.id, default: 0] - canonicalLine) < abs(order[$1.id, default: 0] - canonicalLine)
+                }) { paired.insert(mirror.id) }
+            }
+            messages.append(contentsOf: fallback.filter { !paired.contains($0.id) })
+            messages.sort { order[$0.id, default: 0] < order[$1.id, default: 0] }
+        }
+        if malformed > 0 { warnings.append("Partial history: \(malformed) malformed or incomplete JSONL records.") }
+        if omitted > 0 { warnings.append("\(omitted) reasoning, attachment, unsupported or oversized blocks omitted/abbreviated.") }
+        if messages.isEmpty { warnings.append("No readable messages in this source.") }
+        let title = messages.first(where: { $0.role == .user })?.text.components(separatedBy: .newlines).first ?? nativeID
+        return SessionHistorySession(id: agent.rawValue + ":" + nativeID, nativeSessionID: nativeID, agent: agent, projectPath: cwd, title: String(title.prefix(120)), sourcePath: url.path, updatedAt: updatedAt, messages: messages, warnings: warnings)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -1,0 +1,167 @@
+import Foundation
+import CryptoKit
+
+/// Local history is a read-only projection, independent of the live Session reducer.
+public actor SessionHistoryRepository {
+    private struct Entry: Codable { var modified: Date; var size: Int; var session: SessionHistorySession }
+    private struct Cache: Codable { var version: Int = 4; var entries: [String: Entry]; var pendingPaths: Set<String>? = nil }
+    private let roots: [(URL, SessionHistoryAgent)]
+    private let directory: URL
+    private let refreshByteBudget: Int
+    private var entries: [String: Entry] = [:]
+    private var favorites = Set<String>()
+    private var issues: [String] = []
+    private var refreshedAt: Date?
+    private var pendingPaths = Set<String>()
+    private var loaded = false
+    private var indexDirty = false
+    public init(claudeHome: URL? = nil, codexHome: URL? = nil, cacheDirectory: URL? = nil, refreshByteBudget: Int = 256 * 1024 * 1024) {
+        self.refreshByteBudget = max(1, refreshByteBudget)
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let env = ProcessInfo.processInfo.environment
+        let claude = claudeHome ?? env["CLAUDE_CONFIG_DIR"].map { URL(fileURLWithPath: $0) } ?? home.appendingPathComponent(".claude")
+        let codex = codexHome ?? env["CODEX_HOME"].map { URL(fileURLWithPath: $0) } ?? home.appendingPathComponent(".codex")
+        roots = [(claude.appendingPathComponent("projects").resolvingSymlinksInPath(), .claude), (codex.appendingPathComponent("sessions").resolvingSymlinksInPath(), .codex), (codex.appendingPathComponent("archived_sessions").resolvingSymlinksInPath(), .codex)]
+        directory = cacheDirectory ?? home.appendingPathComponent("Library/Application Support/VibeBuddy/SessionHistory")
+    }
+    private func ensureLoaded() {
+        guard !loaded else { return }
+        loaded = true
+        if let data = try? Data(contentsOf: directory.appendingPathComponent("favorites.json")), let decoded = try? JSONDecoder().decode(Set<String>.self, from: data) { favorites = decoded }
+        if let data = try? Data(contentsOf: directory.appendingPathComponent("index.json")), let cache = try? JSONDecoder().decode(Cache.self, from: data), cache.version == 4 {
+            // Never reuse another configured source home's cached content.
+            let configuredRoots = roots
+            entries = cache.entries.filter { path, _ in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } }
+            pendingPaths = cache.pendingPaths ?? []
+        }
+    }
+    public func snapshot() -> SessionHistorySnapshot {
+        ensureLoaded()
+        var byID: [String: SessionHistorySession] = [:]
+        for entry in entries.values {
+            var session = entry.session; session.isFavorite = favorites.contains(session.id)
+            if let existing = byID[session.id], existing.isAvailable && (!session.isAvailable || existing.updatedAt >= session.updatedAt) { continue }
+            byID[session.id] = session
+        }
+        return SessionHistorySnapshot(sessions: byID.values.sorted { $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt > $1.updatedAt }, issues: issues, refreshedAt: refreshedAt)
+    }
+    public func refresh(rebuild: Bool = false) throws -> SessionHistorySnapshot {
+        ensureLoaded()
+        let fm = FileManager.default
+        issues = []
+        var changed = rebuild
+        var cacheFailure: Error?
+        var discovered = Set<String>()
+        var totalBytes = 0
+        var pendingCount = 0
+        var excludedChildren = 0
+        if rebuild { pendingPaths.formUnion(entries.keys) }
+        for (root, agent) in roots {
+            guard fm.fileExists(atPath: root.path) else { issues.append("Source directory unavailable: \(root.path)"); continue }
+            var enumerationErrors = 0
+            guard let iterator = fm.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey, .contentModificationDateKey], options: [.skipsHiddenFiles], errorHandler: { _, _ in enumerationErrors += 1; return true }) else {
+                issues.append("Unable to enumerate source: \(root.path)"); continue
+            }
+            for case let file as URL in iterator {
+                if agent == .claude, file.lastPathComponent == "subagents" { iterator.skipDescendants(); excludedChildren += 1; continue }
+                guard file.pathExtension == "jsonl" else { continue }
+                if agent == .claude, file.lastPathComponent.hasPrefix("agent-") { excludedChildren += 1; continue }
+                do {
+                    let values = try file.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey, .contentModificationDateKey])
+                    guard values.isRegularFile == true, values.isSymbolicLink != true else { continue }
+                    discovered.insert(file.path)
+                    let size = values.fileSize ?? 0
+                    let modified = values.contentModificationDate ?? .distantPast
+                    if !pendingPaths.contains(file.path), let cached = entries[file.path], cached.modified == modified, cached.size == size, cached.session.isAvailable { continue }
+                    if totalBytes > 0 && totalBytes + min(size, SessionHistoryParser.byteLimit) > refreshByteBudget {
+                        pendingPaths.insert(file.path)
+                        pendingCount += 1
+                        continue
+                    }
+                    totalBytes += min(size, SessionHistoryParser.byteLimit)
+                    entries[file.path] = try autoreleasepool {
+                        var session = try SessionHistoryParser.read(url: file, agent: agent, updatedAt: modified)
+                        do { try save(session, name: contentFilename(file.path)) } catch { cacheFailure = error; throw error }
+                        session.messages = []
+                        return Entry(modified: modified, size: size, session: session)
+                    }
+                    pendingPaths.remove(file.path)
+                    changed = true
+                } catch {
+                    issues.append("Unreadable history source: \(file.path)")
+                    if var cached = entries[file.path], cached.session.isAvailable { cached.session.isAvailable = false; entries[file.path] = cached; changed = true }
+                }
+            }
+            if enumerationErrors > 0 { issues.append("Partial coverage: \(enumerationErrors) inaccessible paths in \(root.path).") }
+        }
+        for path in entries.keys where !discovered.contains(path) {
+            // Retain a cached transcript for provenance/favorites, but never claim its source is available.
+            if entries[path]?.session.isAvailable == true { entries[path]?.session.isAvailable = false; changed = true }
+        }
+        if excludedChildren > 0 { issues.append("Scope: \(excludedChildren) Claude child-session directories/files excluded from parent history.") }
+        if pendingCount > 0 { issues.append("Indexing: \(pendingCount) sources pending; refresh continues the next bounded batch.") }
+        refreshedAt = Date()
+        indexDirty = indexDirty || changed
+        if let cacheFailure { throw cacheFailure }
+        if indexDirty {
+            try save(Cache(entries: entries, pendingPaths: pendingPaths), name: "index.json")
+            indexDirty = false
+        }
+        return snapshot()
+    }
+    /// Snapshots retain metadata only; load the selected transcript off the main actor.
+    public func session(id: String) throws -> SessionHistorySession? {
+        guard let metadata = snapshot().sessions.first(where: { $0.id == id }) else { return nil }
+        return try load(metadata)
+    }
+    private func load(_ metadata: SessionHistorySession) throws -> SessionHistorySession {
+        let data = try Data(contentsOf: directory.appendingPathComponent(contentFilename(metadata.sourcePath)))
+        var full = try JSONDecoder().decode(SessionHistorySession.self, from: data)
+        guard full.id == metadata.id, full.sourcePath == metadata.sourcePath else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        full.isFavorite = metadata.isFavorite
+        full.isAvailable = metadata.isAvailable && FileManager.default.isReadableFile(atPath: metadata.sourcePath)
+        return full
+    }
+    private func contentFilename(_ path: String) -> String {
+        SHA256.hash(data: Data(path.utf8)).map { String(format: "%02x", $0) }.joined() + ".json"
+    }
+    public func setFavorite(sessionID: String, isFavorite: Bool) throws {
+        ensureLoaded()
+        var next = favorites
+        if isFavorite { next.insert(sessionID) } else { next.remove(sessionID) }
+        try save(next, name: "favorites.json")
+        favorites = next
+    }
+    public func search(_ query: String, projectPath: String? = nil, favoritesOnly: Bool = false, limit: Int = 200) throws -> [SessionHistorySearchResult] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty, limit > 0 else { return [] }
+        var results: [SessionHistorySearchResult] = []
+        for session in snapshot().sessions {
+            try Task.checkCancellation()
+            guard projectPath == nil || session.projectPath == projectPath, !favoritesOnly || session.isFavorite else { continue }
+            let reachedLimit = try autoreleasepool {
+                let full = try load(session)
+                for (index, message) in full.messages.enumerated() {
+                    if index.isMultiple(of: 64) { try Task.checkCancellation() }
+                    guard let range = message.text.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive]) else { continue }
+                    let start = message.text.index(range.lowerBound, offsetBy: -70, limitedBy: message.text.startIndex) ?? message.text.startIndex
+                    let end = message.text.index(range.upperBound, offsetBy: 130, limitedBy: message.text.endIndex) ?? message.text.endIndex
+                    results.append(SessionHistorySearchResult(sessionID: session.id, messageID: message.id, excerpt: String(message.text[start..<end])))
+                    if results.count >= limit { return true }
+                }
+                return false
+            }
+            if reachedLimit { return results }
+        }
+        return results
+    }
+    private func save<T: Encodable>(_ value: T, name: String) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        let file = directory.appendingPathComponent(name)
+        try JSONEncoder().encode(value).write(to: file, options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryResumePolicyTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryResumePolicyTests.swift
@@ -44,7 +44,7 @@ struct HistoryResumePolicyTests {
         live.terminalRef = nil
         #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == nil)
         live.terminalRef = TerminalRef(cwd: item.projectPath)
-        live.historyOnly = true
+        live.agent = .codex
         #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == nil)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryResumePolicyTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryResumePolicyTests.swift
@@ -34,7 +34,7 @@ struct HistoryResumePolicyTests {
     }
 
     @Test func resolvesOnlyUniqueExactLiveIdentity() {
-        let item = history()
+        var item = history()
         var live = AgentSession(id: item.nativeSessionID, agent: .claudeCode, project: "project", status: .done,
                                 terminalRef: TerminalRef(cwd: item.projectPath), statusSince: Date(), updatedAt: Date())
         #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == live)
@@ -44,7 +44,7 @@ struct HistoryResumePolicyTests {
         live.terminalRef = nil
         #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == nil)
         live.terminalRef = TerminalRef(cwd: item.projectPath)
-        live.agent = .codex
+        item.agent = .codex
         #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == nil)
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryResumePolicyTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryResumePolicyTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+@Suite("Historical session action boundaries")
+struct HistoryResumePolicyTests {
+    private func history() -> SessionHistorySession {
+        SessionHistorySession(id: "claude:test", nativeSessionID: "019c6e27-e55b-73d1-87d8-4e01f1f75043", agent: .claude,
+                              projectPath: "/tmp/project", title: "Example", sourcePath: "/tmp/source.jsonl",
+                              updatedAt: Date(), messages: [])
+    }
+
+    @Test func commandQuotesShellMetacharactersWithoutExecuting() {
+        var item = history()
+        item.projectPath = "/tmp/a'b $(touch unwanted) `echo nope`"
+        #expect(HistoryResumePolicy.command(for: item, directoryExists: true) ==
+                "cd -- '/tmp/a'\"'\"'b $(touch unwanted) `echo nope`' && claude --resume '019c6e27-e55b-73d1-87d8-4e01f1f75043'")
+        item.projectPath = "/tmp/a\ncommand"
+        #expect(HistoryResumePolicy.command(for: item, directoryExists: true) == nil)
+    }
+
+    @Test func refusesMissingSourcesDirectoriesAndUnknownCodexProvenance() {
+        var item = history()
+        #expect(HistoryResumePolicy.command(for: item, directoryExists: false) == nil)
+        item.isAvailable = false
+        #expect(HistoryResumePolicy.command(for: item, directoryExists: true) == nil)
+        item.isAvailable = true
+        item.agent = .codex
+        #expect(HistoryResumePolicy.command(for: item, directoryExists: true) == nil)
+        item.agent = .claude
+        item.nativeSessionID = "bad; command"
+        #expect(HistoryResumePolicy.command(for: item, directoryExists: true) == nil)
+    }
+
+    @Test func resolvesOnlyUniqueExactLiveIdentity() {
+        let item = history()
+        var live = AgentSession(id: item.nativeSessionID, agent: .claudeCode, project: "project", status: .done,
+                                terminalRef: TerminalRef(cwd: item.projectPath), statusSince: Date(), updatedAt: Date())
+        #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == live)
+        #expect(HistoryResumePolicy.liveSession(for: item, in: [live, live]) == nil)
+        live.terminalRef = TerminalRef(cwd: "/different/project")
+        #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == nil)
+        live.terminalRef = nil
+        #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == nil)
+        live.terminalRef = TerminalRef(cwd: item.projectPath)
+        live.historyOnly = true
+        #expect(HistoryResumePolicy.liveSession(for: item, in: [live]) == nil)
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionHistoryTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionHistoryTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class SessionHistoryTests: XCTestCase {
+    func testIncrementalSearchIdentityFavoritesAndMissingSource() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude")
+        let codex = root.appendingPathComponent("codex")
+        let cache = root.appendingPathComponent("cache")
+        let c = claude.appendingPathComponent("projects/project/same.jsonl")
+        let x = codex.appendingPathComponent("sessions/rollout.jsonl")
+        for file in [c, x] { try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true) }
+        let original = #"{"uuid":"u1","sessionId":"same","cwd":"/project-a","type":"user","message":{"role":"user","content":[{"type":"text","text":"中文恢复 await worker()"}]}}"# + "\n"
+        try Data(original.utf8).write(to: c)
+        try Data((#"{"type":"session_meta","payload":{"id":"same","cwd":"/project-b"}}"# + "\n" + #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"HELLO"}]}}"# + "\n").utf8).write(to: x)
+        let child = claude.appendingPathComponent("projects/project/subagents/agent-child.jsonl")
+        try FileManager.default.createDirectory(at: child.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(original.replacingOccurrences(of: "中文恢复 await worker()", with: "child must not replace parent").utf8).write(to: child)
+        let repository = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        let initial = try await repository.refresh()
+        XCTAssertEqual(initial.sessions.count, 2)
+        XCTAssertTrue(initial.sessions.allSatisfy { $0.messages.isEmpty })
+        let loaded = try await repository.session(id: "claude:same")
+        XCTAssertEqual(loaded?.messages.count, 1)
+        XCTAssertTrue(initial.issues.contains { $0.contains("child-session") })
+        XCTAssertEqual(Set(initial.sessions.map(\.id)), ["claude:same", "codex:same"])
+        let chinese = try await repository.search("恢复")
+        XCTAssertEqual(chinese.first?.sessionID, "claude:same")
+        let code = try await repository.search("await worker()")
+        XCTAssertEqual(code.first?.messageID, chinese.first?.messageID)
+        let english = try await repository.search("hello")
+        XCTAssertEqual(english.count, 1)
+        try await repository.setFavorite(sessionID: "claude:same", isFavorite: true)
+        let appended = original + #"{"uuid":"a1","sessionId":"same","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"new result"}]}}"# + "\n{broken"
+        try Data(appended.utf8).write(to: c)
+        let incremental = try await repository.refresh()
+        XCTAssertEqual(incremental.sessions.first(where: { $0.agent == .claude })?.messageCount, 2)
+        XCTAssertFalse(incremental.sessions.first(where: { $0.agent == .claude })!.warnings.isEmpty)
+        let stable = try await repository.search("恢复")
+        XCTAssertEqual(stable.first?.messageID, chinese.first?.messageID)
+        let restarted = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        let restored = await restarted.snapshot()
+        XCTAssertTrue(restored.sessions.first(where: { $0.agent == .claude })!.isFavorite)
+        let rebuilt = try await restarted.refresh(rebuild: true)
+        XCTAssertTrue(rebuilt.sessions.first(where: { $0.agent == .claude })!.isFavorite)
+        XCTAssertEqual(try Data(contentsOf: c), Data(appended.utf8))
+        try FileManager.default.removeItem(at: c)
+        let missing = try await restarted.refresh()
+        XCTAssertFalse(missing.sessions.first(where: { $0.agent == .claude })!.isAvailable)
+        XCTAssertTrue(missing.sessions.first(where: { $0.agent == .claude })!.isFavorite)
+    }
+
+    func testRefreshBatchesAdvanceAndWarmRefreshDoesNotRewriteIndex() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude")
+        let codex = root.appendingPathComponent("codex")
+        let cache = root.appendingPathComponent("cache")
+        let project = claude.appendingPathComponent("projects/p")
+        try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+        for id in ["one", "two"] {
+            let row = "{\"uuid\":\"u\",\"sessionId\":\"\(id)\",\"message\":{\"role\":\"user\",\"content\":\"hello\"}}"
+            try Data(row.utf8).write(to: project.appendingPathComponent(id + ".jsonl"))
+        }
+        let repo = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, refreshByteBudget: 1)
+        let first = try await repo.refresh()
+        XCTAssertEqual(first.sessions.count, 1)
+        XCTAssertTrue(first.issues.contains { $0.contains("Indexing:") })
+        let second = try await repo.refresh()
+        XCTAssertEqual(second.sessions.count, 2)
+        XCTAssertTrue(second.sessions.allSatisfy(\.isAvailable))
+        let index = cache.appendingPathComponent("index.json")
+        let sentinel = Date(timeIntervalSince1970: 1234)
+        try FileManager.default.setAttributes([.modificationDate: sentinel], ofItemAtPath: index.path)
+        _ = try await repo.refresh()
+        let modified = try FileManager.default.attributesOfItem(atPath: index.path)[.modificationDate] as? Date
+        XCTAssertEqual(modified, sentinel)
+        _ = try await repo.refresh(rebuild: true)
+        let rebuilt = try await repo.refresh()
+        XCTAssertEqual(rebuilt.sessions.count, 2)
+        XCTAssertFalse(rebuilt.issues.contains { $0.contains("Indexing:") })
+    }
+
+    func testFailedCacheWriteRetriesWithoutSourceChange() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude")
+        let codex = root.appendingPathComponent("codex")
+        let file = claude.appendingPathComponent("projects/p/s.jsonl")
+        let cache = root.appendingPathComponent("cache")
+        try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(#"{"uuid":"u","sessionId":"s","message":{"role":"user","content":"hello"}}"#.utf8).write(to: file)
+        try Data("blocked".utf8).write(to: cache)
+        let repo = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        do { _ = try await repo.refresh(); XCTFail("Expected cache write failure") } catch { }
+        try FileManager.default.removeItem(at: cache)
+        _ = try await repo.refresh()
+        let reopened = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        let restored = await reopened.snapshot()
+        XCTAssertEqual(restored.sessions.count, 1)
+    }
+
+    func testCodexMirrorDoesNotConsumeEarlierEventOnlyTurn() throws {
+        let file = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".jsonl")
+        defer { try? FileManager.default.removeItem(at: file) }
+        let lines = [
+            #"{"type":"event_msg","payload":{"type":"user_message","message":"continue"}}"#,
+            #"{"type":"event_msg","payload":{"type":"agent_message","message":"first answer"}}"#,
+            #"{"type":"event_msg","payload":{"type":"user_message","message":"continue"}}"#,
+            #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}}"#
+        ]
+        try Data(lines.joined(separator: "\n").utf8).write(to: file)
+        let session = try SessionHistoryParser.read(url: file, agent: .codex, updatedAt: Date())
+        XCTAssertEqual(session.messages.map(\.text), ["continue", "first answer", "continue"])
+    }
+
+    func testCodexMessageIdentitySurvivesSourcePrepend() throws {
+        let file = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".jsonl")
+        defer { try? FileManager.default.removeItem(at: file) }
+        let existing = #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"original target"}]}}"#
+        let prepended = existing.replacingOccurrences(of: "original target", with: "unrelated new message")
+        try Data(existing.utf8).write(to: file)
+        let before = try SessionHistoryParser.read(url: file, agent: .codex, updatedAt: Date())
+        try Data((prepended + "\n" + existing).utf8).write(to: file)
+        let after = try SessionHistoryParser.read(url: file, agent: .codex, updatedAt: Date())
+        XCTAssertEqual(after.messages.first(where: { $0.id == before.messages[0].id })?.text, "original target")
+        XCTAssertNotEqual(after.messages[0].id, before.messages[0].id)
+    }
+
+    func testCanonicalCodexMessagesDoNotDuplicateEventMirrorsAndToolsExport() throws {
+        let file = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".jsonl")
+        defer { try? FileManager.default.removeItem(at: file) }
+        let lines = [
+            #"{"type":"event_msg","payload":{"type":"user_message","message":"request"}}"#,
+            #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"request"}]}}"#,
+            #"{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"echo hello"}}"#,
+            #"{"type":"response_item","payload":{"type":"function_call_output","output":"```sample```"}}"#,
+            #"{"type":"event_msg","payload":{"type":"agent_message","message":"event-only answer"}}"#,
+            #"{"type":"event_msg","payload":{"type":"user_message","message":"request"}}"#,
+            #"{"type":"response_item","payload":{"type":"message","role":"assistant","channel":"analysis","content":[{"type":"output_text","text":"private reasoning"}]}}"#
+        ]
+        try Data(lines.joined(separator: "\n").utf8).write(to: file)
+        let session = try SessionHistoryParser.read(url: file, agent: .codex, updatedAt: Date())
+        XCTAssertEqual(session.messages.count, 5)
+        XCTAssertEqual(session.messages.last?.text, "request")
+        XCTAssertTrue(session.messages.contains { $0.text == "event-only answer" })
+        XCTAssertEqual(session.messages[1].toolName, "shell")
+        XCTAssertFalse(session.messages.contains { $0.text.contains("private reasoning") })
+        XCTAssertTrue(SessionHistoryExport.markdown(session: session).contains("````text"))
+    }
+}

--- a/VibeBuddyMacApp/Sources/AppWindows.swift
+++ b/VibeBuddyMacApp/Sources/AppWindows.swift
@@ -18,7 +18,7 @@ final class AppWindows: NSObject, NSWindowDelegate {
         if dashboardWindow == nil {
             dashboardWindow = makeWindow(
                 content: dashboardContent, title: "vibebuddy", id: "dashboard",
-                size: NSSize(width: 1000, height: 660), minimum: NSSize(width: 760, height: 480),
+                size: NSSize(width: 1180, height: 760), minimum: NSSize(width: 940, height: 620),
                 resizable: true)
         }
         present(dashboardWindow!)

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -11,6 +11,8 @@ struct DashboardView: View {
     @State private var projectScope: DashboardSessionList.ProjectScope = .all
     @State private var query: String = ""
     @State private var showNewTask = false
+    @State private var libraryScope = "live"
+    @StateObject private var history = HistoryLibraryModel()
     // Demo instance pre-selects the approval session so the detail pane (diff +
     // Approve/Deny) is shown for screenshots; nil in normal use.
     @State private var selection: String? =
@@ -36,10 +38,37 @@ struct DashboardView: View {
     var body: some View {
         VStack(spacing: 0) {
             MacBuddyBar(model: model, voice: model.voiceChat, query: $query, searchFocused: $searchFocused)
-            HSplitView {
-                projectSidebar
-                sessionsColumn
-                detailColumn
+            HStack(spacing: 12) {
+                Picker("Library", selection: $libraryScope) {
+                    Text("Current tasks").tag("live")
+                    Text("History").tag("history")
+                    Text("Favorites").tag("favorites")
+                }
+                .pickerStyle(.segmented).frame(maxWidth: 380)
+                Spacer()
+                if libraryScope != "live" {
+                    let waiting = model.sessions.filter { $0.status == .needsResponse }.count
+                    if waiting > 0 {
+                        Button("\(waiting) need a response") {
+                            libraryScope = "live"
+                            statusFilter = .requiresInput
+                            projectScope = .all
+                            query = ""
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16).padding(.bottom, 8)
+            Divider()
+            if libraryScope == "live" {
+                HSplitView {
+                    projectSidebar
+                    sessionsColumn
+                    detailColumn
+                }
+            } else {
+                HistoryWorkbenchView(history: history, model: model, query: query,
+                                     favoritesOnly: libraryScope == "favorites")
             }
         }
         .background(MacTheme.bg)
@@ -70,7 +99,7 @@ struct DashboardView: View {
                 Button("") {
                     // Text editors (including detail composers/questions) own
                     // Return while editing; a selected row must not steal it.
-                    if !searchFocused, !(NSApp.keyWindow?.firstResponder is NSTextView),
+                    if libraryScope == "live", !searchFocused, !(NSApp.keyWindow?.firstResponder is NSTextView),
                        let s = selectedSession { model.jump(s) }
                 }
                     .keyboardShortcut(.return, modifiers: [])
@@ -172,7 +201,7 @@ struct DashboardView: View {
                 .padding(.horizontal, 12).padding(.bottom, 12)
             }
         }
-        .frame(minWidth: 240, idealWidth: 320, maxWidth: .infinity, maxHeight: .infinity)
+        .frame(minWidth: 220, idealWidth: 280, maxWidth: 360, maxHeight: .infinity)
     }
 
     private var detailColumn: some View {
@@ -180,14 +209,19 @@ struct DashboardView: View {
             VStack(spacing: 12) {
                 Group {
                     if let s = selectedSession {
-                        DetailCard(session: s, model: model)
+                        VStack(spacing: 0) {
+                            DetailCard(session: s, model: model)
+                            Divider()
+                            RecentOutputPane(session: s, model: model)
+                        }.id(s.id)
                     } else {
                         ContentUnavailableView("Select a session", systemImage: "sidebar.right")
                             .frame(maxWidth: .infinity, minHeight: 200)
                     }
                 }
                 .companionCard(radius: MacTheme.panelRadius)
-                usageCard
+                DisclosureGroup("Account usage") { usageCard }
+                    .font(.caption).padding(.horizontal, 4)
             }
             .padding(12)
         }
@@ -243,9 +277,9 @@ private struct MacBuddyBar: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            PetFace(state: model.buddyState, voice: .init(voice.phase), greet: greet, bare: true, scale: 0.9)
+            PetFace(state: model.buddyState, voice: .init(voice.phase), greet: greet, bare: true, scale: 0.55)
                 .onTapGesture { greet += 1; voice.toggle() }
-            SpeechBubble {
+            Group {
                 VStack(alignment: .leading, spacing: 1) {
                     HStack(spacing: 6) {
                         if !companionEnabled {
@@ -275,7 +309,7 @@ private struct MacBuddyBar: View {
             Spacer(minLength: 12)
             SearchPill(query: $query, focused: searchFocused)
         }
-        .padding(.horizontal, 20).padding(.top, 6).padding(.bottom, 12)
+        .padding(.horizontal, 16).padding(.vertical, 6)
         .sheet(isPresented: $voice.showConsent) { VoiceConsentSheet(voice: voice) }
     }
 }
@@ -650,6 +684,52 @@ private struct TranscriptSheet: View {
                 .padding()
             }
         }
+    }
+}
+
+/// Bounded live output in the main reading pane; never described as full history.
+private struct RecentOutputPane: View {
+    let session: AgentSession
+    @ObservedObject var model: MenuBarModel
+    @State private var output: RecentOutput?
+    @State private var loading = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Recent output").font(.headline)
+                Spacer()
+                Button("Refresh") { Task { await reload() } }.disabled(loading)
+            }
+            if let output {
+                Text(output.sourceLabel).font(.caption).foregroundStyle(.secondary)
+                if !output.statusLine.isEmpty {
+                    Text(output.statusLine).font(.caption).foregroundStyle(.secondary)
+                }
+                Text("A limited recent excerpt. Open History to read indexed local conversations.")
+                    .font(.caption).foregroundStyle(.secondary)
+                if output.entries.isEmpty {
+                    Text("No recent output is available from this source.")
+                        .foregroundStyle(.secondary)
+                }
+                ForEach(Array(output.entries.enumerated()), id: \.offset) { _, entry in
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(entry.role == "assistant" ? "Assistant" : "You")
+                            .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                        Text(entry.text).font(.body).textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            } else { ProgressView() }
+        }
+        .padding(20)
+        .task(id: session.id) { await reload() }
+    }
+
+    private func reload() async {
+        loading = true
+        output = await model.recentOutput(for: session.id)
+        loading = false
     }
 }
 

--- a/VibeBuddyMacApp/Sources/HistorySessionActions.swift
+++ b/VibeBuddyMacApp/Sources/HistorySessionActions.swift
@@ -1,0 +1,82 @@
+import AppKit
+import SwiftUI
+import VibeBuddyKit
+import VibeBuddyMacCore
+
+@MainActor
+struct HistorySessionActions: View {
+    let session: SessionHistorySession
+    @ObservedObject var model: MenuBarModel
+    @State private var feedback: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let live = Self.liveSession(for: session, in: model.sessions) {
+                Button("Jump to current session") {
+                    guard let current = Self.liveSession(for: session, in: model.sessions) else {
+                        feedback = "The live session is no longer available."
+                        return
+                    }
+                    model.jump(current)
+                }
+                if live.agent == .codex && live.status != .needsResponse && SessionActionSupport.resolve(for: live).isAvailable {
+                    InstructionComposer(placeholder: live.status == .done ? "Start a new turn…" : "Add to the current turn…") { text in
+                        guard let current = Self.liveSession(for: session, in: model.sessions),
+                              current.status == live.status, current.statusSince == live.statusSince,
+                              current.status != .needsResponse,
+                              SessionActionSupport.resolve(for: current).isAvailable else {
+                            feedback = "The task changed. Review its current state before sending."
+                            return
+                        }
+                        model.answer(current.id, answers: [:], text: text)
+                    }
+                    .id(live.id + String(live.statusSince.timeIntervalSince1970))
+                }
+                if let outcome = model.jumpFeedback[live.id] { Text(outcome.macMessage(for: live)) }
+                if let answer = model.answerFeedback[live.id] { Text(answer) }
+            } else {
+                if Self.resumeCommand(for: session) != nil {
+                    Button("Copy resume command") {
+                        feedback = Self.copyResumeCommand(for: session)
+                            ? "Resume command copied. Run it in your terminal to continue."
+                            : "The resume command is no longer available."
+                    }
+                }
+                Text(Self.unavailableReason(for: session)).foregroundStyle(.secondary)
+            }
+            if let feedback { Text(feedback).foregroundStyle(.secondary) }
+        }
+        .font(.caption)
+        .onChange(of: session.id) { _, _ in feedback = nil }
+    }
+
+    static func liveSession(for history: SessionHistorySession, in sessions: [AgentSession]) -> AgentSession? {
+        HistoryResumePolicy.liveSession(for: history, in: sessions)
+    }
+
+    static func resumeCommand(for history: SessionHistorySession) -> String? {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: history.projectPath, isDirectory: &isDirectory)
+        return HistoryResumePolicy.command(for: history, directoryExists: exists && isDirectory.boolValue)
+    }
+
+    @discardableResult
+    static func copyResumeCommand(for history: SessionHistorySession) -> Bool {
+        guard let command = resumeCommand(for: history) else { return false }
+        NSPasteboard.general.clearContents()
+        return NSPasteboard.general.setString(command, forType: .string)
+    }
+
+    static func unavailableReason(for history: SessionHistorySession) -> String {
+        if !history.isAvailable { return "Source unavailable. Cached history does not establish a recoverable session." }
+        if history.agent == .codex {
+            return "This archive does not establish a Codex CLI or Desktop target. Open the original task in Codex to continue."
+        }
+        var isDirectory: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: history.projectPath, isDirectory: &isDirectory) || !isDirectory.boolValue {
+            return "The original project directory is unavailable."
+        }
+        if resumeCommand(for: history) == nil { return "This record has no valid session identity for resuming." }
+        return "Copy the resume command and run it in your terminal. Copying does not start or continue a task."
+    }
+}

--- a/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
+++ b/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
@@ -1,0 +1,414 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+import VibeBuddyKit
+import VibeBuddyMacCore
+
+/// The history library never inserts archived records into the live snapshot.
+@MainActor
+final class HistoryLibraryModel: ObservableObject {
+    @Published private(set) var snapshot = SessionHistorySnapshot()
+    @Published private(set) var results: [SessionHistorySearchResult] = []
+    @Published private(set) var loading = false
+    @Published private(set) var searching = false
+    @Published private(set) var searchError: String?
+    @Published var error: String?
+    @Published private(set) var transcript: SessionHistorySession?
+    @Published private(set) var readingError: String?
+    @Published private(set) var reading = false
+    private var readGeneration = 0
+    private let repository: SessionHistoryRepository
+    private var searchGeneration = 0
+
+    init() {
+        let environment = ProcessInfo.processInfo.environment
+        if let root = environment["VIBEBUDDY_E2E_ROOT"] {
+            let url = URL(fileURLWithPath: root)
+            repository = SessionHistoryRepository(
+                claudeHome: url.appendingPathComponent("agents/claude"),
+                codexHome: url.appendingPathComponent("agents/codex"),
+                cacheDirectory: url.appendingPathComponent("history"))
+        } else {
+            repository = SessionHistoryRepository()
+        }
+    }
+
+    func refresh(rebuild: Bool = false) async {
+        guard !loading else { return }
+        loading = true
+        defer { loading = false }
+        do {
+            snapshot = try await repository.refresh(rebuild: rebuild)
+            error = nil
+        } catch { self.error = error.localizedDescription }
+    }
+
+    func search(_ query: String, project: String?, favorites: Bool) async {
+        searchGeneration += 1
+        let generation = searchGeneration
+        searching = true
+        // Clear old query results immediately; delayed queries must never overwrite newer ones.
+        results = []
+        searchError = nil
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            searching = false
+            return
+        }
+        do { try await Task.sleep(for: .milliseconds(180)) } catch { return }
+        guard !Task.isCancelled else { return }
+        do {
+            let found = try await repository.search(query, projectPath: project, favoritesOnly: favorites, limit: 200)
+            guard generation == searchGeneration, !Task.isCancelled else { return }
+            results = found
+        } catch {
+            guard generation == searchGeneration, !Task.isCancelled else { return }
+            searchError = error.localizedDescription
+        }
+        searching = false
+    }
+
+    func read(_ id: String?) async {
+        readGeneration += 1
+        let generation = readGeneration
+        readingError = nil
+        guard let id else { transcript = nil; reading = false; return }
+        if transcript?.id != id { transcript = nil }
+        reading = true
+        do {
+            let result = try await repository.session(id: id)
+            guard generation == readGeneration, !Task.isCancelled else { return }
+            transcript = result
+            if result == nil { readingError = "This record is no longer indexed. Refresh the library." }
+        } catch {
+            guard generation == readGeneration, !Task.isCancelled else { return }
+            readingError = error.localizedDescription
+        }
+        if generation == readGeneration { reading = false }
+    }
+
+    func toggleFavorite(_ session: SessionHistorySession) async {
+        do {
+            try await repository.setFavorite(sessionID: session.id, isFavorite: !session.isFavorite)
+            snapshot = await repository.snapshot()
+            if transcript?.id == session.id { transcript?.isFavorite = !session.isFavorite }
+        } catch { self.error = error.localizedDescription }
+    }
+}
+
+struct HistoryWorkbenchView: View {
+    @ObservedObject var history: HistoryLibraryModel
+    @ObservedObject var model: MenuBarModel
+    let query: String
+    let favoritesOnly: Bool
+    @State private var project: String?
+    @State private var selection: String?
+    @State private var targetMessage: String?
+    @State private var exportError: String?
+
+    private var isSearching: Bool { !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    private var sessions: [SessionHistorySession] {
+        history.snapshot.sessions.filter {
+            (project == nil || $0.projectPath == project) && (!favoritesOnly || $0.isFavorite)
+        }
+    }
+    private var projects: [String] {
+        Array(Set(history.snapshot.sessions.map(\.projectPath))).sorted()
+    }
+    private var selected: SessionHistorySession? {
+        guard let selection else { return nil }
+        return sessions.first { $0.id == selection }
+    }
+    private var readKey: String {
+        guard let selected else { return "" }
+        return "\(selected.id)|\(selected.updatedAt.timeIntervalSince1970)|\(selected.isAvailable)"
+    }
+    private var searchKey: String {
+        "\(query)\u{1f}\(project ?? "")\u{1f}\(favoritesOnly)\u{1f}\(history.snapshot.refreshedAt?.timeIntervalSince1970 ?? 0)\u{1f}\(sessions.filter(\.isFavorite).count)"
+    }
+
+    var body: some View {
+        HSplitView {
+            sidebar
+            sessionList
+            readingPane
+        }
+        .task {
+            await history.refresh()
+            while !Task.isCancelled {
+                do { try await Task.sleep(for: .seconds(30)) } catch { return }
+                await history.refresh()
+            }
+        }
+        .task(id: searchKey) { await history.search(query, project: project, favorites: favoritesOnly) }
+        .task(id: readKey) { await history.read(selected?.id) }
+        .onChange(of: project) { _, _ in clearSelection() }
+        .onChange(of: favoritesOnly) { _, _ in clearSelection() }
+        .onChange(of: query) { _, _ in clearSelection() }
+        .onChange(of: sessions.map(\.id)) { _, ids in
+            if let selection, !ids.contains(selection) { clearSelection() }
+        }
+        .alert("Could not export", isPresented: Binding(get: { exportError != nil }, set: { if !$0 { exportError = nil } })) {
+            Button("OK") { exportError = nil }
+        } message: { Text(exportError ?? "") }
+    }
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Local library").font(.headline)
+            Text("Claude Code · Codex\nIncludes archived Codex sessions")
+                .font(.caption).foregroundStyle(.secondary)
+            Button { project = nil } label: {
+                Label("All projects", systemImage: "tray.full")
+                    .frame(maxWidth: .infinity, alignment: .leading).padding(8)
+                    .background(project == nil ? Color.accentColor.opacity(0.12) : .clear, in: RoundedRectangle(cornerRadius: 6))
+            }.buttonStyle(.plain)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 4) {
+                    ForEach(projects, id: \.self) { path in
+                        Button { project = path } label: {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Label(path.isEmpty ? "Unknown project" : URL(fileURLWithPath: path).lastPathComponent,
+                                      systemImage: "folder")
+                                Text(path).font(.caption2).foregroundStyle(.secondary).lineLimit(2)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading).padding(8)
+                            .background(project == path ? Color.accentColor.opacity(0.12) : .clear, in: RoundedRectangle(cornerRadius: 6))
+                        }.buttonStyle(.plain).help(path)
+                    }
+                }
+            }
+            Divider()
+            if history.loading { ProgressView("Updating library…").font(.caption) }
+            if let date = history.snapshot.refreshedAt {
+                Text("Updated \(date.formatted(date: .omitted, time: .shortened))")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+            HStack {
+                Button("Refresh") { Task { await history.refresh() } }
+                Menu {
+                    Button("Rebuild index") { Task { await history.refresh(rebuild: true) } }
+                } label: { Image(systemName: "ellipsis.circle") }
+                .menuStyle(.borderlessButton).frame(width: 24)
+            }.disabled(history.loading)
+            if let error = history.error { Text(error).font(.caption).foregroundStyle(.red).textSelection(.enabled) }
+            if !history.snapshot.issues.isEmpty {
+                DisclosureGroup("Source notices (\(history.snapshot.issues.count))") {
+                    ScrollView { Text(history.snapshot.issues.joined(separator: "\n")).font(.caption).textSelection(.enabled) }
+                        .frame(maxHeight: 130)
+                }.font(.caption)
+            }
+        }
+        .padding(12).frame(minWidth: 170, idealWidth: 210, maxWidth: 270)
+        .frame(maxHeight: .infinity).background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private var sessionList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(isSearching ? "Message matches" : favoritesOnly ? "Favorites" : "History").font(.headline)
+                Spacer()
+                Text("\(isSearching ? history.results.count : sessions.count)").foregroundStyle(.secondary)
+            }.padding(12)
+            if isSearching && history.searching { ProgressView("Searching…") }
+            if isSearching, let error = history.searchError {
+                Text("Search could not complete: \(error)").font(.caption).foregroundStyle(.red).padding(12)
+            }
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    if isSearching {
+                        ForEach(history.results) { hit in
+                            if let session = sessions.first(where: { $0.id == hit.sessionID }) {
+                                Button {
+                                    selection = session.id
+                                    targetMessage = hit.messageID
+                                } label: { row(session, excerpt: hit.excerpt, active: selection == session.id && targetMessage == hit.messageID) }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    } else {
+                        ForEach(sessions) { session in
+                            Button { selection = session.id; targetMessage = nil } label: {
+                                row(session, excerpt: nil, active: selection == session.id)
+                            }.buttonStyle(.plain)
+                        }
+                    }
+                    if !history.loading && !(isSearching && history.searching) && (isSearching ? history.results.isEmpty && history.searchError == nil : sessions.isEmpty) {
+                        ContentUnavailableView(isSearching ? "No matching messages" : "No sessions in this view", systemImage: "text.magnifyingglass",
+                                               description: Text("Check the project filter and source notices, or refresh the library."))
+                    }
+                }.padding(.horizontal, 8)
+            }
+            if isSearching && history.results.count == 200 {
+                Text("Showing the first 200 matches. Narrow your query or project.").font(.caption).padding(8)
+            }
+        }.frame(minWidth: 230, idealWidth: 300, maxWidth: 380)
+    }
+
+    private func row(_ session: SessionHistorySession, excerpt: String?, active: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top) {
+                Text(session.title).font(.body.weight(.medium)).lineLimit(2)
+                if session.isFavorite { Image(systemName: "star.fill").foregroundStyle(.yellow) }
+            }
+            Text("\(session.agent.displayName) · \(session.updatedAt.formatted(date: .abbreviated, time: .shortened))")
+                .font(.caption).foregroundStyle(.secondary)
+            if let excerpt { Text(excerpt).font(.caption).lineLimit(3) }
+            if !session.isAvailable { Label("Source unavailable", systemImage: "exclamationmark.triangle").font(.caption) }
+            else if !session.warnings.isEmpty { Label("Partial or limited record", systemImage: "info.circle").font(.caption) }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading).padding(10)
+        .background(active ? Color.accentColor.opacity(0.12) : .clear, in: RoundedRectangle(cornerRadius: 8))
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder private var readingPane: some View {
+        if let metadata = selected {
+            let session = readingSession(metadata)
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(session.title).font(.title2.weight(.semibold)).textSelection(.enabled).lineLimit(3)
+                    Text("\(session.agent.displayName) · \(session.projectPath)").font(.caption).foregroundStyle(.secondary).textSelection(.enabled)
+                    ViewThatFits(in: .horizontal) {
+                        HStack { sessionActions(session) }
+                        VStack(alignment: .leading) { sessionActions(session) }
+                    }
+                    HistorySessionActions(session: session, model: model)
+                    ForEach(session.warnings, id: \.self) { warning in
+                        Text(warning).font(.caption).foregroundStyle(.secondary)
+                    }
+                    if !session.isAvailable {
+                        Text("The source is unavailable. Showing the last indexed copy.").font(.caption).foregroundStyle(.secondary)
+                    }
+                }.padding(16).frame(maxWidth: .infinity, alignment: .leading)
+                Divider()
+                if history.reading && history.transcript?.id != metadata.id {
+                    ProgressView("Reading conversation…").frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = history.readingError {
+                    VStack(spacing: 12) {
+                        Text(error).foregroundStyle(.secondary)
+                        Button("Retry") { Task { await history.read(metadata.id) } }
+                    }.frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    HistoryMessageReader(session: session, targetMessage: targetMessage)
+                }
+            }
+            .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
+            .id(session.id)
+        } else {
+            ContentUnavailableView("Select a conversation", systemImage: "text.book.closed",
+                                   description: Text("Read local history without changing a task's live state."))
+                .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func readingSession(_ metadata: SessionHistorySession) -> SessionHistorySession {
+        var value = metadata
+        if let loaded = history.transcript, loaded.id == metadata.id, loaded.sourcePath == metadata.sourcePath {
+            value.messages = loaded.messages
+            value.isAvailable = metadata.isAvailable && loaded.isAvailable
+        }
+        return value
+    }
+
+    @ViewBuilder private func sessionActions(_ session: SessionHistorySession) -> some View {
+        Button { Task { await history.toggleFavorite(session) } } label: {
+            Label(session.isFavorite ? "Unfavorite" : "Favorite", systemImage: session.isFavorite ? "star.fill" : "star")
+        }
+        Button("Export Markdown…") { export(session) }
+            .disabled(history.reading || history.transcript?.id != session.id || history.readingError != nil)
+        Button("Show source") { NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: session.sourcePath)]) }
+            .disabled(!session.isAvailable)
+    }
+
+    private func clearSelection() { selection = nil; targetMessage = nil }
+
+    private func export(_ session: SessionHistorySession) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
+        panel.nameFieldStringValue = "\(session.agent.rawValue)-\(session.nativeSessionID).md"
+        panel.canCreateDirectories = true
+        if let root = E2ERunConfiguration.current?.root { panel.directoryURL = root }
+        let completion: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .OK, let url = panel.url else { return }
+            do { try SessionHistoryExport.markdown(session: session).write(to: url, atomically: true, encoding: .utf8) }
+            catch { exportError = error.localizedDescription }
+        }
+        if let window = NSApp.keyWindow {
+            panel.beginSheetModal(for: window, completionHandler: completion)
+        } else {
+            panel.begin(completionHandler: completion)
+        }
+    }
+}
+
+private struct HistoryMessageReader: View {
+    let session: SessionHistorySession
+    let targetMessage: String?
+    @State private var expandedTools = Set<String>()
+    @State private var pageStart = 0
+    private let pageSize = 30
+    private var pageEnd: Int { min(pageStart + pageSize, session.messages.count) }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    Color.clear.frame(height: 1).id("page-top")
+                    if let targetMessage, !session.messages.contains(where: { $0.id == targetMessage }) {
+                        Text("This search match is no longer in the current record. Search again to locate the updated message.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    if pageStart > 0 {
+                        Button("Earlier messages") {
+                            pageStart = max(0, pageStart - pageSize)
+                            proxy.scrollTo("page-top", anchor: .top)
+                        }
+                    }
+                    if !session.messages.isEmpty {
+                        Text("Messages \(pageStart + 1)–\(pageEnd) of \(session.messages.count)")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    if session.messages.isEmpty {
+                        Text("No readable messages in this record.").foregroundStyle(.secondary)
+                    }
+                    ForEach(Array(session.messages.dropFirst(pageStart).prefix(pageSize))) { message in
+                        VStack(alignment: .leading, spacing: 6) {
+                            if message.role == .tool {
+                                DisclosureGroup(message.toolName ?? "Tool call", isExpanded: Binding(
+                                    get: { expandedTools.contains(message.id) },
+                                    set: { if $0 { expandedTools.insert(message.id) } else { expandedTools.remove(message.id) } })) {
+                                    Text(message.text).font(.system(.callout, design: .monospaced)).textSelection(.enabled)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                            } else {
+                                Text(message.role.rawValue.capitalized).font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                                Text(message.text).font(.body).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(message.id == targetMessage ? Color.accentColor.opacity(0.13) : .clear, in: RoundedRectangle(cornerRadius: 8))
+                        .id(message.id)
+                    }
+                    if pageEnd < session.messages.count {
+                        Button("Later messages") {
+                            pageStart = pageEnd
+                            proxy.scrollTo("page-top", anchor: .top)
+                        }
+                    }
+                }.padding(16)
+            }
+            .onChange(of: session.messages.count) { _, count in
+                pageStart = min(pageStart, max(0, count - 1))
+            }
+            .task(id: targetMessage) {
+                if let targetMessage, let index = session.messages.firstIndex(where: { $0.id == targetMessage }) {
+                    pageStart = index
+                    expandedTools.insert(targetMessage)
+                    await Task.yield()
+                    proxy.scrollTo(targetMessage, anchor: .top)
+                }
+            }
+        }
+    }
+}

--- a/docs/session-history.md
+++ b/docs/session-history.md
@@ -1,0 +1,44 @@
+# Mac local session history
+
+The Dashboard has three library scopes: **Current tasks**, **History**, and
+**Favorites**. Current tasks keeps the daemon's live state and actions. History
+reads local Claude Code and Codex conversation files independently; selecting or
+searching an archive never inserts it into the live snapshot.
+
+Open History to index `~/.claude/projects`, `~/.codex/sessions`, and
+`~/.codex/archived_sessions`. `CLAUDE_CONFIG_DIR` and `CODEX_HOME` replace the
+respective home directory. Project groups use the original full working directory;
+matching basenames and worktrees are not merged. Claude child/sidechain transcripts
+are excluded so their shared parent ID cannot replace the parent conversation.
+
+Search matches message text, including Chinese and code substrings. Select a result
+to highlight that message; matching tool messages expand. The reading pane shows
+30 messages at a time, with Earlier/Later controls for context. Large source files
+and individual messages have explicit resource limits; source notices and each
+record's warnings identify incomplete or omitted content. Reasoning and images are
+not rendered as full content. Search is substring-based, not semantic search.
+
+The app checks sources on opening the library, on Refresh, and every 30 seconds
+while the library is open. Initial indexing advances in bounded batches; pending
+coverage is reported. The local index stores metadata and separate per-source text
+caches under `~/Library/Application Support/VibeBuddy/SessionHistory`. Only selected
+text is loaded for reading. Rebuild index re-reads the sources; favorites are saved
+separately and retained. Missing sources retain their last indexed copy with an
+unavailable label; they are not evidence of a finished or controllable task.
+
+**Export Markdown** uses the system save panel. It includes source identity,
+available user/assistant text, readable tool records and completeness warnings.
+Cancelling does not create a file. Export and favorites do not modify source logs.
+History is not automatically included in voice or completion-summary context.
+
+For a uniquely matched live Session, history reuses the existing Jump and supported
+Codex input actions, checking live identity again at the time of the action.
+For a historical Claude conversation with a valid ID and existing project directory,
+**Copy resume command** prepares a shell-quoted command for the user to run; copying
+does not run it. Unknown Codex CLI/Desktop provenance is shown as unsupported rather
+than opening a new task or typing into a terminal. Source visibility alone does not
+establish approval or control capability.
+
+SSH history mirroring and MCP/CLI access are separate future work. This feature does
+not install hooks, synchronize repositories or replace the running app. Mac App Store
+sandbox acceptance is separate from this direct-distribution implementation.


### PR DESCRIPTION
## Changes

The Mac Dashboard now supports reading current output and browsing local Claude/Codex history without treating archived records as live tasks. Adds message search with highlighted navigation, persistent favorites, Markdown export through the system save panel, and capability-checked links to existing session actions.

History indexing is incremental and bounded: 32 MiB per source, 128K characters per message, and explicit notices for incomplete or unavailable content. Unknown Codex provenance does not enable resume actions; historical Claude sessions can copy a validated resume command.

## Validation

- Isolated Debug app build and 18 focused history, resume, dashboard, and recent-output tests passed before integration.
- Real transcript copies exercised reading, search navigation, favorites across restart, missing sources, native export and cancellation.
- Real corpus probe: 2,971 sessions / 641,755 available messages; 359 MiB peak RSS; unchanged refresh 0.516 s.
- Fresh isolated Debug build on latest main passed; all 18 focused tests passed again. Targeted code review passed, including removal of a dependency on an unmerged Copilot-only field.

Actual terminal resume and live provider approval remain unverified; hook replay does not establish those behaviors. No installed-app replacement, release, cross-machine access, or Mac App Store acceptance is included.
