### PR TITLE
Add project-local verify-vibebuddy skill

### DIFF
--- a/.cursor/skills/verify-vibebuddy/SKILL.md
+++ b/.cursor/skills/verify-vibebuddy/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: verify-vibebuddy
+description: "Drive VibeBuddy (Mac menu-bar companion, headless vibebuddyd on the LAN HTTP surface, iPhone, Watch) the way a user does. Use to launch an isolated daemon, prove dashboard sessions, phone pairing, remote approval, question reply, or iPhone Demo, and capture evidence without touching the installed app on :9876."
+---
+
+# Verify VibeBuddy
+
+VibeBuddy is a personal-use **Mac, iPhone, and Apple Watch** companion for Claude Code, Codex, Grok Build/Bot, and Cursor usage. Users touch native apps, not a website. The Mac is the hub: the menu-bar app embeds the same HTTP + WebSocket server as the headless `vibebuddyd` (`docs/getting-started.md`). Phones and hooks talk to that server with a bearer token (ADR-0009).
+
+This skill drives an **isolated** `vibebuddyd` (the repo's documented headless path) and, on a Mac with simulators, the iPhone Demo. It does **not** replace `/Applications`, bind **:9876**, or write the login `~/Library/Application Support/vibebuddy/` token.
+
+Read `features/README.md` before a run. Drive the mapped feature file, not a convenient substitute.
+
+Helper (executable; invoke only via these paths):
+
+```bash
+ctrl=".cursor/skills/verify-vibebuddy/helpers/control-vibebuddy"
+```
+
+## Launch
+
+Documented user/dev start for the hub:
+
+```bash
+swift run --package-path VibeBuddyMac vibebuddyd --pair   # production-shaped; defaults to :9876
+```
+
+Verification start — isolated port, disposable HOME, never :9876:
+
+```bash
+export VERIFY_RUN_ID="${VERIFY_RUN_ID:-vb-$(date +%Y%m%dT%H%M%S)}"
+export VIBEBUDDY_QA_PORT="${VIBEBUDDY_QA_PORT:-18765}"   # must not be 9876
+export VERIFY_EVIDENCE_DIR="${VERIFY_EVIDENCE_DIR:-$PWD/.scratch/verify-vibebuddy/$VERIFY_RUN_ID}"
+"$ctrl" launch            # or: "$ctrl" launch --pair
+```
+
+Ready when **both** are true:
+
+- `GET http://127.0.0.1:$VIBEBUDDY_QA_PORT/health` returns `ok` (unauthenticated).
+- `vibebuddyd: listening on 0.0.0.0:<port>` is in the run's `daemon.log`.
+
+The helper builds with `swift build --package-path VibeBuddyMac --product vibebuddyd` (Swift 6, macOS 14+, Xcode 26.6 / XcodeGen for the GUI apps — `docs/getting-started.md#build-from-source`). It restores `VibeBuddyMac/Package.resolved` after the build, matching `tools/watch-live-qa.sh`.
+
+`--pair` opens the same **120-second** registration window as Mac **Pair a phone** / `vibebuddyd --pair`.
+
+Teardown is **Cleanup** below. Keep the daemon up for the whole drive; do not restart between doctor and the first action unless doctor fails.
+
+**Host gap:** `VibeBuddyMac/Package.swift` is `platforms: [.macOS(.v14)]`. Linux cannot compile or run `vibebuddyd`, the menu-bar app, or the iPhone/Watch apps. If `launch` prints `blocked: host is Linux`, stop. Do not invent a web/CLI stand-in. Report that acceptance gap.
+
+**Do not** launch the installed menu-bar app, `open VibeBuddyMacApp.xcodeproj` Run, or a second production instance. A second production Mac app takes the `SingleInstanceLock` and returns to the existing dashboard (`docs/qa/mac-1.3.3.md`). Isolated E2E GUI requires bundle id `com.vibebuddy.e2e.<id>` plus `VIBEBUDDY_E2E_*` (`VibeBuddyKit` `E2ERunConfiguration`) and is out of this skill's default path.
+
+## Doctor
+
+Run before the first drive, after any surprise, and on every fresh session:
+
+```bash
+"$ctrl" doctor
+```
+
+Worth driving only when the report includes all of:
+
+- Disposable `HOME` is `<state>/home`, not the login home.
+- The recorded PID is alive and is `vibebuddyd`.
+- That PID owns `VIBEBUDDY_QA_PORT` (not 9876).
+- `GET /health` → `ok`.
+- `GET /snapshot` without a token → `401`.
+- `GET /snapshot` with `Authorization: Bearer <run token>` → `200` JSON (`sessions`, optional `sourceID`).
+
+If doctor fails, do not drive. `cleanup`, fix the skill/host, `launch` again, `doctor` again.
+
+## Drive
+
+The phone's user path **is** this HTTP surface (`/snapshot`, `/decision`, `/answer`, `/device`, `/ws`). CLI hooks use `/hook`, `/approval`, `/terminal` with the same token (header or `?token=`). Prefer those routes and snapshot fields over coordinates.
+
+Stable handles:
+
+| Surface | Handle |
+| --- | --- |
+| Health | `GET /health` body `ok` |
+| Snapshot | `GET /snapshot` → `sessions[].id`, `.status` (`needsResponse` / `working` / `done`), `.waitKind` (`permission` / `question`), `.project`, `.pendingApproval.id`, `.pendingQuestion` |
+| Hook ingest | `POST /hook?agent=claude` (or `codex`, `grok`, …) |
+| Held approval | `POST /approval` then `POST /decision` `{"approvalId","decision"}` with `allow` / `deny` / `alwaysAllow` / `allowSession` |
+| Question | `POST /answer` `{"sessionId","answer"}` (optional `expectedQuestionId`) |
+| Pairing | `POST /device` during the 120s window; `403` outside it |
+| Mac UI | Footer **Dashboard**, **Pair a phone**, **Scan this in the vibebuddy iOS app within 2 minutes.**, QR `accessibilityLabel` **Pairing QR code**, **Approve** / **Deny** |
+| iPhone UI | **Scan to pair**, **See the demo (no Mac needed)**, **Approve**, **Deny**, **Reply**, demo title **Demo**, demo sessions `demo-edit` / `demo-build` / `demo-work` |
+| iPhone env | `VIBEBUDDY_HOST` / `VIBEBUDDY_PORT` / `VIBEBUDDY_TOKEN` (launch-only, not saved); `VIBEBUDDY_DEMO=1` |
+
+```bash
+"$ctrl" hook --agent claude --json '{"hook_event_name":"SessionStart","session_id":"vb-verify-dash","cwd":"/tmp/verify-gateway"}'
+"$ctrl" snapshot --pretty
+"$ctrl" approval --session-id vb-verify-ap --cwd /tmp/verify-gateway --tool Bash --command 'rm -rf /tmp/vibebuddy-verify-should-ask'
+"$ctrl" approval --json '{"hook_event_name":"PreToolUse","session_id":"vb-verify-askq","cwd":"/tmp/verify-docs-review","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Which revision style should I use?","options":[{"label":"Short"}]}]}}'
+"$ctrl" decision --approval-id '<pendingApproval.id from snapshot>' --decision allow
+"$ctrl" answer --session-id vb-verify-q --text 'use the short revision'
+"$ctrl" device --name 'Verify Phone' --device-id 'verify-phone-1'
+"$ctrl" sim-demo
+```
+
+`Read` / `Grep` / `Glob` PreToolUse calls are auto-allowed (`ApprovalShortCircuit`) and never become a card. Use `Bash` (or another non-read-only tool) without `bypassPermissions`. `/approval` **holds ~25s**; POST it, then snapshot + decision, as `tools/watch-live-qa.sh` does.
+
+Recipes live in `features/`. Drive one mapped feature per proof unless a later run is covering the map.
+
+## Evidence
+
+Named location (survives cleanup):
+
+```text
+$VERIFY_EVIDENCE_DIR/<feature-id>/
+```
+
+Default: `.scratch/verify-vibebuddy/<VERIFY_RUN_ID>/` (`.scratch/` is gitignored). Generation proofs for this Cloud Agent also copy into the assigned store `media/` path when `VERIFY_EVIDENCE_DIR` is set there.
+
+```bash
+"$ctrl" evidence --label dashboard-sessions
+```
+
+Writes `meta.txt`, `health.txt`, `snapshot.json`, and a daemon log tail. Transcripts of launch/doctor/cleanup append to `$VERIFY_EVIDENCE_DIR/transcripts/`.
+
+Proof standards:
+
+- Exercise the real user path: hook ingest + snapshot (what the dashboard shows), `/decision` (what **Approve** sends), `/device` (what pairing registration sends). Do not poke `SessionStore` in-process or call test-only endpoints.
+- Capture the action **and** the resulting snapshot (status / `pendingApproval` / registry), not only the final screen.
+- Side effects: `sessions[]` in `/snapshot`, `device-registry.json` after a paired `POST /device`, `/approval` response body containing `permissionDecision` after a decision.
+- UI proof on a Mac: screenshot of the isolated iPhone Demo or isolated daemon-backed simulator with the app identity visible (`Demo` or the seeded project name). Menu-bar pixels are not reachable from CUA without extra setup (`docs/qa/mac-1.3.3.md`).
+- Never paste pairing tokens, QR payloads, or API keys into issues, PR bodies, or screenshots (`CONTRIBUTING.md`).
+- iPhone Demo (`VIBEBUDDY_DEMO=1` / **See the demo**) proves chrome only. It does not prove a live Mac, APNs, or a real agent.
+- Mocks only at production boundaries the app already isolates (no VibeBuddy cloud). Do not stub `/health` or `/snapshot`.
+
+## Cleanup
+
+Kill only the PID recorded in this run's `run.env`. Never `killall vibebuddyd` or the installed app.
+
+```bash
+"$ctrl" cleanup
+```
+
+Removes `/tmp/vibebuddy-verify-<id>` (HOME, journal, pid, daemon log). **Does not** delete `$VERIFY_EVIDENCE_DIR`. After cleanup, confirm the evidence files still exist at that path. If `VERIFY_EVIDENCE_DIR` is inside the state dir, cleanup refuses.
+
+After a failed iteration, run `cleanup` before the next `launch` so ports and held `/approval` curls are not stranded.
+
+## Helpers
+
+All commands above are `$ctrl <subcommand>`. The script is `helpers/control-vibebuddy` and must stay executable (`chmod +x`). It owns launch, doctor, drive verbs, evidence, sim-demo, and cleanup. Do not reverse-engineer env files by hand; `doctor` and `evidence` print the run identity.
+
+Isolation: two verification runs can coexist if they use different `VERIFY_RUN_ID` and `VIBEBUDDY_QA_PORT` values. They must not share HOME or the production token file. They must not use 9876.
+
+Existing Mac-only QA that this skill wraps rather than replaces: `tools/watch-live-qa.sh` (isolated daemon + simulators), `scripts/phone_qa_harness.sh` (live phone against a daemon — defaults to :9876, so point it at the isolated URL or do not use it here).

--- a/.cursor/skills/verify-vibebuddy/features/README.md
+++ b/.cursor/skills/verify-vibebuddy/features/README.md
@@ -1,0 +1,42 @@
+# VibeBuddy verification map
+
+This directory is the maintained source for verifying user-facing VibeBuddy behavior. Read this index before driving, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Launch an isolated `vibebuddyd` with `.cursor/skills/verify-vibebuddy/helpers/control-vibebuddy launch` (add `--pair` only for pairing recipes).
+- `VIBEBUDDY_QA_PORT` is set and is **not** `9876` (default `18765`).
+- Disposable `HOME` is the run state dir, not the login home. Production `~/Library/Application Support/vibebuddy/token` is unused.
+- `VERIFY_EVIDENCE_DIR` is outside the scratch state dir so cleanup cannot eat proof.
+- `control-vibebuddy doctor` reports health `ok`, snapshot `401` without a token, snapshot `200` with the run token, and the recorded PID owning the isolated port.
+- Never drive the installed menu-bar app, a simulator pointed at `:9876`, or an instance this run did not start.
+- On Linux, or without Swift/Xcode, `launch` / `doctor` report `blocked` and the feature is `verified-unreachable` with that host gap — not verified via a fake harness.
+
+## Driving conventions
+
+- Start every recipe from a freshly launched isolated daemon unless the feature file says otherwise.
+- Drive the hub through `control-vibebuddy` HTTP verbs (the same routes the iPhone and hooks use). Drive iPhone Demo through `control-vibebuddy sim-demo` plus the labeled buttons.
+- Treat every command as literal. Keep session ids, project paths, and decision strings unchanged.
+- After a mutation, re-read `/snapshot` (or the Demo UI) from a second call. Do not trust the write response alone.
+- Restore nothing on the user's Mac. Cleanup stops this run's PID only. Keep proof artifacts.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting snapshot or UI, not only the final screen.
+- HTTP proof includes the command, status code, and a saved `snapshot.json` under `$VERIFY_EVIDENCE_DIR/<feature-id>/`.
+- UI proof includes a screenshot with VibeBuddy identity visible (`Demo` title or a seeded project name).
+- Record the feature id and entry point on every artifact (`evidence --label <id>` writes `meta.txt`).
+- An unreachable path is reported with the attempted command and the unmet precondition (macOS, Swift, simulator, pairing window, real agent).
+- Do not report a skipped entry point as verified through a different path. Demo is not live pairing. A hook-seeded snapshot is not a real Claude Code session.
+
+## Feature entry contract
+
+Each feature file starts with an H1 and one paragraph. It then uses exactly these four H2 sections in order: `Sub-features`, `How to get to it (user POV)`, `Driving it with control-vibebuddy`, `Gotchas`.
+
+## Features
+
+- [Dashboard sessions](./dashboard-sessions.md) covers the three session states the dashboard and menu feed show.
+- [Phone pairing](./phone-pairing.md) covers the two-minute pairing window and device registration.
+- [Remote approval](./remote-approval.md) covers Approve / Deny on a held permission.
+- [Question reply](./question-reply.md) covers answering a waiting question.
+- [iPhone Demo](./iphone-demo.md) covers exploring the iPhone chrome without a Mac.

--- a/.cursor/skills/verify-vibebuddy/features/dashboard-sessions.md
+++ b/.cursor/skills/verify-vibebuddy/features/dashboard-sessions.md
@@ -1,0 +1,41 @@
+# Dashboard sessions
+
+The Mac Dashboard, menu-bar feed, and iPhone task list show every known Session in exactly one of the three states: `needsResponse`, `working`, or `done`, with project, model, and current activity when the hub has it.
+
+## Sub-features
+
+- `dash-working` shows a session that received `UserPromptSubmit` as `working`.
+- `dash-done` shows a session that received `Stop` as `done`.
+- `dash-need-permission` shows a Notification whose message contains `permission` as `needsResponse` + `waitKind=permission`.
+- `dash-need-question` shows any other wait Notification as `needsResponse` + `waitKind=question`.
+- `dash-empty` shows no sessions on a freshly launched isolated daemon.
+
+## How to get to it (user POV)
+
+- On Mac: click the menu-bar cat, then **Dashboard** in the footer control row (or the Open Dashboard hotkey).
+- On Mac: stay in the menu panel and read the activity feed (Needs response pinned above the rest).
+- On iPhone: after pairing, open the dashboard list (title is the Mac name).
+- A coding-agent hook POST to the hub is what actually creates the rows the user sees.
+
+## Driving it with control-vibebuddy
+
+Preconditions:
+
+- Isolated `vibebuddyd` is healthy (`control-vibebuddy doctor`).
+- No leftover sessions named `vb-verify-work`, `vb-verify-done`, `vb-verify-ask`, `vb-verify-q`.
+- You are not looking at the installed app on :9876.
+
+- **Empty board.** Read the snapshot before seeding. Run `control-vibebuddy snapshot --pretty`. `sessions` is `[]`.
+- **Working.** Start a turn. Run `control-vibebuddy hook --agent claude --json '{"hook_event_name":"SessionStart","session_id":"vb-verify-work","cwd":"/tmp/verify-gateway"}'` then `control-vibebuddy hook --agent claude --json '{"hook_event_name":"UserPromptSubmit","session_id":"vb-verify-work","cwd":"/tmp/verify-gateway"}'`. A second snapshot shows `id=vb-verify-work`, `status=working`, `project=verify-gateway`.
+- **Done.** Finish another session. Run `control-vibebuddy hook --agent claude --json '{"hook_event_name":"SessionStart","session_id":"vb-verify-done","cwd":"/tmp/verify-docs"}'` then `control-vibebuddy hook --agent claude --json '{"hook_event_name":"Stop","session_id":"vb-verify-done","cwd":"/tmp/verify-docs","message":"Published the release notes."}'`. Snapshot shows `vb-verify-done` `status=done` and summary containing `Published the release notes.`
+- **Needs permission.** Raise a wait whose message names permission. Run `control-vibebuddy hook --agent claude --json '{"hook_event_name":"Notification","session_id":"vb-verify-ask","cwd":"/tmp/verify-review","message":"needs your permission"}'`. Snapshot shows `status=needsResponse`, `waitKind=permission`, `project=verify-review`.
+- **Needs question.** Raise a wait that is not a permission. Run `control-vibebuddy hook --agent claude --json '{"hook_event_name":"Notification","session_id":"vb-verify-q","cwd":"/tmp/verify-docs-review","message":"Which revision style should I use?"}'`. Snapshot shows `status=needsResponse`, `waitKind=question`.
+- **Proof.** Run `control-vibebuddy evidence --label dashboard-sessions`. `snapshot.json` contains all four ids with the statuses above. On a Mac with a simulator pointed at this isolated port, a screenshot of the iPhone dashboard also shows `verify-review` / `verify-gateway` (optional; HTTP snapshot is the hub proof).
+
+## Gotchas
+
+- `project` is the last path component of `cwd`. Assert `verify-gateway`, not the full path.
+- A Notification with Claude `notification_type` that is not a wait (for example `auth_success`) is dropped and creates no row.
+- `quota_auto_resume*` Notifications become metadata, not `needsResponse`.
+- This recipe seeds the hub. It does not prove a real Claude Code / Codex process, Glance pixels, or Watch complications.
+- `UserPromptSubmit` without a later `Stop` stays `working`. Do not treat a later snapshot as `done` unless a stop (or equivalent) arrived.

--- a/.cursor/skills/verify-vibebuddy/features/iphone-demo.md
+++ b/.cursor/skills/verify-vibebuddy/features/iphone-demo.md
@@ -1,0 +1,39 @@
+# iPhone Demo
+
+**See the demo (no Mac needed)** (or `VIBEBUDDY_DEMO=1`) shows the iPhone dashboard with sample sessions and no network, so the chrome is reviewable without pairing. Demo **Approve** / **Reply** only mutate that in-memory sample.
+
+## Sub-features
+
+- `demo-enter` opens Demo from the Connect screen or the launch env.
+- `demo-approval` **Approve** / **Deny** on `demo-edit` (Edit diff) or `demo-build` (full Bash command) clears that sample wait.
+- `demo-reply` **Reply** on a sample question moves that row to `working` with summary `Answered from phone: …`.
+- `demo-identity` the navigation title is **Demo**, not a Mac name.
+- `demo-not-live` Demo never calls `/snapshot` or `/decision` on a daemon.
+
+## How to get to it (user POV)
+
+- On iPhone Connect: tap **See the demo (no Mac needed)**.
+- For simulator QA: launch `com.vibebuddy.app` with `VIBEBUDDY_DEMO=1` (and usually `VIBEBUDDY_SKIP_NOTIFICATIONS=1`), as `tools/watch-qa-shots.sh` / `tools/watch-relay-qa.sh` do.
+- Watch Demo pages use `VIBEBUDDY_WATCH_PAGE` / `VIBEBUDDY_WATCH_SCENARIO` (separate Watch QA, not this file's default drive).
+
+## Driving it with control-vibebuddy
+
+Preconditions:
+
+- macOS with a booted iOS Simulator and a Debug `VibeBuddyApp.app` (see helper error text for the `xcodegen` / `xcodebuild` command).
+- You are not launching the App Store install or a device that already holds a production pairing you care about. Simulator env pairing is launch-only and not saved.
+- Isolated `vibebuddyd` is **not** required. If a daemon is running for another feature, leave it alone; Demo must not be pointed at it.
+
+- **Launch Demo.** Run `control-vibebuddy sim-demo`. The helper installs the Debug app if present and launches with `VIBEBUDDY_DEMO=1`.
+- **Identity.** The iPhone UI title is **Demo**. Sample rows include `todo-app` (Edit sort-reminders, id `demo-edit`), `search-indexer` (Bash tests, id `demo-build`), and `ios-vibebuddy` (`demo-work`, working / followed).
+- **Approve sample.** Open `todo-app` / `demo-edit`. Tap **Approve**. The Edit wait disappears and that row is `working`. **Deny** is the same visible clear (Demo does not distinguish allow vs deny in the sample store).
+- **Reply sample.** On a question row, tap **Reply**, submit any non-empty text. The row summary starts with `Answered from phone:`.
+- **Proof.** Screenshot the Demo dashboard with the **Demo** title and at least one sample project visible, plus a second shot after Approve on `demo-edit`. Save under `$VERIFY_EVIDENCE_DIR/iphone-demo/`. Run `control-vibebuddy evidence --label iphone-demo` for `meta.txt` (host / run id). On Linux or without simctl, `sim-demo` prints `blocked` — record `verified-unreachable` with that host gap. Do not substitute App Store marketing screenshots.
+
+## Gotchas
+
+- Demo is **not** pairing, APNs, Live Activity recovery, or a real agent. A Demo screenshot never verifies those features.
+- `VIBEBUDDY_HOST` / `PORT` / `TOKEN` win over a saved pairing for that launch. Do not set them when you intend Demo; `sim-demo` sets only `VIBEBUDDY_DEMO=1`.
+- Demo `decide` always looks like success (`.received`) and ignores allow vs deny. Prove chrome, not decision semantics — those belong to [remote-approval](./remote-approval.md).
+- Watch Demo (`VIBEBUDDY_WATCH_SCENARIO`) is a different entry point. Do not mark Watch pages verified because iPhone Demo launched.
+- `noData` Watch shots intentionally ignore `VIBEBUDDY_DEMO` (`tools/watch-qa-shots.sh`). Do not mix that mode into this recipe.

--- a/.cursor/skills/verify-vibebuddy/features/phone-pairing.md
+++ b/.cursor/skills/verify-vibebuddy/features/phone-pairing.md
@@ -1,0 +1,44 @@
+# Phone pairing
+
+Pairing is the owner's explicit, time-limited consent to link an iPhone to this Mac over the LAN. The phone scans a QR (host, port, bearer token) or types those values; the Mac accepts `POST /device` only while the pairing window is open.
+
+## Sub-features
+
+- `pair-window` opens a two-minute registration window from **Pair a phone** or `vibebuddyd --pair`.
+- `pair-reject` refuses `POST /device` when the window is closed (`403`).
+- `pair-accept` accepts a structured device body while the window is open (`200`) and records the phone.
+- `pair-forget` requires a new window before the same phone can register again after forget (production Settings **Forget all phones**).
+- `pair-reconnect` lets an already saved phone reconnect later without opening a new window (live app; not this isolated first-registration proof).
+
+## How to get to it (user POV)
+
+- On Mac: menu-bar cat → phone-details popover or Settings → **Pair a phone**. Scan the QR labeled **Pairing QR code** within 2 minutes (`Scan this in the vibebuddy iOS app within 2 minutes.`).
+- On iPhone Connect: **Scan to pair**, or **Enter address manually** (Host / Port / Token) then **Connect**.
+- Headless: `vibebuddyd --pair` prints `Pairing enabled for 120 seconds.`
+- Tailscale: enable **Use Tailscale for remote access**, paste the tailnet host, then pair to that address (still the same token and port).
+
+## Driving it with control-vibebuddy
+
+Preconditions:
+
+- First prove the closed window, then the open window. Use two launches or launch with `--pair` only for the accept step.
+- Isolated port is not `9876`.
+- `doctor` passes for whichever instance you are driving.
+- Do not screenshot the token or QR payload.
+
+- **Closed window.** Launch without pairing. Run `control-vibebuddy launch` then `control-vibebuddy doctor`. Register a phone. Run `code=$(control-vibebuddy device --name 'Verify Phone' --device-id 'verify-phone-1' | tail -n 1)`. The last line is `403`.
+- **Proof of reject.** Run `control-vibebuddy evidence --label phone-pairing-rejected`. `meta.txt` records the run. There is no new paired entry in `device-registry.json` (file missing or entries empty).
+- **Cleanup the reject instance.** Run `control-vibebuddy cleanup`. Confirm the reject evidence directory still exists.
+- **Open window.** Launch with pairing. Run `control-vibebuddy launch --pair` then `control-vibebuddy doctor`. Daemon log contains `Pairing enabled for 120 seconds.`
+- **Accept.** Register inside two minutes. Run `code=$(control-vibebuddy device --name 'Verify Phone' --device-id 'verify-phone-1' | tail -n 1)`. The last line is `200`.
+- **Confirm persistence.** Run `control-vibebuddy evidence --label phone-pairing`. `device-registry.json` includes `verify-phone-1` / `Verify Phone`.
+- **iPhone UI entry (Mac + simulator only).** Point a simulator at this isolated host/port/token via `SIMCTL_CHILD_VIBEBUDDY_HOST` / `PORT` / `TOKEN` and use **Scan to pair** or manual **Connect**. A connected dashboard title is the Mac name, not `Demo`. If simctl is missing, record `verified-unreachable` for this entry only; the HTTP accept/reject still stands.
+
+## Gotchas
+
+- The window is **120 seconds**. If `POST /device` is `403` after `--pair`, the window expired — relaunch with `--pair`, do not retry against a stale process.
+- Saved pairing is not proof the phone is online or that push works (`CONTEXT.md` Pairing / Push coverage).
+- `POST /device` is token-gated. A 401 is a wrong bearer, not a closed window.
+- Historical registrations without recorded consent show as **registered**, not **paired**, in Settings.
+- `scripts/phone_qa_harness.sh` defaults to `:9876` and the login token file. Do not point it at production during this skill.
+- Never commit or paste the run token, QR JSON, or Tailscale host from a real machine.

--- a/.cursor/skills/verify-vibebuddy/features/question-reply.md
+++ b/.cursor/skills/verify-vibebuddy/features/question-reply.md
@@ -1,0 +1,41 @@
+# Question reply
+
+When a Session is `needsResponse` with `waitKind=question` and an answerable `pendingQuestion`, the user replies from the iPhone **Reply** composer, a question card's options, the Mac card, or Watch quick answers. Claude's `AskUserQuestion` is held on `POST /approval`; the answer returns in the hook's `updatedInput`.
+
+## Sub-features
+
+- `q-hold` holds Claude `AskUserQuestion` on the approval route and surfaces `pendingQuestion`.
+- `q-text` sends a free-text `POST /answer` `{"sessionId","answer"}` (older clients; fills the first question).
+- `q-options` sends structured `answers` keyed by item id, matching the card buttons.
+- `q-expired` an `expectedQuestionId` that no longer matches returns `409` and does not become a steer.
+- `q-readonly` a present-at-Mac wait is `answerable: false`; the user answers on the Mac prompt.
+
+## How to get to it (user POV)
+
+- On iPhone: open the waiting row, tap **Reply**, type or tap an option, submit.
+- On Mac Dashboard / Glance: the question card with the same options.
+- On Watch: quick answers only for a single-string wait.
+- Claude Code raises this via the approval hook when the tool is `AskUserQuestion`. Codex questions arrive through the connected app-server (`/answer` with that session's question id).
+
+## Driving it with control-vibebuddy
+
+Preconditions:
+
+- Isolated daemon, `doctor` passed. Headless presence is false, so the card stays answerable.
+- No session `vb-verify-askq` already holding a question.
+- Decide within the approval timeout (~25s, same hold as permissions).
+
+- **Hold AskUserQuestion.** Run `control-vibebuddy approval --json '{"hook_event_name":"PreToolUse","session_id":"vb-verify-askq","cwd":"/tmp/verify-docs-review","tool_name":"AskUserQuestion","tool_use_id":"toolu_verify","tool_input":{"questions":[{"question":"Which revision style should I use?","header":"Style","multiSelect":false,"options":[{"label":"Short","description":"Brief"},{"label":"Long","description":"Full"}]}]}}'`.
+- **See the card.** Poll `control-vibebuddy snapshot` until `vb-verify-askq` has `status=needsResponse`, `waitKind=question`, and `pendingQuestion.prompt` equal to `Which revision style should I use?`. Record `pendingQuestion.id`.
+- **Reply.** Run `control-vibebuddy answer --session-id vb-verify-askq --text 'Short' --question-id '<pendingQuestion.id>'`. HTTP 200.
+- **Confirm.** Snapshot: `pendingQuestion` is absent and `status=working`. The held approval response body includes `permissionDecision` `allow` and `updatedInput.answers` mapping `Which revision style should I use?` to `Short`.
+- **Expired identity.** After the card is gone, run `control-vibebuddy answer --session-id vb-verify-askq --text 'too late' --question-id '<old id>'`. HTTP `409`. The session does not gain a new wait.
+- **Proof.** Run `control-vibebuddy evidence --label question-reply`. Keep snapshot-with-question and snapshot-after-answer. Do not treat a Notification-only row (`waitKind=question` but no `pendingQuestion`) as this feature — that path is dashboard visibility only (`dash-need-question`).
+
+## Gotchas
+
+- AskUserQuestion is handled on **`/approval`**, not `/hook`. A Notification that says "which revision" paints the dashboard but does not create a held `QuestionRegistry` wait.
+- Presence at the Mac makes the phone card read-only; isolated `vibebuddyd` does not claim presence.
+- An expired Answer must not fall through to steer or `turn/start` (`CONTEXT.md` Session action).
+- Multi-select questions need `answers` with arrays. The helper's `--text` only fills the first item (same as an older phone client).
+- Codex Desktop questions may never be answerable from VibeBuddy. Record `verified-unreachable` if `pendingQuestion.answerable` is `false` or missing on a Desktop-origin session.

--- a/.cursor/skills/verify-vibebuddy/features/remote-approval.md
+++ b/.cursor/skills/verify-vibebuddy/features/remote-approval.md
@@ -1,0 +1,44 @@
+# Remote approval
+
+When a Session is `needsResponse` with `waitKind=permission` and an answerable `pendingApproval`, the user reviews the tool (command preview or a bounded diff) and chooses **Approve**, **Deny**, **Always allow this**, or **Allow all this session**. The phone sends `POST /decision`; the held CLI hook then continues.
+
+## Sub-features
+
+- `appr-hold` holds a non-read-only `PreToolUse` (for example `Bash`) until a decision or the ~25s timeout.
+- `appr-allow` **Approve** resolves `allow` and clears `pendingApproval`.
+- `appr-deny` **Deny** resolves `deny`.
+- `appr-always` **Always allow this** persists a rule (or echoes Claude `permission_suggestions`) when `canPersistDecision` is true.
+- `appr-unauth` `POST /decision` without a bearer token is `401`.
+
+## How to get to it (user POV)
+
+- On Mac Dashboard or Glance card: **Approve** (split button), **More approval options** → **Always allow this** / **Allow all this session**, or **Deny**.
+- On iPhone dashboard row / detail: the same **Approve** split button and **Deny**.
+- On Watch: one-shot approve only when the full command is present (Demo `demo-build`); Edit diffs stay on the phone.
+- The CLI approval hook is what raises the card (`hooks/approval-hook.sh` → `POST /approval`).
+
+## Driving it with control-vibebuddy
+
+Preconditions:
+
+- Isolated daemon, `doctor` passed.
+- No session `vb-verify-ap` already holding an approval.
+- You will decide within ~25 seconds of `approval`.
+
+- **Seed a turn.** Run `control-vibebuddy hook --agent claude --json '{"hook_event_name":"SessionStart","session_id":"vb-verify-ap","cwd":"/tmp/verify-gateway"}'` then `control-vibebuddy hook --agent claude --json '{"hook_event_name":"UserPromptSubmit","session_id":"vb-verify-ap","cwd":"/tmp/verify-gateway"}'`.
+- **Hold a Bash permission.** Run `control-vibebuddy approval --session-id vb-verify-ap --cwd /tmp/verify-gateway --tool Bash --command 'rm -rf /tmp/vibebuddy-verify-should-ask'`. The helper backgrounds the holding POST.
+- **See the card.** Poll `control-vibebuddy snapshot` until `sessions[id=vb-verify-ap].pendingApproval` is present, `status=needsResponse`, `waitKind=permission`. Record `pendingApproval.id`.
+- **Approve.** Run `control-vibebuddy decision --approval-id '<that id>' --decision allow`. Exit is success and HTTP 200.
+- **Confirm.** Snapshot again: `pendingApproval` is absent and `status=working`. The held `approval-vb-verify-ap.out` in the state dir contains `permissionDecision` `allow`.
+- **Unauthenticated control.** `curl -sS -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:$VIBEBUDDY_QA_PORT/decision -d '{"approvalId":"x","decision":"allow"}'` prints `401`.
+- **Proof.** Run `control-vibebuddy evidence --label remote-approval`. Keep the before/after snapshot extracts (card present, then cleared) in that folder. On a Mac UI, screenshot **Approve** / **Deny** on the isolated instance only if you also captured the HTTP before/after.
+
+## Gotchas
+
+- `Read`, `Grep`, `Glob`, `LS`, and other `ApprovalShortCircuit.readOnlyTools` never become a card. `Bash` / `Edit` do (unless `bypassPermissions` or a matching always-allow rule).
+- `approvalId` is a UUID from the daemon, not the session id. Always read it from the snapshot.
+- A second `POST /decision` for the same id is `409` (`conflict`). Do not retry as if it were a network miss.
+- Presence at the Mac can make the phone card read-only (`answerable: false`). Headless `vibebuddyd` reports not present, so isolated runs stay answerable.
+- Codex Desktop / MCP elicitation may show a wait the companion cannot remotely resolve. If snapshot `pendingApproval.answerable` is `false`, the user must use the Mac prompt — do not call that path verified via `/decision`.
+- Grok Build: **Allow** may not dismiss the native prompt unless Grok's permission mode agrees (`docs/getting-started.md`).
+- Timeout with no decision returns an empty 200 to the hook (CLI shows its own prompt). That is not an Approve.

--- a/.cursor/skills/verify-vibebuddy/helpers/control-vibebuddy
+++ b/.cursor/skills/verify-vibebuddy/helpers/control-vibebuddy
@@ -1,0 +1,706 @@
+#!/usr/bin/env bash
+# Isolated VibeBuddy verification harness.
+# Start, health-check, drive, and tear down a disposable vibebuddyd.
+# Never binds :9876 and never touches the installed menu-bar app.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: control-vibebuddy <command> [args]
+
+  launch [--pair]     Build (macOS) and start an isolated vibebuddyd.
+  doctor              Read-only: is this instance worth driving?
+  hook --agent <kind> --json '<payload>'
+  snapshot [--pretty]
+  approval --session-id <id> --cwd <dir> --tool <name> [--command <text>] [--file-path <p>] [--old <s>] [--new <s>]
+                      | --json '<PreToolUse or AskUserQuestion payload>'
+  decision --approval-id <id> --decision <allow|deny|alwaysAllow|allowSession>
+  answer --session-id <id> --text <answer> [--question-id <id>]
+  device --name <name> --device-id <id> [--apns-token <t>]
+  evidence --label <id>   Copy health/snapshot/transcripts into VERIFY_EVIDENCE_DIR.
+  sim-demo                Launch iPhone Demo in a simulator (macOS + simctl only).
+  cleanup                 Stop the PID this run started. Keeps evidence.
+
+Environment:
+  VERIFY_RUN_ID           Default: timestamp. Isolates state between runs.
+  VERIFY_STATE_DIR        Process scratch (HOME, logs, pid). Deleted on cleanup.
+  VERIFY_EVIDENCE_DIR     Proof artifacts. Survives cleanup. Default:
+                          <repo>/.scratch/verify-vibebuddy/<VERIFY_RUN_ID>
+  VIBEBUDDY_QA_PORT       Isolated listen port. Default 18765. Must not be 9876.
+  VIBEBUDDY_QA_TOKEN      Isolated bearer token. Default: generated.
+USAGE
+}
+
+die() { echo "control-vibebuddy: $*" >&2; exit 2; }
+fail() { echo "control-vibebuddy: $*" >&2; exit 1; }
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+find_repo() {
+  local d="$script_dir"
+  while [[ "$d" != "/" ]]; do
+    if [[ -f "$d/VibeBuddyMac/Package.swift" && -f "$d/CONTEXT.md" ]]; then
+      printf '%s\n' "$d"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  return 1
+}
+
+REPO="${VERIFY_REPO:-$(find_repo || true)}"
+[[ -n "$REPO" ]] || die "could not find the iOS-vibebuddy repo (looking for VibeBuddyMac/Package.swift)"
+
+RUN_ID="${VERIFY_RUN_ID:-$(date +%Y%m%dT%H%M%S)}"
+STATE_DIR="${VERIFY_STATE_DIR:-${TMPDIR:-/tmp}/vibebuddy-verify-${RUN_ID}}"
+EVIDENCE_DIR="${VERIFY_EVIDENCE_DIR:-$REPO/.scratch/verify-vibebuddy/$RUN_ID}"
+ENV_FILE="$STATE_DIR/run.env"
+HOST="127.0.0.1"
+
+mkdir -p "$EVIDENCE_DIR/transcripts"
+
+log_transcript() {
+  local name="$1"
+  local dest="$EVIDENCE_DIR/transcripts/${name}.txt"
+  {
+    echo "=== $name $(date -u +%Y-%m-%dT%H:%M:%SZ) run=$RUN_ID ==="
+    cat
+    echo
+  } | tee -a "$dest"
+}
+
+write_env() {
+  umask 077
+  mkdir -p "$STATE_DIR"
+  cat >"$ENV_FILE" <<EOF
+VERIFY_RUN_ID=$RUN_ID
+VERIFY_STATE_DIR=$STATE_DIR
+VERIFY_EVIDENCE_DIR=$EVIDENCE_DIR
+VERIFY_HOST=$HOST
+VIBEBUDDY_PORT=$PORT
+VIBEBUDDY_TOKEN=$TOKEN
+VIBEBUDDY_PID=${DAEMON_PID:-}
+VIBEBUDDY_HOME=$STATE_DIR/home
+VIBEBUDDY_PAIR=${PAIR:-0}
+VIBEBUDDY_BINARY=${BINARY:-}
+EOF
+}
+
+load_env() {
+  [[ -f "$ENV_FILE" ]] || return 1
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  HOST="${VERIFY_HOST:-127.0.0.1}"
+  PORT="${VIBEBUDDY_PORT:-}"
+  TOKEN="${VIBEBUDDY_TOKEN:-}"
+  DAEMON_PID="${VIBEBUDDY_PID:-}"
+  PAIR="${VIBEBUDDY_PAIR:-0}"
+  BINARY="${VIBEBUDDY_BINARY:-}"
+}
+
+base_url() { printf 'http://%s:%s' "$HOST" "$PORT"; }
+
+auth_header() { printf 'Authorization: Bearer %s' "$TOKEN"; }
+
+curl_auth() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -X "$method" "$(base_url)$path" \
+    -H "$(auth_header)" \
+    -H 'Content-Type: application/json' \
+    "$@"
+}
+
+host_blocker() {
+  local os
+  os="$(uname -s)"
+  if [[ "$os" != "Darwin" ]]; then
+    cat <<EOF
+blocked: host is $os, not macOS. vibebuddyd is a macOS 14+ executable
+(VibeBuddyMac/Package.swift platforms: [.macOS(.v14)]). The menu-bar app,
+iPhone app, and Watch app also require Xcode and Apple platforms.
+EOF
+    if ! command -v swift >/dev/null 2>&1; then
+      echo "blocked: swift is not on PATH; this checkout cannot be built here."
+    fi
+    if ! command -v xcodebuild >/dev/null 2>&1; then
+      echo "blocked: xcodebuild is not on PATH; VibeBuddyMacApp / VibeBuddyApp cannot be built here."
+    fi
+    if ! command -v xcrun >/dev/null 2>&1; then
+      echo "blocked: xcrun/simctl unavailable; iPhone Demo and Watch QA cannot be launched here."
+    fi
+    echo "Do not invent a web or CLI stand-in. Do not bind :9876. Do not touch an installed app."
+    return 0
+  fi
+  if ! command -v swift >/dev/null 2>&1; then
+    echo "blocked: macOS host but swift is not on PATH (need Swift 6 / Xcode 26.6)."
+    return 0
+  fi
+  return 1
+}
+
+refuse_production_port() {
+  local port="$1"
+  if [[ "$port" == "9876" ]]; then
+    die "refusing port 9876 (the installed menu-bar / production daemon port). Use VIBEBUDDY_QA_PORT."
+  fi
+  if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1024 || port > 65535 )); then
+    die "invalid port '$port' (need 1024-65535, not 9876)"
+  fi
+}
+
+port_listener_pid() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -n 1 || true
+    return
+  fi
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnp 2>/dev/null | python3 -c "
+import re, sys
+port = sys.argv[1]
+for line in sys.stdin:
+    if ':' + port + ' ' in line or line.rstrip().endswith(':' + port):
+        m = re.search(r'pid=(\d+)', line)
+        if m:
+            print(m.group(1))
+            break
+" "$port" || true
+    return
+  fi
+}
+
+pid_alive() {
+  local pid="$1"
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+cmd_launch() {
+  PAIR=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --pair) PAIR=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "launch: unknown arg $1" ;;
+    esac
+  done
+
+  if blocker="$(host_blocker)"; then
+    printf '%s\n' "$blocker" | log_transcript launch
+    die "$(printf '%s\n' "$blocker" | head -n 1)"
+  fi
+
+  PORT="${VIBEBUDDY_QA_PORT:-18765}"
+  refuse_production_port "$PORT"
+  TOKEN="${VIBEBUDDY_QA_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_hex(16))')}"
+
+  if existing="$(port_listener_pid "$PORT")"; [[ -n "$existing" ]]; then
+    die "port $PORT already has a listener (pid $existing). Pick another VIBEBUDDY_QA_PORT."
+  fi
+
+  mkdir -p "$STATE_DIR/home" "$STATE_DIR/home/Library/Application Support/vibebuddy"
+  umask 077
+
+  local resolved_bak="$STATE_DIR/Package.resolved.bak"
+  if [[ -f "$REPO/VibeBuddyMac/Package.resolved" ]]; then
+    cp "$REPO/VibeBuddyMac/Package.resolved" "$resolved_bak"
+  fi
+  echo "→ building vibebuddyd (isolated; will restore Package.resolved)" | log_transcript launch
+  if ! (cd "$REPO" && swift build --package-path VibeBuddyMac --product vibebuddyd); then
+    [[ -f "$resolved_bak" ]] && cp "$resolved_bak" "$REPO/VibeBuddyMac/Package.resolved"
+    die "swift build of vibebuddyd failed"
+  fi
+  [[ -f "$resolved_bak" ]] && cp "$resolved_bak" "$REPO/VibeBuddyMac/Package.resolved"
+
+  BINARY="$(cd "$REPO" && swift build --package-path VibeBuddyMac --product vibebuddyd --show-bin-path)/vibebuddyd"
+  [[ -x "$BINARY" ]] || die "built binary missing: $BINARY"
+
+  local args=()
+  [[ "$PAIR" == "1" ]] && args+=(--pair)
+
+  echo "→ starting isolated vibebuddyd on :$PORT (HOME=$STATE_DIR/home pair=$PAIR)" | log_transcript launch
+  HOME="$STATE_DIR/home" \
+    VIBEBUDDY_PORT="$PORT" \
+    VIBEBUDDY_TOKEN="$TOKEN" \
+    VIBEBUDDY_JOURNAL_PATH="$STATE_DIR/journal.json" \
+    VIBEBUDDY_DELIVERY_LOG_PATH="$STATE_DIR/delivery.json" \
+    VIBEBUDDY_DEVICE_REGISTRY_PATH="$STATE_DIR/device-registry.json" \
+    VIBEBUDDY_MISSED_PATH="$STATE_DIR/missed.json" \
+    "$BINARY" "${args[@]}" >"$STATE_DIR/daemon.log" 2>&1 &
+  DAEMON_PID=$!
+  write_env
+
+  local i
+  for i in $(seq 1 40); do
+    if curl -fsS "$(base_url)/health" >/dev/null 2>&1; then
+      break
+    fi
+    if ! pid_alive "$DAEMON_PID"; then
+      echo "daemon exited during startup; log:" | log_transcript launch
+      tail -n 80 "$STATE_DIR/daemon.log" | log_transcript launch
+      die "vibebuddyd exited before /health answered"
+    fi
+    sleep 0.25
+  done
+  local health
+  health="$(curl -fsS "$(base_url)/health" || true)"
+  if [[ "$health" != "ok" ]]; then
+    tail -n 80 "$STATE_DIR/daemon.log" | log_transcript launch
+    die "daemon never became ready (GET /health != ok)"
+  fi
+  if ! grep -q "listening on 0.0.0.0:${PORT}" "$STATE_DIR/daemon.log"; then
+    echo "warning: ready via /health but missing the listening log line" | log_transcript launch
+  fi
+  {
+    echo "ready url=$(base_url) pid=$DAEMON_PID pair=$PAIR"
+    echo "token is in $ENV_FILE (do not paste tokens into issues or screenshots)"
+    echo "evidence=$EVIDENCE_DIR"
+  } | log_transcript launch
+}
+
+require_instance() {
+  load_env || fail "no run.env at $ENV_FILE — run launch first"
+  [[ -n "$PORT" && -n "$TOKEN" ]] || fail "run.env is incomplete"
+  refuse_production_port "$PORT"
+}
+
+cmd_doctor() {
+  local issues=0
+  local report
+  report="$(mktemp)"
+  {
+    echo "run_id=$RUN_ID"
+    echo "state_dir=$STATE_DIR"
+    echo "evidence_dir=$EVIDENCE_DIR"
+    echo "host=$(uname -s) $(uname -m)"
+  } >"$report"
+
+  if blocker="$(host_blocker)"; then
+    printf '%s\n' "$blocker" >>"$report"
+    cat "$report" | log_transcript doctor
+    rm -f "$report"
+    fail "instance is not worth driving (host cannot run VibeBuddy)"
+  fi
+
+  if ! load_env; then
+    echo "run.env missing — no isolated instance was started by this run" >>"$report"
+    cat "$report" | log_transcript doctor
+    rm -f "$report"
+    fail "no isolated instance"
+  fi
+
+  refuse_production_port "$PORT"
+  echo "url=$(base_url)" >>"$report"
+  echo "pid=${DAEMON_PID:-none}" >>"$report"
+  echo "pair=$PAIR" >>"$report"
+  echo "home=${VIBEBUDDY_HOME:-}" >>"$report"
+
+  if [[ "${VIBEBUDDY_HOME:-}" != "$STATE_DIR/home" ]]; then
+    echo "FAIL home is not the disposable run home" >>"$report"
+    issues=1
+  else
+    echo "ok disposable HOME" >>"$report"
+  fi
+
+  if [[ -f "$HOME/Library/Application Support/vibebuddy/token" ]] && \
+     [[ "${VIBEBUDDY_HOME:-}" == "$HOME"* ]]; then
+    echo "FAIL isolated HOME collapsed onto the login HOME" >>"$report"
+    issues=1
+  fi
+
+  if ! pid_alive "${DAEMON_PID:-}"; then
+    echo "FAIL pid ${DAEMON_PID:-?} is not running" >>"$report"
+    issues=1
+  else
+    echo "ok pid $DAEMON_PID alive" >>"$report"
+    if [[ -n "${BINARY:-}" && -r "/proc/$DAEMON_PID/cmdline" ]]; then
+      if tr '\0' ' ' <"/proc/$DAEMON_PID/cmdline" | grep -q 'vibebuddyd'; then
+        echo "ok pid command is vibebuddyd" >>"$report"
+      else
+        echo "FAIL pid $DAEMON_PID is not vibebuddyd" >>"$report"
+        issues=1
+      fi
+    elif [[ "$(uname -s)" == "Darwin" ]]; then
+      local cmd
+      cmd="$(ps -p "$DAEMON_PID" -o comm= 2>/dev/null || true)"
+      if [[ "$cmd" == *vibebuddyd* ]]; then
+        echo "ok pid command is $cmd" >>"$report"
+      else
+        echo "FAIL pid $DAEMON_PID command is '$cmd', expected vibebuddyd" >>"$report"
+        issues=1
+      fi
+    fi
+  fi
+
+  local listener
+  listener="$(port_listener_pid "$PORT")"
+  if [[ -z "$listener" ]]; then
+    echo "FAIL nothing listens on $PORT" >>"$report"
+    issues=1
+  elif [[ -n "${DAEMON_PID:-}" && "$listener" != "$DAEMON_PID" ]]; then
+    echo "FAIL port $PORT is owned by pid $listener, not $DAEMON_PID" >>"$report"
+    issues=1
+  else
+    echo "ok port $PORT owned by $listener" >>"$report"
+  fi
+
+  local health
+  health="$(curl -sS --max-time 2 "$(base_url)/health" || true)"
+  if [[ "$health" == "ok" ]]; then
+    echo "ok GET /health => ok" >>"$report"
+  else
+    echo "FAIL GET /health => '${health:-<empty>}'" >>"$report"
+    issues=1
+  fi
+
+  local unauth
+  unauth="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "$(base_url)/snapshot" || true)"
+  if [[ "$unauth" == "401" ]]; then
+    echo "ok GET /snapshot without token => 401" >>"$report"
+  else
+    echo "FAIL GET /snapshot without token => $unauth (expected 401)" >>"$report"
+    issues=1
+  fi
+
+  local snap_code snap
+  snap="$(mktemp)"
+  snap_code="$(curl -sS -o "$snap" -w '%{http_code}' --max-time 4 \
+    "$(base_url)/snapshot" -H "$(auth_header)" || true)"
+  if [[ "$snap_code" == "200" ]] && python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$snap"; then
+    echo "ok GET /snapshot with token => 200 JSON" >>"$report"
+    python3 - "$snap" >>"$report" <<'PY'
+import json, sys
+snap = json.load(open(sys.argv[1]))
+sessions = snap.get("sessions") or []
+print(f"ok snapshot sessions={len(sessions)} sourceID={snap.get('sourceID')}")
+for s in sessions:
+    print("  - {id} status={status} wait={wait} project={project}".format(
+        id=s.get("id"), status=s.get("status"), wait=s.get("waitKind"),
+        project=s.get("project")))
+PY
+  else
+    echo "FAIL GET /snapshot with token => $snap_code" >>"$report"
+    issues=1
+  fi
+  rm -f "$snap"
+
+  cat "$report" | log_transcript doctor
+  rm -f "$report"
+  if [[ "$issues" -ne 0 ]]; then
+    fail "doctor found $issues problem(s) — do not drive this instance"
+  fi
+  echo "doctor: instance is worth driving"
+}
+
+cmd_hook() {
+  require_instance
+  local agent="claude" json=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent) agent="$2"; shift 2 ;;
+      --json) json="$2"; shift 2 ;;
+      *) die "hook: unknown arg $1" ;;
+    esac
+  done
+  [[ -n "$json" ]] || die "hook: --json is required"
+  local code
+  code="$(curl -sS -o /tmp/vb-hook-body.$$ -w '%{http_code}' -X POST \
+    "$(base_url)/hook?agent=${agent}" \
+    -H "$(auth_header)" -H 'Content-Type: application/json' \
+    --data-binary "$json")"
+  if [[ "$code" != "200" ]]; then
+    cat /tmp/vb-hook-body.$$ >&2 || true
+    rm -f /tmp/vb-hook-body.$$
+    fail "POST /hook => $code"
+  fi
+  rm -f /tmp/vb-hook-body.$$
+  echo "ok POST /hook?agent=$agent"
+}
+
+cmd_snapshot() {
+  require_instance
+  local pretty=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --pretty) pretty=1; shift ;;
+      *) die "snapshot: unknown arg $1" ;;
+    esac
+  done
+  local body
+  body="$(curl_auth GET /snapshot)"
+  if [[ "$pretty" == "1" ]]; then
+    python3 -c 'import json,sys; print(json.dumps(json.loads(sys.stdin.read()), indent=2))' <<<"$body"
+  else
+    printf '%s\n' "$body"
+  fi
+}
+
+cmd_approval() {
+  require_instance
+  local sid="" cwd="" tool="Bash" command="" file_path="" old="" new="" json=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session-id) sid="$2"; shift 2 ;;
+      --cwd) cwd="$2"; shift 2 ;;
+      --tool) tool="$2"; shift 2 ;;
+      --command) command="$2"; shift 2 ;;
+      --file-path) file_path="$2"; shift 2 ;;
+      --old) old="$2"; shift 2 ;;
+      --new) new="$2"; shift 2 ;;
+      --json) json="$2"; shift 2 ;;
+      *) die "approval: unknown arg $1" ;;
+    esac
+  done
+  local payload
+  if [[ -n "$json" ]]; then
+    payload="$json"
+    sid="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("session_id",""))' "$json")"
+  else
+  [[ -n "$sid" && -n "$cwd" ]] || die "approval: --session-id and --cwd are required, or pass --json"
+  payload="$(python3 - "$sid" "$cwd" "$tool" "$command" "$file_path" "$old" "$new" <<'PY'
+import json, sys
+sid, cwd, tool, command, file_path, old, new = sys.argv[1:]
+tool_input = {}
+if command:
+    tool_input["command"] = command
+if file_path:
+    tool_input["file_path"] = file_path
+if old:
+    tool_input["old_string"] = old
+if new:
+    tool_input["new_string"] = new
+if not tool_input:
+    tool_input["command"] = "rm -rf /tmp/vibebuddy-verify-should-ask"
+print(json.dumps({
+    "hook_event_name": "PreToolUse",
+    "session_id": sid,
+    "cwd": cwd,
+    "tool_name": tool,
+    "tool_input": tool_input,
+}))
+PY
+)"
+  fi
+  [[ -n "$sid" ]] || sid="held"
+  # Holding POST: the route blocks until /decision or the 25s timeout.
+  curl_auth POST /approval --data-binary "$payload" \
+    >"$STATE_DIR/approval-${sid}.out" 2>"$STATE_DIR/approval-${sid}.err" &
+  echo $! >"$STATE_DIR/approval-${sid}.pid"
+  echo "ok POST /approval holding (pid $(cat "$STATE_DIR/approval-${sid}.pid"))"
+}
+
+cmd_decision() {
+  require_instance
+  local id="" decision=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --approval-id) id="$2"; shift 2 ;;
+      --decision) decision="$2"; shift 2 ;;
+      *) die "decision: unknown arg $1" ;;
+    esac
+  done
+  [[ -n "$id" && -n "$decision" ]] || die "decision: --approval-id and --decision are required"
+  case "$decision" in
+    allow|deny|alwaysAllow|allowSession) ;;
+    *) die "decision: unknown decision '$decision'" ;;
+  esac
+  local code
+  code="$(curl -sS -o /tmp/vb-dec-body.$$ -w '%{http_code}' -X POST \
+    "$(base_url)/decision" -H "$(auth_header)" -H 'Content-Type: application/json' \
+    --data-binary "$(python3 -c 'import json,sys; print(json.dumps({"approvalId":sys.argv[1],"decision":sys.argv[2]}))' "$id" "$decision")")"
+  if [[ "$code" != "200" ]]; then
+    echo "POST /decision => $code" >&2
+    cat /tmp/vb-dec-body.$$ >&2 || true
+    rm -f /tmp/vb-dec-body.$$
+    fail "decision failed"
+  fi
+  rm -f /tmp/vb-dec-body.$$
+  echo "ok POST /decision $decision"
+}
+
+cmd_answer() {
+  require_instance
+  local sid="" text="" qid=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session-id) sid="$2"; shift 2 ;;
+      --text) text="$2"; shift 2 ;;
+      --question-id) qid="$2"; shift 2 ;;
+      *) die "answer: unknown arg $1" ;;
+    esac
+  done
+  [[ -n "$sid" && -n "$text" ]] || die "answer: --session-id and --text are required"
+  local payload
+  payload="$(python3 - "$sid" "$text" "$qid" <<'PY'
+import json, sys
+sid, text, qid = sys.argv[1:]
+body = {"sessionId": sid, "answer": text}
+if qid:
+    body["expectedQuestionId"] = qid
+print(json.dumps(body))
+PY
+)"
+  local code
+  code="$(curl -sS -o /tmp/vb-ans-body.$$ -w '%{http_code}' -X POST \
+    "$(base_url)/answer" -H "$(auth_header)" -H 'Content-Type: application/json' \
+    --data-binary "$payload")"
+  echo "POST /answer => $code"
+  cat /tmp/vb-ans-body.$$
+  echo
+  rm -f /tmp/vb-ans-body.$$
+  [[ "$code" == "200" ]] || fail "answer failed"
+}
+
+cmd_device() {
+  require_instance
+  local name="" device_id="" apns=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --name) name="$2"; shift 2 ;;
+      --device-id) device_id="$2"; shift 2 ;;
+      --apns-token) apns="$2"; shift 2 ;;
+      *) die "device: unknown arg $1" ;;
+    esac
+  done
+  [[ -n "$name" && -n "$device_id" ]] || die "device: --name and --device-id are required"
+  local payload
+  payload="$(python3 - "$name" "$device_id" "$apns" <<'PY'
+import json, sys
+name, device_id, apns = sys.argv[1:]
+body = {"name": name, "deviceID": device_id, "model": "iPhone", "systemVersion": "iOS 17.0"}
+if apns:
+    body["token"] = apns
+print(json.dumps(body))
+PY
+)"
+  local code
+  code="$(curl -sS -o /tmp/vb-dev-body.$$ -w '%{http_code}' -X POST \
+    "$(base_url)/device" -H "$(auth_header)" -H 'Content-Type: application/json' \
+    --data-binary "$payload")"
+  echo "POST /device => $code"
+  cat /tmp/vb-dev-body.$$ 2>/dev/null || true
+  echo
+  rm -f /tmp/vb-dev-body.$$
+  printf '%s\n' "$code"
+}
+
+cmd_evidence() {
+  local label=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --label) label="$2"; shift 2 ;;
+      *) die "evidence: unknown arg $1" ;;
+    esac
+  done
+  [[ -n "$label" ]] || die "evidence: --label is required"
+  local dest="$EVIDENCE_DIR/$label"
+  mkdir -p "$dest"
+  {
+    echo "run_id=$RUN_ID"
+    echo "captured_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "host=$(uname -s) $(uname -m)"
+    echo "evidence=$dest"
+    if load_env; then
+      echo "url=$(base_url)"
+      echo "pid=${DAEMON_PID:-}"
+      echo "port=$PORT"
+      echo "pair=$PAIR"
+    else
+      echo "instance=none"
+    fi
+  } >"$dest/meta.txt"
+  if load_env && [[ -n "${PORT:-}" ]]; then
+    curl -sS --max-time 2 "$(base_url)/health" >"$dest/health.txt" || echo "health-failed" >"$dest/health.txt"
+    curl -sS --max-time 4 "$(base_url)/snapshot" -H "$(auth_header)" >"$dest/snapshot.json" || \
+      echo '{"error":"snapshot-failed"}' >"$dest/snapshot.json"
+    [[ -f "$STATE_DIR/daemon.log" ]] && tail -n 40 "$STATE_DIR/daemon.log" >"$dest/daemon-tail.txt" || true
+    [[ -f "$STATE_DIR/device-registry.json" ]] && cp "$STATE_DIR/device-registry.json" "$dest/device-registry.json" || true
+  fi
+  echo "ok evidence at $dest"
+}
+
+cmd_sim_demo() {
+  if blocker="$(host_blocker)"; then
+    printf '%s\n' "$blocker" | log_transcript sim-demo
+    die "$(printf '%s\n' "$blocker" | head -n 1)"
+  fi
+  command -v xcrun >/dev/null 2>&1 || die "xcrun is required for sim-demo"
+  local phone_name="${WATCH_RELAY_PHONE:-iPhone 16}"
+  local udid
+  udid="$(xcrun simctl list devices booted | awk -v n="$phone_name" '$0 ~ n {print}' | sed -n 's/.*(\([A-F0-9-]*\)).*/\1/p' | head -n 1 || true)"
+  if [[ -z "$udid" ]]; then
+    udid="$(xcrun simctl list devices booted | sed -n 's/.*(\([A-F0-9-]*\)) *(Booted).*/\1/p' | head -n 1 || true)"
+  fi
+  [[ -n "$udid" ]] || die "no booted iOS Simulator. Boot one, then retry."
+  local app="$REPO/.build/watch-live-qa/Build/Products/Debug-iphonesimulator/VibeBuddyApp.app"
+  if [[ ! -d "$app" ]]; then
+    die "VibeBuddyApp.app not built at $app. On a Mac: xcodegen generate --spec VibeBuddyApp/project.yml && xcodebuild -project VibeBuddyApp/VibeBuddyApp.xcodeproj -scheme VibeBuddyApp -destination 'generic/platform=iOS Simulator' -derivedDataPath .build/watch-live-qa build CODE_SIGNING_ALLOWED=NO"
+  fi
+  xcrun simctl install "$udid" "$app"
+  xcrun simctl terminate "$udid" com.vibebuddy.app 2>/dev/null || true
+  SIMCTL_CHILD_VIBEBUDDY_DEMO=1 SIMCTL_CHILD_VIBEBUDDY_SKIP_NOTIFICATIONS=1 \
+    xcrun simctl launch "$udid" com.vibebuddy.app >/dev/null
+  echo "ok launched Demo on simulator $udid"
+}
+
+cmd_cleanup() {
+  local killed=0
+  if load_env && [[ -n "${DAEMON_PID:-}" ]]; then
+    if pid_alive "$DAEMON_PID"; then
+      kill "$DAEMON_PID" 2>/dev/null || true
+      local i
+      for i in $(seq 1 20); do
+        pid_alive "$DAEMON_PID" || break
+        sleep 0.1
+      done
+      if pid_alive "$DAEMON_PID"; then
+        kill -9 "$DAEMON_PID" 2>/dev/null || true
+      fi
+      killed=1
+      echo "ok sent signal to pid $DAEMON_PID"
+    else
+      echo "ok pid ${DAEMON_PID} already gone"
+    fi
+    shopt -s nullglob
+    for hold in "$STATE_DIR"/approval-*.pid; do
+      local hpid
+      hpid="$(cat "$hold" 2>/dev/null || true)"
+      if pid_alive "$hpid"; then
+        kill "$hpid" 2>/dev/null || true
+      fi
+    done
+    shopt -u nullglob
+  else
+    echo "ok no run.env — nothing this run started"
+  fi
+
+  if [[ -d "$STATE_DIR" ]]; then
+    case "$EVIDENCE_DIR" in
+      "$STATE_DIR"|"$STATE_DIR"/*)
+        die "refusing to delete STATE_DIR because evidence lives inside it ($EVIDENCE_DIR). Set VERIFY_EVIDENCE_DIR outside the scratch dir."
+        ;;
+    esac
+    rm -rf "$STATE_DIR"
+    echo "ok removed scratch $STATE_DIR"
+  fi
+  echo "ok evidence kept at $EVIDENCE_DIR (killed=$killed)"
+  echo "cleanup complete" | log_transcript cleanup
+}
+
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  launch) cmd_launch "$@" ;;
+  doctor) cmd_doctor "$@" ;;
+  hook) cmd_hook "$@" ;;
+  snapshot) cmd_snapshot "$@" ;;
+  approval) cmd_approval "$@" ;;
+  decision) cmd_decision "$@" ;;
+  answer) cmd_answer "$@" ;;
+  device) cmd_device "$@" ;;
+  evidence) cmd_evidence "$@" ;;
+  sim-demo) cmd_sim_demo "$@" ;;
+  cleanup) cmd_cleanup "$@" ;;
+  -h|--help|help|"") usage; [[ -n "$cmd" ]] || exit 2 ;;
+  *) usage; die "unknown command: $cmd" ;;
+esac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a project-local verification skill so an agent can drive VibeBuddy the way a user does: isolated `vibebuddyd`, the same HTTP routes the iPhone and hooks use, and iPhone Demo on a simulator.

## What landed

- `.cursor/skills/verify-vibebuddy/SKILL.md` — launch, doctor, drive, evidence, cleanup, helpers
- `helpers/control-vibebuddy` — executable harness (never binds `:9876`, never uses the login token file)
- Feature map for the first five user surfaces:
  - dashboard sessions (the three states)
  - phone pairing (120s window)
  - remote approval
  - question reply
  - iPhone Demo

## Isolation

Verification starts `vibebuddyd` on `VIBEBUDDY_QA_PORT` (default `18765`) with a disposable `HOME`. It does not replace an installed Mac app or the production daemon on `:9876`.

## Proof of this skill

Ran the generated helper end to end on the Cloud Agent host: launch → doctor → drive `dashboard-sessions` → evidence → cleanup.

That host is Linux, with no Swift/Xcode/simctl. Launch/doctor/sim-demo exited `blocked` with that precise gap. Drive refused to invent a stand-in. Cleanup left no process on `:18765` or `:9876` and kept the evidence files. Live Mac/iPhone/Watch acceptance is still required on an Apple machine.

Keep the map honest later with `/maintain-verification-skill`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cfe6275-4ee0-5035-a8db-e067ae0cf5be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cfe6275-4ee0-5035-a8db-e067ae0cf5be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

