### PR TITLE
Local token consumption and richer account quota

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -297,6 +297,12 @@ code, and tests — don't drift to synonyms.
 - **AccountUsage** — provider quota (Codex app-server RPC, Claude `/usage` CLI):
   window, remaining, reset, freshness, `stale` / unavailable reason. Collected by
   isolated, individually switchable adapters that can never move session state.
+- **Token consumption** — local, read-only aggregation of tokens spent in Claude
+  Code transcripts and Codex CLI/Desktop rollouts (input, output, cache-read,
+  reasoning), grouped by agent, model and project over today and the last seven
+  days. Distinct from **AccountUsage** (quota remaining) and from a Session's
+  current-turn `tokens` / cumulative `spentTokens`. Composed into the snapshot
+  beside quota; never feeds the session reducer and never leaves the machine.
 - **Grok Bot** — the cloud bot product opened by `com.anysphere.sand`, distinct
   from Grok Build CLI (`grok`). Its account quota has the independent `grokBot`
   provider identity. The optional Mac observer uses the official client's

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -294,9 +294,13 @@ code, and tests — don't drift to synonyms.
   Identified phones can be saved before APNs registration; push counts include
   only records with a token. Expiring a push token retains the phone identity,
   so push availability never decides whether that phone is paired.
-- **AccountUsage** — provider quota (Codex app-server RPC, Claude `/usage` CLI):
-  window, remaining, reset, freshness, `stale` / unavailable reason. Collected by
-  isolated, individually switchable adapters that can never move session state.
+- **AccountUsage** — provider quota (Codex app-server RPC, Claude `/usage` CLI,
+  Cursor/Grok local sources): window, remaining, reset, freshness, `stale` /
+  unavailable reason, plus extra named windows (Claude model-week, Codex Spark),
+  credits remaining, and extra-usage spend when the local source reports them.
+  Collected by isolated, individually switchable adapters that can never move
+  session state. Extra windows never replace the weekly remaining slot.
+  Distinct from **Token consumption** (local spend ledger) and from billed invoices.
 - **Token consumption** — local, read-only aggregation of tokens spent in Claude
   Code transcripts and Codex CLI/Desktop rollouts (input, output, cache-read,
   reasoning), grouped by agent, model and project over today and the last seven

--- a/VibeBuddyApp/Sources/AccountQuotaView.swift
+++ b/VibeBuddyApp/Sources/AccountQuotaView.swift
@@ -87,6 +87,18 @@ struct AccountQuotaView: View {
                                     ForEach(Array(windows.enumerated()), id: \.offset) { _, window in
                                         reading(window, now: context.date)
                                     }
+                                    if let credits = quota.credits {
+                                        LabeledContent(credits.label ?? "Credits", value: QuotaPresentation.creditsLine(credits))
+                                        if let reset = credits.resetsAt {
+                                            Text(QuotaPresentation.resetLine(from: reset, now: context.date))
+                                                .font(.caption).foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    if let spend = quota.spend, !spend.isEmpty {
+                                        ForEach(spend) { row in
+                                            LabeledContent(row.label, value: QuotaPresentation.spendLine(row))
+                                        }
+                                    }
                                     if let reason = quota.unavailableReason {
                                         Text(reason).font(.callout).foregroundStyle(.secondary)
                                     }
@@ -133,7 +145,7 @@ struct AccountQuotaView: View {
         return VStack(alignment: .leading, spacing: 6) {
             Text(Self.title(window)).font(.headline)
             if let remaining {
-                Text("\(remaining)% remaining").monospacedDigit()
+                Text(QuotaPresentation.remainingLine(remainingPercent: remaining)).monospacedDigit()
                 ProgressView(value: Double(remaining), total: 100)
             } else { Text("Remaining unknown") }
             switch status {
@@ -147,8 +159,14 @@ struct AccountQuotaView: View {
                 Text(dashboard.state == .connected ? "Recent Mac reading" : "Cached · Mac unreachable")
             }
             if let reset = window.resetsAt {
-                Text("Resets: \(reset.formatted(date: .abbreviated, time: .shortened))")
+                Text(QuotaPresentation.resetLine(from: reset, now: now))
             } else { Text("Reset time unknown") }
+            if let remaining, let minutes = window.durationMinutes, minutes >= 10_080,
+               let reset = window.resetsAt,
+               let pace = QuotaPresentation.weeklyPace(
+                usedPercent: 100 - remaining, resetsAt: reset, windowMinutes: minutes, now: now) {
+                Text(pace.caption).font(.caption).foregroundStyle(.secondary)
+            }
             if let observed = window.observedAt {
                 Text("Updated: \(observed.formatted(date: .abbreviated, time: .shortened))")
             } else { Text("Update time unknown") }

--- a/VibeBuddyApp/Sources/AccountQuotaView.swift
+++ b/VibeBuddyApp/Sources/AccountQuotaView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VibeBuddyKit
 
-/// Read-only rendering of the exact account readings relayed to the Watch.
+/// Usage sheet: local token spend plus the account quota readings relayed to the Watch.
 struct AccountQuotaView: View {
     @EnvironmentObject private var dashboard: DashboardStore
     @EnvironmentObject private var connection: ConnectionStore
@@ -12,21 +12,66 @@ struct AccountQuotaView: View {
             TimelineView(.periodic(from: .now, by: 30)) { context in
                 List {
                     Section {
-                        if connection.pairing == nil {
-                            Text("Pair with your Mac to see account quota.")
+                        if connection.pairing == nil && !connection.demo {
+                            Text("Pair with your Mac to see usage.")
                         } else {
-                            Text(connection.pairing?.macName ?? "Mac")
-                            if dashboard.state != .connected {
+                            Text(connection.pairing?.macName ?? (connection.demo ? "Demo" : "Mac"))
+                            if connection.pairing != nil, dashboard.state != .connected {
                                 Label("Mac unreachable · saved readings only", systemImage: "wifi.slash")
                             }
                         }
                     } footer: {
-                        Text("Account allowance from your Mac, separate from a task's context usage. Manage accounts and quota sources on your Mac.")
+                        Text("Token spend is from local Claude Code and Codex logs on the Mac. Account quota is remaining allowance. Neither is a billed invoice.")
+                    }
+                    if let consumption = dashboard.lastTokenConsumption {
+                        ForEach(consumption.windows) { window in
+                            Section(window.kind.title) {
+                                if window.counts.isEmpty {
+                                    Text("No spend in this window")
+                                        .foregroundStyle(.secondary)
+                                } else {
+                                    LabeledContent("Estimated cost", value: TokenConsumptionSnapshot.formatUSD(window.counts.estimatedUSD))
+                                    LabeledContent("Tokens", value: TokenConsumptionSnapshot.formatTokens(window.counts.totalTokens))
+                                    LabeledContent("Billed / cache", value: "\(TokenConsumptionSnapshot.formatTokens(window.counts.billedTokens)) · \(TokenConsumptionSnapshot.formatTokens(window.counts.cachedInputTokens))")
+                                    LabeledContent("Sessions", value: "\(window.counts.sessionCount)")
+                                    if !window.byAgent.isEmpty {
+                                        Text("By agent").font(.caption).foregroundStyle(.secondary)
+                                        ForEach(window.byAgent) { row in
+                                            LabeledContent(row.label, value: "\(TokenConsumptionSnapshot.formatTokens(row.counts.totalTokens)) · \(TokenConsumptionSnapshot.formatUSD(row.counts.estimatedUSD))")
+                                        }
+                                    }
+                                    if !window.byModel.isEmpty {
+                                        Text("By model").font(.caption).foregroundStyle(.secondary)
+                                        ForEach(Array(window.byModel.prefix(6))) { row in
+                                            LabeledContent(row.label, value: TokenConsumptionSnapshot.formatTokens(row.counts.totalTokens))
+                                        }
+                                    }
+                                    if !window.byProject.isEmpty {
+                                        Text("By project").font(.caption).foregroundStyle(.secondary)
+                                        ForEach(Array(window.byProject.prefix(4))) { row in
+                                            LabeledContent(row.label, value: TokenConsumptionSnapshot.formatTokens(row.counts.totalTokens))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if let observed = dashboard.lastTokenConsumption?.observedAt {
+                            Section {
+                                Text("Token spend updated \(observed.formatted(date: .abbreviated, time: .shortened))")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    } else if connection.pairing != nil || connection.demo {
+                        Section("Token consumption") {
+                            Text("Not provided by this Mac yet")
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     if connection.pairing != nil {
                         ForEach(AccountUsageProvider.allCases) { provider in
                             let quota = dashboard.lastProviderQuota.first { $0.provider == provider }
-                            Section(provider.displayName) {
+                            Section("\(provider.displayName) quota") {
                                 if let quota {
                                     if let account = quota.accountLabel {
                                         Text(account).font(.caption).foregroundStyle(.secondary)
@@ -54,7 +99,7 @@ struct AccountQuotaView: View {
                     }
                 }
             }
-            .navigationTitle("Account quota")
+            .navigationTitle("Usage")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { ToolbarItem(placement: .confirmationAction) { Button("Done") { dismiss() } } }
         }

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -106,6 +106,8 @@ final class DashboardStore: ObservableObject {
     /// untouched — normalization already happened where the provider's own
     /// convention was still known.
     @Published private(set) var lastProviderQuota: [ProviderQuota] = []
+    /// Local Claude Code / Codex token spend as the Mac last reported it.
+    @Published private(set) var lastTokenConsumption: TokenConsumptionSnapshot?
     private var runTask: Task<Void, Never>?
     private var connectionGeneration = UUID()
     /// Decides which sound (if any) each snapshot earns. Reset per connection so
@@ -342,6 +344,7 @@ final class DashboardStore: ObservableObject {
         runTask?.cancel()
         isDemo = false
         lastProviderQuota = []
+        lastTokenConsumption = nil
         if self.pairing != pairing { phoneActions = [:]; phoneActionIdentity = [:] }
         self.pairing = pairing
         ConnectionStore.observePairing(pairing)
@@ -413,6 +416,7 @@ final class DashboardStore: ObservableObject {
         state = .connecting
         groups = SessionGroups([])
         lastProviderQuota = []
+        lastTokenConsumption = nil
         relayToWatch([])
     }
 
@@ -519,6 +523,7 @@ final class DashboardStore: ObservableObject {
         stop()
         isDemo = true
         lastProviderQuota = []
+        lastTokenConsumption = TokenConsumptionSnapshot.demo()
         pairing = nil
         state = .connected
         let demo = Self.demoSessions()
@@ -909,6 +914,7 @@ final class DashboardStore: ObservableObject {
         // Never let its old Mac readings repopulate a newly selected source.
         guard !Task.isCancelled else { return }
         lastProviderQuota = snapshot.providerQuota ?? []
+        lastTokenConsumption = snapshot.tokenConsumption
         buddySessionIDs = BuddyScope.pruned(buddySessionIDs, toLive: snapshot.sessions)
         state = .connected
         confirmConnectedPairing()

--- a/VibeBuddyApp/Sources/DashboardView.swift
+++ b/VibeBuddyApp/Sources/DashboardView.swift
@@ -120,7 +120,7 @@ struct DashboardView: View {
         .toolbar {
             // The title is the paired Mac: a status dot, its name, and a menu
             // holding everything about the link (address, reconnect, forget).
-            // "New task" lives in the composer; account quota has its own read-only entry.
+            // "New task" lives in the composer; usage (quota + token spend) has its own read-only entry.
             ToolbarItem(placement: .principal) {
                 MacTitleMenu(title: macTitle, pairing: connection.pairing, demo: connection.demo,
                              state: dashboard.state,
@@ -134,7 +134,7 @@ struct DashboardView: View {
                              disconnect: { connection.clear(); dashboard.forgetPairing() })
             }
             ToolbarItem(placement: .topBarLeading) {
-                Button { showQuota = true } label: { Label("Account quota", systemImage: "gauge.with.dots.needle.50percent") }
+                Button { showQuota = true } label: { Label("Usage", systemImage: "chart.bar.xaxis") }
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button { showSettings = true } label: { Image(systemName: "gearshape") }

--- a/VibeBuddyApp/Tests/AccountQuotaTests.swift
+++ b/VibeBuddyApp/Tests/AccountQuotaTests.swift
@@ -23,6 +23,22 @@ final class AccountQuotaTests: XCTestCase {
         XCTAssertTrue(AccountQuotaView.windows(.unavailable(.cursor, reason: "Collection disabled")).isEmpty)
     }
 
+    func testRemainingLineAndCreditsStayOnTheQuotaSurface() {
+        var quota = ProviderQuota(provider: .claude, weeklyRemainingPercent: 42,
+                                  weeklyWindowDurationMinutes: 10080, observedAt: Date())
+        quota.credits = QuotaCredits(remaining: 80, label: "Credits")
+        quota.spend = [QuotaSpend(label: "Extra usage", amount: 6.5)]
+        quota.otherWindows = [
+            QuotaWindow(remainingPercent: 82, durationMinutes: 10080, resetsAt: Date().addingTimeInterval(3600),
+                        observedAt: Date(), label: "Fable only")
+        ]
+        let windows = AccountQuotaView.windows(quota)
+        XCTAssertEqual(windows.last?.label, "Fable only")
+        XCTAssertEqual(QuotaPresentation.remainingLine(remainingPercent: 42), "42% left · 58% used")
+        XCTAssertEqual(quota.credits?.remaining, 80)
+        XCTAssertEqual(quota.spend?.first?.amount, 6.5)
+    }
+
     func testSwitchingMacClearsPublishedQuotaBeforeNewSnapshot() async throws {
         let quota = ProviderQuota(provider: .codex, weeklyRemainingPercent: 63, observedAt: Date())
         let store = DashboardStore(streamer: QuotaStreamer(quota: quota), notifier: SilentNotifier(),

--- a/VibeBuddyApp/Tests/AccountQuotaTests.swift
+++ b/VibeBuddyApp/Tests/AccountQuotaTests.swift
@@ -30,10 +30,13 @@ final class AccountQuotaTests: XCTestCase {
         store.start(PairingPayload(host: "mac-a", port: 9, token: "test"))
         for _ in 0..<100 where store.lastProviderQuota.isEmpty { try await Task.sleep(for: .milliseconds(10)) }
         XCTAssertEqual(store.lastProviderQuota, [quota])
+        XCTAssertNotNil(store.lastTokenConsumption)
         store.start(PairingPayload(host: "mac-b", port: 9, token: "test"))
         XCTAssertTrue(store.lastProviderQuota.isEmpty)
+        XCTAssertNil(store.lastTokenConsumption)
         store.forgetPairing()
         XCTAssertTrue(store.lastProviderQuota.isEmpty)
+        XCTAssertNil(store.lastTokenConsumption)
     }
 }
 
@@ -42,7 +45,7 @@ private struct QuotaStreamer: SnapshotStreaming {
     func stream(_ pairing: PairingPayload) -> AsyncThrowingStream<Snapshot, Error> {
         AsyncThrowingStream { continuation in
             if pairing.host == "mac-a" {
-                continuation.yield(Snapshot(sessions: [], serverTime: Date(), sourceID: "mac-a", providerQuota: [quota]))
+                continuation.yield(Snapshot(sessions: [], serverTime: Date(), sourceID: "mac-a", providerQuota: [quota], tokenConsumption: TokenConsumptionSnapshot.demo()))
             }
             continuation.finish()
         }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Cost.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Cost.swift
@@ -18,6 +18,23 @@ public enum Pricing {
         guard let tokens, tokens > 0 else { return nil }
         return Double(tokens) / 1_000_000 * blendedRatePerMTok(model)
     }
+
+    /// List-price estimate for a vibe-usage-style token split. Cache reads are
+    /// billed at a tenth of the blended rate; reasoning counts as output.
+    /// Zero when nothing is billable. Estimates only.
+    public static func estimatedUSD(
+        inputTokens: Int,
+        outputTokens: Int,
+        cachedInputTokens: Int,
+        reasoningOutputTokens: Int,
+        model: String?
+    ) -> Double {
+        let billed = max(0, inputTokens) + max(0, outputTokens) + max(0, reasoningOutputTokens)
+        let cached = max(0, cachedInputTokens)
+        guard billed > 0 || cached > 0 else { return 0 }
+        let rate = blendedRatePerMTok(model)
+        return Double(billed) / 1_000_000 * rate + Double(cached) / 1_000_000 * rate * 0.1
+    }
 }
 
 /// Watches per-session cumulative spend and fires once when a session crosses the

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -621,6 +621,9 @@ public struct Snapshot: Codable, Sendable, Equatable {
     /// Agents the Mac can start a new task for right now (Claude Code when the
     /// CLI supports `--bg`, Codex when the app-server daemon is connected).
     public var dispatchAgents: [AgentKind]?
+    /// Local Claude Code / Codex token spend, aggregated beside quota. Optional
+    /// so older phones ignore it. Composed outside the session reducer.
+    public var tokenConsumption: TokenConsumptionSnapshot?
 
     public init(
         sessions: [AgentSession],
@@ -629,7 +632,8 @@ public struct Snapshot: Codable, Sendable, Equatable {
         observationDiagnostics: [AgentObservationDiagnostic]? = nil,
         providerQuota: [ProviderQuota]? = nil,
         recentDirectories: [String]? = nil,
-        dispatchAgents: [AgentKind]? = nil
+        dispatchAgents: [AgentKind]? = nil,
+        tokenConsumption: TokenConsumptionSnapshot? = nil
     ) {
         self.sessions = sessions
         self.serverTime = serverTime
@@ -638,11 +642,12 @@ public struct Snapshot: Codable, Sendable, Equatable {
         self.providerQuota = providerQuota
         self.recentDirectories = recentDirectories
         self.dispatchAgents = dispatchAgents
+        self.tokenConsumption = tokenConsumption
     }
 
     enum CodingKeys: String, CodingKey {
         case sourceID, sessions, serverTime, observationDiagnostics
-        case providerQuota, recentDirectories, dispatchAgents
+        case providerQuota, recentDirectories, dispatchAgents, tokenConsumption
     }
 
     public init(from decoder: Decoder) throws {
@@ -661,6 +666,7 @@ public struct Snapshot: Codable, Sendable, Equatable {
         }
         recentDirectories = try c.decodeIfPresent([String].self, forKey: .recentDirectories)
         dispatchAgents = try c.decodeIfPresent([AgentKind].self, forKey: .dispatchAgents)
+        tokenConsumption = try c.decodeIfPresent(TokenConsumptionSnapshot.self, forKey: .tokenConsumption)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -672,6 +678,7 @@ public struct Snapshot: Codable, Sendable, Equatable {
         try c.encodeIfPresent(providerQuota, forKey: .providerQuota)
         try c.encodeIfPresent(recentDirectories, forKey: .recentDirectories)
         try c.encodeIfPresent(dispatchAgents, forKey: .dispatchAgents)
+        try c.encodeIfPresent(tokenConsumption, forKey: .tokenConsumption)
     }
 }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ProviderQuota.swift
@@ -59,6 +59,8 @@ public struct ProviderQuota: Codable, Equatable, Sendable, Identifiable {
     public var shortWindowDurationMinutes: Int?
     /// Windows whose duration cannot truthfully be called weekly or short.
     public var otherWindows: [QuotaWindow]?
+    public var credits: QuotaCredits?
+    public var spend: [QuotaSpend]?
     /// When the Mac last read a usable value from this provider's local source.
     public var observedAt: Date?
     /// Why the source produced nothing, when it produced nothing.
@@ -77,6 +79,8 @@ public struct ProviderQuota: Codable, Equatable, Sendable, Identifiable {
         shortWindowResetsAt: Date? = nil,
         shortWindowDurationMinutes: Int? = nil,
         otherWindows: [QuotaWindow]? = nil,
+        credits: QuotaCredits? = nil,
+        spend: [QuotaSpend]? = nil,
         observedAt: Date? = nil,
         unavailableReason: String? = nil,
         isCached: Bool? = nil
@@ -90,6 +94,8 @@ public struct ProviderQuota: Codable, Equatable, Sendable, Identifiable {
         self.shortWindowResetsAt = shortWindowResetsAt
         self.shortWindowDurationMinutes = shortWindowDurationMinutes
         self.otherWindows = otherWindows
+        self.credits = credits
+        self.spend = spend
         self.observedAt = observedAt
         self.unavailableReason = unavailableReason
         self.isCached = isCached

--- a/VibeBuddyKit/Sources/VibeBuddyKit/QuotaPresentation.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/QuotaPresentation.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+/// Credits remaining on an account pool (prepaid, monthly cap, reset credits).
+/// Optional on the wire so older phones ignore it.
+public struct QuotaCredits: Codable, Equatable, Sendable {
+    public var remaining: Double
+    public var limit: Double?
+    public var remainingPercent: Int?
+    public var resetsAt: Date?
+    public var label: String?
+
+    public init(
+        remaining: Double,
+        limit: Double? = nil,
+        remainingPercent: Int? = nil,
+        resetsAt: Date? = nil,
+        label: String? = nil
+    ) {
+        self.remaining = remaining
+        self.limit = limit
+        self.remainingPercent = remainingPercent.flatMap { (0...100).contains($0) ? $0 : nil }
+        self.resetsAt = resetsAt
+        self.label = label
+    }
+}
+
+/// One billed or estimated spend figure. Not an invoice.
+public struct QuotaSpend: Codable, Equatable, Sendable, Identifiable {
+    public var label: String
+    public var amount: Double
+    public var currencyCode: String
+
+    public var id: String { label }
+
+    public init(label: String, amount: Double, currencyCode: String = "USD") {
+        self.label = label
+        self.amount = amount
+        self.currencyCode = currencyCode
+    }
+}
+
+/// How a weekly window is tracking against a linear burn to reset.
+public enum QuotaPace: String, Sendable {
+    case onTrack
+    case ahead
+    case behind
+
+    public var caption: String {
+        switch self {
+        case .onTrack: return "On track for this window"
+        case .ahead: return "Ahead of this window's pace"
+        case .behind: return "Behind this window's pace"
+        }
+    }
+}
+
+/// Local remaining/reset wording. English like the rest of the usage surfaces;
+/// not CodexBar's localization stack.
+public enum QuotaPresentation {
+    public static func remainingLine(usedPercent: Int) -> String {
+        let remaining = max(0, min(100, 100 - usedPercent))
+        if remaining == 0 { return "0% left · \(usedPercent)% used" }
+        if remaining == 100 { return "100% left" }
+        return "\(remaining)% left · \(usedPercent)% used"
+    }
+
+    public static func remainingLine(remainingPercent: Int) -> String {
+        remainingLine(usedPercent: max(0, min(100, 100 - remainingPercent)))
+    }
+
+    public static func resetCountdown(from date: Date, now: Date) -> String {
+        let seconds = date.timeIntervalSince(now)
+        if seconds <= 0 { return "now" }
+        let totalMinutes = max(1, Int(ceil(seconds / 60)))
+        let days = totalMinutes / (24 * 60)
+        let hours = (totalMinutes / 60) % 24
+        let minutes = totalMinutes % 60
+        if days > 0 {
+            if hours > 0 { return "in \(days)d \(hours)h" }
+            return "in \(days)d"
+        }
+        if hours > 0 {
+            return minutes > 0 ? "in \(hours)h \(minutes)m" : "in \(hours)h"
+        }
+        return "in \(totalMinutes)m"
+    }
+
+    public static func resetAbsolute(from date: Date, now: Date, calendar: Calendar = .current) -> String {
+        if calendar.isDate(date, inSameDayAs: now) {
+            return date.formatted(date: .omitted, time: .shortened)
+        }
+        if let tomorrow = calendar.date(byAdding: .day, value: 1, to: now),
+           calendar.isDate(date, inSameDayAs: tomorrow) {
+            return "tomorrow, \(date.formatted(date: .omitted, time: .shortened))"
+        }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    public static func resetLine(from date: Date, now: Date, calendar: Calendar = .current) -> String {
+        let countdown = resetCountdown(from: date, now: now)
+        if countdown == "now" { return "Resets now" }
+        return "Resets \(countdown) · \(resetAbsolute(from: date, now: now, calendar: calendar))"
+    }
+
+    public static func creditsLine(_ credits: QuotaCredits) -> String {
+        let number = creditsNumber(credits.remaining)
+        if let limit = credits.limit, limit > 0 {
+            return "\(number) / \(creditsNumber(limit)) left"
+        }
+        return "\(number) left"
+    }
+
+    public static func creditsLine(_ credits: QuotaCredits?) -> String? {
+        credits.map(creditsLine)
+    }
+
+    /// CodexBar-style stable id fragment: letters and digits, dashes between.
+    public static func slug(_ value: String) -> String {
+        var result = ""
+        var lastWasDash = false
+        for scalar in value.lowercased().unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+                lastWasDash = false
+            } else if !lastWasDash {
+                result.append("-")
+                lastWasDash = true
+            }
+        }
+        return result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    public static func scopedOnlyTitle(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Scoped week" : "\(trimmed) only"
+    }
+
+    /// `seven_day_sonnet` → `Sonnet only`.
+    public static func extraWindowTitle(fromStatusLineKey key: String) -> String {
+        var name = key
+        let lowered = key.lowercased()
+        for prefix in ["seven_day_", "five_hour_", "seven-day-", "five-hour-"] where lowered.hasPrefix(prefix) {
+            name = String(key.dropFirst(prefix.count))
+            break
+        }
+        let words = name.split { $0 == "_" || $0 == "-" }
+            .map { $0.lowercased().capitalized }
+            .joined(separator: " ")
+        return scopedOnlyTitle(words.isEmpty ? key : words)
+    }
+
+    public static func isAllModelsScope(_ name: String) -> Bool {
+        slug(name) == "all-models" || slug(name).hasSuffix("-all-models")
+    }
+
+    public static func spendLine(_ spend: QuotaSpend) -> String {
+        spend.amount.formatted(.currency(code: spend.currencyCode).locale(Locale(identifier: "en_US")))
+    }
+
+    public static func weeklyPace(
+        usedPercent: Int,
+        resetsAt: Date,
+        windowMinutes: Int,
+        now: Date
+    ) -> QuotaPace? {
+        guard windowMinutes > 0, resetsAt > now else { return nil }
+        let duration = TimeInterval(windowMinutes * 60)
+        let remaining = resetsAt.timeIntervalSince(now)
+        guard remaining <= duration else { return nil }
+        let elapsed = max(0, duration - remaining)
+        if elapsed == 0 { return usedPercent == 0 ? .onTrack : nil }
+        let expected = (elapsed / duration) * 100
+        let delta = Double(usedPercent) - expected
+        if abs(delta) <= 6 { return .onTrack }
+        return delta > 0 ? .ahead : .behind
+    }
+
+    public static func creditsNumber(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = value >= 100 ? 0 : 2
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
+    }
+}

--- a/VibeBuddyKit/Sources/VibeBuddyKit/TokenConsumption.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/TokenConsumption.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+/// Which calendar window a token-consumption summary covers.
+public enum TokenConsumptionWindowKind: String, Codable, Sendable {
+    case today
+    case last7Days
+
+    public var title: String {
+        switch self {
+        case .today: return "Today"
+        case .last7Days: return "Last 7 days"
+        }
+    }
+}
+
+/// Non-overlapping token buckets, matching vibe-usage's Anthropic-style split:
+/// cache reads and reasoning are stored separately from uncached input / output.
+public struct TokenCountBreakdown: Codable, Equatable, Sendable {
+    public var inputTokens: Int
+    public var outputTokens: Int
+    public var cachedInputTokens: Int
+    public var reasoningOutputTokens: Int
+    /// Sum of per-entry list-price estimates; never a billed invoice.
+    public var estimatedUSD: Double
+    public var sessionCount: Int
+
+    /// Tokens that drive spend (excludes cache reads).
+    public var billedTokens: Int { inputTokens + outputTokens + reasoningOutputTokens }
+
+    public var totalTokens: Int { billedTokens + cachedInputTokens }
+
+    public init(
+        inputTokens: Int = 0,
+        outputTokens: Int = 0,
+        cachedInputTokens: Int = 0,
+        reasoningOutputTokens: Int = 0,
+        estimatedUSD: Double = 0,
+        sessionCount: Int = 0
+    ) {
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cachedInputTokens = cachedInputTokens
+        self.reasoningOutputTokens = reasoningOutputTokens
+        self.estimatedUSD = estimatedUSD
+        self.sessionCount = sessionCount
+    }
+
+    public var isEmpty: Bool { totalTokens == 0 && sessionCount == 0 }
+
+    public static func + (lhs: Self, rhs: Self) -> Self {
+        TokenCountBreakdown(
+            inputTokens: lhs.inputTokens + rhs.inputTokens,
+            outputTokens: lhs.outputTokens + rhs.outputTokens,
+            cachedInputTokens: lhs.cachedInputTokens + rhs.cachedInputTokens,
+            reasoningOutputTokens: lhs.reasoningOutputTokens + rhs.reasoningOutputTokens,
+            estimatedUSD: lhs.estimatedUSD + rhs.estimatedUSD,
+            sessionCount: lhs.sessionCount + rhs.sessionCount)
+    }
+}
+
+/// One slice of a consumption window (an agent, model, or project).
+public struct TokenConsumptionRow: Codable, Equatable, Sendable, Identifiable {
+    public var key: String
+    public var label: String
+    public var counts: TokenCountBreakdown
+    public var id: String { key }
+
+    public init(key: String, label: String, counts: TokenCountBreakdown) {
+        self.key = key
+        self.label = label
+        self.counts = counts
+    }
+}
+
+public struct TokenConsumptionWindow: Codable, Equatable, Sendable, Identifiable {
+    public var kind: TokenConsumptionWindowKind
+    public var counts: TokenCountBreakdown
+    public var byAgent: [TokenConsumptionRow]
+    public var byModel: [TokenConsumptionRow]
+    public var byProject: [TokenConsumptionRow]
+    public var id: TokenConsumptionWindowKind { kind }
+
+    public init(
+        kind: TokenConsumptionWindowKind,
+        counts: TokenCountBreakdown,
+        byAgent: [TokenConsumptionRow] = [],
+        byModel: [TokenConsumptionRow] = [],
+        byProject: [TokenConsumptionRow] = []
+    ) {
+        self.kind = kind
+        self.counts = counts
+        self.byAgent = byAgent
+        self.byModel = byModel
+        self.byProject = byProject
+    }
+}
+
+/// Local token-consumption totals composed beside quota. Optional on the wire
+/// so older phones ignore it. Never carries prompts or session progress.
+public struct TokenConsumptionSnapshot: Codable, Equatable, Sendable {
+    public var observedAt: Date
+    public var windows: [TokenConsumptionWindow]
+    public var warnings: [String]?
+
+    public init(observedAt: Date, windows: [TokenConsumptionWindow], warnings: [String]? = nil) {
+        self.observedAt = observedAt
+        self.windows = windows
+        self.warnings = warnings
+    }
+
+    public func window(_ kind: TokenConsumptionWindowKind) -> TokenConsumptionWindow? {
+        windows.first { $0.kind == kind }
+    }
+
+    /// Compact display for token counts (1.2M, 45K).
+    public static func formatTokens(_ n: Int) -> String {
+        if n >= 1_000_000 {
+            let value = Double(n) / 1_000_000
+            return String(format: value >= 10 ? "%.0fM" : "%.1fM", value)
+        }
+        if n >= 1_000 { return "\(n / 1_000)K" }
+        return "\(n)"
+    }
+
+    public static func formatUSD(_ usd: Double) -> String {
+        String(format: "≈ $%.2f", usd)
+    }
+
+    /// Sample totals for Demo mode. Not a reading of anyone's logs.
+    public static func demo(now: Date = Date()) -> TokenConsumptionSnapshot {
+        let today = TokenCountBreakdown(
+            inputTokens: 420_000, outputTokens: 86_000,
+            cachedInputTokens: 1_800_000, reasoningOutputTokens: 24_000,
+            estimatedUSD: 18.40, sessionCount: 4)
+        let week = TokenCountBreakdown(
+            inputTokens: 2_400_000, outputTokens: 410_000,
+            cachedInputTokens: 9_200_000, reasoningOutputTokens: 95_000,
+            estimatedUSD: 96.10, sessionCount: 19)
+        return TokenConsumptionSnapshot(observedAt: now, windows: [
+            TokenConsumptionWindow(
+                kind: .today, counts: today,
+                byAgent: [
+                    TokenConsumptionRow(key: "claudeCode", label: AgentKind.claudeCode.displayName,
+                                        counts: TokenCountBreakdown(inputTokens: 300_000, outputTokens: 60_000,
+                                                                    cachedInputTokens: 1_200_000, reasoningOutputTokens: 0,
+                                                                    estimatedUSD: 14.20, sessionCount: 2)),
+                    TokenConsumptionRow(key: "codex", label: AgentKind.codex.displayName,
+                                        counts: TokenCountBreakdown(inputTokens: 120_000, outputTokens: 26_000,
+                                                                    cachedInputTokens: 600_000, reasoningOutputTokens: 24_000,
+                                                                    estimatedUSD: 4.20, sessionCount: 2)),
+                ],
+                byModel: [
+                    TokenConsumptionRow(key: "claude-opus-4-8", label: "claude-opus-4-8",
+                                        counts: TokenCountBreakdown(inputTokens: 300_000, outputTokens: 60_000,
+                                                                    cachedInputTokens: 1_200_000, estimatedUSD: 14.20, sessionCount: 2)),
+                    TokenConsumptionRow(key: "gpt-5-codex", label: "gpt-5-codex",
+                                        counts: TokenCountBreakdown(inputTokens: 120_000, outputTokens: 26_000,
+                                                                    cachedInputTokens: 600_000, reasoningOutputTokens: 24_000,
+                                                                    estimatedUSD: 4.20, sessionCount: 2)),
+                ],
+                byProject: [
+                    TokenConsumptionRow(key: "ios-vibebuddy", label: "ios-vibebuddy",
+                                        counts: TokenCountBreakdown(inputTokens: 210_000, outputTokens: 40_000,
+                                                                    cachedInputTokens: 900_000, estimatedUSD: 9.10, sessionCount: 2)),
+                    TokenConsumptionRow(key: "todo-app", label: "todo-app",
+                                        counts: TokenCountBreakdown(inputTokens: 210_000, outputTokens: 46_000,
+                                                                    cachedInputTokens: 900_000, reasoningOutputTokens: 24_000,
+                                                                    estimatedUSD: 9.30, sessionCount: 2)),
+                ]),
+            TokenConsumptionWindow(
+                kind: .last7Days, counts: week,
+                byAgent: [
+                    TokenConsumptionRow(key: "claudeCode", label: AgentKind.claudeCode.displayName,
+                                        counts: TokenCountBreakdown(inputTokens: 1_600_000, outputTokens: 280_000,
+                                                                    cachedInputTokens: 6_000_000, estimatedUSD: 72.00, sessionCount: 11)),
+                    TokenConsumptionRow(key: "codex", label: AgentKind.codex.displayName,
+                                        counts: TokenCountBreakdown(inputTokens: 800_000, outputTokens: 130_000,
+                                                                    cachedInputTokens: 3_200_000, reasoningOutputTokens: 95_000,
+                                                                    estimatedUSD: 24.10, sessionCount: 8)),
+                ],
+                byModel: [
+                    TokenConsumptionRow(key: "claude-opus-4-8", label: "claude-opus-4-8",
+                                        counts: TokenCountBreakdown(inputTokens: 1_200_000, outputTokens: 210_000,
+                                                                    cachedInputTokens: 4_400_000, estimatedUSD: 58.00, sessionCount: 7)),
+                    TokenConsumptionRow(key: "claude-sonnet-4-5", label: "claude-sonnet-4-5",
+                                        counts: TokenCountBreakdown(inputTokens: 400_000, outputTokens: 70_000,
+                                                                    cachedInputTokens: 1_600_000, estimatedUSD: 14.00, sessionCount: 4)),
+                    TokenConsumptionRow(key: "gpt-5-codex", label: "gpt-5-codex",
+                                        counts: TokenCountBreakdown(inputTokens: 800_000, outputTokens: 130_000,
+                                                                    cachedInputTokens: 3_200_000, reasoningOutputTokens: 95_000,
+                                                                    estimatedUSD: 24.10, sessionCount: 8)),
+                ],
+                byProject: [
+                    TokenConsumptionRow(key: "ios-vibebuddy", label: "ios-vibebuddy",
+                                        counts: TokenCountBreakdown(inputTokens: 1_100_000, outputTokens: 190_000,
+                                                                    cachedInputTokens: 4_000_000, reasoningOutputTokens: 40_000,
+                                                                    estimatedUSD: 44.00, sessionCount: 9)),
+                    TokenConsumptionRow(key: "todo-app", label: "todo-app",
+                                        counts: TokenCountBreakdown(inputTokens: 800_000, outputTokens: 140_000,
+                                                                    cachedInputTokens: 3_100_000, reasoningOutputTokens: 30_000,
+                                                                    estimatedUSD: 32.00, sessionCount: 6)),
+                    TokenConsumptionRow(key: "search-indexer", label: "search-indexer",
+                                        counts: TokenCountBreakdown(inputTokens: 500_000, outputTokens: 80_000,
+                                                                    cachedInputTokens: 2_100_000, reasoningOutputTokens: 25_000,
+                                                                    estimatedUSD: 20.10, sessionCount: 4)),
+                ]),
+        ])
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/CostTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/CostTests.swift
@@ -24,6 +24,10 @@ struct CostTests {
         #expect(oneM == 30)
         #expect(Pricing.estimatedUSD(tokens: 0, model: "claude-opus-4-8") == nil)
         #expect(Pricing.estimatedUSD(tokens: nil, model: "claude-opus-4-8") == nil)
+        let split = Pricing.estimatedUSD(inputTokens: 1_000_000, outputTokens: 0,
+                                         cachedInputTokens: 1_000_000, reasoningOutputTokens: 0,
+                                         model: "claude-opus-4-8")
+        #expect(split == 33) // 30 billed + 3 cache-read
     }
 
     @Test("budget fires once when a session crosses, not again while it stays over")

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaWireCompatTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/ProviderQuotaWireCompatTests.swift
@@ -49,6 +49,29 @@ struct ProviderQuotaWireCompatTests {
         #expect(snap.sessions.isEmpty)
     }
 
+    @Test("credits and spend round-trip and stay optional on old payloads")
+    func creditsAndSpendAreAdditive() throws {
+        let json = """
+        {"sessions":[],"serverTime":1700000000,
+         "providerQuota":[{"provider":"codex","weeklyRemainingPercent":70}]}
+        """.data(using: .utf8)!
+        let snap = try JSONDecoder().decode(Snapshot.self, from: json)
+        #expect(snap.providerQuota?.first?.credits == nil)
+        #expect(snap.providerQuota?.first?.spend == nil)
+
+        var row = ProviderQuota(provider: .codex, weeklyRemainingPercent: 70)
+        row.credits = QuotaCredits(remaining: 12.5, label: "Credits")
+        row.spend = [QuotaSpend(label: "Extra usage", amount: 4.2)]
+        let encoded = try JSONDecoder().decode(
+            Snapshot.self,
+            from: JSONEncoder().encode(Snapshot(
+                sessions: [], serverTime: Date(timeIntervalSince1970: 1_700_000_000),
+                sourceID: "mac-1", providerQuota: [row]))
+        )
+        #expect(encoded.providerQuota?.first?.credits?.remaining == 12.5)
+        #expect(encoded.providerQuota?.first?.spend?.first?.amount == 4.2)
+    }
+
     @Test("new clients still keep Cursor when present")
     func newClientKeepsCursor() throws {
         let snap = sampleSnapshot(includingCursor: true)

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/QuotaPresentationTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/QuotaPresentationTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("Quota presentation")
+struct QuotaPresentationTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test("remaining shows both leftover and used except at the extremes")
+    func remainingLine() {
+        #expect(QuotaPresentation.remainingLine(usedPercent: 0) == "100% left")
+        #expect(QuotaPresentation.remainingLine(usedPercent: 100) == "0% left · 100% used")
+        #expect(QuotaPresentation.remainingLine(usedPercent: 41) == "59% left · 41% used")
+        #expect(QuotaPresentation.remainingLine(remainingPercent: 59) == "59% left · 41% used")
+    }
+
+    @Test("reset line pairs a countdown with today/tomorrow/absolute time")
+    func resetLine() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let laterToday = now.addingTimeInterval(2 * 3600 + 15 * 60)
+        #expect(QuotaPresentation.resetCountdown(from: laterToday, now: now) == "in 2h 15m")
+        let line = QuotaPresentation.resetLine(from: laterToday, now: now, calendar: calendar)
+        #expect(line.hasPrefix("Resets in 2h 15m · "))
+        let tomorrow = now.addingTimeInterval(26 * 3600)
+        #expect(QuotaPresentation.resetAbsolute(from: tomorrow, now: now, calendar: calendar)
+            .hasPrefix("tomorrow, "))
+        #expect(QuotaPresentation.resetCountdown(from: now.addingTimeInterval(-1), now: now) == "now")
+    }
+
+    @Test("weekly pace compares used percent to a linear burn")
+    func weeklyPace() {
+        let reset = now.addingTimeInterval(4 * 24 * 60 * 60)
+        #expect(QuotaPresentation.weeklyPace(usedPercent: 44, resetsAt: reset, windowMinutes: 10_080, now: now) == .onTrack)
+        #expect(QuotaPresentation.weeklyPace(usedPercent: 90, resetsAt: reset, windowMinutes: 10_080, now: now) == .ahead)
+        #expect(QuotaPresentation.weeklyPace(usedPercent: 5, resetsAt: reset, windowMinutes: 10_080, now: now) == .behind)
+    }
+
+    @Test("status-line keys become scoped titles")
+    func extraTitles() {
+        #expect(QuotaPresentation.extraWindowTitle(fromStatusLineKey: "seven_day_sonnet") == "Sonnet only")
+        #expect(QuotaPresentation.scopedOnlyTitle("Fable") == "Fable only")
+        #expect(QuotaPresentation.isAllModelsScope("all models"))
+        #expect(QuotaPresentation.slug("Example Model Plus") == "example-model-plus")
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/TokenConsumptionWireTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/TokenConsumptionWireTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("Token consumption wire")
+struct TokenConsumptionWireTests {
+    @Test("old snapshot JSON without tokenConsumption still decodes")
+    func missingFieldIsNil() throws {
+        let json = """
+        {"sessions":[],"serverTime":1700000000,"sourceID":"mac-1"}
+        """.data(using: .utf8)!
+        let snap = try JSONDecoder().decode(Snapshot.self, from: json)
+        #expect(snap.tokenConsumption == nil)
+        #expect(snap.sessions.isEmpty)
+    }
+
+    @Test("tokenConsumption round-trips on Snapshot")
+    func roundTrip() throws {
+        let consumption = TokenConsumptionSnapshot.demo(now: Date(timeIntervalSince1970: 1_700_000_000))
+        let source = Snapshot(sessions: [], serverTime: Date(timeIntervalSince1970: 1_700_000_000),
+                              sourceID: "mac-1", tokenConsumption: consumption)
+        let back = try JSONDecoder().decode(Snapshot.self, from: JSONEncoder().encode(source))
+        #expect(back.tokenConsumption == consumption)
+        #expect(TokenConsumptionSnapshot.formatTokens(1_200_000) == "1.2M")
+        #expect(TokenConsumptionSnapshot.formatUSD(4.2) == "≈ $4.20")
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/AccountUsage.swift
@@ -5,6 +5,7 @@ import VibeBuddyKit
 public enum AccountUsageWindowKind: String, Codable, Sendable {
     case primary
     case secondary
+    case extra
 }
 
 public struct AccountUsageWindow: Codable, Equatable, Sendable, Identifiable {
@@ -13,21 +14,43 @@ public struct AccountUsageWindow: Codable, Equatable, Sendable, Identifiable {
     public var windowDurationMinutes: Int?
     public var resetsAt: Date?
     public var label: String?
+    /// Stable identity for extra windows (model-week, Spark, …). Nil on
+    /// cached primary/secondary rows that predate this field.
+    public var key: String?
 
-    public var id: AccountUsageWindowKind { kind }
+    public var id: String { key ?? kind.rawValue }
 
     public init(
         kind: AccountUsageWindowKind,
         usedPercent: Int,
         windowDurationMinutes: Int?,
         resetsAt: Date?,
-        label: String? = nil
+        label: String? = nil,
+        key: String? = nil
     ) {
         self.kind = kind
         self.usedPercent = usedPercent
         self.windowDurationMinutes = windowDurationMinutes
         self.resetsAt = resetsAt
         self.label = label
+        self.key = key
+    }
+
+    public static func extra(
+        key: String,
+        label: String,
+        usedPercent: Int,
+        windowDurationMinutes: Int?,
+        resetsAt: Date?
+    ) -> AccountUsageWindow {
+        AccountUsageWindow(
+            kind: .extra,
+            usedPercent: usedPercent,
+            windowDurationMinutes: windowDurationMinutes,
+            resetsAt: resetsAt,
+            label: label,
+            key: key
+        )
     }
 }
 
@@ -50,6 +73,10 @@ public struct AccountUsageSnapshot: Codable, Equatable, Sendable {
     public var accountLabel: String?
     public var usageDetail: String?
     public var hasAvailableUsage: Bool?
+    /// Model-week / Spark / other named windows. Not the weekly projection slot.
+    public var extraWindows: [AccountUsageWindow]?
+    public var credits: QuotaCredits?
+    public var spend: [QuotaSpend]?
 
     /// Extra Grok spend is not the shared subscription allowance.
     public var quotaWindows: [AccountUsageWindow] {
@@ -58,6 +85,17 @@ public struct AccountUsageSnapshot: Codable, Equatable, Sendable {
 
     public var windows: [AccountUsageWindow] {
         [primary, secondary].compactMap { $0 }
+    }
+
+    /// Account usage / iPhone Usage rows, including scoped extras that must
+    /// not steal the weekly remaining slot.
+    public var displayWindows: [AccountUsageWindow] {
+        windows + (extraWindows ?? [])
+    }
+
+    /// Quota alerts include extras; Grok extra-usage spend still stays out.
+    public var alertWindows: [AccountUsageWindow] {
+        quotaWindows + (extraWindows ?? [])
     }
 
     public init(
@@ -69,7 +107,10 @@ public struct AccountUsageSnapshot: Codable, Equatable, Sendable {
         latestDailyTokens: Int?,
         fetchedAt: Date,
         periodStart: Date? = nil,
-        periodEnd: Date? = nil
+        periodEnd: Date? = nil,
+        extraWindows: [AccountUsageWindow]? = nil,
+        credits: QuotaCredits? = nil,
+        spend: [QuotaSpend]? = nil
     ) {
         self.provider = provider
         self.planType = planType
@@ -80,6 +121,34 @@ public struct AccountUsageSnapshot: Codable, Equatable, Sendable {
         self.periodStart = periodStart
         self.periodEnd = periodEnd
         self.fetchedAt = fetchedAt
+        self.extraWindows = extraWindows
+        self.credits = credits
+        self.spend = spend
+    }
+
+    /// A live primary/secondary sample (status line, rate-limit stream) must
+    /// not erase extras the collector already learned.
+    public func preservingUnspecifiedExtras(from previous: AccountUsageSnapshot?) -> AccountUsageSnapshot {
+        guard let previous, previous.provider == provider else { return self }
+        var result = self
+        let incoming = extraWindows ?? []
+        let prior = previous.extraWindows ?? []
+        if incoming.isEmpty {
+            result.extraWindows = previous.extraWindows
+        } else if !prior.isEmpty {
+            var byID: [String: AccountUsageWindow] = [:]
+            for window in prior { byID[window.id] = window }
+            for window in incoming { byID[window.id] = window }
+            var seen: Set<String> = []
+            var merged: [AccountUsageWindow] = []
+            for window in incoming + prior where seen.insert(window.id).inserted {
+                if let kept = byID[window.id] { merged.append(kept) }
+            }
+            result.extraWindows = merged
+        }
+        if result.credits == nil { result.credits = previous.credits }
+        if (result.spend ?? []).isEmpty { result.spend = previous.spend }
+        return result
     }
 
     /// Grok's last period is not a reading of its new allowance.
@@ -490,7 +559,7 @@ public actor AccountUsageCollector {
         guard isEnabled else { return state }
         let currentGeneration = generation
         failureCount = 0
-        let live = snapshot
+        let live = snapshot.preservingUnspecifiedExtras(from: state.snapshot)
         state = .available(live, nextRefreshAt: now.addingTimeInterval(holdFor))
         do {
             try await cache.save(live, permit: cacheCommitGate.permit(generation: currentGeneration))
@@ -535,11 +604,11 @@ public struct AccountUsageAlertMonitor: Sendable {
         guard thresholdPercent > 0 else { return [] }
         guard state.collectionEnabled, !state.isStale, let snapshot = state.snapshot else { return [] }
 
-        let currentKeys = Dictionary(uniqueKeysWithValues: snapshot.quotaWindows.map {
-            ($0.kind, Self.key(provider: snapshot.provider, window: $0))
+        let currentKeys = Dictionary(uniqueKeysWithValues: snapshot.alertWindows.map {
+            ($0.id, Self.key(provider: snapshot.provider, window: $0))
         })
-        for (kind, currentKey) in currentKeys {
-            let prefix = snapshot.provider.rawValue + "|" + kind.rawValue + "|"
+        for (identity, currentKey) in currentKeys {
+            let prefix = snapshot.provider.rawValue + "|" + identity + "|"
             alertedWindowKeys = alertedWindowKeys.filter {
                 !$0.hasPrefix(prefix) || $0 == currentKey
             }
@@ -550,7 +619,7 @@ public struct AccountUsageAlertMonitor: Sendable {
 
         if !didObserveFreshSnapshot {
             didObserveFreshSnapshot = true
-            for window in snapshot.quotaWindows {
+            for window in snapshot.alertWindows {
                 let key = Self.key(provider: snapshot.provider, window: window)
                 observedWindowKeys.insert(key)
                 if window.usedPercent >= thresholdPercent {
@@ -561,7 +630,7 @@ public struct AccountUsageAlertMonitor: Sendable {
         }
 
         var alerts: [AccountUsageWindow] = []
-        for window in snapshot.quotaWindows {
+        for window in snapshot.alertWindows {
             let key = Self.key(provider: snapshot.provider, window: window)
             guard observedWindowKeys.contains(key) else {
                 observedWindowKeys.insert(key)
@@ -583,7 +652,7 @@ public struct AccountUsageAlertMonitor: Sendable {
             .map { String(Int64($0.timeIntervalSince1970.rounded())) }
             ?? "none"
         let duration = window.windowDurationMinutes.map(String.init) ?? "none"
-        return "\(provider.rawValue)|\(window.kind.rawValue)|\(reset)|\(duration)"
+        return "\(provider.rawValue)|\(window.id)|\(reset)|\(duration)"
     }
 }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ClaudeCLIUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ClaudeCLIUsageProvider.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import VibeBuddyKit
 
 public enum ClaudeUsageResponseDecoder {
     private struct Envelope: Decodable {
@@ -35,15 +36,14 @@ public enum ClaudeUsageResponseDecoder {
             now: fetchedAt,
             calendar: calendar
         )
-        let secondary = try window(
-            named: "Current week (all models)",
-            kind: .secondary,
-            durationMinutes: 7 * 24 * 60,
+        let weekWindows = try scopedWeekWindows(
             in: envelope.result,
             now: fetchedAt,
             calendar: calendar
         )
-        guard primary != nil || secondary != nil else {
+        let secondary = weekWindows.allModels
+        let extras = weekWindows.extras
+        guard primary != nil || secondary != nil || !extras.isEmpty else {
             throw AccountUsageError.incompatibleFormat
         }
 
@@ -54,8 +54,83 @@ public enum ClaudeUsageResponseDecoder {
             secondary: secondary,
             lifetimeTokens: nil,
             latestDailyTokens: nil,
-            fetchedAt: fetchedAt
+            fetchedAt: fetchedAt,
+            extraWindows: extras.isEmpty ? nil : extras,
+            credits: credits(in: envelope.result),
+            spend: spend(in: envelope.result)
         )
+    }
+
+    private struct ScopedWeeks {
+        var allModels: AccountUsageWindow?
+        var extras: [AccountUsageWindow]
+    }
+
+    /// Every `Current week (NAME):` line. All-models stays the weekly slot;
+    /// Sonnet/Opus/Fable and friends become extras so they cannot steal it.
+    private static func scopedWeekWindows(
+        in output: String,
+        now: Date,
+        calendar: Calendar
+    ) throws -> ScopedWeeks {
+        let pattern = #"(?m)^Current week \(([^)]+)\):\s*([0-9]+(?:\.[0-9]+)?)% used([^\n]*)$"#
+        let expression = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(output.startIndex..<output.endIndex, in: output)
+        var allModels: AccountUsageWindow?
+        var extras: [AccountUsageWindow] = []
+        var seen: Set<String> = []
+        for match in expression.matches(in: output, range: range) {
+            guard let nameRange = Range(match.range(at: 1), in: output),
+                  let percentRange = Range(match.range(at: 2), in: output),
+                  let percent = Double(output[percentRange]), percent.isFinite,
+                  (0...100).contains(percent) else { continue }
+            let name = String(output[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else { continue }
+            var reset: Date?
+            if let suffixRange = Range(match.range(at: 3), in: output) {
+                reset = try parseResetSuffix(String(output[suffixRange]), now: now, calendar: calendar, durationMinutes: 7 * 24 * 60)
+            }
+            if QuotaPresentation.isAllModelsScope(name) {
+                allModels = AccountUsageWindow(
+                    kind: .secondary,
+                    usedPercent: Int(percent.rounded()),
+                    windowDurationMinutes: 7 * 24 * 60,
+                    resetsAt: reset
+                )
+                continue
+            }
+            let slug = QuotaPresentation.slug(name)
+            guard !slug.isEmpty, seen.insert(slug).inserted else { continue }
+            extras.append(.extra(
+                key: "claude-weekly-scoped-\(slug)",
+                label: QuotaPresentation.scopedOnlyTitle(name),
+                usedPercent: Int(percent.rounded()),
+                windowDurationMinutes: 7 * 24 * 60,
+                resetsAt: reset
+            ))
+        }
+        return ScopedWeeks(allModels: allModels, extras: extras)
+    }
+
+    private static func credits(in output: String) -> QuotaCredits? {
+        let pattern = #"(?im)^Credits remaining:\s*\$?([0-9]+(?:\.[0-9]+)?)\b"#
+        guard let match = try? firstDouble(pattern, in: output) else { return nil }
+        return QuotaCredits(remaining: match, label: "Credits")
+    }
+
+    private static func spend(in output: String) -> [QuotaSpend]? {
+        let pattern = #"(?im)^Extra usage:\s*\$([0-9]+(?:\.[0-9]+)?)\b"#
+        guard let amount = try? firstDouble(pattern, in: output) else { return nil }
+        return [QuotaSpend(label: "Extra usage", amount: amount)]
+    }
+
+    private static func firstDouble(_ pattern: String, in output: String) throws -> Double? {
+        let expression = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(output.startIndex..<output.endIndex, in: output)
+        guard let match = expression.firstMatch(in: output, range: range),
+              let valueRange = Range(match.range(at: 1), in: output),
+              let value = Double(output[valueRange]), value.isFinite else { return nil }
+        return value
     }
 
     private static func window(
@@ -77,15 +152,7 @@ public enum ClaudeUsageResponseDecoder {
         // A missing or malformed date cannot erase an independently valid percentage.
         var reset: Date?
         if let suffixRange = Range(match.range(at: 2), in: output) {
-            let suffix = String(output[suffixRange])
-            let datePattern = #"resets\s+(.+?)\s+\(([^()]+)\)\s*$"#
-            let regex = try NSRegularExpression(pattern: datePattern)
-            if let dateMatch = regex.firstMatch(in: suffix, range: NSRange(suffix.startIndex..<suffix.endIndex, in: suffix)),
-               let dateRange = Range(dateMatch.range(at: 1), in: suffix),
-               let zoneRange = Range(dateMatch.range(at: 2), in: suffix) {
-                reset = parseReset(String(suffix[dateRange]), timeZoneID: String(suffix[zoneRange]),
-                                   now: now, calendar: calendar, durationMinutes: durationMinutes)
-            }
+            reset = try parseResetSuffix(String(output[suffixRange]), now: now, calendar: calendar, durationMinutes: durationMinutes)
         }
         return AccountUsageWindow(
             kind: kind,
@@ -93,6 +160,21 @@ public enum ClaudeUsageResponseDecoder {
             windowDurationMinutes: durationMinutes,
             resetsAt: reset
         )
+    }
+
+    private static func parseResetSuffix(
+        _ suffix: String,
+        now: Date,
+        calendar: Calendar,
+        durationMinutes: Int
+    ) throws -> Date? {
+        let datePattern = #"resets\s+(.+?)\s+\(([^()]+)\)\s*$"#
+        let regex = try NSRegularExpression(pattern: datePattern)
+        guard let dateMatch = regex.firstMatch(in: suffix, range: NSRange(suffix.startIndex..<suffix.endIndex, in: suffix)),
+              let dateRange = Range(dateMatch.range(at: 1), in: suffix),
+              let zoneRange = Range(dateMatch.range(at: 2), in: suffix) else { return nil }
+        return parseReset(String(suffix[dateRange]), timeZoneID: String(suffix[zoneRange]),
+                          now: now, calendar: calendar, durationMinutes: durationMinutes)
     }
 
     /// `/usage` drops the minutes when a window resets on the hour — "Sep 5 at

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAdditionalRateLimitMapper.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAdditionalRateLimitMapper.swift
@@ -1,0 +1,275 @@
+import Foundation
+import VibeBuddyKit
+
+/// Maps Codex `additional_rate_limits` (Spark and other named windows) onto
+/// extra `AccountUsageWindow`s. Reimplemented from CodexBar's mapper; not vendored.
+enum CodexAdditionalRateLimitMapper {
+    static let sparkWindowID = "codex-spark"
+    static let sparkWeeklyWindowID = "codex-spark-weekly"
+    static let sparkWindowTitle = "Codex Spark 5-hour"
+    static let sparkWeeklyWindowTitle = "Codex Spark Weekly"
+
+    static func windows(from entries: [AdditionalRateLimitDTO]?) -> [AccountUsageWindow]? {
+        guard let entries, !entries.isEmpty else { return nil }
+        var usedIDs = Set<String>()
+        let mapped = entries.flatMap { windows(from: $0, usedIDs: &usedIDs) }
+        return mapped.isEmpty ? nil : mapped
+    }
+
+    private static func windows(
+        from entry: AdditionalRateLimitDTO,
+        usedIDs: inout Set<String>
+    ) -> [AccountUsageWindow] {
+        if isSpark(entry) {
+            return sparkWindows(from: entry, usedIDs: &usedIDs)
+        }
+        guard let snapshot = entry.primaryWindow ?? entry.secondaryWindow,
+              let id = windowID(for: entry), usedIDs.insert(id).inserted,
+              let window = snapshot.model(
+                key: id,
+                label: windowTitle(for: entry)
+              ) else { return [] }
+        return [window]
+    }
+
+    private static func sparkWindows(
+        from entry: AdditionalRateLimitDTO,
+        usedIDs: inout Set<String>
+    ) -> [AccountUsageWindow] {
+        let candidates: [(FlexibleRateWindow?, Bool)] = [
+            (entry.primaryWindow, true),
+            (entry.secondaryWindow, false),
+        ]
+        return candidates.compactMap { snapshot, fiveHourFallback in
+            guard let snapshot else { return nil }
+            let fiveHour = isFiveHour(snapshot, fallback: fiveHourFallback)
+            let id = fiveHour ? sparkWindowID : sparkWeeklyWindowID
+            guard usedIDs.insert(id).inserted else { return nil }
+            return snapshot.model(
+                key: id,
+                label: fiveHour ? sparkWindowTitle : sparkWeeklyWindowTitle,
+                defaultMinutes: fiveHour ? 5 * 60 : 7 * 24 * 60
+            )
+        }
+    }
+
+    private static func isFiveHour(_ snapshot: FlexibleRateWindow, fallback: Bool) -> Bool {
+        guard let minutes = snapshot.windowMinutes, minutes > 0 else { return fallback }
+        if minutes <= 6 * 60 { return true }
+        if minutes >= 6 * 24 * 60 { return false }
+        return fallback
+    }
+
+    private static func windowID(for entry: AdditionalRateLimitDTO) -> String? {
+        guard let source = firstNonEmpty(entry.meteredFeature, entry.limitName) else { return nil }
+        let slug = QuotaPresentation.slug(source)
+        return slug.isEmpty ? nil : "codex-\(slug)"
+    }
+
+    private static func windowTitle(for entry: AdditionalRateLimitDTO) -> String {
+        firstNonEmpty(entry.limitName, entry.meteredFeature) ?? "Codex extra limit"
+    }
+
+    private static func isSpark(_ entry: AdditionalRateLimitDTO) -> Bool {
+        [entry.limitName, entry.meteredFeature]
+            .compactMap { $0?.lowercased() }
+            .contains { $0.contains("spark") }
+    }
+
+    private static func firstNonEmpty(_ values: String?...) -> String? {
+        for value in values {
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let trimmed, !trimmed.isEmpty { return trimmed }
+        }
+        return nil
+    }
+}
+
+struct AdditionalRateLimitDTO: Decodable {
+    var limitName: String?
+    var meteredFeature: String?
+    var primaryWindow: FlexibleRateWindow?
+    var secondaryWindow: FlexibleRateWindow?
+
+    private enum CodingKeys: String, CodingKey {
+        case limitName, limit_name
+        case meteredFeature, metered_feature
+        case primary, secondary
+        case rateLimit, rate_limit
+        case usedPercent, used_percent
+        case windowDurationMins, window_duration_mins
+        case resetsAt, resets_at, resetAt, reset_at
+        case limitWindowSeconds, limit_window_seconds
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        limitName = (try? values.decode(String.self, forKey: .limitName))
+            ?? (try? values.decode(String.self, forKey: .limit_name))
+        meteredFeature = (try? values.decode(String.self, forKey: .meteredFeature))
+            ?? (try? values.decode(String.self, forKey: .metered_feature))
+
+        let nested = (try? values.decode(NestedRateLimitDTO.self, forKey: .rateLimit))
+            ?? (try? values.decode(NestedRateLimitDTO.self, forKey: .rate_limit))
+        primaryWindow = nested?.primary
+            ?? (try? values.decode(FlexibleRateWindow.self, forKey: .primary))
+        secondaryWindow = nested?.secondary
+            ?? (try? values.decode(FlexibleRateWindow.self, forKey: .secondary))
+
+        if primaryWindow == nil {
+            primaryWindow = try? FlexibleRateWindow(from: decoder)
+        }
+    }
+}
+
+private struct NestedRateLimitDTO: Decodable {
+    var primary: FlexibleRateWindow?
+    var secondary: FlexibleRateWindow?
+
+    private enum CodingKeys: String, CodingKey {
+        case primary, secondary
+        case primaryWindow = "primary_window"
+        case secondaryWindow = "secondary_window"
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        primary = (try? values.decode(FlexibleRateWindow.self, forKey: .primary))
+            ?? (try? values.decode(FlexibleRateWindow.self, forKey: .primaryWindow))
+        secondary = (try? values.decode(FlexibleRateWindow.self, forKey: .secondary))
+            ?? (try? values.decode(FlexibleRateWindow.self, forKey: .secondaryWindow))
+    }
+}
+
+struct FlexibleRateWindow: Decodable {
+    var usedPercent: Double?
+    var windowMinutes: Int?
+    var resetsAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case usedPercent, used_percent
+        case windowDurationMins, window_duration_mins
+        case resetsAt, resets_at, resetAt, reset_at
+        case limitWindowSeconds, limit_window_seconds
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard let parsed = FlexibleRateWindow(container: values) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "rate window missing used percent"))
+        }
+        self = parsed
+    }
+
+    init?(container values: KeyedDecodingContainer<CodingKeys>) {
+        usedPercent = Self.flexibleDouble(values, [.usedPercent, .used_percent])
+        windowMinutes = Self.flexibleInt(values, [.windowDurationMins, .window_duration_mins])
+        if windowMinutes == nil,
+           let seconds = Self.flexibleInt(values, [.limitWindowSeconds, .limit_window_seconds]),
+           seconds > 0 {
+            windowMinutes = seconds / 60
+        }
+        if let timestamp = Self.flexibleInt(values, [.resetsAt, .resets_at, .resetAt, .reset_at]),
+           timestamp > 0 {
+            resetsAt = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        }
+        guard let usedPercent, usedPercent.isFinite, (0...100).contains(usedPercent) else { return nil }
+    }
+
+    func model(key: String, label: String, defaultMinutes: Int? = nil) -> AccountUsageWindow? {
+        guard let usedPercent, usedPercent.isFinite, (0...100).contains(usedPercent) else { return nil }
+        return .extra(
+            key: key,
+            label: label,
+            usedPercent: Int(usedPercent.rounded()),
+            windowDurationMinutes: windowMinutes ?? defaultMinutes,
+            resetsAt: resetsAt
+        )
+    }
+
+    private static func flexibleDouble(
+        _ values: KeyedDecodingContainer<CodingKeys>,
+        _ keys: [CodingKeys]
+    ) -> Double? {
+        for key in keys {
+            if let value = try? values.decode(Double.self, forKey: key) { return value }
+            if let value = try? values.decode(Int.self, forKey: key) { return Double(value) }
+            if let value = try? values.decode(String.self, forKey: key),
+               let parsed = Double(value.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return parsed
+            }
+        }
+        return nil
+    }
+
+    private static func flexibleInt(
+        _ values: KeyedDecodingContainer<CodingKeys>,
+        _ keys: [CodingKeys]
+    ) -> Int? {
+        for key in keys {
+            if let value = try? values.decode(Int.self, forKey: key) { return value }
+            if let value = try? values.decode(Double.self, forKey: key), value.isFinite {
+                return Int(value)
+            }
+            if let value = try? values.decode(String.self, forKey: key),
+               let parsed = Int(value.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return parsed
+            }
+        }
+        return nil
+    }
+}
+
+struct CreditDetailsDTO: Decodable {
+    var hasCredits: Bool?
+    var unlimited: Bool?
+    var balance: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case hasCredits, has_credits, unlimited, balance
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        hasCredits = (try? values.decode(Bool.self, forKey: .hasCredits))
+            ?? (try? values.decode(Bool.self, forKey: .has_credits))
+        unlimited = try? values.decode(Bool.self, forKey: .unlimited)
+        if let value = try? values.decode(Double.self, forKey: .balance) {
+            balance = value
+        } else if let value = try? values.decode(Int.self, forKey: .balance) {
+            balance = Double(value)
+        } else if let value = try? values.decode(String.self, forKey: .balance) {
+            balance = Double(value.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    var model: QuotaCredits? {
+        if unlimited == true { return nil }
+        guard let balance, balance.isFinite, balance >= 0 else { return nil }
+        if hasCredits == false { return nil }
+        return QuotaCredits(remaining: balance, label: "Credits")
+    }
+}
+
+/// One malformed extra limit must not discard its siblings.
+struct LossyAdditionalRateLimit: Decodable {
+    var value: AdditionalRateLimitDTO?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try? container.decode(AdditionalRateLimitDTO.self)
+    }
+
+    static func decodeArray<Key: CodingKey>(
+        _ values: KeyedDecodingContainer<Key>,
+        keys: [Key]
+    ) -> [AdditionalRateLimitDTO]? {
+        for key in keys {
+            if let decoded = try? values.decode([LossyAdditionalRateLimit].self, forKey: key) {
+                let mapped = decoded.compactMap(\.value)
+                return mapped.isEmpty ? nil : mapped
+            }
+        }
+        return nil
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CodexAppServerUsageProvider.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import VibeBuddyKit
 
 public enum CodexUsageResponseDecoder {
     /// The same mapping for results already received on a live app-server
@@ -52,7 +53,12 @@ public enum CodexUsageResponseDecoder {
                 secondary: limits.secondary.flatMap { $0.model(kind: .secondary) },
                 lifetimeTokens: usage.summary.lifetimeTokens,
                 latestDailyTokens: usage.dailyUsageBuckets?.max(by: { $0.startDate < $1.startDate })?.tokens,
-                fetchedAt: fetchedAt
+                fetchedAt: fetchedAt,
+                extraWindows: CodexAdditionalRateLimitMapper.windows(
+                    from: limits.additionalRateLimits ?? result.additionalRateLimits
+                ),
+                credits: limits.credits?.model ?? result.credits?.model,
+                spend: usage.summary.spend
             )
         } catch let error as AccountUsageError {
             throw error
@@ -563,6 +569,23 @@ private struct RateLimitsEnvelope: Decodable {
 private struct RateLimitsResultDTO: Decodable {
     var rateLimits: RateLimitsDTO?
     var rateLimitsByLimitId: [String: RateLimitsDTO]?
+    var additionalRateLimits: [AdditionalRateLimitDTO]?
+    var credits: CreditDetailsDTO?
+
+    private enum CodingKeys: String, CodingKey {
+        case rateLimits, rateLimitsByLimitId
+        case additionalRateLimits
+        case additionalRateLimitsSnake = "additional_rate_limits"
+        case credits
+    }
+
+    init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        rateLimits = try? values.decode(RateLimitsDTO.self, forKey: .rateLimits)
+        rateLimitsByLimitId = try? values.decode([String: RateLimitsDTO].self, forKey: .rateLimitsByLimitId)
+        additionalRateLimits = LossyAdditionalRateLimit.decodeArray(values, keys: [.additionalRateLimits, .additionalRateLimitsSnake])
+        credits = try? values.decode(CreditDetailsDTO.self, forKey: .credits)
+    }
 }
 
 private struct RateLimitsDTO: Decodable {
@@ -570,14 +593,23 @@ private struct RateLimitsDTO: Decodable {
     var planType: String?
     var primary: RateLimitWindowDTO?
     var secondary: RateLimitWindowDTO?
+    var additionalRateLimits: [AdditionalRateLimitDTO]?
+    var credits: CreditDetailsDTO?
 
-    private enum CodingKeys: String, CodingKey { case limitId, planType, primary, secondary }
+    private enum CodingKeys: String, CodingKey {
+        case limitId, planType, primary, secondary, credits
+        case additionalRateLimits
+        case additionalRateLimitsSnake = "additional_rate_limits"
+    }
+
     init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         limitId = try values.decodeIfPresent(String.self, forKey: .limitId)
         planType = try? values.decode(String.self, forKey: .planType)
         primary = try? values.decode(RateLimitWindowDTO.self, forKey: .primary)
         secondary = try? values.decode(RateLimitWindowDTO.self, forKey: .secondary)
+        additionalRateLimits = LossyAdditionalRateLimit.decodeArray(values, keys: [.additionalRateLimits, .additionalRateLimitsSnake])
+        credits = try? values.decode(CreditDetailsDTO.self, forKey: .credits)
     }
 }
 
@@ -617,6 +649,29 @@ private struct UsageResultDTO: Decodable {
 
 private struct UsageSummaryDTO: Decodable {
     var lifetimeTokens: Int?
+    var extraUsageUsd: Double?
+    var extraUsage: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case lifetimeTokens
+        case extraUsageUsd, extra_usage_usd
+        case extraUsage, extra_usage
+    }
+
+    init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        lifetimeTokens = try? values.decode(Int.self, forKey: .lifetimeTokens)
+        extraUsageUsd = (try? values.decode(Double.self, forKey: .extraUsageUsd))
+            ?? (try? values.decode(Double.self, forKey: .extra_usage_usd))
+        extraUsage = (try? values.decode(Double.self, forKey: .extraUsage))
+            ?? (try? values.decode(Double.self, forKey: .extra_usage))
+    }
+
+    var spend: [QuotaSpend]? {
+        let amount = extraUsageUsd ?? extraUsage
+        guard let amount, amount.isFinite, amount > 0 else { return nil }
+        return [QuotaSpend(label: "Extra usage", amount: amount)]
+    }
 }
 
 private struct DailyUsageBucketDTO: Decodable {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorUsageProvider.swift
@@ -82,6 +82,27 @@ public enum CursorUsageSummaryDecoder {
         let end = parseTimestamp(summary.billingCycleEnd)
         let duration = durationMinutes(from: start, to: end)
 
+        var spend: [QuotaSpend]?
+        if let onDemand = summary.individualUsage?.onDemand,
+           let used = onDemand.used, used > 0 {
+            spend = [QuotaSpend(label: "On-demand", amount: Double(used))]
+        }
+        var credits: QuotaCredits?
+        if let remaining = summary.individualUsage?.plan?.remaining {
+            credits = QuotaCredits(
+                remaining: Double(remaining),
+                limit: summary.individualUsage?.plan?.limit.map(Double.init),
+                label: "Plan remaining"
+            )
+        } else if let remaining = summary.individualUsage?.onDemand?.remaining,
+                  (summary.individualUsage?.onDemand?.limit ?? 0) > 0 {
+            credits = QuotaCredits(
+                remaining: Double(remaining),
+                limit: summary.individualUsage?.onDemand?.limit.map(Double.init),
+                label: "On-demand remaining"
+            )
+        }
+
         if let pool = summary.individualUsage?.plan,
            pool.autoPercentUsed != nil || pool.apiPercentUsed != nil {
             func window(_ value: Double?, kind: AccountUsageWindowKind, label: String) throws -> AccountUsageWindow? {
@@ -93,7 +114,8 @@ public enum CursorUsageSummaryDecoder {
             return try AccountUsageSnapshot(provider: .cursor, planType: summary.membershipType,
                 primary: window(pool.autoPercentUsed, kind: .primary, label: "Cursor Models"),
                 secondary: window(pool.apiPercentUsed, kind: .secondary, label: "Other Models"),
-                lifetimeTokens: nil, latestDailyTokens: nil, fetchedAt: fetchedAt)
+                lifetimeTokens: nil, latestDailyTokens: nil, fetchedAt: fetchedAt,
+                credits: credits, spend: spend)
         }
 
         guard let primaryUsed = primaryUsedPercent(from: summary) else {
@@ -138,7 +160,9 @@ public enum CursorUsageSummaryDecoder {
             secondary: secondary,
             lifetimeTokens: nil,
             latestDailyTokens: nil,
-            fetchedAt: fetchedAt
+            fetchedAt: fetchedAt,
+            credits: credits,
+            spend: spend
         )
     }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokUsageProvider.swift
@@ -113,6 +113,7 @@ public enum GrokUsageResponseDecoder {
         }
 
         var onDemand: AccountUsageWindow?
+        var extraSpend: [QuotaSpend]?
         if let cap = config.onDemandCap?.val, cap > 0, let used = config.onDemandUsedValue {
             let percent = min(100, max(0, used / cap * 100))
             guard percent.isFinite else { throw AccountUsageError.incompatibleFormat }
@@ -120,8 +121,17 @@ public enum GrokUsageResponseDecoder {
                 kind: .secondary,
                 usedPercent: Int(percent.rounded()),
                 windowDurationMinutes: durationMinutes,
-                resetsAt: resetsAt
+                resetsAt: resetsAt,
+                label: "Extra usage"
             )
+            if used > 0 {
+                extraSpend = [QuotaSpend(label: "Extra usage", amount: used)]
+            }
+        }
+
+        var credits: QuotaCredits?
+        if let prepaid = config.prepaidBalance?.val, prepaid.isFinite, prepaid > 0 {
+            credits = QuotaCredits(remaining: prepaid, label: "Prepaid")
         }
 
         return AccountUsageSnapshot(
@@ -138,7 +148,9 @@ public enum GrokUsageResponseDecoder {
             latestDailyTokens: nil,
             fetchedAt: fetchedAt,
             periodStart: start,
-            periodEnd: resetsAt
+            periodEnd: resetsAt,
+            credits: credits,
+            spend: extraSpend
         )
     }
 
@@ -248,6 +260,7 @@ private struct BillingConfigDTO: Decodable {
     var used: CentDTO?
     var onDemandCap: CentDTO?
     var onDemandUsed: CentDTO?
+    var prepaidBalance: CentDTO?
     var billingPeriodStart: String?
     var billingPeriodEnd: String?
     /// Present on some CLI-proxy credits payloads (CodexBar).

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/ProviderQuotaProjection.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/ProviderQuotaProjection.swift
@@ -39,20 +39,23 @@ public extension ProviderQuota {
         let others = snapshot.quotaWindows.filter {
             // Preserve independent pools even when they share a duration.
             $0.kind != weekly?.kind && $0.kind != short?.kind
-        }.map {
+        } + (snapshot.extraWindows ?? [])
+        let projectedOthers = others.map {
             QuotaWindow(remainingPercent: Self.remaining(fromUsedPercent: $0.usedPercent),
                         durationMinutes: $0.windowDurationMinutes, resetsAt: $0.resetsAt,
                         observedAt: snapshot.fetchedAt, isCached: state.isStale, label: $0.label)
         }
         let weeklyRemaining = Self.remaining(fromUsedPercent: weekly?.usedPercent)
         let shortRemaining = Self.remaining(fromUsedPercent: short?.usedPercent)
-        let usable = weeklyRemaining != nil || shortRemaining != nil || others.contains { $0.remainingPercent != nil }
+        let usable = weeklyRemaining != nil || shortRemaining != nil || projectedOthers.contains { $0.remainingPercent != nil }
         self.init(provider: provider, accountLabel: snapshot.accountLabel,
                   weeklyRemainingPercent: weeklyRemaining, weeklyResetsAt: weekly?.resetsAt,
                   weeklyWindowDurationMinutes: weekly?.windowDurationMinutes,
                   shortWindowRemainingPercent: shortRemaining, shortWindowResetsAt: short?.resetsAt,
                   shortWindowDurationMinutes: short?.windowDurationMinutes,
-                  otherWindows: others.isEmpty ? nil : others,
+                  otherWindows: projectedOthers.isEmpty ? nil : projectedOthers,
+                  credits: snapshot.credits,
+                  spend: snapshot.spend,
                   observedAt: usable || provider == .grokBot ? snapshot.fetchedAt : nil,
                   unavailableReason: state.unavailableReason?.displayText(provider: provider)
                     ?? (usable ? nil : snapshot.usageDetail)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -93,6 +93,8 @@ public actor SessionStore {
     public let sourceID: String?
     /// Account allowance, kept beside the reducer rather than inside it.
     private var providerQuota: [ProviderQuota] = []
+    /// Local token spend, kept beside the reducer rather than inside it.
+    private var tokenConsumption: TokenConsumptionSnapshot?
     private var subscribers: [UUID: AsyncStream<Snapshot>.Continuation] = [:]
     private var needsResponseHandler: (@Sendable (AgentSession) async -> Void)?
     private var staleAfter: TimeInterval
@@ -718,6 +720,14 @@ public actor SessionStore {
         broadcast()
     }
 
+    /// Replace the current token-consumption summary. Composed into every
+    /// snapshot beside quota; never reaches the reducer.
+    public func setTokenConsumption(_ snapshot: TokenConsumptionSnapshot?) {
+        guard snapshot != tokenConsumption else { return }
+        tokenConsumption = snapshot
+        broadcast()
+    }
+
     /// The one place a runtime snapshot is assembled: sessions and diagnostics
     /// from the reducer, allowance from beside it.
     private func currentSnapshot(now: Date) -> Snapshot {
@@ -735,6 +745,7 @@ public actor SessionStore {
         }
         snapshot.sourceID = sourceID
         snapshot.providerQuota = providerQuota.isEmpty ? nil : providerQuota
+        snapshot.tokenConsumption = tokenConsumption
         let directories = recentDirectories()
         snapshot.recentDirectories = directories.isEmpty ? nil : directories
         snapshot.sessions = snapshot.sessions.map { session in

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/StatusLineSample.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/StatusLineSample.swift
@@ -23,6 +23,7 @@ public struct StatusLineSample: Sendable, Equatable {
     /// The claude.ai rate-limit windows, when the CLI reports them.
     public var fiveHour: AccountUsageWindow?
     public var sevenDay: AccountUsageWindow?
+    public var extraWindows: [AccountUsageWindow] = []
 
     public init(sessionID: String) { self.sessionID = sessionID }
 
@@ -61,6 +62,7 @@ public struct StatusLineSample: Sendable, Equatable {
         if let limits = obj["rate_limits"] as? [String: Any] {
             sample.fiveHour = Self.window(limits["five_hour"], kind: .primary, minutes: 5 * 60)
             sample.sevenDay = Self.window(limits["seven_day"], kind: .secondary, minutes: 7 * 24 * 60)
+            sample.extraWindows = Self.extraWindows(from: limits)
         }
         return sample
     }
@@ -68,12 +70,53 @@ public struct StatusLineSample: Sendable, Equatable {
     /// The subscription allowance this sample carries, in the collectors'
     /// shape, or nil when the CLI sent no `rate_limits`.
     public func usageSnapshot(fetchedAt: Date) -> AccountUsageSnapshot? {
-        guard fiveHour != nil || sevenDay != nil else { return nil }
+        guard fiveHour != nil || sevenDay != nil || !extraWindows.isEmpty else { return nil }
         return AccountUsageSnapshot(
             provider: .claude, planType: nil,
             primary: fiveHour, secondary: sevenDay,
             lifetimeTokens: nil, latestDailyTokens: nil,
-            fetchedAt: fetchedAt)
+            fetchedAt: fetchedAt,
+            extraWindows: extraWindows.isEmpty ? nil : extraWindows)
+    }
+
+    private static let reservedRateLimitKeys: Set<String> = ["five_hour", "seven_day"]
+
+    private static func extraWindows(from limits: [String: Any]) -> [AccountUsageWindow] {
+        var extras: [AccountUsageWindow] = []
+        var seen: Set<String> = []
+        for (rawKey, value) in limits.sorted(by: { $0.key < $1.key }) where !reservedRateLimitKeys.contains(rawKey) {
+            let minutes: Int?
+            let lowered = rawKey.lowercased()
+            if lowered.contains("five_hour") || lowered.contains("five-hour") {
+                minutes = 5 * 60
+            } else if lowered.contains("seven_day") || lowered.contains("seven-day") {
+                minutes = 7 * 24 * 60
+            } else {
+                minutes = nil
+            }
+            guard let window = Self.window(value, kind: .extra, minutes: minutes ?? 0) else { continue }
+            let slug: String
+            let key: String
+            if lowered.hasPrefix("seven_day_") || lowered.hasPrefix("five_hour_")
+                || lowered.hasPrefix("seven-day-") || lowered.hasPrefix("five-hour-") {
+                let stripped = QuotaPresentation.extraWindowTitle(fromStatusLineKey: rawKey)
+                    .replacingOccurrences(of: " only", with: "")
+                slug = QuotaPresentation.slug(stripped)
+                key = "claude-weekly-scoped-\(slug)"
+            } else {
+                slug = QuotaPresentation.slug(rawKey)
+                key = "claude-status-\(slug)"
+            }
+            guard !slug.isEmpty, seen.insert(key).inserted else { continue }
+            extras.append(.extra(
+                key: key,
+                label: QuotaPresentation.extraWindowTitle(fromStatusLineKey: rawKey),
+                usedPercent: window.usedPercent,
+                windowDurationMinutes: minutes,
+                resetsAt: window.resetsAt
+            ))
+        }
+        return extras
     }
 
     private static func window(_ value: Any?, kind: AccountUsageWindowKind, minutes: Int) -> AccountUsageWindow? {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/TokenConsumptionScan.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/TokenConsumptionScan.swift
@@ -1,0 +1,530 @@
+import Foundation
+import VibeBuddyKit
+
+/// One assistant/API call's tokens. Internal to local log aggregation; never
+/// enters the session reducer.
+struct TokenUsageEntry: Equatable, Sendable {
+    var agent: AgentKind
+    var model: String
+    var project: String
+    var sessionID: String
+    var timestamp: Date
+    var inputTokens: Int
+    var outputTokens: Int
+    var cachedInputTokens: Int
+    var reasoningOutputTokens: Int
+
+    var usageScore: Int { inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }
+
+    var estimatedUSD: Double {
+        Pricing.estimatedUSD(
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            cachedInputTokens: cachedInputTokens,
+            reasoningOutputTokens: reasoningOutputTokens,
+            model: model)
+    }
+}
+
+/// Walks the same Claude Code / Codex homes session history already uses and
+/// folds token usage into today / last-7-day summaries. Read-only.
+public enum TokenConsumptionScan {
+    public static let recency: TimeInterval = 14 * 24 * 60 * 60
+    public static let refreshInterval: TimeInterval = 5 * 60
+
+    public static func defaultClaudeHomes(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> [URL] {
+        var homes = [home.appendingPathComponent(".claude")]
+        if let configured = environment["CLAUDE_CONFIG_DIR"], !configured.isEmpty {
+            let extra = URL(fileURLWithPath: configured)
+            if extra.standardizedFileURL != homes[0].standardizedFileURL {
+                homes.append(extra)
+            }
+        }
+        return homes
+    }
+
+    public static func defaultCodexHome(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        if let configured = environment["CODEX_HOME"], !configured.isEmpty {
+            return URL(fileURLWithPath: configured)
+        }
+        return home.appendingPathComponent(".codex")
+    }
+
+    public static func snapshot(
+        claudeHomes: [URL],
+        codexHome: URL,
+        now: Date,
+        calendar: Calendar = .current,
+        fileManager: FileManager = .default
+    ) -> TokenConsumptionSnapshot {
+        var warnings: [String] = []
+        let since = now.addingTimeInterval(-recency)
+        var entries: [TokenUsageEntry] = []
+        for home in claudeHomes {
+            entries += ClaudeTokenConsumptionParser.parse(
+                home: home, since: since, fileManager: fileManager, warnings: &warnings)
+        }
+        entries += CodexTokenConsumptionParser.parse(
+            home: codexHome, since: since, fileManager: fileManager, warnings: &warnings)
+        return TokenConsumptionAggregator.snapshot(
+            entries: entries, now: now, calendar: calendar, warnings: warnings)
+    }
+}
+
+enum TokenConsumptionAggregator {
+    static let topN = 8
+
+    static func snapshot(
+        entries: [TokenUsageEntry],
+        now: Date,
+        calendar: Calendar,
+        warnings: [String]
+    ) -> TokenConsumptionSnapshot {
+        let todayStart = calendar.startOfDay(for: now)
+        // Inclusive of today plus the previous six calendar days.
+        let weekStart = calendar.date(byAdding: .day, value: -6, to: todayStart)
+            ?? now.addingTimeInterval(-7 * 24 * 60 * 60)
+        let windows = [
+            window(.today, entries: entries, start: todayStart, end: now),
+            window(.last7Days, entries: entries, start: weekStart, end: now),
+        ]
+        return TokenConsumptionSnapshot(
+            observedAt: now,
+            windows: windows,
+            warnings: warnings.isEmpty ? nil : Array(warnings.prefix(8)))
+    }
+
+    private static func window(
+        _ kind: TokenConsumptionWindowKind,
+        entries: [TokenUsageEntry],
+        start: Date,
+        end: Date
+    ) -> TokenConsumptionWindow {
+        let slice = entries.filter { $0.timestamp >= start && $0.timestamp <= end }
+        return TokenConsumptionWindow(
+            kind: kind,
+            counts: totals(slice),
+            byAgent: rows(slice, key: { $0.agent.rawValue }, label: { $0.agent.displayName }, limit: nil),
+            byModel: rows(slice, key: { $0.model }, label: { $0.model }, limit: topN),
+            byProject: rows(slice, key: { $0.project }, label: { $0.project }, limit: topN))
+    }
+
+    private static func totals(_ entries: [TokenUsageEntry]) -> TokenCountBreakdown {
+        var counts = TokenCountBreakdown()
+        var sessions = Set<String>()
+        for entry in entries {
+            counts.inputTokens += entry.inputTokens
+            counts.outputTokens += entry.outputTokens
+            counts.cachedInputTokens += entry.cachedInputTokens
+            counts.reasoningOutputTokens += entry.reasoningOutputTokens
+            counts.estimatedUSD += entry.estimatedUSD
+            sessions.insert(entry.sessionID)
+        }
+        counts.sessionCount = sessions.count
+        return counts
+    }
+
+    private static func rows(
+        _ entries: [TokenUsageEntry],
+        key: (TokenUsageEntry) -> String,
+        label: (TokenUsageEntry) -> String,
+        limit: Int?
+    ) -> [TokenConsumptionRow] {
+        var grouped: [String: [TokenUsageEntry]] = [:]
+        var labels: [String: String] = [:]
+        for entry in entries {
+            let k = key(entry)
+            grouped[k, default: []].append(entry)
+            labels[k] = label(entry)
+        }
+        var result = grouped.keys.map { k in
+            TokenConsumptionRow(key: k, label: labels[k] ?? k, counts: totals(grouped[k] ?? []))
+        }
+        result.sort {
+            if $0.counts.billedTokens != $1.counts.billedTokens {
+                return $0.counts.billedTokens > $1.counts.billedTokens
+            }
+            return $0.key < $1.key
+        }
+        if let limit { return Array(result.prefix(limit)) }
+        return result
+    }
+}
+
+enum TokenLogJSON {
+    /// Per-file read budget. JSONL is append-only; a start-only cap would drop
+    /// the newest usage, so we stream until this limit and then warn.
+    static let byteLimit = 128 * 1024 * 1024
+
+    static func int(_ value: Any?) -> Int {
+        switch value {
+        case let i as Int: return max(0, i)
+        case let i as Int64: return max(0, Int(clamping: i))
+        case let d as Double where d.isFinite: return max(0, Int(d.rounded()))
+        case let n as NSNumber: return max(0, n.intValue)
+        default: return 0
+        }
+    }
+
+    /// Stream complete lines instead of slurp-from-start so a large transcript
+    /// still contributes its recent `token_count` / assistant usage records.
+    static func objects(url: URL) -> [[String: Any]] {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return [] }
+        defer { try? handle.close() }
+        var objects: [[String: Any]] = []
+        var remainder = Data()
+        var total = 0
+        while true {
+            let chunk = (try? handle.read(upToCount: 64 * 1024)) ?? Data()
+            if chunk.isEmpty { break }
+            total += chunk.count
+            remainder.append(chunk)
+            while let newline = remainder.firstIndex(of: 10) {
+                let line = Data(remainder[..<newline])
+                remainder.removeSubrange(...newline)
+                guard !line.isEmpty else { continue }
+                if let obj = try? JSONSerialization.jsonObject(with: line) as? [String: Any] {
+                    objects.append(obj)
+                }
+            }
+            if total > byteLimit { break }
+        }
+        if total <= byteLimit, !remainder.isEmpty,
+           let obj = try? JSONSerialization.jsonObject(with: remainder) as? [String: Any] {
+            objects.append(obj)
+        }
+        return objects
+    }
+
+    static func date(_ raw: Any?, iso: ISO8601DateFormatter, fractional: ISO8601DateFormatter) -> Date? {
+        guard let string = raw as? String, !string.isEmpty else { return nil }
+        return fractional.date(from: string) ?? iso.date(from: string)
+    }
+
+    static func projectName(_ cwd: String?, fallback: String) -> String {
+        guard let cwd else { return fallback }
+        let trimmed = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/\\"))
+        guard !trimmed.isEmpty else { return fallback }
+        return trimmed.split(whereSeparator: { $0 == "/" || $0 == "\\" }).last.map(String.init) ?? fallback
+    }
+}
+
+private struct TokenLogFile {
+    let url: URL
+    let size: Int
+    let mtime: Date
+    let sessionID: String
+    let fallbackProject: String
+}
+
+enum TokenLogDiscovery {
+    static func jsonlFiles(
+        in root: URL,
+        since: Date,
+        sessionID: (URL) -> String,
+        fallbackProject: (URL) -> String,
+        fileManager: FileManager,
+        warnings: inout [String]
+    ) -> [TokenLogFile] {
+        guard fileManager.fileExists(atPath: root.path) else { return [] }
+        var readable = true
+        guard let enumerator = fileManager.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in
+                readable = false
+                return true
+            }
+        ) else {
+            warnings.append("Unable to enumerate \(root.path)")
+            return []
+        }
+        var files: [TokenLogFile] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl" else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey, .contentModificationDateKey])
+            guard values?.isRegularFile == true else { continue }
+            let mtime = values?.contentModificationDate ?? .distantPast
+            guard mtime >= since else { continue }
+            files.append(TokenLogFile(
+                url: url,
+                size: values?.fileSize ?? 0,
+                mtime: mtime,
+                sessionID: sessionID(url),
+                fallbackProject: fallbackProject(url)))
+        }
+        if !readable {
+            warnings.append("Incomplete read of \(root.path)")
+        }
+        return files
+    }
+
+    static func bestCopy(_ files: [TokenLogFile]) -> [TokenLogFile] {
+        var groups: [String: [TokenLogFile]] = [:]
+        for file in files { groups[file.sessionID, default: []].append(file) }
+        return groups.values.compactMap { group in
+            group.max { a, b in
+                if a.size != b.size { return a.size < b.size }
+                if a.mtime != b.mtime { return a.mtime < b.mtime }
+                return a.url.path > b.url.path
+            }
+        }
+    }
+}
+
+enum ClaudeTokenConsumptionParser {
+    static func parse(
+        home: URL,
+        since: Date,
+        fileManager: FileManager,
+        warnings: inout [String]
+    ) -> [TokenUsageEntry] {
+        let projects = home.appendingPathComponent("projects", isDirectory: true)
+        let files = TokenLogDiscovery.bestCopy(TokenLogDiscovery.jsonlFiles(
+            in: projects,
+            since: since,
+            sessionID: { $0.deletingPathExtension().lastPathComponent },
+            fallbackProject: { projectFromRelative($0, under: projects) },
+            fileManager: fileManager,
+            warnings: &warnings))
+        return files.flatMap { file in
+            if file.size > TokenLogJSON.byteLimit {
+                warnings.append("Skipped oversized Claude transcript \(file.url.lastPathComponent)")
+                return []
+            }
+            return parseFile(file)
+        }
+    }
+
+    private static func projectFromRelative(_ url: URL, under projects: URL) -> String {
+        let prefix = projects.standardizedFileURL.path + "/"
+        let path = url.standardizedFileURL.path
+        guard path.hasPrefix(prefix) else { return "unknown" }
+        let relative = String(path.dropFirst(prefix.count))
+        let first = relative.split(separator: "/").first.map(String.init) ?? ""
+        return first.split(separator: "-").last.map(String.init) ?? "unknown"
+    }
+
+    private static func parseFile(_ file: TokenLogFile) -> [TokenUsageEntry] {
+        let iso = ISO8601DateFormatter()
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var keyed: [String: TokenUsageEntry] = [:]
+        var anonymous: [TokenUsageEntry] = []
+        var lastModel: String?
+        var sessionProject = file.fallbackProject
+        var foundCwd = false
+
+        for obj in TokenLogJSON.objects(url: file.url) {
+            if !foundCwd, let cwd = obj["cwd"] as? String, !cwd.trimmingCharacters(in: .whitespaces).isEmpty {
+                sessionProject = TokenLogJSON.projectName(cwd, fallback: file.fallbackProject)
+                foundCwd = true
+            }
+            guard (obj["type"] as? String) == "assistant" else { continue }
+            let message = obj["message"] as? [String: Any]
+            guard let usage = message?["usage"] as? [String: Any] else { continue }
+            guard let timestamp = TokenLogJSON.date(obj["timestamp"], iso: iso, fractional: fractional) else { continue }
+
+            let rawModel = (message?["model"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !rawModel.isEmpty, rawModel != "<synthetic>" { lastModel = rawModel }
+            let model = (rawModel.isEmpty || rawModel == "<synthetic>") ? (lastModel ?? "claude-unknown") : rawModel
+            let input = TokenLogJSON.int(usage["input_tokens"]) + cacheCreation(usage)
+            let output = TokenLogJSON.int(usage["output_tokens"])
+            let cached = TokenLogJSON.int(usage["cache_read_input_tokens"])
+            if input + output + cached == 0 { continue }
+
+            let entry = TokenUsageEntry(
+                agent: .claudeCode, model: model, project: sessionProject,
+                sessionID: file.sessionID, timestamp: timestamp,
+                inputTokens: input, outputTokens: output,
+                cachedInputTokens: cached, reasoningOutputTokens: 0)
+            if let key = dedupeKey(obj, message: message) {
+                if keyed[key]?.usageScore ?? -1 < entry.usageScore { keyed[key] = entry }
+            } else {
+                anonymous.append(entry)
+            }
+        }
+
+        var result = anonymous + Array(keyed.values)
+        for i in result.indices { result[i].project = sessionProject }
+        return result
+    }
+
+    private static func cacheCreation(_ usage: [String: Any]) -> Int {
+        let direct = TokenLogJSON.int(usage["cache_creation_input_tokens"])
+        let breakdown = usage["cache_creation"] as? [String: Any] ?? [:]
+        let split = TokenLogJSON.int(breakdown["ephemeral_5m_input_tokens"])
+            + TokenLogJSON.int(breakdown["ephemeral_1h_input_tokens"])
+        return max(direct, split)
+    }
+
+    private static func dedupeKey(_ obj: [String: Any], message: [String: Any]?) -> String? {
+        let messageID = (message?["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let requestID = (obj["requestId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !messageID.isEmpty || !requestID.isEmpty { return "call:\(messageID)\u{0}\(requestID)" }
+        if let uuid = obj["uuid"] as? String, !uuid.isEmpty { return uuid }
+        return nil
+    }
+}
+
+enum CodexTokenConsumptionParser {
+    static func parse(
+        home: URL,
+        since: Date,
+        fileManager: FileManager,
+        warnings: inout [String]
+    ) -> [TokenUsageEntry] {
+        let roots = [
+            home.appendingPathComponent("sessions", isDirectory: true),
+            home.appendingPathComponent("archived_sessions", isDirectory: true),
+        ]
+        var discovered: [TokenLogFile] = []
+        for root in roots {
+            discovered += TokenLogDiscovery.jsonlFiles(
+                in: root, since: since,
+                sessionID: { $0.deletingPathExtension().lastPathComponent },
+                fallbackProject: { _ in "unknown" },
+                fileManager: fileManager, warnings: &warnings)
+        }
+        var bySession: [String: (file: TokenLogFile, entries: [TokenUsageEntry])] = [:]
+        for file in discovered {
+            if file.size > TokenLogJSON.byteLimit {
+                warnings.append("Skipped oversized Codex rollout \(file.url.lastPathComponent)")
+                continue
+            }
+            let parsed = parseFile(file)
+            let sessionID = parsed.sessionID ?? file.sessionID
+            let candidate = TokenLogFile(
+                url: file.url, size: file.size, mtime: file.mtime,
+                sessionID: sessionID, fallbackProject: parsed.project)
+            if let existing = bySession[sessionID] {
+                let keepNew = candidate.size != existing.file.size
+                    ? candidate.size > existing.file.size
+                    : candidate.mtime >= existing.file.mtime
+                if keepNew { bySession[sessionID] = (candidate, parsed.entries) }
+            } else {
+                bySession[sessionID] = (candidate, parsed.entries)
+            }
+        }
+        return bySession.values.flatMap(\.entries)
+    }
+
+    private static func parseFile(_ file: TokenLogFile) -> (sessionID: String?, project: String, entries: [TokenUsageEntry]) {
+        let iso = ISO8601DateFormatter()
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var sessionID: String?
+        var project = file.fallbackProject
+        var sessionMetaCount = 0
+        var skippingReplay = false
+        var model = "unknown"
+        var prevTotal: [String: Int]?
+        var prevCumulativeTotal: Int?
+        var entries: [TokenUsageEntry] = []
+
+        for obj in TokenLogJSON.objects(url: file.url) {
+            let type = obj["type"] as? String
+            if type == "session_meta", let payload = obj["payload"] as? [String: Any] {
+                sessionMetaCount += 1
+                if sessionMetaCount == 1 {
+                    if let id = payload["id"] as? String, !id.isEmpty { sessionID = id }
+                    project = projectName(from: payload, fallback: project)
+                } else {
+                    skippingReplay = true
+                }
+                continue
+            }
+            if type == "turn_context", let payload = obj["payload"] as? [String: Any],
+               let name = payload["model"] as? String, !name.isEmpty {
+                model = name
+                continue
+            }
+            guard type == "event_msg", let payload = obj["payload"] as? [String: Any],
+                  let eventType = payload["type"] as? String else { continue }
+            if eventType == "thread_settings_applied",
+               let settings = payload["thread_settings"] as? [String: Any],
+               let name = settings["model"] as? String, !name.isEmpty {
+                model = name
+                continue
+            }
+            if eventType == "task_started" {
+                skippingReplay = false
+                continue
+            }
+            guard eventType == "token_count" else { continue }
+            guard let info = payload["info"] as? [String: Any] else { continue }
+
+            let currentTotal = info["total_token_usage"] as? [String: Any]
+            let cumulative = TokenLogJSON.int(currentTotal?["total_tokens"])
+            let isDuplicate = cumulative > 0 && cumulative == prevCumulativeTotal
+            if cumulative > 0 { prevCumulativeTotal = cumulative }
+
+            var usage = info["last_token_usage"] as? [String: Any]
+            if usage == nil, let curr = currentTotal {
+                if let prev = prevTotal {
+                    let inputDelta = TokenLogJSON.int(curr["input_tokens"]) - prev["input_tokens", default: 0]
+                    let outputDelta = TokenLogJSON.int(curr["output_tokens"]) - prev["output_tokens", default: 0]
+                    let cachedDelta = TokenLogJSON.int(curr["cached_input_tokens"]) - prev["cached_input_tokens", default: 0]
+                    let reasoningDelta = TokenLogJSON.int(curr["reasoning_output_tokens"]) - prev["reasoning_output_tokens", default: 0]
+                    if inputDelta < 0 || outputDelta < 0 || cachedDelta < 0 || reasoningDelta < 0 {
+                        usage = curr
+                    } else {
+                        usage = [
+                            "input_tokens": inputDelta,
+                            "output_tokens": outputDelta,
+                            "cached_input_tokens": cachedDelta,
+                            "reasoning_output_tokens": reasoningDelta,
+                        ]
+                    }
+                } else {
+                    usage = curr
+                }
+            }
+            if let curr = currentTotal {
+                prevTotal = [
+                    "input_tokens": TokenLogJSON.int(curr["input_tokens"]),
+                    "output_tokens": TokenLogJSON.int(curr["output_tokens"]),
+                    "cached_input_tokens": TokenLogJSON.int(curr["cached_input_tokens"]),
+                    "reasoning_output_tokens": TokenLogJSON.int(curr["reasoning_output_tokens"]),
+                ]
+            }
+            if skippingReplay || isDuplicate { continue }
+            guard let usage else { continue }
+            guard let timestamp = TokenLogJSON.date(obj["timestamp"], iso: iso, fractional: fractional) else { continue }
+            if let named = info["model"] as? String, !named.isEmpty { model = named }
+            else if let named = payload["model"] as? String, !named.isEmpty { model = named }
+
+            // OpenAI-style fields overlap; prefer `cached_input_tokens` the way
+            // vibe-usage does (`||`), rather than summing both names.
+            let cachedPrimary = TokenLogJSON.int(usage["cached_input_tokens"])
+            let cached = cachedPrimary > 0 ? cachedPrimary : TokenLogJSON.int(usage["cache_read_input_tokens"])
+            let reasoning = TokenLogJSON.int(usage["reasoning_output_tokens"])
+            let input = max(0, TokenLogJSON.int(usage["input_tokens"]) - cached)
+            let output = max(0, TokenLogJSON.int(usage["output_tokens"]) - reasoning)
+            if input + output + cached + reasoning == 0 { continue }
+            entries.append(TokenUsageEntry(
+                agent: .codex, model: model, project: project,
+                sessionID: sessionID ?? file.sessionID, timestamp: timestamp,
+                inputTokens: input, outputTokens: output,
+                cachedInputTokens: cached, reasoningOutputTokens: reasoning))
+        }
+        return (sessionID, project, entries)
+    }
+
+    private static func projectName(from meta: [String: Any], fallback: String) -> String {
+        if let git = meta["git"] as? [String: Any], let url = git["repository_url"] as? String {
+            let trimmed = url.hasSuffix(".git") ? String(url.dropLast(4)) : url
+            let parts = trimmed.split(separator: "/").suffix(2).map(String.init)
+            if parts.count == 2 { return parts.joined(separator: "/") }
+        }
+        return TokenLogJSON.projectName(meta["cwd"] as? String, fallback: fallback)
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageLiveTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageLiveTests.swift
@@ -68,6 +68,23 @@ struct AccountUsageLiveTests {
         #expect(state == .disabled)
     }
 
+    @Test("a live sample without extras keeps extras the collector already had")
+    func livePreservesExtras() async {
+        let collector = AccountUsageCollector(provider: CountingProvider(), cache: MemoryCache(), enabled: true)
+        var fetched = live(usedPercent: 20)
+        fetched.extraWindows = [
+            .extra(key: "codex-spark", label: "Codex Spark 5-hour", usedPercent: 33,
+                   windowDurationMinutes: 300, resetsAt: nil)
+        ]
+        fetched.credits = QuotaCredits(remaining: 9, label: "Credits")
+        _ = await collector.acceptLive(fetched, holdFor: 60, now: now)
+        let liveOnly = live(usedPercent: 40)
+        let state = await collector.acceptLive(liveOnly, holdFor: 60, now: now)
+        #expect(state.snapshot?.primary?.usedPercent == 40)
+        #expect(state.snapshot?.extraWindows?.first?.key == "codex-spark")
+        #expect(state.snapshot?.credits?.remaining == 9)
+    }
+
     @Test("the feed remembers the latest sample per provider and streams to subscribers")
     func feed() async {
         let feed = AccountUsageLiveFeed()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/AccountUsageTests.swift
@@ -48,6 +48,63 @@ struct AccountUsageTests {
         #expect(snapshot.lifetimeTokens == 1_234_567)
         #expect(snapshot.latestDailyTokens == 34_000)
         #expect(snapshot.fetchedAt == now)
+        #expect(snapshot.extraWindows == nil)
+    }
+
+    @Test("Codex additional_rate_limits map Spark extras without stealing weekly remaining")
+    func codexAdditionalRateLimits() throws {
+        let rateLimits = Data(#"""
+        {
+          "result":{
+            "rateLimits":{
+              "planType":"pro",
+              "primary":{"usedPercent":20,"windowDurationMins":300,"resetsAt":1788318000},
+              "secondary":{"usedPercent":10,"windowDurationMins":10080,"resetsAt":1788912000},
+              "additional_rate_limits":[
+                {
+                  "limit_name":"GPT-5.3-Codex-Spark",
+                  "metered_feature":"spark",
+                  "rate_limit":{
+                    "primary_window":{"used_percent":33,"reset_at":1788318000,"limit_window_seconds":18000},
+                    "secondary_window":{"used_percent":44,"reset_at":1788912000,"limit_window_seconds":604800}
+                  }
+                }
+              ],
+              "credits":{"has_credits":true,"balance":12.5}
+            }
+          }
+        }
+        """#.utf8)
+        let usage = Data(#"{"result":{"summary":{"lifetimeTokens":1,"extra_usage_usd":4.2}}}"#.utf8)
+        let snapshot = try CodexUsageResponseDecoder.decode(
+            rateLimitsResponse: rateLimits, usageResponse: usage, fetchedAt: now)
+        #expect(snapshot.primary?.usedPercent == 20)
+        #expect(snapshot.secondary?.usedPercent == 10)
+        #expect(snapshot.extraWindows?.map(\.key) == ["codex-spark", "codex-spark-weekly"])
+        #expect(snapshot.extraWindows?.map(\.label) == ["Codex Spark 5-hour", "Codex Spark Weekly"])
+        #expect(snapshot.extraWindows?.map(\.usedPercent) == [33, 44])
+        #expect(snapshot.credits?.remaining == 12.5)
+        #expect(snapshot.spend?.first?.amount == 4.2)
+        let quota = ProviderQuota(.available(snapshot, nextRefreshAt: nil), provider: .codex)
+        #expect(quota.weeklyRemainingPercent == 90)
+        #expect(quota.shortWindowRemainingPercent == 80)
+        #expect(quota.otherWindows?.map(\.label) == ["Codex Spark 5-hour", "Codex Spark Weekly"])
+        #expect(quota.credits?.remaining == 12.5)
+        #expect(quota.spend?.first?.label == "Extra usage")
+    }
+
+    @Test("Claude extra usage dollars and credits remaining parse beside Fable week")
+    func claudeCreditsAndSpend() throws {
+        let output = """
+        Current session: 9% used · resets Sep 2 at 6:39pm (UTC)
+        Current week (all models): 15% used · resets Sep 5 at 7:59pm (UTC)
+        Extra usage: $6.50
+        Credits remaining: 80
+        """
+        let data = try JSONSerialization.data(withJSONObject: ["is_error": false, "result": output])
+        let snapshot = try ClaudeUsageResponseDecoder.decode(data, fetchedAt: now)
+        #expect(snapshot.spend?.first?.amount == 6.5)
+        #expect(snapshot.credits?.remaining == 80)
     }
 
     @Test("official Claude usage output maps session and weekly windows")
@@ -88,6 +145,14 @@ struct AccountUsageTests {
         #expect(snapshot.secondary?.resetsAt == calendar.date(from: DateComponents(
             year: 2026, month: 9, day: 5, hour: 19, minute: 59
         )))
+        #expect(snapshot.extraWindows?.map(\.key) == ["claude-weekly-scoped-fable"])
+        #expect(snapshot.extraWindows?.first?.label == "Fable only")
+        #expect(snapshot.extraWindows?.first?.usedPercent == 18)
+        #expect(snapshot.extraWindows?.first?.windowDurationMinutes == 10_080)
+        let quota = ProviderQuota(.available(snapshot, nextRefreshAt: nil), provider: .claude)
+        #expect(quota.weeklyRemainingPercent == 85)
+        #expect(quota.otherWindows?.first?.label == "Fable only")
+        #expect(quota.otherWindows?.first?.remainingPercent == 82)
     }
 
     @Test("a Claude window that resets on the hour prints no minutes and still parses")
@@ -123,6 +188,7 @@ struct AccountUsageTests {
         #expect(snapshot.primary?.resetsAt == calendar.date(from: DateComponents(
             year: 2026, month: 9, day: 3, hour: 14, minute: 30
         )))
+        #expect(snapshot.extraWindows?.first?.label == "Fable only")
     }
 
     @Test("provider percentages outside zero through one hundred are rejected")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokUsageProviderTests.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import Testing
+import VibeBuddyKit
 @testable import VibeBuddyMacCore
 
 @Suite("Grok usage adapter")
@@ -98,6 +99,29 @@ struct GrokUsageProviderTests {
         #expect(snapshot.secondary?.usedPercent == 25)
         #expect(snapshot.secondary?.windowDurationMinutes == 10_080)
         #expect(Self.matches(snapshot.secondary?.resetsAt, "2026-09-06T11:36:49Z"))
+        #expect(snapshot.spend?.first?.amount == 1250)
+        #expect(snapshot.quotaWindows.map(\.kind) == [.primary])
+    }
+
+    @Test("prepaid balance is credits and never a quota-percent window")
+    func prepaidCredits() throws {
+        let response = Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{"config":{"creditUsagePercent":36.0,
+        "currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-08-30T11:36:49.308758+00:00",
+        "end":"2026-09-06T11:36:49.308758+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},
+        "prepaidBalance":{"val":42.5},"isUnifiedBillingUser":true,
+        "billingPeriodStart":"2026-08-30T11:36:49.308758+00:00",
+        "billingPeriodEnd":"2026-09-06T11:36:49.308758+00:00"},"subscription_tier":"SuperGrok Heavy"}}
+        """#.utf8)
+        let snapshot = try GrokUsageResponseDecoder.decode(billingResponse: response, fetchedAt: now)
+        #expect(snapshot.credits?.remaining == 42.5)
+        #expect(snapshot.credits?.label == "Prepaid")
+        #expect(snapshot.primary?.usedPercent == 36)
+        #expect(snapshot.extraWindows == nil)
+        let quota = ProviderQuota(.available(snapshot, nextRefreshAt: nil), provider: .grok)
+        #expect(quota.weeklyRemainingPercent == 64)
+        #expect(quota.credits?.remaining == 42.5)
+        #expect(quota.otherWindows == nil)
     }
 
     @Test("a percentage outside zero through one hundred is rejected")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ProviderQuotaProjectionTests.swift
@@ -290,6 +290,8 @@ struct ProviderQuotaProjectionTests {
         #expect(result.observedAt == observed)
         #expect(result.freshness(now: observed) == .live)
         #expect(result.unavailableReason == nil)
+        #expect(result.credits?.remaining == 1200)
+        #expect(result.credits?.limit == 2000)
         // Watch/home surfaces must not show "Window unavailable" while live.
         let display = result.displayWindow(preferring: .weekly)
         #expect(display.remainingPercent == 60)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionStoreTests.swift
@@ -226,6 +226,16 @@ struct SessionStoreTests {
         #expect(snap.providerQuota?.map(\.provider) == AccountUsageProvider.allCases)
         #expect(snap.providerQuota?.contains { $0.provider == .cursor } == true)
     }
+
+    @Test("Token consumption rides the snapshot without creating sessions")
+    func includesTokenConsumptionInWireSnapshot() async {
+        let store = SessionStore(sourceID: "test")
+        let consumption = TokenConsumptionSnapshot.demo(now: Date(timeIntervalSince1970: 1_700_000_000))
+        await store.setTokenConsumption(consumption)
+        let snap = await store.snapshot(now: Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(snap.sessions.isEmpty)
+        #expect(snap.tokenConsumption == consumption)
+    }
 }
 
 private extension Array where Element == AgentObservationDiagnostic {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/StatusLineTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/StatusLineTests.swift
@@ -59,6 +59,24 @@ struct StatusLineTests {
         #expect(ProviderQuota(.available(usage, nextRefreshAt: nil), provider: .claude).weeklyRemainingPercent == 59)
     }
 
+    @Test("status-line keys besides five_hour and seven_day become extra windows")
+    func extraRateLimitKeys() throws {
+        var doc = json(statusLineJSON)
+        var limits = doc["rate_limits"] as! [String: Any]
+        limits["seven_day_fable"] = ["used_percentage": 70.4, "resets_at": 1_788_857_600]
+        doc["rate_limits"] = limits
+        let sample = try #require(StatusLineSample.decode(doc))
+        #expect(sample.extraWindows.map(\.key) == ["claude-weekly-scoped-fable"])
+        #expect(sample.extraWindows.first?.label == "Fable only")
+        #expect(sample.extraWindows.first?.usedPercent == 70)
+        #expect(sample.extraWindows.first?.windowDurationMinutes == 10_080)
+        let usage = try #require(sample.usageSnapshot(fetchedAt: now))
+        let quota = ProviderQuota(.available(usage, nextRefreshAt: nil), provider: .claude)
+        #expect(quota.weeklyRemainingPercent == 59)
+        #expect(quota.otherWindows?.first?.label == "Fable only")
+        #expect(quota.otherWindows?.first?.remainingPercent == 30)
+    }
+
     @Test("without rate_limits there is no usage snapshot, and without a session id no sample")
     func decodeEdges() {
         var doc = json(statusLineJSON)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TokenConsumptionScanTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/TokenConsumptionScanTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+@testable import VibeBuddyMacCore
+import VibeBuddyKit
+
+@Suite("Token consumption — Claude / Codex log aggregation")
+struct TokenConsumptionScanTests {
+    private let now = date("2026-07-21T12:00:00Z")
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    @Test("Claude counts cache creation, keeps the first cwd, and drops zero-usage rows")
+    func claudeCacheAndCwd() throws {
+        let root = try makeRoot()
+        try writeClaude(root, project: "-Users-dev-my-hyphen-project", session: "session-a", lines: [
+            claudeUser("2026-07-21T10:00:00.000Z", cwd: "/Users/dev/my-hyphen-project"),
+            claudeAssistant("2026-07-21T10:05:00.000Z", cwd: "/Users/dev/my-hyphen-project/packages/api",
+                            model: "claude-opus-4-8", uuid: "usage-a",
+                            usage: ["input_tokens": 11, "output_tokens": 7,
+                                    "cache_read_input_tokens": 13,
+                                    "cache_creation_input_tokens": 17,
+                                    "cache_creation": ["ephemeral_5m_input_tokens": 5,
+                                                       "ephemeral_1h_input_tokens": 12]]),
+            claudeAssistant("2026-07-21T10:35:00.000Z", cwd: "/Users/dev/my-hyphen-project",
+                            model: "<synthetic>", uuid: "synthetic-zero",
+                            usage: ["input_tokens": 0, "output_tokens": 0]),
+        ])
+        let snap = TokenConsumptionScan.snapshot(
+            claudeHomes: [root], codexHome: root.appendingPathComponent("empty-codex"),
+            now: now, calendar: calendar)
+        let today = try #require(snap.window(.today))
+        #expect(today.counts.inputTokens == 28) // 11 + max(17, 5+12)
+        #expect(today.counts.outputTokens == 7)
+        #expect(today.counts.cachedInputTokens == 13)
+        #expect(today.counts.sessionCount == 1)
+        #expect(today.byProject.first?.label == "my-hyphen-project")
+        #expect(today.byModel.first?.key == "claude-opus-4-8")
+    }
+
+    @Test("Claude streaming blocks that share a message id count once, keeping the higher usage")
+    func claudeDedupeByMessageID() throws {
+        let root = try makeRoot()
+        try writeClaude(root, project: "-proj", session: "s1", lines: [
+            claudeAssistant("2026-07-21T10:05:00.000Z", cwd: "/tmp/proj", model: "claude-sonnet-4-5",
+                            uuid: "a", messageID: "msg-1", requestID: "req-1",
+                            usage: ["input_tokens": 10, "output_tokens": 2]),
+            claudeAssistant("2026-07-21T10:05:01.000Z", cwd: "/tmp/proj", model: "claude-sonnet-4-5",
+                            uuid: "b", messageID: "msg-1", requestID: "req-1",
+                            usage: ["input_tokens": 10, "output_tokens": 8]),
+        ])
+        let snap = TokenConsumptionScan.snapshot(
+            claudeHomes: [root], codexHome: root.appendingPathComponent("empty-codex"),
+            now: now, calendar: calendar)
+        let today = try #require(snap.window(.today))
+        #expect(today.counts.inputTokens == 10)
+        #expect(today.counts.outputTokens == 8)
+    }
+
+    @Test("Codex last_token_usage is normalized and duplicate cumulative totals count once")
+    func codexDuplicateAndCacheSplit() throws {
+        let root = try makeRoot()
+        try writeCodex(root, name: "rollout-a.jsonl", lines: [
+            sessionMeta("2026-07-21T10:00:00.000Z", id: "a-1", cwd: "/Users/x/search-indexer"),
+            event("2026-07-21T10:00:00.000Z", "task_started"),
+            tokenCount("2026-07-21T10:01:00.000Z", last: usage(1000, cached: 200, output: 100, reasoning: 40), total: 1100),
+            tokenCount("2026-07-21T10:01:00.000Z", last: usage(1000, cached: 200, output: 100, reasoning: 40), total: 1100),
+            tokenCount("2026-07-21T10:05:00.000Z", last: usage(2000, cached: 0, output: 200, reasoning: 0), total: 3300),
+        ])
+        let snap = TokenConsumptionScan.snapshot(
+            claudeHomes: [root.appendingPathComponent("empty-claude")],
+            codexHome: root.appendingPathComponent(".codex"),
+            now: now, calendar: calendar)
+        let today = try #require(snap.window(.today))
+        #expect(today.counts.inputTokens == 2800) // (1000-200) + 2000
+        #expect(today.counts.outputTokens == 260) // (100-40) + 200
+        #expect(today.counts.cachedInputTokens == 200)
+        #expect(today.counts.reasoningOutputTokens == 40)
+        #expect(today.byProject.first?.label == "search-indexer")
+        #expect(today.byAgent.first?.key == AgentKind.codex.rawValue)
+    }
+
+    @Test("Codex turn_context names the model; cached_input_tokens is not summed with cache_read")
+    func codexTurnContextAndCacheFallback() throws {
+        let root = try makeRoot()
+        try writeCodex(root, name: "rollout-b.jsonl", lines: [
+            sessionMeta("2026-07-21T10:00:00.000Z", id: "b-1", cwd: "/Users/x/search-indexer"),
+            json(["timestamp": "2026-07-21T10:00:01.000Z", "type": "turn_context",
+                  "payload": ["model": "gpt-5.4"]]),
+            json(["timestamp": "2026-07-21T10:01:00.000Z", "type": "event_msg",
+                  "payload": ["type": "token_count",
+                              "info": ["total_token_usage": ["total_tokens": 1500],
+                                       "last_token_usage": ["input_tokens": 1200,
+                                                            "cached_input_tokens": 200,
+                                                            "cache_read_input_tokens": 200,
+                                                            "output_tokens": 100,
+                                                            "reasoning_output_tokens": 0]]]]),
+        ])
+        let snap = TokenConsumptionScan.snapshot(
+            claudeHomes: [root.appendingPathComponent("empty-claude")],
+            codexHome: root.appendingPathComponent(".codex"),
+            now: now, calendar: calendar)
+        let today = try #require(snap.window(.today))
+        #expect(today.counts.inputTokens == 1000) // 1200 - 200, not 1200 - 400
+        #expect(today.counts.cachedInputTokens == 200)
+        #expect(today.byModel.first?.key == "gpt-5.4")
+    }
+
+    @Test("A copied parent block after a second session_meta is skipped until the child's task_started")
+    func codexSkipsReplayedHistory() throws {
+        let root = try makeRoot()
+        try writeCodex(root, name: "rollout-child.jsonl", lines: [
+            sessionMeta("2026-07-21T11:00:00.000Z", id: "child-1", cwd: "/Users/x/proj"),
+            sessionMeta("2026-07-21T10:00:00.000Z", id: "parent-1", cwd: "/Users/x/proj"),
+            tokenCount("2026-07-21T10:01:00.000Z", last: usage(5000, cached: 0, output: 500, reasoning: 0), total: 5500),
+            event("2026-07-21T11:00:02.000Z", "task_started"),
+            tokenCount("2026-07-21T11:01:00.000Z", last: usage(80, cached: 0, output: 20, reasoning: 0), total: 5600),
+        ])
+        let snap = TokenConsumptionScan.snapshot(
+            claudeHomes: [root.appendingPathComponent("empty-claude")],
+            codexHome: root.appendingPathComponent(".codex"),
+            now: now, calendar: calendar)
+        let today = try #require(snap.window(.today))
+        #expect(today.counts.inputTokens == 80)
+        #expect(today.counts.outputTokens == 20)
+    }
+
+    @Test("Older-than-today entries land in the 7-day window only")
+    func windowsSplitByDay() throws {
+        let entries = [
+            TokenUsageEntry(agent: .claudeCode, model: "claude-opus-4-8", project: "a",
+                            sessionID: "old", timestamp: date("2026-07-16T10:00:00Z"),
+                            inputTokens: 100, outputTokens: 10, cachedInputTokens: 0, reasoningOutputTokens: 0),
+            TokenUsageEntry(agent: .codex, model: "gpt-5-codex", project: "b",
+                            sessionID: "new", timestamp: date("2026-07-21T10:00:00Z"),
+                            inputTokens: 50, outputTokens: 5, cachedInputTokens: 0, reasoningOutputTokens: 0),
+        ]
+        let snap = TokenConsumptionAggregator.snapshot(entries: entries, now: now, calendar: calendar, warnings: [])
+        #expect(snap.window(.today)?.counts.inputTokens == 50)
+        #expect(snap.window(.today)?.counts.sessionCount == 1)
+        #expect(snap.window(.last7Days)?.counts.inputTokens == 150)
+        #expect(snap.window(.last7Days)?.counts.sessionCount == 2)
+        #expect(snap.window(.last7Days)?.byAgent.count == 2)
+    }
+
+    private func makeRoot() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("vb-tokens-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeClaude(_ root: URL, project: String, session: String, lines: [String]) throws {
+        let dir = root.appendingPathComponent("projects/\(project)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try lines.joined(separator: "\n").write(to: dir.appendingPathComponent("\(session).jsonl"), atomically: true, encoding: .utf8)
+    }
+
+    private func writeCodex(_ root: URL, name: String, lines: [String]) throws {
+        let dir = root.appendingPathComponent(".codex/sessions/2026/07/21", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try lines.joined(separator: "\n").write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+
+    private func claudeUser(_ timestamp: String, cwd: String) -> String {
+        json(["type": "user", "timestamp": timestamp, "cwd": cwd])
+    }
+
+    private func claudeAssistant(
+        _ timestamp: String, cwd: String, model: String, uuid: String,
+        messageID: String? = nil, requestID: String? = nil, usage: [String: Any]
+    ) -> String {
+        var message: [String: Any] = ["role": "assistant", "model": model, "usage": usage]
+        if let messageID { message["id"] = messageID }
+        var obj: [String: Any] = ["type": "assistant", "timestamp": timestamp, "cwd": cwd,
+                                  "uuid": uuid, "message": message]
+        if let requestID { obj["requestId"] = requestID }
+        return json(obj)
+    }
+
+    private func sessionMeta(_ timestamp: String, id: String, cwd: String) -> String {
+        json(["timestamp": timestamp, "type": "session_meta",
+              "payload": ["id": id, "cwd": cwd, "timestamp": timestamp]])
+    }
+
+    private func event(_ timestamp: String, _ type: String) -> String {
+        json(["timestamp": timestamp, "type": "event_msg", "payload": ["type": type]])
+    }
+
+    private func tokenCount(_ timestamp: String, last: [String: Int], total: Int) -> String {
+        json(["timestamp": timestamp, "type": "event_msg",
+              "payload": ["type": "token_count",
+                          "info": ["model": "gpt-5.2",
+                                   "total_token_usage": ["total_tokens": total],
+                                   "last_token_usage": last]]])
+    }
+
+    private func usage(_ input: Int, cached: Int, output: Int, reasoning: Int) -> [String: Int] {
+        ["input_tokens": input, "cached_input_tokens": cached,
+         "output_tokens": output, "reasoning_output_tokens": reasoning,
+         "total_tokens": input + output]
+    }
+
+    private func json(_ object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
+private func date(_ iso: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: iso)!
+}

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -19,6 +19,7 @@ struct DashboardView: View {
         ProcessInfo.processInfo.environment["VIBEBUDDY_DEMO"] == "1" ? "demo-edit" : nil
     @FocusState private var searchFocused: Bool
     @AppStorage(VoiceSettings.companionEnabledKey) private var companionEnabled = false
+    @State private var showTokenConsumption = true
 
     private var projection: DashboardSessionList {
         DashboardSessionList(model.sessions, project: projectScope, status: statusFilter,
@@ -220,6 +221,8 @@ struct DashboardView: View {
                     }
                 }
                 .companionCard(radius: MacTheme.panelRadius)
+                DisclosureGroup("Token consumption", isExpanded: $showTokenConsumption) { tokenConsumptionCard }
+                    .font(.caption).padding(.horizontal, 4)
                 DisclosureGroup("Account usage") { usageCard }
                     .font(.caption).padding(.horizontal, 4)
             }
@@ -245,6 +248,14 @@ struct DashboardView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .companionCard(radius: MacTheme.panelRadius)
         }
+    }
+
+    @ViewBuilder private var tokenConsumptionCard: some View {
+        TokenConsumptionSummaryView(snapshot: model.tokenConsumption, compact: true)
+            .font(MacTheme.font(12))
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .companionCard(radius: MacTheme.panelRadius)
     }
 }
 

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -32,6 +32,8 @@ final class MenuBarModel: ObservableObject {
     @Published private(set) var recentDirectories: [String] = []
     /// Agents a new task can be started for from this Mac.
     @Published private(set) var dispatchAgents: [AgentKind] = []
+    /// Local Claude Code / Codex token spend, beside quota. Nil until the first scan.
+    @Published private(set) var tokenConsumption: TokenConsumptionSnapshot?
     private let claudeLauncher: ClaudeBackgroundLauncher = {
         guard let run = E2ERunConfiguration.current else { return ClaudeBackgroundLauncher() }
         return ClaudeBackgroundLauncher(executable: nil, jobsDirectory: run.file("agents").appendingPathComponent("claude/jobs", isDirectory: true))
@@ -161,6 +163,7 @@ final class MenuBarModel: ObservableObject {
         actionHandler: { [weak self] action in await self?.performVoiceAction(action) ?? "" },
         onStart: { [weak self] in self?.readAloud.stop() })
     private var pollTask: Task<Void, Never>?
+    private var tokenScanTask: Task<Void, Never>?
     private var glance: GlanceWindow?
     @Published private(set) var pairingInProgress = false
     @Published private(set) var changingPairing = false
@@ -283,12 +286,14 @@ final class MenuBarModel: ObservableObject {
         if isDemo {
             sessions = MacDemoData.sessions()
             observationDiagnostics = MacDemoData.observationDiagnostics()
+            tokenConsumption = TokenConsumptionSnapshot.demo()
         } else if runtimeEnabled {
             notifier.requestAuthorization()
             startServer()
             preparePairing()
             startPolling()
             usage.start()
+            startTokenConsumptionScan()
         }
         // Create the glance on the next main-runloop tick — NOT synchronously here.
         // Hosting/displaying a SwiftUI view that observes `self` while `init` is
@@ -406,6 +411,32 @@ final class MenuBarModel: ObservableObject {
         }
     }
 
+    /// Independent of the 2s session poll: reading transcripts is slow and must
+    /// not stall approvals. Isolated from the reducer the same way quota is.
+    private func startTokenConsumptionScan() {
+        tokenScanTask?.cancel()
+        let claudeHomes: [URL]
+        let codexHome: URL
+        if let run = E2ERunConfiguration.current {
+            claudeHomes = [run.file("agents").appendingPathComponent("claude", isDirectory: true)]
+            codexHome = run.file("agents").appendingPathComponent("codex", isDirectory: true)
+        } else {
+            claudeHomes = TokenConsumptionScan.defaultClaudeHomes()
+            codexHome = TokenConsumptionScan.defaultCodexHome()
+        }
+        tokenScanTask = Task { [weak self, store] in
+            while !Task.isCancelled {
+                let snapshot = await Task.detached(priority: .utility) {
+                    TokenConsumptionScan.snapshot(
+                        claudeHomes: claudeHomes, codexHome: codexHome, now: Date())
+                }.value
+                await store.setTokenConsumption(snapshot)
+                self?.tokenConsumption = snapshot
+                try? await Task.sleep(for: .seconds(TokenConsumptionScan.refreshInterval))
+            }
+        }
+    }
+
     private func startPolling() {
         pollTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -427,6 +458,7 @@ final class MenuBarModel: ObservableObject {
                 if await self.claudeLauncher.isSupported() { agents.append(.claudeCode) }
                 if self.codexAppServerDiagnostics.connected { agents.append(.codex) }
                 self.dispatchAgents = agents
+                self.tokenConsumption = snapshot.tokenConsumption
                 self.lifecycleTimeline = await self.store.recentLifecycle()
                 self.missedThisWeek = await self.store.missedCounts()
                 self.buddySessionIDs = BuddyScope.pruned(self.buddySessionIDs, toLive: snapshot.sessions)
@@ -1197,6 +1229,7 @@ final class MenuBarModel: ObservableObject {
 
     deinit {
         pollTask?.cancel()
+        tokenScanTask?.cancel()
         glanceCardTicker?.cancel()
     }
 }

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -9,8 +9,17 @@ struct AccountUsageSummaryView: View {
     var compact = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: compact ? 7 : 10) {
-            if let snapshot = state.snapshot?.excludingExpiredGrokWindows(at: Date()) {
+        TimelineView(.periodic(from: .now, by: 30)) { context in
+            VStack(alignment: .leading, spacing: compact ? 7 : 10) {
+                summary(now: context.date)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func summary(now: Date) -> some View {
+            if let snapshot = state.snapshot?.excludingExpiredGrokWindows(at: now) {
                 if let account = snapshot.accountLabel {
                     Text(account).font(.caption).foregroundStyle(.secondary)
                 }
@@ -33,14 +42,30 @@ struct AccountUsageSummaryView: View {
                             .font(.caption2).foregroundStyle(.secondary)
                     }
                 }
-                if snapshot.windows.isEmpty {
+                if snapshot.displayWindows.isEmpty {
                     if provider != .grok && provider != .grokBot {
                         Label("No quota windows supplied", systemImage: "gauge.with.dots.needle.0percent")
                             .foregroundStyle(.secondary)
                     }
                 } else {
-                    ForEach(snapshot.windows) { window in
-                        windowRow(window)
+                    ForEach(snapshot.displayWindows) { window in
+                        windowRow(window, now: now)
+                    }
+                }
+
+                if let credits = snapshot.credits {
+                    LabeledContent(credits.label ?? "Credits", value: QuotaPresentation.creditsLine(credits))
+                        .font(.caption)
+                    if let reset = credits.resetsAt {
+                        Text(QuotaPresentation.resetLine(from: reset, now: now))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if let spend = snapshot.spend, !spend.isEmpty {
+                    ForEach(spend) { row in
+                        LabeledContent(row.label, value: QuotaPresentation.spendLine(row))
+                            .font(.caption)
                     }
                 }
 
@@ -74,34 +99,44 @@ struct AccountUsageSummaryView: View {
                     .font(.caption)
                     .foregroundStyle(reason == .collectionDisabled ? Color.secondary : Color.orange)
                     .fixedSize(horizontal: false, vertical: true)
-                if reason != .collectionDisabled, let retry = state.nextRefreshAt, retry > Date() {
+                if reason != .collectionDisabled, let retry = state.nextRefreshAt, retry > now {
                     Text("Retry \(retry, style: .relative)")
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
             }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func windowRow(_ window: AccountUsageWindow) -> some View {
+    private func windowRow(_ window: AccountUsageWindow, now: Date) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(windowTitle(window)).font(.caption.weight(.semibold))
                 Spacer(minLength: 4)
-                Text(provider == .grokBot ? "\(window.usedPercent)% used · \(100 - window.usedPercent)% left" : "\(window.usedPercent)% used")
+                Text(QuotaPresentation.remainingLine(usedPercent: window.usedPercent))
                     .font(.caption.monospacedDigit())
             }
             ProgressView(value: Double(window.usedPercent), total: 100)
                 .tint(window.usedPercent >= 90 ? .orange : .accentColor)
             if let reset = window.resetsAt {
-                Text("Resets \(reset, style: .relative) · \(reset.formatted(date: .abbreviated, time: .shortened))")
+                Text(QuotaPresentation.resetLine(from: reset, now: now))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             } else {
                 Text("Reset time unavailable")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+            }
+            if let minutes = window.windowDurationMinutes, minutes >= 10_080,
+               let reset = window.resetsAt,
+               let pace = QuotaPresentation.weeklyPace(
+                usedPercent: window.usedPercent,
+                resetsAt: reset,
+                windowMinutes: minutes,
+                now: now
+               ) {
+                Text(pace.caption)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
             }
         }
     }
@@ -110,7 +145,11 @@ struct AccountUsageSummaryView: View {
         if provider == .grok, window.kind == .secondary { return "Extra usage" }
         if let label = window.label { return label }
         guard let minutes = window.windowDurationMinutes else {
-            return window.kind == .primary ? "Primary window" : "Secondary window"
+            switch window.kind {
+            case .primary: return "Primary window"
+            case .secondary: return "Secondary window"
+            case .extra: return "Extra window"
+            }
         }
         if minutes % 10_080 == 0 { return "\(minutes / 10_080)-week window" }
         if minutes % 1_440 == 0 { return "\(minutes / 1_440)-day window" }

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -283,3 +283,78 @@ struct AccountUsageSettings: View {
         }
     }
 }
+
+struct TokenConsumptionSummaryView: View {
+    let snapshot: TokenConsumptionSnapshot?
+    var compact = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 10 : 14) {
+            if let snapshot {
+                ForEach(snapshot.windows) { window in
+                    windowBlock(window)
+                }
+                Text("Updated \(snapshot.observedAt.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                if let warnings = snapshot.warnings, !warnings.isEmpty {
+                    Text(warnings.prefix(2).joined(separator: "\n"))
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+                Text("From local Claude Code transcripts and Codex rollouts. Estimates only — not an invoice. Distinct from account quota remaining.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Label("Waiting for the first local scan", systemImage: "chart.bar")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func windowBlock(_ window: TokenConsumptionWindow) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(window.kind.title).font(.caption.weight(.semibold))
+                Spacer(minLength: 4)
+                if window.counts.isEmpty {
+                    Text("No spend").foregroundStyle(.secondary)
+                } else {
+                    Text("\(TokenConsumptionSnapshot.formatUSD(window.counts.estimatedUSD)) · \(TokenConsumptionSnapshot.formatTokens(window.counts.totalTokens))")
+                        .monospacedDigit()
+                }
+            }
+            .font(.caption)
+            if !window.counts.isEmpty {
+                Text("\(TokenConsumptionSnapshot.formatTokens(window.counts.billedTokens)) billed · \(TokenConsumptionSnapshot.formatTokens(window.counts.cachedInputTokens)) cache · \(window.counts.sessionCount) sessions")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                rowList("By agent", window.byAgent)
+                rowList("By model", compact ? Array(window.byModel.prefix(4)) : window.byModel)
+                rowList("By project", compact ? Array(window.byProject.prefix(4)) : window.byProject)
+            }
+        }
+    }
+
+    @ViewBuilder private func rowList(_ title: String?, _ rows: [TokenConsumptionRow]) -> some View {
+        if !rows.isEmpty {
+            VStack(alignment: .leading, spacing: 3) {
+                if let title {
+                    Text(title).font(.caption2.weight(.semibold)).foregroundStyle(.secondary)
+                }
+                ForEach(rows) { row in
+                    HStack {
+                        Text(row.label).lineLimit(1)
+                        Spacer(minLength: 8)
+                        Text("\(TokenConsumptionSnapshot.formatTokens(row.counts.totalTokens)) · \(TokenConsumptionSnapshot.formatUSD(row.counts.estimatedUSD))")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.caption2)
+                }
+            }
+        }
+    }
+}

--- a/VibeBuddyMacApp/Sources/UserNotificationsNotifier.swift
+++ b/VibeBuddyMacApp/Sources/UserNotificationsNotifier.swift
@@ -130,7 +130,7 @@ final class UserNotificationsNotifier: NSObject, AttentionNotifier, UNUserNotifi
         return (
             title: String(localized: "\(provider.displayName) usage reached \(threshold)%"),
             body: String(localized: "\(window.usedPercent)% used in the \(duration) window.\(reset)"),
-            id: "\(provider.rawValue)-usage-\(window.kind.rawValue)-\(window.resetsAt?.timeIntervalSince1970 ?? 0)"
+            id: "\(provider.rawValue)-usage-\(window.id)-\(window.resetsAt?.timeIntervalSince1970 ?? 0)"
         )
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Port vibe-usage’s token-consumption stats and CodexBar’s stronger quota extras into Vibebuddy. Neither product is cloned wholesale. Consumption stays on the vibe-usage parser contract already in this PR. Quota grows on existing `AccountUsage` (Mac Account usage + iPhone Usage), stays local, and is not uploaded.

## Domain / ADRs

Followed `docs/agents/domain.md`. Glossary: **Token consumption** (local spend ledger) vs **AccountUsage** (quota remaining, now including extra windows / credits / spend). Neither feeds `SessionReducer`.

No ADR override:

- **ADR-0003** (no tracking): local aggregation and local quota reads only.
- **AccountUsage isolation**: composed onto the snapshot, never a session-progress signal.
- **ADR-0011**: no new observation source. Codex extras come from the existing app-server `account/rateLimits` / `account/usage` payloads. Glance / menu-bar list / Watch home grammar unchanged (Watch still lists `otherWindows`).

## Token consumption (kept)

From [vibe-cafe/vibe-usage](https://github.com/vibe-cafe/vibe-usage), the parsing/aggregation core — not the 30+ extra tools, cloud sync, 30-minute upload buckets, or their UI.

- Claude JSONL + Codex rollouts, today + last 7 calendar days, by agent / model / project, list-price estimate. Not an invoice.
- Mac Dashboard detail column “Token consumption”; iPhone toolbar **Usage** sheet lists spend first, then quota.

## Quota extras (from CodexBar)

Reimplemented against [steipete/CodexBar](https://github.com/steipete/CodexBar) — not vendored.

**Stolen**

- Claude scoped weekly limits (`Current week (Fable|Sonnet|…)` → `NAME only`). All-models stays the weekly remaining slot; extras cannot steal it.
- Status-line `rate_limits` keys besides `five_hour` / `seven_day`, merged with `/usage` extras on live samples.
- Codex `additional_rate_limits` (Spark 5-hour + weekly, plus other named extras). Accepts app-server camelCase and snake_case `used_percent` / `reset_at` / `limit_window_seconds`.
- Credits remaining when the local source has them (Codex `credits.balance`, Grok prepaid, Cursor plan remaining, Claude `Credits remaining:`).
- Extra-usage spend dollars when present (Claude `/usage`, Codex usage summary, Grok on-demand, Cursor on-demand).
- Remaining/reset presentation: `N% left · M% used`, countdown + today/tomorrow/absolute, weekly linear pace. English like the rest of the usage surfaces — not CodexBar’s localization stack.

**Skipped**

- 60+ new providers, menu-bar meter, WidgetKit, confetti, 21 languages.
- Claude Admin / OpenAI Admin / chatgpt.com OAuth spend APIs.
- CodexBar’s local cost scan (consumption already uses vibe-usage).
- Upload / cloud sync.
- Dedicated Watch credits UI; redeemable reset-credit inventory.

## Checks

Small tests only: Claude Fable extra does not replace all-models weekly remaining; Claude credits/spend lines; Codex Spark extras + credits; status-line `seven_day_fable`; Grok prepaid credits vs extra-usage percent; Cursor remaining credits; remaining/reset/pace copy; live samples keep extras; wire credits/spend stay optional.

**Acceptance gap (this environment):** Ubuntu cloud agent, no `swift` / `xcodebuild` / Xcode. Package tests, Mac/iOS builds, isolated app launch, and screenshots were not run here. Did not replace a running installed app. Real-device / Demo-mode dashboard confirmation remains a host-Mac gap. No new files under the run `media/` directory.

On a Mac:

```
swift test --package-path VibeBuddyKit --filter 'TokenConsumption|QuotaPresentation|ProviderQuotaWire'
swift test --package-path VibeBuddyMac --filter 'AccountUsage|StatusLine|GrokUsage|ProviderQuotaProjection'
```

Then an isolated Mac build (xcodegen + xcodebuild, separate DerivedData) and open Dashboard → Account usage (scoped week / credits / reset countdown) and iPhone Usage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0776cc1-f77e-5a67-b707-ca99bde4c6ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0776cc1-f77e-5a67-b707-ca99bde4c6ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

