### PR TITLE
feat: control channel, full Cursor hook coverage, and an ACP host for cursor-agent

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,19 @@ code, and tests — don't drift to synonyms.
   submits as the next message. One per conversation, replaced by a newer one,
   expired after 30 minutes. Continuing a *finished* Cursor chat is the other
   direction: `cursor-agent --resume <composer id>` in a terminal.
+- **Cursor ACP host** — `CursorACPMonitor`: one `cursor-agent acp` process per
+  conversation vibebuddy started, spoken to over stdio JSON-RPC (Agent Client
+  Protocol). The live source for that conversation (`ObservationSource.acp`)
+  and its write path: `session/prompt` continues, `session/cancel` stops,
+  `session/request_permission` and `cursor/ask_question` / `cursor/create_plan`
+  become cards. Dies with the daemon. The IDE's hooks and transcript for the
+  same id only corroborate while it runs (ADR-0016, amendment 1).
+- **Control channel** (`ControlChannel`) — the one write path the daemon would
+  use for a session right now: `hook` (Cursor IDE, follow-ups only), `acp`
+  (hosted CLI), `appserver` (Codex), `cloud` (Cursor cloud agent), `none`
+  (seen, unreachable). Stamped on every snapshot; the phone's composer and the
+  Watch's buttons decide what to offer from it first, from the agent second.
+  Distinct from an observation source, which says how a session is *seen*.
 - **Daemon** — the Mac menu-bar app's embedded HTTP + WebSocket server
   (`:9876`) that ingests hooks, runs the reducer, and broadcasts snapshots.
 - **Glance** — the Mac status surface at the top of the menu-bar screen, drawn
@@ -140,7 +153,10 @@ code, and tests — don't drift to synonyms.
   `userStopped`: Codex words a requested stop and a crash the same
   ("interrupted"), so without that mark the failure heuristic would ring the
   error cue for something the user asked for. An interruption this Mac did not
-  send is unmarked and still reads as a failure.
+  send is unmarked and still reads as a failure. Since 2026-09-13 a Cursor
+  conversation on the `acp` channel is stopped the same way (`session/cancel`,
+  marked `userStopped`) and a cloud agent's run is cancelled through the API;
+  a Cursor chat in the IDE still cannot be stopped from here.
 - **Session action / SessionActionIntent** — what a client asks of an existing
   session: **answer** (bind to the current question), **steer** (supplement the
   running turn), **continue** (open the next turn), **stop** (interrupt the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,10 +197,18 @@ code, and tests — don't drift to synonyms.
   <prompt>` in that directory; the job's `state.json` gives the full session
   id the hooks will report). Codex goes through the app-server daemon
   (`thread/start` → `thread/name/set` → `turn/start`, the user's own
-  model/approval/sandbox defaults). Other agents answer 501. The snapshot's
-  `dispatchAgents` says which agents can be started right now (Claude when
-  the CLI lists `--bg`, Codex when the daemon is connected); the "New task"
-  entry offers only those and is disabled when there are none.
+  model/approval/sandbox defaults). Cursor is hosted over ACP by
+  `CursorACPMonitor` when the CLI is signed in, else opened in a terminal; a
+  Cursor request may add `model`, `mode` (`plan` / `ask`; agent is the CLI's
+  default and travels as nil) and `worktree` (a fresh Git worktree the CLI
+  creates under `~/.cursor/worktrees/<repo>/<name>`), which become the CLI's
+  global options `--model`, `--mode` and `-w` in front of `acp` or `--`.
+  Model and mode must be plain tokens or the dispatch is `rejected`. Other
+  agents answer 501. The snapshot's `dispatchAgents` says which agents can
+  be started right now (Claude when the CLI lists `--bg`, Codex when the
+  daemon is connected); its `cursorModels` is the signed-in CLI's
+  `--list-models`, probed once per sign-in verdict. The "New task" entry
+  offers only those agents and is disabled when there are none.
 - **Question relay** — the agent's question answered from the phone or the Mac
   card through the agent's own contract: Claude's `AskUserQuestion` on a
   blocking PreToolUse hook (answered with `updatedInput.answers`, keyed by

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -208,7 +208,11 @@ code, and tests — don't drift to synonyms.
   connection (answered per question id). `QuestionRegistry` holds the wait;
   `AnswerDispatch` sends an answer there first and types into a tmux pane only
   when nothing is waiting. A `PendingQuestion` now carries every question
-  (`items`), multi-select and "Other".
+  (`items`), multi-select and "Other". The Watch answers a one-part question
+  with the text it showed; a prompt whose every question offers choices it
+  **walks** — one question per screen, the whole set sent once as
+  `WatchSessionAction.answerAll` and checked by `WatchQuestionSet` on both
+  sides — and a prompt with any free-text question stays on the iPhone.
 - **Status line sample** — one status line JSON from Claude Code, copied to the
   daemon by `hooks/vibebuddy-statusline.sh` on every event (ObservationSource
   `statusline`). It fills a known session's name, effort, cost, context, PR and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,7 +36,8 @@ code, and tests — don't drift to synonyms.
   or in `cursor-agent`. Its **composer id** is its identity everywhere:
   Cursor's hooks send it as `conversation_id`, its transcript directory is named
   after it, and its row in Cursor's `composerHeaders` table is keyed by it. That
-  one id is what lets the three Cursor sources describe one session.
+  one id is what lets the three Cursor sources describe one session — and, for a
+  cloud agent, the Cloud Agents API too.
 - **Cursor agent transcript** — `~/.cursor/projects/<flattened project path>/
   agent-transcripts/<composer id>/<composer id>.jsonl`, also the file Cursor's
   hooks name in `transcript_path`. Three line shapes and no tool results:
@@ -52,12 +53,28 @@ code, and tests — don't drift to synonyms.
   name, its workspace and branch, its model, its real context-token figures and
   Cursor's own `status`; conversations with no live evidence appear as
   `historyOnly` rows. Never drives the three states.
-- **Cursor follow-up** — text the phone queues for a *running* Cursor turn.
+- **Cursor cloud agent** — a Cursor conversation that runs on Cursor's machines
+  against a **GitHub repository**, not on this Mac against a folder. Cursor gives
+  it a `bc-`-prefixed id and uses that same id as the agent id in its **Cloud
+  Agents API** (`api.cursor.com/v1`). No hook fires for it, no transcript is
+  written for it, and it does not appear in the composer store either, so that
+  API is its *only* source — of its state and of its existence. `ACTIVE` is
+  working, `IDLE` is done, `ARCHIVED` ends it; the repository stands in for the
+  project, the agent's Cursor page is the jump, the runs list is the
+  conversation (v1 has no `/conversation`), and a live run can be cancelled. It
+  replays nothing that was already idle at launch. Needs its own
+  `cursorCloudAPIKey` Keychain slot — separate from the session Cookie and from
+  the CLI's own login. The shape is ADR-0011's Codex Desktop thread, not
+  ADR-0016's local Cursor chat.
+- **Cursor follow-up** — text the phone queues for a *running local* Cursor turn.
   Cursor cannot be interrupted or steered mid-turn, so the supplement waits and
   Cursor's own `stop` hook collects it as `followup_message`, which Cursor
   submits as the next message. One per conversation, replaced by a newer one,
   expired after 30 minutes. Continuing a *finished* Cursor chat is the other
-  direction: `cursor-agent --resume <composer id>` in a terminal.
+  direction: `cursor-agent --resume <composer id>` in a terminal. A **cloud**
+  agent is the mirror image: a running one refuses a follow-up (Cursor allows one
+  run at a time, and answers `409 agent_busy`), and a finished one is continued
+  by starting its next run over the API.
 - **Cursor ACP host** — `CursorACPMonitor`: one `cursor-agent acp` process per
   conversation vibebuddy started, spoken to over stdio JSON-RPC (Agent Client
   Protocol). The live source for that conversation (`ObservationSource.acp`)

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -18,6 +18,8 @@ final class DashboardStore: ObservableObject {
     @Published private(set) var recentDirectories: [String] = []
     /// Agents the Mac can start a new task for right now.
     @Published private(set) var dispatchAgents: [AgentKind] = []
+    /// Models the Mac's signed-in Cursor CLI lists, for a Cursor dispatch.
+    @Published private(set) var cursorModels: [String] = []
     /// Sessions the user has pointed the buddy at (in-memory, never persisted).
     /// Empty = the buddy sees all sessions; pruned to live IDs on every snapshot.
     @Published private(set) var buddySessionIDs: Set<String> = []
@@ -918,6 +920,7 @@ final class DashboardStore: ObservableObject {
         observationDiagnostics = snapshot.observationDiagnostics ?? []
         recentDirectories = snapshot.recentDirectories ?? []
         dispatchAgents = snapshot.dispatchAgents ?? []
+        cursorModels = snapshot.cursorModels ?? []
         // A cancelled stream may resume after awaiting notification delivery.
         // Never let its old Mac readings repopulate a newly selected source.
         guard !Task.isCancelled else { return }

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -194,7 +194,7 @@ final class DashboardStore: ObservableObject {
             return result(.accepted)
         case .refused:
             return result(.refused)
-        case .decide, .answer, .stop:
+        case .decide, .answer, .answerAll, .stop:
             break
         }
         if isDemo {
@@ -220,7 +220,15 @@ final class DashboardStore: ObservableObject {
         case .decide(let approvalId, let decision):
             guard await decisionClient.decide(pairing, approvalId: approvalId, decision: decision)
             else { return result(.failed) }
-        case .answer(_, let text):
+        case .answer, .answerAll:
+            // One string for a one-question wait; a checked set of picks, keyed
+            // by question, for a prompt the wrist walked — the same structured
+            // form this phone's own card sends.
+            let (text, answers): (String?, QuestionAnswers?) = switch revalidated {
+            case .answer(_, let text): (text, nil)
+            case .answerAll(_, let answers): (nil, answers)
+            default: (nil, nil)
+            }
             // Three different answers, because they mean three different things
             // on a wrist. `.expired` is the Mac saying this question is gone —
             // the same thing `refused` says for a stop, and the opposite of
@@ -228,7 +236,7 @@ final class DashboardStore: ObservableObject {
             // request the Mac may well have carried out, which is the one case
             // where claiming it did not send would be a lie.
             switch await decisionClient.phoneAnswer(pairing, session: current, text: text,
-                                                    answers: nil, requestID: request.attemptId) {
+                                                    answers: answers, requestID: request.attemptId) {
             case .received: break
             case .expired: return result(.refused)
             case .unconfirmed: return result(.unknown)
@@ -268,6 +276,11 @@ final class DashboardStore: ObservableObject {
             return decideDemo(approvalId) == .received
         case .answer(_, let text):
             return answerDemo(sessionId, text: text)
+        case .answerAll(_, let answers):
+            // The sample has no agent to read a structured answer; the picks
+            // become the sentence the summary shows, in question order.
+            return answerDemo(sessionId, text: answers.sorted { $0.key < $1.key }
+                                .map { $0.value.joined(separator: ", ") }.joined(separator: "; "))
         case .stop:
             return stopDemo(sessionId)
         case .duplicate, .refused:

--- a/VibeBuddyApp/Sources/NewTaskSheet.swift
+++ b/VibeBuddyApp/Sources/NewTaskSheet.swift
@@ -3,7 +3,10 @@ import VibeBuddyKit
 
 /// Start a new task on the Mac from the phone: a directory the Mac has seen a
 /// session run in, the agent, the prompt, an optional name. Claude Code runs
-/// as a `claude --bg` background session, Codex as a daemon thread.
+/// as a `claude --bg` background session, Codex as a daemon thread, Cursor as
+/// a `cursor-agent` conversation vibebuddy hosts over ACP — for which the
+/// CLI's own global options (model, plan/ask mode, a fresh worktree) are
+/// offered too.
 struct NewTaskSheet: View {
     @ObservedObject var dashboard: DashboardStore
     @Environment(\.dismiss) private var dismiss
@@ -12,6 +15,27 @@ struct NewTaskSheet: View {
     @State private var prompt: String
     @State private var name = ""
     @State private var busy = false
+    /// Cursor only. An empty model is the CLI's default; `agent` is the mode
+    /// the CLI starts in when no `--mode` is given, so it travels as nil.
+    @State private var cursorModel = ""
+    @State private var cursorMode: CursorMode = .agent
+    @State private var cursorWorktree = false
+
+    /// `cursor-agent --mode` takes `plan` or `ask`; agent mode has no flag
+    /// (cursor.com/docs/cli/reference/parameters).
+    enum CursorMode: String, CaseIterable, Identifiable {
+        case agent, plan, ask
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .agent: return "Agent"
+            case .plan: return "Plan"
+            case .ask: return "Ask"
+            }
+        }
+        /// The wire value: nil for the default so an older Mac sees no change.
+        var wireValue: String? { self == .agent ? nil : rawValue }
+    }
 
     /// `initialPrompt` carries text typed into the dashboard's composer with
     /// no reply target — the composer's "new task" meaning lands here.
@@ -48,11 +72,11 @@ struct NewTaskSheet: View {
                     TextField("What should \(agent.displayName) do?", text: $prompt, axis: .vertical).lineLimit(3...8)
                     TextField("Name (optional)", text: $name)
                 }
+                if agent == .cursor {
+                    cursorSection
+                }
                 Section {
-                    Text(agent == .codex
-                         ? "Runs as a new Codex thread on your Mac through the app-server daemon, with your usual model, approval and sandbox settings. It appears in Codex Desktop and in Working here."
-                         : "Runs as a Claude Code background session on your Mac (claude --bg) with your usual settings. It appears in Working here; Jump opens a terminal attached to it.")
-                        .font(.caption).foregroundStyle(.secondary)
+                    Text(explanation).font(.caption).foregroundStyle(.secondary)
                 }
             }
             .navigationTitle("New task")
@@ -72,11 +96,52 @@ struct NewTaskSheet: View {
         }
     }
 
+    /// Cursor's three launch choices. The model list comes from the Mac's
+    /// `cursor-agent --list-models`; when the Mac has none, the row stays
+    /// out and the CLI's default model is used.
+    private var cursorSection: some View {
+        Section {
+            if !dashboard.cursorModels.isEmpty {
+                Picker("Model", selection: $cursorModel) {
+                    Text("Default").tag("")
+                    ForEach(dashboard.cursorModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+            }
+            Picker("Mode", selection: $cursorMode) {
+                ForEach(CursorMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            Toggle("Run in a new worktree", isOn: $cursorWorktree)
+        } header: {
+            Text("Cursor")
+        } footer: {
+            Text("A new worktree is created on your Mac under ~/.cursor/worktrees/<repo>/<name>; Plan and Ask are read-only.")
+        }
+    }
+
+    private var explanation: String {
+        switch agent {
+        case .codex:
+            return "Runs as a new Codex thread on your Mac through the app-server daemon, with your usual model, approval and sandbox settings. It appears in Codex Desktop and in Working here."
+        case .cursor:
+            return "Hosted by vibebuddy on your Mac over the Cursor CLI. It appears in Working here and can be stopped, continued and answered from this phone; it ends if vibebuddy quits."
+        default:
+            return "Runs as a Claude Code background session on your Mac (claude --bg) with your usual settings. It appears in Working here; Jump opens a terminal attached to it."
+        }
+    }
+
     private func start() {
         busy = true
+        let cursor = agent == .cursor
         let request = DispatchRequest(agent: agent, cwd: directory,
                                       prompt: prompt.trimmingCharacters(in: .whitespacesAndNewlines),
-                                      name: name.isEmpty ? nil : name)
+                                      name: name.isEmpty ? nil : name,
+                                      model: cursor && !cursorModel.isEmpty ? cursorModel : nil,
+                                      mode: cursor ? cursorMode.wireValue : nil,
+                                      worktree: cursor && cursorWorktree ? true : nil)
         Task {
             let result = await dashboard.dispatch(request)
             busy = false

--- a/VibeBuddyApp/Tests/WatchRelayTests.swift
+++ b/VibeBuddyApp/Tests/WatchRelayTests.swift
@@ -718,6 +718,52 @@ final class WatchRelayTests: XCTestCase {
         XCTAssertTrue(answers.isEmpty)
     }
 
+    func testAWalkedPromptIsForwardedOnceAsStructuredAnswers() async throws {
+        // Cursor's usual AskQuestion: every question offers choices, so the
+        // wrist walks them and the phone forwards the set the way its own
+        // card would — structured, keyed by question, never as one string.
+        let transport = FakeWatchTransport()
+        let client = AnsweringDecisionClient(answer: .received)
+        var walked = askingCodex(at: now)
+        walked.pendingQuestion = PendingQuestion(
+            id: "q-1", prompt: "Which tone?",
+            questions: [QuestionItem(id: "tone", text: "Which tone?",
+                                     options: [QuestionOption(id: "t", label: "Tighten"),
+                                               QuestionOption(id: "p", label: "Plain language", value: "plain")]),
+                        QuestionItem(id: "files", text: "Which files?",
+                                     options: [QuestionOption(id: "x", label: "README"),
+                                               QuestionOption(id: "y", label: "CHANGELOG")],
+                                     multiSelect: true)])
+        let store = try await answeringStore(transport, sessions: [walked], client: client)
+
+        let alert = try XCTUnwrap(transport.states.last?.alerts.first)
+        XCTAssertEqual(alert.pendingId, "q-1")
+        XCTAssertTrue(alert.isAnswerable)
+        XCTAssertEqual(alert.questions?.map(\.id), ["tone", "files"])
+        XCTAssertNil(WatchQuickAnswers.resolve(for: alert), "not one string")
+
+        var action = WatchSessionActionState()
+        let request = try XCTUnwrap(action.begin(
+            alert: alert, answers: ["tone": ["plain"], "files": ["CHANGELOG", "README"]], attemptId: "t-1"))
+        let result = await transport.tap(request)
+
+        XCTAssertEqual(result.outcome, .accepted)
+        let answers = await client.answers
+        XCTAssertEqual(answers.count, 1)
+        XCTAssertEqual(answers.first?.questionID, "q-1")
+        XCTAssertNil(answers.first?.text)
+        XCTAssertEqual(answers.first?.answers, ["tone": ["plain"], "files": ["README", "CHANGELOG"]])
+        XCTAssertEqual(store.allSessions.first?.status, .needsResponse, "accepted is not answered")
+
+        // A set missing a question never gets past the gate, even hand-made.
+        let partial = WatchSessionActionRequest(attemptId: "t-2", sessionId: "task-ask",
+                                                action: .answerAll(pendingId: "q-1", answers: ["tone": ["plain"]]))
+        let refused = await transport.tap(partial)
+        XCTAssertEqual(refused.outcome, .refused)
+        let still = await client.answers
+        XCTAssertEqual(still.count, 1)
+    }
+
     func testADemoAnswerClearsTheSampleQuestionThroughTheSameRelay() async throws {
         let transport = FakeWatchTransport()
         let store = demoStore(transport)

--- a/VibeBuddyApp/Watch/WatchAnswerControl.swift
+++ b/VibeBuddyApp/Watch/WatchAnswerControl.swift
@@ -36,7 +36,12 @@ struct WatchAnswerControl: View {
     }
 
     var body: some View {
-        if let choices {
+        if let questions = alert.questions {
+            // A prompt with several questions is walked one screen at a time
+            // and sent as one set; the one-string path below never sees it.
+            WatchQuestionWalkControl(store: store, alert: alert, questions: questions,
+                                     blocked: blocked, phase: phase)
+        } else if let choices {
             VStack(alignment: .leading, spacing: 6) {
                 // No buttons at all while nothing could travel. A tap that
                 // cannot leave the wrist is worse than no button, and the card
@@ -61,15 +66,7 @@ struct WatchAnswerControl: View {
                     }
                 }
 
-                if let message = statusText {
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        if phase == .sending { ProgressView().controlSize(.mini) }
-                        Text(message)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
+                WatchAnswerStatusLine(phase: phase)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             // One sheet for the whole control: every way in leads to the same
@@ -130,6 +127,24 @@ struct WatchAnswerControl: View {
         }
         .buttonStyle(.bordered)
         .buttonBorderShape(.roundedRectangle(radius: 12))
+    }
+}
+
+/// What the wrist may say about an answer in flight — one string or a set of
+/// picks, the sentence is the same because what happened to it is the same.
+struct WatchAnswerStatusLine: View {
+    let phase: WatchSessionActionAttempt.Phase?
+
+    var body: some View {
+        if let message = statusText {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                if phase == .sending { ProgressView().controlSize(.mini) }
+                Text(message)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
     }
 
     /// Never "Answered". The wrist knows the Mac took the text; the question

--- a/VibeBuddyApp/Watch/WatchQuestionWalk.swift
+++ b/VibeBuddyApp/Watch/WatchQuestionWalk.swift
@@ -1,0 +1,306 @@
+import SwiftUI
+import VibeBuddyKit
+
+/// Answering a prompt with several questions from the wrist, one screen each.
+///
+/// Cursor's `AskQuestion` usually asks two or three things at once, each with
+/// its own choices. One string cannot answer that, but one pick per question
+/// can, so the card offers a walk: question 1, pick; question 2, pick; then
+/// one page that reads the whole set back and sends it once. Leaving the walk
+/// anywhere before Send discards every pick — a half-answered prompt is not
+/// an answer, and nothing partial is ever kept or sent.
+///
+/// The control only exists for a prompt the iPhone would actually forward
+/// (`WatchAlert.questions`, set by the same `WatchQuestionSet` rule the gate
+/// re-runs). The one-question wait keeps its own control, unchanged.
+struct WatchQuestionWalkControl: View {
+    @ObservedObject var store: WatchStateStore
+    let alert: WatchAlert
+    let questions: [WatchQuestionItem]
+    /// Why nothing can be sent right now, from the card's own link check.
+    let blocked: LocalizedStringResource?
+    let phase: WatchSessionActionAttempt.Phase?
+    @State private var walk: WatchQuestionWalkDraft?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // No button while nothing could travel; the card above has already
+            // named the broken link.
+            if blocked == nil {
+                Button {
+                    walk = WatchQuestionWalkDraft(alert: alert, questions: questions)
+                } label: {
+                    Label {
+                        Text("Answer ^[\(questions.count) questions](inflect: true)")
+                    } icon: {
+                        Image(systemName: "list.number")
+                    }
+                    .font(CompanionType.font(13, .heavy))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.roundedRectangle(radius: 12))
+                .disabled(store.pendingAction.isBusy)
+            }
+            WatchAnswerStatusLine(phase: phase)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .sheet(item: $walk) { draft in
+            WatchQuestionWalkView(draft: draft, project: alert.project, agent: alert.agent,
+                                  macName: store.state?.macName) { answers in
+                store.submitAnswers(sessionId: draft.sessionId,
+                                    pendingId: draft.pendingId, answers: answers)
+            }
+        }
+    }
+}
+
+/// The prompt a walk was opened about, captured when it began.
+///
+/// The questions are copied, not read back off the card: a snapshot arriving
+/// mid-walk replaces the card's `alert` in place, and a pick made on question
+/// 2 must stay a pick on the question 2 the wearer read. The identity is what
+/// the store re-checks against the live alert before anything is sent.
+struct WatchQuestionWalkDraft: Identifiable, Equatable {
+    let id = UUID()
+    let sessionId: String
+    let pendingId: String
+    let items: [WatchQuestionItem]
+
+    /// Nil when the alert carries no identity — which is also when no answer
+    /// may be sent for it.
+    init?(alert: WatchAlert, questions: [WatchQuestionItem]) {
+        guard let pendingId = alert.pendingId, !pendingId.isEmpty, !questions.isEmpty else { return nil }
+        self.sessionId = alert.sessionId
+        self.pendingId = pendingId
+        self.items = questions
+    }
+}
+
+/// The walk itself: one question per screen, then the review.
+///
+/// State lives here and nowhere else, so dismissing the sheet — swipe, Cancel,
+/// or the crown — drops every pick at once. It closes only when a send was
+/// actually started; a send the wrist had to decline leaves the page up with
+/// the reason on it, because a page that dismisses itself is indistinguishable
+/// from one that worked.
+struct WatchQuestionWalkView: View {
+    let draft: WatchQuestionWalkDraft
+    let project: String
+    let agent: AgentKind
+    let macName: String?
+    /// Returns false when nothing at all was started, and the page stays up.
+    let onSend: (QuestionAnswers) -> Bool
+
+    @State private var index = 0
+    /// Picks per question id, as option values, in the order they were made.
+    @State private var picks: [String: [String]] = [:]
+    @State private var refused = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        if index < draft.items.count {
+            let item = draft.items[index]
+            WatchQuestionPage(item: item, position: index + 1, count: draft.items.count,
+                              picked: picks[item.id] ?? [],
+                              onPick: { pick($0, in: item) },
+                              onNext: { advance() },
+                              onBack: index > 0 ? { index -= 1 } : nil)
+        } else {
+            WatchQuestionReviewPage(items: draft.items, picks: picks,
+                                    caption: SessionActionSupport.targetCaption(
+                                        macName: macName, project: project, agent: agent),
+                                    refused: refused,
+                                    onSend: send,
+                                    onBack: { index = max(0, draft.items.count - 1) })
+        }
+    }
+
+    /// A single-select pick is the answer and moves on; a multi-select pick
+    /// toggles, and Next moves on.
+    private func pick(_ option: WatchQuestionOption, in item: WatchQuestionItem) {
+        refused = false
+        if item.multiSelect {
+            var chosen = picks[item.id] ?? []
+            if let at = chosen.firstIndex(of: option.value) { chosen.remove(at: at) }
+            else { chosen.append(option.value) }
+            picks[item.id] = chosen
+        } else {
+            picks[item.id] = [option.value]
+            advance()
+        }
+    }
+
+    private func advance() {
+        index = min(index + 1, draft.items.count)
+    }
+
+    private func send() {
+        var answers: QuestionAnswers = [:]
+        for item in draft.items {
+            guard let chosen = picks[item.id], !chosen.isEmpty else { refused = true; return }
+            answers[item.id] = chosen
+        }
+        if onSend(answers) { dismiss() } else { refused = true }
+    }
+}
+
+/// One question, its choices, and the way forward.
+struct WatchQuestionPage: View {
+    let item: WatchQuestionItem
+    let position: Int
+    let count: Int
+    let picked: [String]
+    let onPick: (WatchQuestionOption) -> Void
+    let onNext: () -> Void
+    let onBack: (() -> Void)?
+
+    /// The same bound as the one-question card: past it the list stops being
+    /// a list, and the wrist says the rest are on the iPhone.
+    private var shown: [WatchQuestionOption] { Array(item.options.prefix(WatchQuickAnswers.maxOptions)) }
+    private var omitted: Int { max(0, item.options.count - shown.count) }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Question \(position) of \(count)")
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                Text(item.text)
+                    .font(CompanionType.font(15, .black))
+                    .lineLimit(4)
+                    .minimumScaleFactor(0.8)
+                    .fixedSize(horizontal: false, vertical: true)
+                if item.multiSelect {
+                    Text("Choose all that apply.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                ForEach(shown) { option in
+                    choice(option)
+                }
+                if omitted > 0 {
+                    Text("\(omitted) more choices — see them on your iPhone.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if item.multiSelect {
+                    Button {
+                        onNext()
+                    } label: {
+                        Text(position == count ? "Review" : "Next")
+                            .font(CompanionType.font(14, .heavy))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .buttonBorderShape(.capsule)
+                    .disabled(picked.isEmpty)
+                }
+                if let onBack {
+                    Button("Back", action: onBack)
+                        .buttonStyle(.bordered)
+                        .buttonBorderShape(.capsule)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 2)
+        }
+    }
+
+    /// Drawn like a quick reply on the card, with a mark when it takes several.
+    private func choice(_ option: WatchQuestionOption) -> some View {
+        Button {
+            onPick(option)
+        } label: {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                if item.multiSelect {
+                    Image(systemName: picked.contains(option.value) ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 12))
+                }
+                Text(option.label)
+                    .font(CompanionType.font(13, .heavy))
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.7)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.bordered)
+        .buttonBorderShape(.roundedRectangle(radius: 12))
+    }
+}
+
+/// The one screen between the picks and someone's agent: where this is going,
+/// and what it says, question by question.
+struct WatchQuestionReviewPage: View {
+    let items: [WatchQuestionItem]
+    let picks: [String: [String]]
+    let caption: String
+    let refused: Bool
+    let onSend: () -> Void
+    let onBack: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Send these answers?")
+                    .font(CompanionType.font(15, .black))
+                    .fixedSize(horizontal: false, vertical: true)
+                // Which Mac, which project, which agent — the same caption the
+                // one-string page and the iPhone's composer show.
+                Text(caption)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
+                ForEach(items) { item in
+                    answer(item)
+                }
+                if refused {
+                    Text("Could not send. The question changed or another action is still pending.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Button {
+                    onSend()
+                } label: {
+                    Text("Send")
+                        .font(CompanionType.font(14, .heavy))
+                        .frame(maxWidth: .infinity)
+                }
+                .tint(CompanionPalette.status(.completeUnread))
+                .buttonStyle(.borderedProminent)
+                .buttonBorderShape(.capsule)
+                .handGestureShortcut(.primaryAction)
+                Button("Back", action: onBack)
+                    .buttonStyle(.bordered)
+                    .buttonBorderShape(.capsule)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 2)
+        }
+    }
+
+    /// The question in the agent's words, and the picks in the words the
+    /// wearer read — labels, never the values that travel.
+    private func answer(_ item: WatchQuestionItem) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(item.text)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Text(labels(for: item))
+                .font(CompanionType.font(13, .heavy))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func labels(for item: WatchQuestionItem) -> String {
+        let chosen = picks[item.id] ?? []
+        return item.options.filter { chosen.contains($0.value) }.map(\.label).joined(separator: ", ")
+    }
+}

--- a/VibeBuddyApp/Watch/WatchStateStore.swift
+++ b/VibeBuddyApp/Watch/WatchStateStore.swift
@@ -269,6 +269,33 @@ final class WatchStateStore: NSObject, ObservableObject {
         return true
     }
 
+    /// Ask the iPhone to answer every question of the prompt these picks were
+    /// made for.
+    ///
+    /// Same binding as `submitAnswer`: the prompt's identity comes from the
+    /// walk, captured when it began, and is matched against the alert the
+    /// *current* state holds. A walk left open while the Mac answered the
+    /// prompt and the agent asked the next one sends nothing, and says so.
+    /// The set is checked here as the iPhone will check it, so nothing partial
+    /// ever leaves the wrist.
+    @discardableResult
+    func submitAnswers(sessionId: String, pendingId: String, answers: QuestionAnswers) -> Bool {
+        guard let state, !pendingId.isEmpty,
+              let current = state.alerts.first(where: {
+                  $0.sessionId == sessionId && $0.isAnswerable && $0.pendingId == pendingId
+              })
+        else { return false }
+        guard let request = pendingAction.begin(alert: current, answers: answers,
+                                                attemptId: UUID().uuidString)
+        else { return false }
+        guard isLive(state) else {
+            pendingAction.fail(attemptId: request.attemptId)
+            return true
+        }
+        send(request)
+        return true
+    }
+
     /// Ask the iPhone to end the turn this confirmation was opened about.
     ///
     /// The turn is the argument, not the screen. `statusSince` comes from the
@@ -391,7 +418,8 @@ final class WatchStateStore: NSObject, ObservableObject {
             switch request.action {
             case .approval(let id, _): self.install(current.resolvingApproval(id))
             case .stop: self.install(current.resolvingStop(request.sessionId))
-            case .answer(let pendingId, _): self.install(current.resolvingAnswer(pendingId))
+            case .answer(let pendingId, _), .answerAll(let pendingId, _):
+                self.install(current.resolvingAnswer(pendingId))
             }
         }
     }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -183,12 +183,13 @@ public struct PendingQuestion: Codable, Sendable, Equatable, Identifiable {
 
     /// Whether this whole wait is one question taking one answer.
     ///
-    /// A surface that can send only a single string — the Watch — may finish
-    /// this wait and no other. A free-text answer to a three-question prompt
-    /// lands on the first item alone (`QuestionRegistry.normalize`) and the
-    /// agent treats the rest as unanswered, so offering one tap for it would
-    /// under-answer without saying so. Multi-select is the same: one tap
-    /// cannot express two picks.
+    /// A single string finishes this wait and no other. A free-text answer to
+    /// a three-question prompt lands on the first item alone
+    /// (`QuestionRegistry.normalize`) and the agent treats the rest as
+    /// unanswered, so offering one tap for it would under-answer without
+    /// saying so. Multi-select is the same: one tap cannot express two picks.
+    /// The Watch sends its text only for this shape; a longer prompt whose
+    /// every question offers choices it walks instead (`WatchQuestionSet`).
     public var isSinglePart: Bool {
         let list = items
         return list.count == 1 && !list[0].multiSelect

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -414,6 +414,51 @@ public struct ChildAgent: Codable, Sendable, Equatable, Identifiable {
     }
 }
 
+/// How a session can be acted on — the write path, as opposed to the
+/// observation sources that are its read paths.
+///
+/// One session, one channel: the daemon stamps whichever it would actually use
+/// to carry an answer, a supplement, a continuation or a stop. The phone's
+/// composer and the Watch's buttons decide availability and wording from this
+/// first and from the agent second, so a Cursor chat in the IDE (hooks: no
+/// interrupt) and a `cursor-agent` vibebuddy hosts over ACP (a real
+/// `session/cancel`) can sit in the same list and each tell the truth.
+public enum ControlChannel: String, Codable, Sendable, CaseIterable {
+    /// The agent's lifecycle hooks: the blocking gates can answer a prompt and
+    /// a `stop` hook can hand over a follow-up, but nothing can interrupt.
+    case hook
+    /// A `cursor-agent acp` process vibebuddy spawned and speaks JSON-RPC to:
+    /// prompt, cancel, permission and question all go through the same pipe.
+    case acp
+    /// The Codex app-server daemon (ADR-0011): `turn/steer`, `turn/start`,
+    /// `turn/interrupt`.
+    case appserver
+    /// Cursor's Cloud Agents API: a run can be cancelled and an idle agent given
+    /// a new run, but a running one cannot be supplemented.
+    case cloud
+    /// Seen but not reachable: a transcript tail or a database row with no live
+    /// channel behind it.
+    case none
+
+    /// The channel to reason about for this session. The Mac's own stamp when
+    /// it has one; otherwise the same rules the clients applied before the
+    /// stamp existed, so a snapshot from an older Mac reads exactly as it did.
+    public static func infer(for session: AgentSession) -> ControlChannel? {
+        if let channel = session.controlChannel { return channel }
+        switch session.agent {
+        case .cursor:
+            let sources = Set((session.observations ?? []).map(\.source))
+            if sources.contains(.cloud) { return .cloud }
+            return sources.contains(.hook) ? .hook : ControlChannel.none
+        case .codex:
+            let live = session.observations?.contains { $0.source == .appserver && $0.health.isHealthy } == true
+            return live ? .appserver : nil
+        default:
+            return nil
+        }
+    }
+}
+
 /// One coding-agent session, as broadcast to the phone.
 public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     public let id: String
@@ -461,6 +506,15 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     /// Stable evidence describing how this session was observed. Optional keeps
     /// snapshots from older Mac builds decodable by newer clients.
     public var observations: [ObservationEvidence]?
+    /// The channel through which this session can be *acted on* right now —
+    /// answered, supplemented, continued or stopped. Distinct from
+    /// `observations`, which say how it is *seen*: a Cursor chat is seen through
+    /// its hooks, its transcript and its database at once, but only the hooks
+    /// can answer it, and a `cursor-agent` vibebuddy hosts over ACP can also be
+    /// stopped. Only the Mac writes it. Optional so snapshots from an older Mac
+    /// decode as "unknown", and `ControlChannel.infer(for:)` then falls back to
+    /// the agent-based rules that predate it.
+    public var controlChannel: ControlChannel?
     /// Live teammate/subagent/task rows for this parent. Optional so older
     /// snapshots decode as "no topology yet"; recovery leaves this empty.
     public var childAgents: [ChildAgent]?
@@ -524,6 +578,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         spentTokens: Int? = nil,
         activeTool: String? = nil,
         observations: [ObservationEvidence]? = nil,
+        controlChannel: ControlChannel? = nil,
         childAgents: [ChildAgent]? = nil,
         childTopologyDegraded: Bool? = nil,
         probeRetired: Bool? = nil,
@@ -560,6 +615,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.spentTokens = spentTokens
         self.activeTool = activeTool
         self.observations = observations
+        self.controlChannel = controlChannel
         self.childAgents = childAgents
         self.childTopologyDegraded = childTopologyDegraded
         self.probeRetired = probeRetired

--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -678,6 +678,9 @@ public struct Snapshot: Codable, Sendable, Equatable {
     /// Agents the Mac can start a new task for right now (Claude Code when the
     /// CLI supports `--bg`, Codex when the app-server daemon is connected).
     public var dispatchAgents: [AgentKind]?
+    /// Models the signed-in Cursor CLI lists (`cursor-agent --list-models`),
+    /// for a Cursor dispatch's `model`. Nil or empty: offer no choice.
+    public var cursorModels: [String]?
 
     public init(
         sessions: [AgentSession],
@@ -686,7 +689,8 @@ public struct Snapshot: Codable, Sendable, Equatable {
         observationDiagnostics: [AgentObservationDiagnostic]? = nil,
         providerQuota: [ProviderQuota]? = nil,
         recentDirectories: [String]? = nil,
-        dispatchAgents: [AgentKind]? = nil
+        dispatchAgents: [AgentKind]? = nil,
+        cursorModels: [String]? = nil
     ) {
         self.sessions = sessions
         self.serverTime = serverTime
@@ -695,11 +699,12 @@ public struct Snapshot: Codable, Sendable, Equatable {
         self.providerQuota = providerQuota
         self.recentDirectories = recentDirectories
         self.dispatchAgents = dispatchAgents
+        self.cursorModels = cursorModels
     }
 
     enum CodingKeys: String, CodingKey {
         case sourceID, sessions, serverTime, observationDiagnostics
-        case providerQuota, recentDirectories, dispatchAgents
+        case providerQuota, recentDirectories, dispatchAgents, cursorModels
     }
 
     public init(from decoder: Decoder) throws {
@@ -718,6 +723,7 @@ public struct Snapshot: Codable, Sendable, Equatable {
         }
         recentDirectories = try c.decodeIfPresent([String].self, forKey: .recentDirectories)
         dispatchAgents = try c.decodeIfPresent([AgentKind].self, forKey: .dispatchAgents)
+        cursorModels = try c.decodeIfPresent([String].self, forKey: .cursorModels)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -729,6 +735,7 @@ public struct Snapshot: Codable, Sendable, Equatable {
         try c.encodeIfPresent(providerQuota, forKey: .providerQuota)
         try c.encodeIfPresent(recentDirectories, forKey: .recentDirectories)
         try c.encodeIfPresent(dispatchAgents, forKey: .dispatchAgents)
+        try c.encodeIfPresent(cursorModels, forKey: .cursorModels)
     }
 }
 
@@ -815,12 +822,28 @@ public struct DispatchRequest: Codable, Sendable, Equatable {
     public var cwd: String
     public var prompt: String
     public var name: String?
+    /// Cursor only (`cursor-agent --model <model>`): one of the snapshot's
+    /// `cursorModels`. Nil leaves the CLI's own default. Ignored by every
+    /// other agent.
+    public var model: String?
+    /// Cursor only (`cursor-agent --mode plan|ask`). Nil is the CLI's default
+    /// agent mode, which has no flag of its own.
+    public var mode: String?
+    /// Cursor only (`cursor-agent -w`): run in a fresh Git worktree the CLI
+    /// creates under `~/.cursor/worktrees/<repo>/<name>` instead of `cwd`.
+    /// Nil and false mean the same thing; nil is omitted on the wire so an
+    /// older Mac reads the request exactly as before.
+    public var worktree: Bool?
 
-    public init(agent: AgentKind, cwd: String, prompt: String, name: String? = nil) {
+    public init(agent: AgentKind, cwd: String, prompt: String, name: String? = nil,
+                model: String? = nil, mode: String? = nil, worktree: Bool? = nil) {
         self.agent = agent
         self.cwd = cwd
         self.prompt = prompt
         self.name = name
+        self.model = model
+        self.mode = mode
+        self.worktree = worktree
     }
 }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
@@ -16,6 +16,15 @@ public enum ObservationSource: String, Codable, Sendable, CaseIterable, Comparab
     case rollout
     case transcript
     case recovery
+    /// A `cursor-agent acp` process vibebuddy itself hosts: its `session/update`
+    /// notifications are the live source for that conversation, and the same
+    /// pipe carries the answers.
+    case acp
+    /// Cursor's Cloud Agents API, polled for a conversation that runs on
+    /// Cursor's infrastructure rather than this Mac. No hook fires for it and
+    /// no transcript is written for it, so for a cloud conversation this is
+    /// the live source.
+    case cloud
 
     public static func < (lhs: Self, rhs: Self) -> Bool {
         guard let left = allCases.firstIndex(of: lhs),
@@ -32,6 +41,8 @@ public enum ObservationSource: String, Codable, Sendable, CaseIterable, Comparab
         case .rollout: "Rollout"
         case .transcript: "Transcript"
         case .recovery: "Recovery"
+        case .acp: "Cursor CLI (ACP)"
+        case .cloud: "Cursor cloud"
         }
     }
 }
@@ -80,6 +91,8 @@ public enum ObservationHealth: String, Codable, Sendable, CaseIterable {
             case .transcript: return "The transcript cannot be read."
             case .hook: return "The hook configuration cannot be read."
             case .recovery: return "The recovery source cannot be read."
+            case .acp: return "The Cursor CLI process vibebuddy started is not answering. Check that cursor-agent is installed and signed in."
+            case .cloud: return "Cursor's Cloud Agents API cannot be reached with the saved key."
             }
         case .notInstalled:
             return "The agent is not installed or has no local configuration."

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ObservationHealth.swift
@@ -7,6 +7,11 @@ public enum ObservationSource: String, Codable, Sendable, CaseIterable, Comparab
     /// local control socket. Authoritative for Codex when fresh; rollout and
     /// hook evidence for the same thread then only corroborates.
     case appserver
+    /// Cursor's Cloud Agents API. A cloud agent runs on Cursor's machines, so no
+    /// hook fires and no transcript is written for it; this is the only live
+    /// source there is for one, and it speaks for `bc-`-prefixed conversations
+    /// alone. Local Cursor conversations are unaffected by it.
+    case cloud
     case gateway
     case hook
     /// Claude Code's status line JSON, forwarded by vibebuddy's wrapper script
@@ -20,11 +25,6 @@ public enum ObservationSource: String, Codable, Sendable, CaseIterable, Comparab
     /// notifications are the live source for that conversation, and the same
     /// pipe carries the answers.
     case acp
-    /// Cursor's Cloud Agents API, polled for a conversation that runs on
-    /// Cursor's infrastructure rather than this Mac. No hook fires for it and
-    /// no transcript is written for it, so for a cloud conversation this is
-    /// the live source.
-    case cloud
 
     public static func < (lhs: Self, rhs: Self) -> Bool {
         guard let left = allCases.firstIndex(of: lhs),
@@ -35,6 +35,7 @@ public enum ObservationSource: String, Codable, Sendable, CaseIterable, Comparab
     public var displayName: String {
         switch self {
         case .appserver: "App server"
+        case .cloud: "Cursor cloud"
         case .gateway: "Grok Bot gateway"
         case .hook: "Hook"
         case .statusline: "Status line"
@@ -42,7 +43,6 @@ public enum ObservationSource: String, Codable, Sendable, CaseIterable, Comparab
         case .transcript: "Transcript"
         case .recovery: "Recovery"
         case .acp: "Cursor CLI (ACP)"
-        case .cloud: "Cursor cloud"
         }
     }
 }
@@ -86,13 +86,13 @@ public enum ObservationHealth: String, Codable, Sendable, CaseIterable {
             switch source {
             case .gateway: return "The Grok Bot gateway cannot be reached. Open Grok Bot and check its connection."
             case .appserver: return "The Codex app-server control socket cannot be reached."
+            case .cloud: return "Cursor's Cloud Agents API cannot be reached. Check the API key in Settings."
             case .statusline: return "The status line forwarder is not installed in Claude's settings."
             case .rollout: return "The rollout stream cannot be read."
             case .transcript: return "The transcript cannot be read."
             case .hook: return "The hook configuration cannot be read."
             case .recovery: return "The recovery source cannot be read."
             case .acp: return "The Cursor CLI process vibebuddy started is not answering. Check that cursor-agent is installed and signed in."
-            case .cloud: return "Cursor's Cloud Agents API cannot be reached with the saved key."
             }
         case .notInstalled:
             return "The agent is not installed or has no local configuration."

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SessionAction.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SessionAction.swift
@@ -78,7 +78,7 @@ public struct SessionActionSupport: Equatable, Sendable {
         // (`turn/interrupt`), a hosted Cursor CLI (`session/cancel`) and a Cursor
         // cloud run (`POST …/cancel`). Everything else is stopped where it runs.
         let channel = ControlChannel.infer(for: session)
-        if session.agent == .cursor, channel == ControlChannel.none, Self.isCursorCloudConversation(session) {
+        if session.agent == .cursor, channel == ControlChannel.none, Self.isCursorCloudAgent(session) {
             return SessionActionSupport(intent: .stop,
                 unsupportedReason: String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here."))
         }
@@ -133,7 +133,7 @@ public struct SessionActionSupport: Equatable, Sendable {
     /// without an API key is the same shape with a different fix.
     private static func unreachableCursorSupport(intent: SessionActionIntent,
                                                  session: AgentSession) -> SessionActionSupport {
-        if isCursorCloudConversation(session) {
+        if isCursorCloudAgent(session) {
             return SessionActionSupport(intent: intent,
                 unsupportedReason: String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here."))
         }
@@ -165,18 +165,20 @@ public struct SessionActionSupport: Equatable, Sendable {
         switch intent {
         case .steer:
             return SessionActionSupport(intent: intent,
-                unsupportedReason: String(localized: "This cloud agent runs one run at a time. It can take a follow-up once this run finishes."))
+                unsupportedReason: String(localized: "This cloud agent is busy. Cursor takes a follow-up once the run finishes."))
         case .continue:
             return SessionActionSupport(intent: intent,
-                note: String(localized: "Starts a new run for this agent in Cursor's cloud."))
+                note: String(localized: "Starts a new run on Cursor's cloud agent."))
         default:
             return SessionActionSupport(intent: intent)
         }
     }
 
-    /// Cursor cloud agents carry `bc-`-prefixed ids everywhere Cursor names
-    /// them: its own database, its API and its hooks.
-    static func isCursorCloudConversation(_ session: AgentSession) -> Bool {
+    /// A Cursor conversation that runs on Cursor's machines rather than this
+    /// Mac. Cursor gives cloud agents a `bc-`-prefixed id and uses it as the
+    /// agent id in its own Cloud Agents API, so the id is the whole test — no
+    /// extra field has to be kept in sync across the wire.
+    public static func isCursorCloudAgent(_ session: AgentSession) -> Bool {
         session.agent == .cursor && session.id.hasPrefix("bc-")
     }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SessionAction.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SessionAction.swift
@@ -47,7 +47,16 @@ public struct SessionActionSupport: Equatable, Sendable {
                 (handling == .remoteAvailable ? WaitHandling.macNativePrompt.message : handling.message))
         }
         let intent: SessionActionIntent = session.status == .done ? .continue : .steer
-        if session.agent == .cursor { return cursorSupport(intent: intent, session: session) }
+        // The channel decides first, the agent second: the same Cursor chat is
+        // supplemented one way through its hooks, another through a hosted
+        // ACP process, and not at all from a transcript tail.
+        switch ControlChannel.infer(for: session) {
+        case .some(.acp): return acpSupport(intent: intent)
+        case .some(.cloud): return cloudSupport(intent: intent)
+        case .some(.hook) where session.agent == .cursor: return cursorHookSupport(intent: intent)
+        case .some(.none) where session.agent == .cursor: return unreachableCursorSupport(intent: intent, session: session)
+        default: break
+        }
         guard session.agent == .codex else {
             return SessionActionSupport(
                 intent: intent,
@@ -65,14 +74,23 @@ public struct SessionActionSupport: Equatable, Sendable {
     /// The daemon re-checks all of this against the live snapshot before it
     /// calls anything.
     public static func resolveStop(for session: AgentSession) -> SessionActionSupport {
-        guard session.agent == .codex else {
+        // Channels that carry a real interrupt: Codex's app-server
+        // (`turn/interrupt`), a hosted Cursor CLI (`session/cancel`) and a Cursor
+        // cloud run (`POST …/cancel`). Everything else is stopped where it runs.
+        let channel = ControlChannel.infer(for: session)
+        if session.agent == .cursor, channel == ControlChannel.none, Self.isCursorCloudConversation(session) {
+            return SessionActionSupport(intent: .stop,
+                unsupportedReason: String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here."))
+        }
+        guard channel == .acp || channel == .cloud || session.agent == .codex else {
             return SessionActionSupport(intent: .stop, unsupportedReason: stopUnsupportedReason(for: session.agent))
         }
         // A Codex session is visible through the rollout tailer and hooks too,
         // and those cannot interrupt anything. Only the app-server connection
         // can, so a session it is not carrying must not offer a Stop button
         // that the Mac would then have to refuse.
-        guard session.observations?.contains(where: { $0.source == .appserver && $0.health.isHealthy }) == true else {
+        if session.agent == .codex,
+           session.observations?.contains(where: { $0.source == .appserver && $0.health.isHealthy }) != true {
             return SessionActionSupport(intent: .stop,
                                         unsupportedReason: String(localized: "Your Mac isn't connected to Codex right now."))
         }
@@ -88,21 +106,16 @@ public struct SessionActionSupport: Equatable, Sendable {
         }
     }
 
-    /// Cursor takes instructions, but never into the turn that is running.
+    /// A Cursor chat reached through its hooks takes instructions, but never
+    /// into the turn that is running.
     ///
     /// A supplement for a live turn is queued and handed to Cursor's own `stop`
     /// hook, which submits it as the next message — Cursor's documented
-    /// auto-continuation, and the only remote write it offers. Continuing a
-    /// finished conversation goes the other way: `cursor-agent --resume` opens
+    /// auto-continuation, and the only remote write the hooks offer. Continuing
+    /// a finished conversation goes the other way: `cursor-agent --resume` opens
     /// the same chat in a terminal, so it needs the CLI to be installed and
-    /// signed in, which only the Mac can know. Both require vibebuddy's hooks,
-    /// so an unhooked Cursor session says so instead of promising delivery.
-    private static func cursorSupport(intent: SessionActionIntent,
-                                      session: AgentSession) -> SessionActionSupport {
-        guard session.observations?.contains(where: { $0.source == .hook }) == true else {
-            return SessionActionSupport(intent: intent,
-                unsupportedReason: String(localized: "Install vibebuddy's Cursor hooks to send instructions from here."))
-        }
+    /// signed in, which only the Mac can know.
+    private static func cursorHookSupport(intent: SessionActionIntent) -> SessionActionSupport {
         switch intent {
         case .steer:
             return SessionActionSupport(intent: intent,
@@ -115,9 +128,63 @@ public struct SessionActionSupport: Equatable, Sendable {
         }
     }
 
+    /// A Cursor conversation vibebuddy can only see — a transcript tail, a
+    /// database row — says so instead of promising delivery. A cloud agent
+    /// without an API key is the same shape with a different fix.
+    private static func unreachableCursorSupport(intent: SessionActionIntent,
+                                                 session: AgentSession) -> SessionActionSupport {
+        if isCursorCloudConversation(session) {
+            return SessionActionSupport(intent: intent,
+                unsupportedReason: String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here."))
+        }
+        return SessionActionSupport(intent: intent,
+            unsupportedReason: String(localized: "Install vibebuddy's Cursor hooks to send instructions from here."))
+    }
+
+    /// A `cursor-agent` vibebuddy hosts over ACP takes every instruction, but
+    /// the protocol has no mid-turn steer: `session/prompt` is sequential, so a
+    /// supplement waits for the running prompt to return and is sent as the
+    /// next one. The composer says so, the same way it does for the hooks.
+    private static func acpSupport(intent: SessionActionIntent) -> SessionActionSupport {
+        switch intent {
+        case .steer:
+            return SessionActionSupport(intent: intent,
+                note: String(localized: "Sent as the next message when this turn ends. Cursor's CLI takes one message at a time."))
+        case .continue:
+            return SessionActionSupport(intent: intent,
+                note: String(localized: "Continues this chat through the Cursor CLI vibebuddy is running."))
+        default:
+            return SessionActionSupport(intent: intent)
+        }
+    }
+
+    /// A Cursor cloud agent runs one run at a time: an idle agent takes a new
+    /// run, a running one refuses a follow-up with `409 agent_busy`, so the
+    /// refusal is made here rather than discovered on the wire.
+    private static func cloudSupport(intent: SessionActionIntent) -> SessionActionSupport {
+        switch intent {
+        case .steer:
+            return SessionActionSupport(intent: intent,
+                unsupportedReason: String(localized: "This cloud agent runs one run at a time. It can take a follow-up once this run finishes."))
+        case .continue:
+            return SessionActionSupport(intent: intent,
+                note: String(localized: "Starts a new run for this agent in Cursor's cloud."))
+        default:
+            return SessionActionSupport(intent: intent)
+        }
+    }
+
+    /// Cursor cloud agents carry `bc-`-prefixed ids everywhere Cursor names
+    /// them: its own database, its API and its hooks.
+    static func isCursorCloudConversation(_ session: AgentSession) -> Bool {
+        session.agent == .cursor && session.id.hasPrefix("bc-")
+    }
+
     private static func stopUnsupportedReason(for agent: AgentKind) -> String {
         if agent == .cursor {
-            // Cursor exposes no interrupt: not on its hooks, not on the CLI.
+            // A Cursor chat in the IDE exposes no interrupt on its hooks; only a
+            // CLI vibebuddy hosts over ACP or a cloud run can be stopped, and
+            // those never reach this line.
             return String(localized: "Stop this in Cursor on your Mac.")
         }
         if agent == .claudeCode {

--- a/VibeBuddyKit/Sources/VibeBuddyKit/ToolActivity.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/ToolActivity.swift
@@ -52,6 +52,8 @@ public enum ToolActivity {
             return "Coordinating"
         case "wait", "wait_agent", "wait_threads":
             return "Waiting"
+        case "thinking", "think":
+            return "Thinking"
         default:
             return nil
         }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/WatchApproval.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/WatchApproval.swift
@@ -57,6 +57,13 @@ public enum WatchSessionAction: Codable, Equatable, Sendable {
     /// Answer this exact question. The Watch UI for it is ticket 03; the
     /// contract is here so both sides speak one grammar.
     case answer(pendingId: String, text: String)
+    /// Answer every question of this exact prompt at once, keyed by item id
+    /// with the option values picked (`WatchQuestionSet`). A separate case
+    /// rather than an optional on `answer`: an iPhone that predates it fails
+    /// to decode the payload and refuses it, which is the right answer for a
+    /// set of picks it could not have checked — and the old case keeps its
+    /// wire shape for every Watch still sending one string.
+    case answerAll(pendingId: String, answers: QuestionAnswers)
     /// End the turn that began at this moment. A stop carries no text, and
     /// `statusSince` is the only thing standing between a stale tap and the
     /// next turn.
@@ -218,6 +225,9 @@ public struct WatchSessionActionGate: Equatable, Sendable {
         case decide(approvalId: String, decision: ApprovalDecision)
         /// Forward this to the Mac's `/answer` as an answer.
         case answer(pendingId: String, text: String)
+        /// Forward this to the Mac's `/answer` as structured answers, one per
+        /// question, already checked against the live prompt.
+        case answerAll(pendingId: String, answers: QuestionAnswers)
         /// Forward this to the Mac's `/answer` as `intent: stop`, carrying the
         /// same `statusSince` the daemon will re-check for itself.
         case stop(statusSince: Date)
@@ -265,6 +275,20 @@ public struct WatchSessionActionGate: Equatable, Sendable {
                   question.isSinglePart,
                   question.id == pendingId else { return .refused }
             return .answer(pendingId: pendingId, text: trimmed)
+        case .answerAll(let pendingId, let answers):
+            guard WaitHandling.resolve(for: session) == .remoteAvailable,
+                  session.waitKind == .question,
+                  let question = session.pendingQuestion,
+                  question.id == pendingId,
+                  // The same rule the projection ran, against the live prompt:
+                  // every question must be pickable, and the set must cover
+                  // every one of them with nothing but its own choices. A
+                  // forged or stale payload cannot half-answer, and cannot
+                  // answer with words the agent never offered.
+                  let items = WatchQuestionSet.enumerable(question),
+                  let checked = WatchQuestionSet.validate(answers, against: items)
+            else { return .refused }
+            return .answerAll(pendingId: pendingId, answers: checked)
         case .stop(let statusSince):
             // The agent rule and the running-turn rule are the same ones the
             // daemon applies; running them here means a stop the Mac would
@@ -324,14 +348,22 @@ public struct WatchSessionActionAttempt: Equatable, Sendable {
     /// carry an approval, an answer and a stop; each control needs to know
     /// whether the attempt in flight is the one it drew.
     public var pendingId: String? {
-        if case .answer(let id, _) = action { return id }
-        return nil
+        switch action {
+        case .answer(let id, _), .answerAll(let id, _): return id
+        case .approval, .stop: return nil
+        }
     }
 
     /// The text on its way to the agent, when there is any. Shown so the wrist
     /// can say *what* it is sending while it is still in flight.
     public var answerText: String? {
         if case .answer(_, let text) = action { return text }
+        return nil
+    }
+
+    /// The picks on their way to the agent, when the answer is a set of them.
+    public var answers: QuestionAnswers? {
+        if case .answerAll(_, let answers) = action { return answers }
         return nil
     }
 
@@ -383,6 +415,25 @@ public struct WatchSessionActionState: Equatable, Sendable {
               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
         return begin(sessionId: alert.sessionId,
                      action: .answer(pendingId: pendingId, text: text),
+                     attemptId: attemptId)
+    }
+
+    /// Start an answer to every question of this alert's prompt at once.
+    ///
+    /// Checked here with the rule the iPhone will re-run, so the wrist never
+    /// sends a set that misses a question or names a choice it was not shown.
+    /// `nil` also when the alert is not one the wrist walks — a one-question
+    /// wait takes its text through `begin(alert:answer:attemptId:)`.
+    public mutating func begin(
+        alert: WatchAlert,
+        answers: QuestionAnswers,
+        attemptId: String
+    ) -> WatchSessionActionRequest? {
+        guard alert.isAnswerable, let pendingId = alert.pendingId,
+              let items = alert.questions,
+              let checked = WatchQuestionSet.validate(answers, against: items) else { return nil }
+        return begin(sessionId: alert.sessionId,
+                     action: .answerAll(pendingId: pendingId, answers: checked),
                      attemptId: attemptId)
     }
 
@@ -457,7 +508,7 @@ public struct WatchSessionActionState: Equatable, Sendable {
         switch current.action {
         case .approval(let id, _):
             stillThere = state.alerts.contains { $0.isDecidable && $0.approvalId == id }
-        case .answer(let pendingId, _):
+        case .answer(let pendingId, _), .answerAll(let pendingId, _):
             stillThere = state.alerts.contains {
                 $0.sessionId == current.sessionId && $0.isAnswerable && $0.pendingId == pendingId
             }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/WatchDashboardState.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/WatchDashboardState.swift
@@ -99,9 +99,12 @@ public struct WatchAlert: Codable, Equatable, Sendable, Identifiable {
     public var tool: String?
     /// Permission: the command or target. Question: the prompt.
     public var request: String?
-    /// Question only: the labels of any predefined answers, so the wrist can
-    /// show what is being asked. Labels only — an option's `value` is text that
-    /// would be typed into someone's terminal, and the Watch cannot send it.
+    /// Question only: the labels of the first question's predefined answers,
+    /// so the wrist can show what is being asked. Labels only — an option's
+    /// `value` is text that would be typed into someone's terminal, and a
+    /// one-string answer from the Watch sends the label it showed. Values
+    /// travel only inside `questions`, where they go back structured and
+    /// checked.
     public var options: [String]
     /// The approval this alert may resolve from the wrist, when the relayed
     /// detail is complete enough to decide on (`WatchApprovalEligibility`).
@@ -113,6 +116,12 @@ public struct WatchAlert: Codable, Equatable, Sendable, Identifiable {
     /// when it lands. Absent for a permission — `approvalId` is that binding —
     /// and absent in relays that predate the shared action contract.
     public var pendingId: String?
+    /// Question only: every question of a prompt the wrist answers screen by
+    /// screen, present exactly when one string could not finish it but a set
+    /// of picks can (`WatchQuestionSet.enumerable`). Nil for the ordinary
+    /// one-question wait, which keeps sending the text it was shown; absent in
+    /// relays that predate the walk.
+    public var questions: [WatchQuestionItem]?
     public var handling: WaitHandling?
     public var waitingSince: Date
 
@@ -129,6 +138,7 @@ public struct WatchAlert: Codable, Equatable, Sendable, Identifiable {
         options: [String] = [],
         approvalId: String? = nil,
         pendingId: String? = nil,
+        questions: [WatchQuestionItem]? = nil,
         handling: WaitHandling? = nil,
         waitingSince: Date
     ) {
@@ -142,6 +152,7 @@ public struct WatchAlert: Codable, Equatable, Sendable, Identifiable {
         self.options = options
         self.approvalId = approvalId
         self.pendingId = pendingId
+        self.questions = questions
         self.handling = handling
         self.waitingSince = waitingSince
     }
@@ -396,6 +407,11 @@ public enum WatchDashboardProjection {
 
     private static func alert(for session: AgentSession) -> WatchAlert {
         let waitKind = session.waitKind ?? .question
+        let question = waitKind == .question ? session.pendingQuestion : nil
+        // A one-part question is answered with the text the wrist was shown,
+        // as before. Anything longer is answered only if every question can
+        // be picked from (`WatchQuestionSet`), and then question by question.
+        let walked = question.flatMap { $0.isSinglePart ? nil : WatchQuestionSet.enumerable($0) }
         return WatchAlert(
             sessionId: session.id,
             agent: session.agent,
@@ -404,19 +420,21 @@ public enum WatchDashboardProjection {
             summary: session.summary,
             tool: session.pendingApproval?.tool,
             request: request(for: session, waitKind: waitKind),
-            options: waitKind == .question
-                ? (session.pendingQuestion?.options.map(\.label) ?? [])
-                : [],
+            // The first question's choices caption the card whichever shape
+            // the producer used: the legacy flat `options`, or `questions`.
+            options: question?.items.first?.options.map(\.label) ?? [],
             // Present only when the wrist has enough to decide on. A question is
             // never decidable here, and neither is an approval whose real detail
             // stayed on the iPhone.
             approvalId: WatchApprovalEligibility.approvalId(for: session),
-            // Only for a question one string can finish. A multi-part or
-            // multi-select wait keeps `handling` (the iPhone can answer it) and
-            // loses the identity, because the wrist has no identity here it
-            // could act on: it would answer one question out of three.
-            pendingId: waitKind == .question
-                ? session.pendingQuestion.flatMap { $0.isSinglePart ? $0.id : nil } : nil,
+            // Only for a question the wrist can finish: one string for a
+            // one-part question, or one pick per question when every question
+            // offers choices. A prompt with a free-text question anywhere
+            // keeps `handling` (the iPhone can answer it) and loses the
+            // identity, because the wrist has no identity here it could act
+            // on: it would answer two questions out of three.
+            pendingId: question.flatMap { $0.isSinglePart || walked != nil ? $0.id : nil },
+            questions: walked,
             handling: WatchApprovalEligibility.approvalId(for: session) != nil
                 ? .watchApproval : WaitHandling.resolve(for: session),
             waitingSince: session.statusSince

--- a/VibeBuddyKit/Sources/VibeBuddyKit/WatchFollowedTask.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/WatchFollowedTask.swift
@@ -65,7 +65,7 @@ public enum WatchStopBlock: String, Codable, Equatable, Sendable {
         else if session.agent == .cursor {
             // A chat in the IDE (hooks) or one only seen in a transcript has no
             // interrupt; a cloud agent without a key is one Settings step away.
-            self = SessionActionSupport.isCursorCloudConversation(session) ? .macNeedsSetup : .macOnly
+            self = SessionActionSupport.isCursorCloudAgent(session) ? .macNeedsSetup : .macOnly
         }
         else if session.agent != .codex { self = .agentUnsupported }
         else { self = .macNotConnected }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/WatchFollowedTask.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/WatchFollowedTask.swift
@@ -53,12 +53,20 @@ public enum WatchStopBlock: String, Codable, Equatable, Sendable {
     /// connection — the rollout tailer and hooks can see a turn, and neither
     /// can end one.
     case macNotConnected
+    /// A Cursor cloud agent this Mac has no API key for: the run can be
+    /// cancelled, but only once the Mac can reach Cursor's API.
+    case macNeedsSetup
 
     /// Derived from the session rather than from the daemon's wording, so the
     /// two can never drift into disagreeing. Only reached for a `working`
-    /// session `resolveStop` refused, which leaves exactly these three causes.
+    /// session `resolveStop` refused, which leaves exactly these causes.
     init(blocking session: AgentSession) {
         if session.agent == .claudeCode { self = .macOnly }
+        else if session.agent == .cursor {
+            // A chat in the IDE (hooks) or one only seen in a transcript has no
+            // interrupt; a cloud agent without a key is one Settings step away.
+            self = SessionActionSupport.isCursorCloudConversation(session) ? .macNeedsSetup : .macOnly
+        }
         else if session.agent != .codex { self = .agentUnsupported }
         else { self = .macNotConnected }
     }
@@ -68,9 +76,12 @@ public enum WatchStopBlock: String, Codable, Equatable, Sendable {
     public func message(agent: AgentKind?) -> String {
         switch self {
         case .macOnly:
+            if agent == .cursor { return String(localized: "Stop this in Cursor on your Mac.") }
             return String(localized: "Stop this on your Mac.")
         case .macNotConnected:
             return String(localized: "Your Mac isn't connected to Codex right now.")
+        case .macNeedsSetup:
+            return String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here.")
         case .agentUnsupported:
             guard let agent else {
                 return String(localized: "This agent can't take instructions from the phone yet — use the terminal.")

--- a/VibeBuddyKit/Sources/VibeBuddyKit/WatchQuickAnswer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/WatchQuickAnswer.swift
@@ -115,7 +115,10 @@ public struct WatchQuickAnswers: Equatable, Sendable {
     /// on the tap — so a card that offers a phrase is a card whose answer will
     /// be forwarded, and a read-only wait never grows a button.
     public static func resolve(for alert: WatchAlert) -> WatchQuickAnswers? {
-        guard alert.isAnswerable else { return nil }
+        // A prompt the wrist walks question by question is not answered with
+        // one string; offering the first question's choices as if they were
+        // the whole answer would send one pick for three questions.
+        guard alert.isAnswerable, alert.questions == nil else { return nil }
         let offered = cleanedOptions(alert.options)
         if !offered.isEmpty {
             return WatchQuickAnswers(source: .options,
@@ -144,6 +147,117 @@ public struct WatchQuickAnswers: Equatable, Sendable {
             let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { continue }
             kept.append(trimmed)
+        }
+        return kept
+    }
+}
+
+// MARK: - A prompt the wrist walks one question at a time
+
+/// One of an item's choices, as the wrist is allowed to pick it.
+///
+/// Unlike `WatchAlert.options`, this carries the option's `value` as well as its
+/// label. The wrist is not typing the value into anyone's terminal: it goes
+/// back structured, keyed by item id, and the iPhone's gate checks every value
+/// against the live question before anything is forwarded — so a value here
+/// can only ever be echoed, never invented.
+public struct WatchQuestionOption: Codable, Equatable, Sendable, Identifiable {
+    public var id: String
+    public var label: String
+    public var value: String
+
+    public init(id: String, label: String, value: String) {
+        self.id = id
+        self.label = label
+        self.value = value
+    }
+}
+
+/// One question of a prompt the wrist answers screen by screen.
+public struct WatchQuestionItem: Codable, Equatable, Sendable, Identifiable {
+    public var id: String
+    public var text: String
+    public var options: [WatchQuestionOption]
+    public var multiSelect: Bool
+
+    public init(id: String, text: String, options: [WatchQuestionOption], multiSelect: Bool = false) {
+        self.id = id
+        self.text = text
+        self.options = options
+        self.multiSelect = multiSelect
+    }
+}
+
+/// The rule for a prompt the wrist cannot finish with one string, but can
+/// finish by picking: every question is walked in turn, and the whole set is
+/// sent once at the end.
+///
+/// Cursor's `AskQuestion` usually asks several things at once, and a wrist
+/// that could only send one string had to send every one of those to the
+/// iPhone (`PendingQuestion.isSinglePart`). Picking is different from typing:
+/// a pick is one of the choices the agent itself offered, so a set of picks
+/// covering every question is a complete answer the agent can read. What a
+/// wrist still cannot do is type an essay, so one free-text question anywhere
+/// in the prompt keeps the whole prompt on the iPhone.
+///
+/// The same rule runs in the projection (does the wrist get the items?) and in
+/// the iPhone's gate (is this set of answers about those items?), so a forged
+/// or stale payload cannot answer a question the wrist was never shown.
+public enum WatchQuestionSet {
+    /// Every question with at least one readable choice — the shape the wrist
+    /// can walk — or `nil` when any question needs typing.
+    public static func enumerable(_ question: PendingQuestion) -> [WatchQuestionItem]? {
+        var items: [WatchQuestionItem] = []
+        for item in question.items {
+            let id = item.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !id.isEmpty else { return nil }
+            let options = readableOptions(item.options)
+            guard !options.isEmpty else { return nil }
+            items.append(WatchQuestionItem(id: id, text: item.text, options: options,
+                                           multiSelect: item.multiSelect))
+        }
+        return items.isEmpty ? nil : items
+    }
+
+    /// The answers as the agent will read them, or `nil` when they are not a
+    /// complete answer to exactly these questions.
+    ///
+    /// Complete means one entry per item, no entry for anything else, at least
+    /// one pick each, exactly one for a single-select, and every pick naming
+    /// one of that item's options — by value, or by id for a producer that
+    /// keeps the two apart. Picks come back as values in the option order,
+    /// which is the form the iPhone's own card sends.
+    public static func validate(_ answers: QuestionAnswers,
+                                against items: [WatchQuestionItem]) -> QuestionAnswers? {
+        guard Set(answers.keys) == Set(items.map(\.id)) else { return nil }
+        var checked: QuestionAnswers = [:]
+        for item in items {
+            guard let picks = answers[item.id] else { return nil }
+            var values: [String] = []
+            for pick in picks {
+                let trimmed = pick.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let option = item.options.first(where: { $0.value == trimmed || $0.id == trimmed })
+                else { return nil }
+                if !values.contains(option.value) { values.append(option.value) }
+            }
+            guard !values.isEmpty, item.multiSelect || values.count == 1 else { return nil }
+            checked[item.id] = item.options.map(\.value).filter(values.contains)
+        }
+        return checked
+    }
+
+    /// Choices as the wrist can show and send them: trimmed labels, no blanks,
+    /// one per value. Unlike `WatchQuickAnswers`, the list is not cut here —
+    /// the gate has to know every real choice, and the wrist bounds what it
+    /// draws for itself.
+    private static func readableOptions(_ options: [QuestionOption]) -> [WatchQuestionOption] {
+        var seen = Set<String>()
+        var kept: [WatchQuestionOption] = []
+        for option in options {
+            let label = option.label.trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = option.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !label.isEmpty, !value.isEmpty, seen.insert(value).inserted else { continue }
+            kept.append(WatchQuestionOption(id: option.id, label: label, value: value))
         }
         return kept
     }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/WatchStoredState.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/WatchStoredState.swift
@@ -20,6 +20,7 @@ public struct WatchStoredState: Codable, Equatable, Sendable {
             // to answer, and an id kept past its words is an actionable card
             // nobody can read.
             redacted.pendingId = nil
+            redacted.questions = nil
             return redacted
         }
         self.state = cached

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/DispatchRequestTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/DispatchRequestTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+@Suite("Dispatch request and Cursor model list on the wire")
+struct DispatchRequestTests {
+    @Test("a Cursor request carries model, mode and worktree; a plain one omits them")
+    func roundTrip() throws {
+        let full = DispatchRequest(agent: .cursor, cwd: "/x/p", prompt: "fix it", name: "fix",
+                                   model: "gpt-5", mode: "plan", worktree: true)
+        let data = try JSONEncoder().encode(full)
+        #expect(try JSONDecoder().decode(DispatchRequest.self, from: data) == full)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains(#""model":"gpt-5""#))
+        #expect(text.contains(#""mode":"plan""#))
+        #expect(text.contains(#""worktree":true"#))
+
+        let plain = DispatchRequest(agent: .codex, cwd: "/x/p", prompt: "list files")
+        let plainText = String(decoding: try JSONEncoder().encode(plain), as: UTF8.self)
+        #expect(!plainText.contains("model"))
+        #expect(!plainText.contains("mode"))
+        #expect(!plainText.contains("worktree"))
+    }
+
+    @Test("a request from a phone that predates the fields decodes with them nil")
+    func olderPayload() throws {
+        let old = #"{"agent":"cursor","cwd":"/x/p","prompt":"fix it","name":"fix"}"#
+        let decoded = try JSONDecoder().decode(DispatchRequest.self, from: Data(old.utf8))
+        #expect(decoded == DispatchRequest(agent: .cursor, cwd: "/x/p", prompt: "fix it", name: "fix"))
+        #expect(decoded.model == nil && decoded.mode == nil && decoded.worktree == nil)
+    }
+
+    @Test("the snapshot carries cursorModels only when the Mac has some")
+    func snapshotModels() throws {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let with = Snapshot(sessions: [], serverTime: now, dispatchAgents: [.cursor],
+                            cursorModels: ["gpt-5", "sonnet-4.5"])
+        let data = try JSONEncoder().encode(with)
+        #expect(try JSONDecoder().decode(Snapshot.self, from: data) == with)
+        #expect(String(decoding: data, as: UTF8.self).contains(#""cursorModels":["gpt-5","sonnet-4.5"]"#))
+
+        let without = Snapshot(sessions: [], serverTime: now, dispatchAgents: [.cursor])
+        let bare = String(decoding: try JSONEncoder().encode(without), as: UTF8.self)
+        #expect(!bare.contains("cursorModels"))
+        // A snapshot from a Mac that predates the field.
+        let older = #"{"sessions":[],"serverTime":1780000000,"dispatchAgents":["cursor"]}"#
+        let decoded = try JSONDecoder().decode(Snapshot.self, from: Data(older.utf8))
+        #expect(decoded.cursorModels == nil)
+        #expect(decoded.dispatchAgents == [.cursor])
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SessionActionTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SessionActionTests.swift
@@ -96,4 +96,82 @@ struct SessionActionTests {
                 .hasPrefix("Mac ·"))
     }
 
+    // MARK: - Control channels
+
+    private func cursor(_ status: SessionStatus, channel: ControlChannel?, id: String = "c1",
+                        sources: [ObservationSource] = []) -> AgentSession {
+        AgentSession(
+            id: id, agent: .cursor, project: "ios-vibebuddy", status: status,
+            observations: sources.map { ObservationEvidence(source: $0, lastObservedAt: now, health: .healthy) },
+            controlChannel: channel,
+            statusSince: now, updatedAt: now)
+    }
+
+    @Test("the Mac's channel stamp decides before the agent does")
+    func channelMatrix() {
+        // hook: supplement queued, continue through the CLI, no interrupt.
+        let hookWorking = SessionActionSupport.resolve(for: cursor(.working, channel: .hook))
+        #expect(hookWorking.intent == .steer && hookWorking.isAvailable && hookWorking.note != nil)
+        #expect(SessionActionSupport.resolve(for: cursor(.done, channel: .hook)).isAvailable)
+        #expect(SessionActionSupport.resolveStop(for: cursor(.working, channel: .hook))
+            .unsupportedReason == "Stop this in Cursor on your Mac.")
+        // acp: everything, with the running turn's supplement still queued.
+        let acpWorking = SessionActionSupport.resolve(for: cursor(.working, channel: .acp))
+        #expect(acpWorking.isAvailable && acpWorking.note?.contains("next message") == true)
+        #expect(SessionActionSupport.resolve(for: cursor(.done, channel: .acp)).isAvailable)
+        #expect(SessionActionSupport.resolveStop(for: cursor(.working, channel: .acp)).isAvailable)
+        #expect(SessionActionSupport.resolveStop(for: cursor(.done, channel: .acp)).isAvailable == false)
+        // cloud: one run at a time — no supplement, a new run when idle, cancel when running.
+        #expect(SessionActionSupport.resolve(for: cursor(.working, channel: .cloud, id: "bc-1")).isAvailable == false)
+        let cloudDone = SessionActionSupport.resolve(for: cursor(.done, channel: .cloud, id: "bc-1"))
+        #expect(cloudDone.isAvailable && cloudDone.note?.contains("new run") == true)
+        #expect(SessionActionSupport.resolveStop(for: cursor(.working, channel: .cloud, id: "bc-1")).isAvailable)
+        // none: seen, not reachable — and a cloud row without a key says which setup is missing.
+        #expect(SessionActionSupport.resolve(for: cursor(.working, channel: ControlChannel.none))
+            .unsupportedReason?.contains("hooks") == true)
+        #expect(SessionActionSupport.resolve(for: cursor(.done, channel: ControlChannel.none, id: "bc-2"))
+            .unsupportedReason?.contains("API key") == true)
+        #expect(SessionActionSupport.resolveStop(for: cursor(.working, channel: ControlChannel.none, id: "bc-2"))
+            .unsupportedReason?.contains("API key") == true)
+    }
+
+    @Test("an older Mac's snapshot infers the channel the way the clients always did")
+    func channelInference() {
+        #expect(ControlChannel.infer(for: cursor(.working, channel: nil, sources: [.hook, .transcript])) == .hook)
+        #expect(ControlChannel.infer(for: cursor(.working, channel: nil, sources: [.transcript])) == ControlChannel.none)
+        #expect(ControlChannel.infer(for: cursor(.working, channel: nil, sources: [.cloud])) == .cloud)
+        #expect(ControlChannel.infer(for: session(status: .working)) == .appserver)
+        #expect(ControlChannel.infer(for: session(status: .working, appServer: nil)) == nil)
+        #expect(ControlChannel.infer(for: session(agent: .claudeCode, status: .working)) == nil)
+        // The stamp wins over the evidence when both are present.
+        #expect(ControlChannel.infer(for: cursor(.working, channel: .acp, sources: [.hook])) == .acp)
+        // And the pre-stamp Cursor behaviour is unchanged for an unstamped session.
+        #expect(SessionActionSupport.resolve(for: cursor(.working, channel: nil, sources: [.transcript]))
+            .unsupportedReason?.contains("hooks") == true)
+        #expect(SessionActionSupport.resolve(for: cursor(.working, channel: nil, sources: [.hook])).isAvailable)
+    }
+
+    @Test("the channel travels in the snapshot and an old snapshot decodes without it")
+    func channelCodable() throws {
+        let stamped = cursor(.working, channel: .acp)
+        let data = try JSONEncoder().encode(stamped)
+        let decoded = try JSONDecoder().decode(AgentSession.self, from: data)
+        #expect(decoded.controlChannel == .acp)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "controlChannel")
+        let old = try JSONDecoder().decode(AgentSession.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(old.controlChannel == nil)
+    }
+
+    @Test("the wrist's stop block follows the channel")
+    func watchStopBlock() {
+        #expect(WatchStopOffer.resolve(for: cursor(.working, channel: .hook))
+            == .blocked(.macOnly))
+        #expect(WatchStopBlock.macOnly.message(agent: .cursor) == "Stop this in Cursor on your Mac.")
+        #expect(WatchStopOffer.resolve(for: cursor(.working, channel: .acp)) == .offered)
+        #expect(WatchStopOffer.resolve(for: cursor(.working, channel: .cloud, id: "bc-1")) == .offered)
+        #expect(WatchStopOffer.resolve(for: cursor(.working, channel: ControlChannel.none, id: "bc-1"))
+            == .blocked(.macNeedsSetup))
+    }
+
 }

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/WatchQuickAnswerTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/WatchQuickAnswerTests.swift
@@ -52,40 +52,197 @@ final class WatchQuickAnswerTests: XCTestCase {
         XCTAssertFalse(choices.replies.contains { if case .phrase = $0 { return true }; return false })
     }
 
-    func testAMultiPartOrMultiSelectQuestionIsNotTheWristsToFinish() throws {
+    func testAPromptWithAFreeTextQuestionIsNotTheWristsToFinish() throws {
         // A free-text answer lands on the first item alone, so a wrist that
         // offered one tap would answer one question out of three and say
-        // nothing about the other two.
+        // nothing about the other two — and a wrist cannot type the essay
+        // the second question wants, so the whole prompt stays on the phone.
         var session = asking()
         session.pendingQuestion = PendingQuestion(
             id: "q-1", prompt: "Which tone?",
-            questions: [QuestionItem(id: "a", text: "Which tone?"),
+            questions: [QuestionItem(id: "a", text: "Which tone?",
+                                     options: [QuestionOption(id: "t", label: "Tighten")]),
                         QuestionItem(id: "b", text: "Ship it today?")])
         let card = try alert(session)
         XCTAssertNil(card.pendingId)
+        XCTAssertNil(card.questions)
         XCTAssertFalse(card.isAnswerable)
         XCTAssertNil(WatchQuickAnswers.resolve(for: card))
         // The wait is still remotely answerable, just not from a wrist.
         XCTAssertEqual(card.handling, .remoteAvailable)
 
-        // Multi-select is the same problem: one tap cannot express two picks.
-        var multi = asking()
-        multi.pendingQuestion = PendingQuestion(
-            id: "q-1", prompt: "Which files?",
-            questions: [QuestionItem(id: "a", text: "Which files?",
-                                     options: [QuestionOption(id: "x", label: "One")],
-                                     multiSelect: true)])
-        XCTAssertNil(WatchQuickAnswers.resolve(for: try alert(multi)))
-
         // And the rule runs again on the tap, so a forged payload naming the
-        // real question id is refused rather than half-answering.
+        // real question id is refused rather than half-answering — whether it
+        // sends one string or a set of picks for the questions it can pick.
         var gate = WatchSessionActionGate()
         let forged = WatchSessionActionRequest(attemptId: "t-1", sessionId: "s-ask",
                                                action: .answer(pendingId: "q-1", text: "Tighten"))
         XCTAssertEqual(gate.admit(forged, sessions: [session]), .refused)
+        let picked = WatchSessionActionRequest(attemptId: "t-2", sessionId: "s-ask",
+                                               action: .answerAll(pendingId: "q-1",
+                                                                  answers: ["a": ["Tighten"]]))
+        XCTAssertEqual(gate.admit(picked, sessions: [session]), .refused)
 
         // One single-select question is still the ordinary case.
         XCTAssertNotNil(WatchQuickAnswers.resolve(for: try alert(asking())))
+    }
+
+    // MARK: walking a prompt one question at a time
+
+    /// Cursor's usual `AskQuestion`: two questions, each with its own choices,
+    /// the second taking several.
+    private var twoPickable: AgentSession {
+        var session = asking()
+        session.pendingQuestion = PendingQuestion(
+            id: "q-1", prompt: "Which tone?",
+            questions: [QuestionItem(id: "tone", text: "Which tone?",
+                                     options: [QuestionOption(id: "t", label: "Tighten"),
+                                               QuestionOption(id: "p", label: "Plain language",
+                                                              value: "plain")]),
+                        QuestionItem(id: "files", text: "Which files?",
+                                     options: [QuestionOption(id: "x", label: "README"),
+                                               QuestionOption(id: "y", label: "CHANGELOG")],
+                                     multiSelect: true)])
+        return session
+    }
+
+    func testAPromptWhoseEveryQuestionOffersChoicesIsWalkedAndSentOnce() throws {
+        let session = twoPickable
+        let card = try alert(session)
+
+        // The wrist gets the identity and every question — text, choices with
+        // their values, and which ones take several picks.
+        XCTAssertEqual(card.pendingId, "q-1")
+        XCTAssertTrue(card.isAnswerable)
+        XCTAssertEqual(card.handling, .remoteAvailable)
+        let items = try XCTUnwrap(card.questions)
+        XCTAssertEqual(items.map(\.id), ["tone", "files"])
+        XCTAssertEqual(items.map(\.text), ["Which tone?", "Which files?"])
+        XCTAssertEqual(items.map(\.multiSelect), [false, true])
+        XCTAssertEqual(items[0].options.map(\.label), ["Tighten", "Plain language"])
+        XCTAssertEqual(items[0].options.map(\.value), ["Tighten", "plain"])
+        // Not one string: the first question's choices are not the answer.
+        XCTAssertNil(WatchQuickAnswers.resolve(for: card))
+        // The card still captions the first question, as every card does.
+        XCTAssertEqual(card.options, ["Tighten", "Plain language"])
+
+        // The whole set goes in one action, bound to the prompt.
+        var action = WatchSessionActionState()
+        let request = try XCTUnwrap(action.begin(
+            alert: card, answers: ["tone": ["plain"], "files": ["CHANGELOG", "README"]],
+            attemptId: "t-1"))
+        XCTAssertEqual(request.action, .answerAll(pendingId: "q-1",
+                                                  answers: ["tone": ["plain"],
+                                                            "files": ["README", "CHANGELOG"]]))
+        XCTAssertEqual(action.action?.pendingId, "q-1")
+        XCTAssertNil(action.action?.answerText)
+        XCTAssertEqual(action.action?.answers?["files"], ["README", "CHANGELOG"])
+
+        // The iPhone re-runs the rule and forwards exactly what was checked.
+        let gate = WatchSessionActionGate()
+        XCTAssertEqual(gate.admit(request, sessions: [session]),
+                       .answerAll(pendingId: "q-1", answers: ["tone": ["plain"],
+                                                              "files": ["README", "CHANGELOG"]]))
+
+        // Accepted is not answered: the attempt stays until a snapshot says
+        // the prompt is gone, exactly as a one-string answer does.
+        action.apply(WatchSessionActionResult(attemptId: "t-1", outcome: .accepted))
+        let asking = WatchDashboardProjection.make(
+            snapshot: Snapshot(sessions: [session], serverTime: now), quotas: [], relay: .live, now: now)
+        action.reconcile(with: asking)
+        XCTAssertNotNil(action.action)
+        XCTAssertNotNil(asking.resolvingAnswer("q-1"))
+        action.reconcile(with: asking.resolvingAnswer("q-1"))
+        XCTAssertNil(action.action)
+
+        // A restored cache keeps neither the identity nor the questions.
+        let cached = WatchStoredState(state: asking, queue: WatchCompletionQueue()).state
+        XCTAssertNil(cached.alerts.first?.questions)
+        XCTAssertFalse(cached.alerts.first?.isAnswerable ?? true)
+    }
+
+    func testAPartialOrInventedAnswerSetNeverLeavesTheWristAndIsRefusedAnyway() throws {
+        let session = twoPickable
+        let card = try alert(session)
+        var action = WatchSessionActionState()
+        let gate = WatchSessionActionGate()
+        func forged(_ answers: QuestionAnswers, _ attempt: String) -> WatchSessionActionRequest {
+            WatchSessionActionRequest(attemptId: attempt, sessionId: "s-ask",
+                                      action: .answerAll(pendingId: "q-1", answers: answers))
+        }
+
+        let incomplete: [(String, QuestionAnswers)] = [
+            ("one question missing", ["tone": ["Tighten"]]),
+            ("an empty pick", ["tone": [], "files": ["README"]]),
+            ("a choice the agent never offered", ["tone": ["Loosen"], "files": ["README"]]),
+            ("a question the agent never asked", ["tone": ["Tighten"], "files": ["README"], "x": ["y"]]),
+            ("two picks for a single-select", ["tone": ["Tighten", "plain"], "files": ["README"]]),
+        ]
+        for (why, answers) in incomplete {
+            XCTAssertNil(action.begin(alert: card, answers: answers, attemptId: "t-1"), why)
+            XCTAssertEqual(gate.admit(forged(answers, "t-1"), sessions: [session]), .refused, why)
+        }
+
+        // Ids are accepted for values and normalized, so an agent that keeps
+        // the two apart still gets the value it will read.
+        XCTAssertEqual(gate.admit(forged(["tone": ["p"], "files": ["y", "y"]], "t-2"), sessions: [session]),
+                       .answerAll(pendingId: "q-1", answers: ["tone": ["plain"], "files": ["CHANGELOG"]]))
+        // The wrong prompt is the wrong prompt.
+        var moved = session
+        moved.pendingQuestion = PendingQuestion(id: "q-2", prompt: "Still?", questions: session.pendingQuestion?.questions)
+        XCTAssertEqual(gate.admit(forged(["tone": ["p"], "files": ["y"]], "t-3"), sessions: [moved]), .refused)
+        // A one-string answer to a walked prompt is still one answer for two
+        // questions, and still refused.
+        let text = WatchSessionActionRequest(attemptId: "t-4", sessionId: "s-ask",
+                                             action: .answer(pendingId: "q-1", text: "Tighten"))
+        XCTAssertEqual(gate.admit(text, sessions: [session]), .refused)
+    }
+
+    func testOneMultiSelectQuestionIsWalkedRatherThanRefused() throws {
+        var multi = asking()
+        multi.pendingQuestion = PendingQuestion(
+            id: "q-1", prompt: "Which files?",
+            questions: [QuestionItem(id: "a", text: "Which files?",
+                                     options: [QuestionOption(id: "x", label: "One"),
+                                               QuestionOption(id: "y", label: "Two")],
+                                     multiSelect: true)])
+        let card = try alert(multi)
+        XCTAssertEqual(card.questions?.count, 1)
+        XCTAssertEqual(card.questions?.first?.multiSelect, true)
+        XCTAssertNil(WatchQuickAnswers.resolve(for: card), "two picks are not one string")
+        let gate = WatchSessionActionGate()
+        let both = WatchSessionActionRequest(attemptId: "t-1", sessionId: "s-ask",
+                                             action: .answerAll(pendingId: "q-1", answers: ["a": ["Two", "One"]]))
+        XCTAssertEqual(gate.admit(both, sessions: [multi]),
+                       .answerAll(pendingId: "q-1", answers: ["a": ["One", "Two"]]))
+
+        // One single-select question with choices keeps the one-string path:
+        // no `questions`, the choices as quick replies, nothing new on screen.
+        let single = try alert(asking(options: [QuestionOption(id: "t", label: "Tighten")]))
+        XCTAssertNil(single.questions)
+        XCTAssertEqual(WatchQuickAnswers.resolve(for: single)?.source, .options)
+    }
+
+    func testTheAnswerSetRoundTripsAndTheOneStringFormStillDecodes() throws {
+        let request = WatchSessionActionRequest(
+            attemptId: "t-1", sessionId: "s-ask",
+            action: .answerAll(pendingId: "q-1", answers: ["tone": ["plain"], "files": ["README", "CHANGELOG"]]))
+        let payload = try JSONEncoder().encode(request)
+        XCTAssertEqual(try JSONDecoder().decode(WatchSessionActionRequest.self, from: payload), request)
+        let json = String(decoding: payload, as: UTF8.self)
+        XCTAssertTrue(json.contains("\"answerAll\""))
+        XCTAssertFalse(json.contains("token"))
+
+        // What an older Watch sends, byte for byte, still means what it meant.
+        let legacy = Data(#"{"attemptId":"t-2","sessionId":"s-ask","action":{"answer":{"pendingId":"q-1","text":"yes"}}}"#.utf8)
+        XCTAssertEqual(try JSONDecoder().decode(WatchSessionActionRequest.self, from: legacy),
+                       WatchSessionActionRequest(attemptId: "t-2", sessionId: "s-ask",
+                                                 action: .answer(pendingId: "q-1", text: "yes")))
+        // And a relay that predates the walk reads as a one-string alert.
+        let old = Data(#"{"sessionId":"s","agent":"codex","project":"p","waitKind":"question","options":[],"waitingSince":0}"#.utf8)
+        let alert = try JSONDecoder().decode(WatchAlert.self, from: old)
+        XCTAssertNil(alert.questions)
+        XCTAssertNil(alert.pendingId)
     }
 
     func testOptionsThatDidNotFitAreCountedRatherThanDropped() throws {

--- a/VibeBuddyMac/Package.resolved
+++ b/VibeBuddyMac/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "25202bedf3917826d0ffeec956c881d03901ce7bf9290a6d3441ec770ae22eb0",
+  "originHash" : "5512fb38df4a19c610914e1602bd7aa922344c87b182ff323b2f651d197c2af1",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -35,15 +35,6 @@
       "state" : {
         "revision" : "89c66b8d6655209268c44f619afcf771d8d83ec9",
         "version" : "2.7.0"
-      }
-    },
-    {
-      "identity" : "sparkle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle",
-      "state" : {
-        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
-        "version" : "2.9.6"
       }
     },
     {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPClient.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPClient.swift
@@ -1,0 +1,226 @@
+import Foundation
+import VibeBuddyKit
+
+/// One `agent acp` process, spoken to over its stdio: JSON-RPC 2.0, one
+/// message per line (cursor.com/docs/cli/acp, agentclientprotocol.com).
+///
+/// The Codex app-server client owns a socket; this one owns a child process
+/// and two pipes. Both do the same three things — send requests and await the
+/// matching response, hand notifications and server-initiated requests to
+/// whoever registered for them, and fail every pending request the moment the
+/// far side goes away — so the monitor built on top can be read next to
+/// `CodexAppServerMonitor` without translation.
+///
+/// Reading and writing take `FileHandle`s rather than a `Process`, so a test can
+/// stand in a scripted agent on a pair of pipes and the same code runs against
+/// it. `spawn` is the production constructor.
+public final class CursorACPClient: @unchecked Sendable {
+    public enum ClientError: Error, Equatable {
+        /// The process ended, or `close()` was called, with the request outstanding.
+        case closed
+        /// The agent answered with a JSON-RPC error.
+        case rpc(code: Int, message: String)
+        /// The agent answered something that is not a JSON-RPC response.
+        case malformed
+        case timeout
+    }
+
+    /// The agent's process, when this client spawned one. Nil on a test pair.
+    public let process: Process?
+    private let reader: FileHandle
+    private let writer: FileHandle
+    private let lock = NSLock()
+    private var nextID = 1
+    private var pending: [Int: CheckedContinuation<[String: Any], Error>] = [:]
+    private var buffer = Data()
+    private var closed = false
+    private var started = false
+
+    /// A `session/update` or any other id-less message from the agent.
+    public var onNotification: (@Sendable (String, [String: Any]?) -> Void)?
+    /// A request the agent expects an answer to (`session/request_permission`,
+    /// `cursor/ask_question`, …). The handler must eventually call `respond`.
+    public var onRequest: (@Sendable (JSONRPCID, String, [String: Any]?) -> Void)?
+    /// The far side is gone: EOF on stdout, or the process exited.
+    public var onClose: (@Sendable () -> Void)?
+
+    public init(reading: FileHandle, writing: FileHandle, process: Process? = nil) {
+        self.reader = reading
+        self.writer = writing
+        self.process = process
+    }
+
+    /// `agent acp` in `cwd`, with any extra arguments in front of `acp` (a
+    /// `-w` worktree flag, for instance). stderr is discarded: the CLI logs
+    /// there and nothing in it is protocol.
+    public static func spawn(executable: URL, cwd: String?, leadingArguments: [String] = [],
+                             environment: [String: String] = ProcessInfo.processInfo.environment) throws -> CursorACPClient {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = leadingArguments + ["acp"]
+        if let cwd, !cwd.isEmpty { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
+        var env = environment
+        env["LANG"] = env["LANG"] ?? "en_US.UTF-8"
+        process.environment = env
+        let stdin = Pipe(), stdout = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = FileHandle.nullDevice
+        let client = CursorACPClient(reading: stdout.fileHandleForReading,
+                                     writing: stdin.fileHandleForWriting, process: process)
+        process.terminationHandler = { [weak client] _ in client?.close() }
+        try process.run()
+        return client
+    }
+
+    /// Begin reading. Handlers registered after this may miss early messages,
+    /// so set them first.
+    public func start() {
+        lock.lock()
+        guard !started else { lock.unlock(); return }
+        started = true
+        lock.unlock()
+        reader.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard let self else { return }
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                self.close()
+                return
+            }
+            self.consume(data)
+        }
+    }
+
+    /// Send a request and await its response. `timeout` nil waits as long as
+    /// the agent takes — the right choice for `session/prompt`, which returns
+    /// only when the whole turn is over.
+    public func request(_ method: String, params: [String: Any] = [:],
+                        timeout: Duration? = .seconds(60)) async throws -> [String: Any] {
+        let id = allocateID()
+        return try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            if closed {
+                lock.unlock()
+                continuation.resume(throwing: ClientError.closed)
+                return
+            }
+            pending[id] = continuation
+            lock.unlock()
+            let message: [String: Any] = ["jsonrpc": "2.0", "id": id, "method": method, "params": params]
+            guard send(message) else {
+                if let waiter = takePending(id) { waiter.resume(throwing: ClientError.closed) }
+                return
+            }
+            if let timeout {
+                Task { [weak self] in
+                    try? await Task.sleep(for: timeout)
+                    if let waiter = self?.takePending(id) { waiter.resume(throwing: ClientError.timeout) }
+                }
+            }
+        }
+    }
+
+    public func notify(_ method: String, params: [String: Any] = [:]) {
+        _ = send(["jsonrpc": "2.0", "method": method, "params": params])
+    }
+
+    public func respond(id: JSONRPCID, result: Any) {
+        _ = send(["jsonrpc": "2.0", "id": id.json, "result": result])
+    }
+
+    public func respondError(id: JSONRPCID, code: Int, message: String) {
+        _ = send(["jsonrpc": "2.0", "id": id.json, "error": ["code": code, "message": message]])
+    }
+
+    public var isClosed: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return closed
+    }
+
+    /// Fail every outstanding request, stop reading, end the process. Idempotent.
+    public func close() {
+        lock.lock()
+        guard !closed else { lock.unlock(); return }
+        closed = true
+        let waiters = pending
+        pending = [:]
+        lock.unlock()
+        reader.readabilityHandler = nil
+        try? writer.close()
+        if let process, process.isRunning { process.terminate() }
+        for waiter in waiters.values { waiter.resume(throwing: ClientError.closed) }
+        onClose?()
+    }
+
+    // MARK: - Wire
+
+    private func allocateID() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        let id = nextID
+        nextID += 1
+        return id
+    }
+
+    private func takePending(_ id: Int) -> CheckedContinuation<[String: Any], Error>? {
+        lock.lock(); defer { lock.unlock() }
+        return pending.removeValue(forKey: id)
+    }
+
+    private func send(_ json: [String: Any]) -> Bool {
+        guard JSONSerialization.isValidJSONObject(json),
+              var data = try? JSONSerialization.data(withJSONObject: json) else { return false }
+        data.append(0x0A)
+        lock.lock()
+        let open = !closed
+        lock.unlock()
+        guard open else { return false }
+        do {
+            try writer.write(contentsOf: data)
+            return true
+        } catch {
+            close()
+            return false
+        }
+    }
+
+    private func consume(_ data: Data) {
+        lock.lock()
+        buffer.append(data)
+        var lines: [Data] = []
+        while let newline = buffer.firstIndex(of: 0x0A) {
+            lines.append(buffer.subdata(in: buffer.startIndex..<newline))
+            buffer.removeSubrange(buffer.startIndex...newline)
+        }
+        lock.unlock()
+        for line in lines where !line.isEmpty { dispatch(line) }
+    }
+
+    private func dispatch(_ line: Data) {
+        guard let message = (try? JSONSerialization.jsonObject(with: line)) as? [String: Any] else { return }
+        let method = message["method"] as? String
+        let id = JSONRPCID(message["id"])
+        if let method {
+            if let id {
+                onRequest?(id, method, message["params"] as? [String: Any])
+            } else {
+                onNotification?(method, message["params"] as? [String: Any])
+            }
+            return
+        }
+        // A response to one of ours.
+        guard case .number(let number)? = id, let waiter = takePending(number) else { return }
+        if let error = message["error"] as? [String: Any] {
+            let code = (error["code"] as? NSNumber)?.intValue ?? -1
+            let text = (error["message"] as? String) ?? "error"
+            waiter.resume(throwing: ClientError.rpc(code: code, message: text))
+        } else if let result = message["result"] as? [String: Any] {
+            waiter.resume(returning: result)
+        } else if message["result"] is NSNull || message.keys.contains("result") {
+            // `session/load` answers `null`; an empty object is the same fact.
+            waiter.resume(returning: [:])
+        } else {
+            waiter.resume(throwing: ClientError.malformed)
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPMonitor.swift
@@ -28,6 +28,25 @@ import VibeBuddyKit
 /// - **Cards are always answerable.** An ACP session has no Cursor UI of its
 ///   own, so presence never makes them read-only; and a request that goes
 ///   unanswered blocks the turn, exactly as the protocol says it will.
+/// What one `agent … acp` process is started with: the directory, and the
+/// model / mode / worktree the dispatch chose as the CLI's global options.
+public struct CursorACPLaunch: Sendable, Equatable {
+    public var cwd: String
+    public var options: CursorLaunchOptions
+
+    public init(cwd: String, options: CursorLaunchOptions = CursorLaunchOptions()) {
+        self.cwd = cwd
+        self.options = options
+    }
+
+    /// The argv in front of `acp`: global options apply to every command
+    /// (cursor.com/docs/cli/reference/parameters), so `--model`, `--mode`
+    /// and `-w` set the conversation up before the ACP server starts. Modes
+    /// could also be set per session over ACP; the flag is the simpler path
+    /// and is enough.
+    public var leadingArguments: [String] { options.arguments }
+}
+
 public actor CursorACPMonitor {
 
     /// How long a card may wait before the agent is told the request was
@@ -56,10 +75,14 @@ public actor CursorACPMonitor {
     private let followups: CursorFollowupQueue
     private let rules: @Sendable (AgentKind) -> PermissionRules
     private let makeID: @Sendable () -> String
-    private let spawn: @Sendable (String) throws -> CursorACPClient
+    private let spawn: @Sendable (CursorACPLaunch) throws -> CursorACPClient
     private let executable: URL?
     private let signInProbe: @Sendable () async -> Bool
+    private let modelsProbe: @Sendable () async -> [String]
     private var signedIn: Bool?
+    /// Cached with the sign-in verdict: `--list-models` is a subprocess and
+    /// runs once per verdict, not once per snapshot.
+    private var models: [String]?
     private var hosted: [String: Hosted] = [:]
 
     public init(store: SessionStore,
@@ -73,7 +96,8 @@ public actor CursorACPMonitor {
                 makeID: @escaping @Sendable () -> String = { UUID().uuidString },
                 executable: URL? = CursorCLI.resolveExecutable(),
                 signInProbe: (@Sendable () async -> Bool)? = nil,
-                spawn: (@Sendable (String) throws -> CursorACPClient)? = nil) {
+                modelsProbe: (@Sendable () async -> [String])? = nil,
+                spawn: (@Sendable (CursorACPLaunch) throws -> CursorACPClient)? = nil) {
         self.store = store
         self.approvals = approvals
         self.approvalContext = approvalContext
@@ -86,9 +110,11 @@ public actor CursorACPMonitor {
         self.executable = executable
         let resolved = executable
         self.signInProbe = signInProbe ?? { await CursorCLI.isSignedIn(executable: resolved) }
-        self.spawn = spawn ?? { cwd in
+        self.modelsProbe = modelsProbe ?? { await CursorCLI.listModels(executable: resolved) }
+        self.spawn = spawn ?? { launch in
             guard let resolved else { throw CursorACPClient.ClientError.closed }
-            return try CursorACPClient.spawn(executable: resolved, cwd: cwd)
+            return try CursorACPClient.spawn(executable: resolved, cwd: launch.cwd,
+                                             leadingArguments: launch.leadingArguments)
         }
     }
 
@@ -104,7 +130,22 @@ public actor CursorACPMonitor {
         return ok
     }
 
-    public func invalidate() { signedIn = nil }
+    public func invalidate() {
+        signedIn = nil
+        models = nil
+    }
+
+    /// The models a dispatch may name, from `cursor-agent --list-models`.
+    /// Empty when the CLI is missing or signed out — the list needs an
+    /// account (`--list-models` "requires a signed-in CLI") — and after a
+    /// probe that returned nothing, until `invalidate()`.
+    public func models() async -> [String] {
+        guard await isSupported() else { return [] }
+        if let models { return models }
+        let listed = await modelsProbe()
+        models = listed
+        return listed
+    }
 
     /// Whether this monitor is carrying the conversation right now.
     public func hosts(_ sessionID: String) -> Bool { hosted[sessionID] != nil }
@@ -126,8 +167,13 @@ public actor CursorACPMonitor {
         guard await isSupported() else {
             return .unavailable("The Cursor CLI is not signed in — run `cursor-agent login` on this Mac")
         }
+        let options: CursorLaunchOptions
+        switch CursorLaunchOptions.from(request) {
+        case .success(let parsed): options = parsed
+        case .failure(let why): return .rejected(why.message)
+        }
         let client: CursorACPClient
-        do { client = try spawn(request.cwd) } catch {
+        do { client = try spawn(CursorACPLaunch(cwd: request.cwd, options: options)) } catch {
             return .unavailable("Couldn't start cursor-agent: \(error)")
         }
         wire(client)
@@ -159,9 +205,11 @@ public actor CursorACPMonitor {
             hosted[sessionID] = Hosted(client: client, cwd: request.cwd)
             await store.setACPHosted(sessionID: sessionID, true)
             let now = Date()
+            // The chosen model names the row from the start; ACP's updates
+            // never say which model answers.
             await store.ingest(HookEvent(kind: .sessionStart, sessionID: sessionID, agent: .cursor,
                                          cwd: request.cwd, sessionName: request.name,
-                                         observationSource: .acp, timestamp: now))
+                                         model: options.model, observationSource: .acp, timestamp: now))
             await store.recordSourceSignal(agent: .cursor, source: .acp, health: .healthy, at: now)
             startTurn(sessionID: sessionID, text: request.prompt)
             return .started(sessionID: sessionID)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPMonitor.swift
@@ -1,0 +1,600 @@
+import Foundation
+import VibeBuddyKit
+
+/// Hosts Cursor CLI conversations over ACP and turns them into sessions the
+/// phone and the Watch can fully act on.
+///
+/// A Cursor chat in the IDE is reached through its hooks, which can answer a
+/// gate and hand over a follow-up but can interrupt nothing (ADR-0016). A
+/// `cursor-agent acp` process vibebuddy spawns itself is a different animal:
+/// the Agent Client Protocol carries `session/prompt`, `session/cancel`,
+/// `session/request_permission` and Cursor's own `cursor/ask_question` and
+/// `cursor/create_plan` over one pipe (cursor.com/docs/cli/acp). So a
+/// conversation this monitor hosts is the Cursor analogue of a Codex thread on
+/// the app-server daemon (ADR-0011): observed and controlled through the same
+/// connection, with `ControlChannel.acp` stamped on its row.
+///
+/// Rules that keep it honest:
+///
+/// - **One process per conversation, alive as long as the daemon is.** The CLI
+///   has no detached mode over ACP; when vibebuddy quits, the turn ends. The
+///   phone is told so at dispatch time.
+/// - **No mid-turn steer.** `session/prompt` is sequential, so a supplement for
+///   a running turn is queued in the same `CursorFollowupQueue` the hooks use
+///   and sent as the next prompt the moment the current one returns.
+/// - **A cancelled turn is a stop the user asked for.** ACP answers
+///   `session/cancel` with `stopReason: "cancelled"`; that ending is marked
+///   `userStopped` so the failure cue stays quiet.
+/// - **Cards are always answerable.** An ACP session has no Cursor UI of its
+///   own, so presence never makes them read-only; and a request that goes
+///   unanswered blocks the turn, exactly as the protocol says it will.
+public actor CursorACPMonitor {
+
+    /// How long a card may wait before the agent is told the request was
+    /// cancelled. ACP blocks the turn until it hears back, so this is the
+    /// upper bound on a turn nobody is answering, not a UI timeout.
+    public static let decisionTimeout: Duration = .seconds(6 * 3600)
+
+    private struct Hosted {
+        let client: CursorACPClient
+        let cwd: String
+        var running = false
+        var stopRequestedAt: Date?
+        var text = ""
+        var tools: [String: String] = [:]
+        var openApprovals: [String: JSONRPCID] = [:]
+        var openQuestions: [String: JSONRPCID] = [:]
+        var children: [String] = []
+    }
+
+    private let store: SessionStore
+    private let approvals: ApprovalRegistry
+    private let approvalContext: ApprovalContextStore
+    private let questions: QuestionRegistry
+    private let allowStore: VibeBuddyAllowStore
+    private let sessionAllow: SessionAllowList
+    private let followups: CursorFollowupQueue
+    private let rules: @Sendable (AgentKind) -> PermissionRules
+    private let makeID: @Sendable () -> String
+    private let spawn: @Sendable (String) throws -> CursorACPClient
+    private let executable: URL?
+    private let signInProbe: @Sendable () async -> Bool
+    private var signedIn: Bool?
+    private var hosted: [String: Hosted] = [:]
+
+    public init(store: SessionStore,
+                approvals: ApprovalRegistry,
+                approvalContext: ApprovalContextStore,
+                questions: QuestionRegistry,
+                allowStore: VibeBuddyAllowStore,
+                sessionAllow: SessionAllowList,
+                followups: CursorFollowupQueue,
+                rules: @escaping @Sendable (AgentKind) -> PermissionRules = { PermissionRules.load(for: $0) },
+                makeID: @escaping @Sendable () -> String = { UUID().uuidString },
+                executable: URL? = CursorCLI.resolveExecutable(),
+                signInProbe: (@Sendable () async -> Bool)? = nil,
+                spawn: (@Sendable (String) throws -> CursorACPClient)? = nil) {
+        self.store = store
+        self.approvals = approvals
+        self.approvalContext = approvalContext
+        self.questions = questions
+        self.allowStore = allowStore
+        self.sessionAllow = sessionAllow
+        self.followups = followups
+        self.rules = rules
+        self.makeID = makeID
+        self.executable = executable
+        let resolved = executable
+        self.signInProbe = signInProbe ?? { await CursorCLI.isSignedIn(executable: resolved) }
+        self.spawn = spawn ?? { cwd in
+            guard let resolved else { throw CursorACPClient.ClientError.closed }
+            return try CursorACPClient.spawn(executable: resolved, cwd: cwd)
+        }
+    }
+
+    // MARK: - Availability
+
+    /// Installed and signed in. Cached like `CursorLauncher`: the probe is a
+    /// subprocess and must not run on every snapshot.
+    public func isSupported() async -> Bool {
+        if let signedIn { return signedIn }
+        guard executable != nil else { signedIn = false; return false }
+        let ok = await signInProbe()
+        signedIn = ok
+        return ok
+    }
+
+    public func invalidate() { signedIn = nil }
+
+    /// Whether this monitor is carrying the conversation right now.
+    public func hosts(_ sessionID: String) -> Bool { hosted[sessionID] != nil }
+
+    public func hostedSessionIDs() -> Set<String> { Set(hosted.keys) }
+
+    /// Whether a turn is running on a hosted conversation.
+    public func isRunning(_ sessionID: String) -> Bool { hosted[sessionID]?.running == true }
+
+    // MARK: - Dispatch
+
+    /// Start a conversation in `cwd` and give it its first prompt. Returns once
+    /// the prompt has been accepted; the turn itself reports through the store.
+    public func dispatch(_ request: DispatchRequest) async -> DispatchOutcome {
+        guard request.agent == .cursor else { return .unsupported("This host only starts Cursor sessions") }
+        guard executable != nil else {
+            return .unavailable("The Cursor CLI (cursor-agent) is not installed on this Mac")
+        }
+        guard await isSupported() else {
+            return .unavailable("The Cursor CLI is not signed in — run `cursor-agent login` on this Mac")
+        }
+        let client: CursorACPClient
+        do { client = try spawn(request.cwd) } catch {
+            return .unavailable("Couldn't start cursor-agent: \(error)")
+        }
+        wire(client)
+        client.start()
+        do {
+            let hello = try await client.request("initialize", params: [
+                "protocolVersion": 1,
+                "clientCapabilities": ["fs": ["readTextFile": false, "writeTextFile": false], "terminal": false],
+                "clientInfo": ["name": "vibebuddy", "version": "1"],
+            ])
+            let version = (hello["protocolVersion"] as? NSNumber)?.intValue
+            guard version == 1 else {
+                client.close()
+                await store.recordSourceSignal(agent: .cursor, source: .acp, health: .unknownVersion, at: Date())
+                return .unavailable("cursor-agent speaks ACP version \(version.map(String.init) ?? "?"), not 1")
+            }
+            // The CLI advertises `cursor_login`; an already signed-in CLI
+            // answers at once, a signed-out one refuses and says so.
+            do { _ = try await client.request("authenticate", params: ["methodId": "cursor_login"]) } catch {
+                client.close()
+                signedIn = nil
+                return .unavailable("The Cursor CLI is not signed in — run `cursor-agent login` on this Mac")
+            }
+            let created = try await client.request("session/new", params: ["cwd": request.cwd, "mcpServers": []])
+            guard let sessionID = created["sessionId"] as? String, !sessionID.isEmpty else {
+                client.close()
+                return .unavailable("session/new returned no session id")
+            }
+            hosted[sessionID] = Hosted(client: client, cwd: request.cwd)
+            await store.setACPHosted(sessionID: sessionID, true)
+            let now = Date()
+            await store.ingest(HookEvent(kind: .sessionStart, sessionID: sessionID, agent: .cursor,
+                                         cwd: request.cwd, sessionName: request.name,
+                                         observationSource: .acp, timestamp: now))
+            await store.recordSourceSignal(agent: .cursor, source: .acp, health: .healthy, at: now)
+            startTurn(sessionID: sessionID, text: request.prompt)
+            return .started(sessionID: sessionID)
+        } catch {
+            client.close()
+            await store.recordSourceSignal(agent: .cursor, source: .acp, health: .sourceUnreadable, at: Date())
+            return .unavailable("cursor-agent did not accept the session: \(error)")
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Continue a hosted conversation that is idle. False when it is running
+    /// (a supplement belongs in the follow-up queue) or not hosted here.
+    public func prompt(sessionID: String, text: String) async -> Bool {
+        guard let entry = hosted[sessionID], !entry.running, !entry.client.isClosed else { return false }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        startTurn(sessionID: sessionID, text: trimmed)
+        return true
+    }
+
+    /// End the running turn. One notification, no retry: ACP promises the
+    /// prompt returns `cancelled` once everything has been aborted, and that
+    /// ending is marked as the user's.
+    public func cancel(sessionID: String) async -> CodexAppServerMonitor.InterruptOutcome {
+        guard var entry = hosted[sessionID] else {
+            return .notSent(String(localized: "This Mac isn't running this Cursor task."))
+        }
+        guard entry.running else {
+            return .notSent(String(localized: "This task has already finished."))
+        }
+        guard !entry.client.isClosed else {
+            return .notSent(String(localized: "The Cursor CLI behind this task has exited."))
+        }
+        entry.stopRequestedAt = Date()
+        hosted[sessionID] = entry
+        entry.client.notify("session/cancel", params: ["sessionId": sessionID])
+        // The protocol requires every open permission request to be answered
+        // `cancelled` once the turn is; the cards come down with them.
+        await withdrawOpenRequests(sessionID: sessionID)
+        return .sent
+    }
+
+    /// End every hosted process. Called when the daemon shuts down.
+    public func shutdown() async {
+        for (sessionID, entry) in hosted {
+            entry.client.close()
+            await store.setACPHosted(sessionID: sessionID, false)
+        }
+        hosted = [:]
+    }
+
+    // MARK: - Turns
+
+    private func startTurn(sessionID: String, text: String) {
+        guard var entry = hosted[sessionID] else { return }
+        entry.running = true
+        entry.text = ""
+        entry.stopRequestedAt = nil
+        hosted[sessionID] = entry
+        let client = entry.client
+        Task { [weak self] in
+            guard let self else { return }
+            let now = Date()
+            await self.store.ingest(HookEvent(kind: .userPromptSubmit, sessionID: sessionID, agent: .cursor,
+                                              cwd: entry.cwd, message: String(text.prefix(220)),
+                                              observationSource: .acp, timestamp: now))
+            var stopReason = "error"
+            var failure: String?
+            do {
+                let result = try await client.request("session/prompt", params: [
+                    "sessionId": sessionID,
+                    "prompt": [["type": "text", "text": text]],
+                ], timeout: nil)
+                stopReason = (result["stopReason"] as? String) ?? "end_turn"
+            } catch CursorACPClient.ClientError.rpc(_, let message) {
+                failure = message
+            } catch {
+                failure = "the Cursor CLI exited before the turn ended"
+            }
+            await self.turnEnded(sessionID: sessionID, stopReason: stopReason, failure: failure)
+        }
+    }
+
+    private func turnEnded(sessionID: String, stopReason: String, failure: String?) async {
+        guard var entry = hosted[sessionID] else { return }
+        entry.running = false
+        let now = Date()
+        let asked = entry.stopRequestedAt != nil
+        let cancelled = stopReason == "cancelled" || asked
+        let succeeded = failure == nil && stopReason == "end_turn"
+        let message: String?
+        switch (failure, stopReason) {
+        case (let text?, _): message = "Turn failed: \(text)"
+        case (nil, "cancelled"): message = "Turn stopped"
+        case (nil, "end_turn"): message = entry.text.isEmpty ? nil : String(entry.text.suffix(220))
+        case (nil, "refusal"): message = "Cursor refused to continue"
+        case (nil, "max_tokens"): message = "Turn hit the token limit"
+        case (nil, "max_turn_requests"): message = "Turn hit the request limit"
+        default: message = "Turn ended: \(stopReason)"
+        }
+        for child in entry.children {
+            await store.ingest(HookEvent(kind: .childLifecycle, sessionID: sessionID, agent: .cursor,
+                                         observationSource: .acp, timestamp: now, childID: child,
+                                         childKind: .subagent, childAction: .stopped))
+        }
+        entry.children = []
+        hosted[sessionID] = entry
+        // A failed ending carries `toolError` as well as its wording, so the
+        // stuck cue does not hang on the failure heuristic recognising a phrase.
+        let ending = HookEvent(kind: .stop, sessionID: sessionID, agent: .cursor, cwd: entry.cwd,
+                               message: message, observationSource: .acp,
+                               toolError: !cancelled && !succeeded, timestamp: now,
+                               completionText: succeeded && !entry.text.isEmpty ? entry.text : nil,
+                               completionSucceeded: cancelled ? false : succeeded)
+        await store.ingest(cancelled ? ending.markingUserStop() : ending)
+        if entry.client.isClosed {
+            hosted[sessionID] = nil
+            await store.setACPHosted(sessionID: sessionID, false)
+            await store.recordSourceSignal(agent: .cursor, source: .acp, health: .temporarilySilent, at: now)
+            return
+        }
+        // A supplement the phone queued while the turn ran goes out now, as
+        // the next prompt — the same moment the hooks' `stop` would have
+        // handed it to Cursor.
+        if !cancelled, let next = await followups.take(conversationID: sessionID, now: now) {
+            startTurn(sessionID: sessionID, text: next)
+        }
+    }
+
+    // MARK: - Incoming
+
+    /// JSON-RPC params are `[String: Any]`, which Swift cannot prove Sendable;
+    /// they are parsed fresh from one line and handed to exactly one task, so
+    /// the hop onto the actor is the only place they cross an isolation line.
+    private struct Payload: @unchecked Sendable { let value: [String: Any]? }
+
+    private func wire(_ client: CursorACPClient) {
+        client.onNotification = { [weak self] method, params in
+            guard let self else { return }
+            let payload = Payload(value: params)
+            Task { await self.handleNotification(method: method, params: payload.value) }
+        }
+        client.onRequest = { [weak self] id, method, params in
+            guard let self else { return }
+            let payload = Payload(value: params)
+            Task { await self.handleRequest(id: id, method: method, params: payload.value, client: client) }
+        }
+        client.onClose = { [weak self] in
+            guard let self else { return }
+            Task { await self.clientClosed(client) }
+        }
+    }
+
+    private func clientClosed(_ client: CursorACPClient) async {
+        for (sessionID, entry) in hosted where entry.client === client {
+            if entry.running { continue }   // `turnEnded` will see `isClosed` and finish up.
+            hosted[sessionID] = nil
+            await store.setACPHosted(sessionID: sessionID, false)
+        }
+    }
+
+    private func handleNotification(method: String, params: [String: Any]?) async {
+        guard method == "session/update",
+              let sessionID = params?["sessionId"] as? String,
+              var entry = hosted[sessionID],
+              let update = params?["update"] as? [String: Any],
+              let kind = update["sessionUpdate"] as? String else { return }
+        let now = Date()
+        switch kind {
+        case "agent_message_chunk":
+            if let text = (update["content"] as? [String: Any])?["text"] as? String {
+                entry.text = String((entry.text + text).suffix(4000))
+                hosted[sessionID] = entry
+            }
+        case "tool_call":
+            let callID = (update["toolCallId"] as? String) ?? UUID().uuidString
+            let name = Self.canonicalTool(kind: update["kind"] as? String, title: update["title"] as? String)
+            entry.tools[callID] = name
+            hosted[sessionID] = entry
+            await store.ingest(HookEvent(kind: .preToolUse, sessionID: sessionID, agent: .cursor,
+                                         cwd: entry.cwd, toolName: name,
+                                         message: update["title"] as? String,
+                                         observationSource: .acp, timestamp: now))
+        case "tool_call_update":
+            let callID = (update["toolCallId"] as? String) ?? ""
+            let status = update["status"] as? String
+            guard status == "completed" || status == "failed" else { return }
+            let name = entry.tools.removeValue(forKey: callID) ?? "tool"
+            hosted[sessionID] = entry
+            await store.ingest(HookEvent(kind: .postToolUse, sessionID: sessionID, agent: .cursor,
+                                         cwd: entry.cwd, toolName: name,
+                                         observationSource: .acp, toolError: status == "failed",
+                                         timestamp: now))
+        case "usage_update":
+            guard let used = (update["used"] as? NSNumber)?.intValue,
+                  let size = (update["size"] as? NSNumber)?.intValue else { return }
+            await store.ingest(HookEvent(kind: .sessionMetadataChanged, sessionID: sessionID, agent: .cursor,
+                                         cwd: entry.cwd, observationSource: .acp, timestamp: now,
+                                         enrichment: TranscriptInfo(contextTokens: used, contextWindow: size)))
+        default:
+            // plan, agent_thought_chunk, user_message_chunk (replay), config
+            // changes: understood, and none of them moves the three states.
+            return
+        }
+    }
+
+    private func handleRequest(id: JSONRPCID, method: String, params: [String: Any]?, client: CursorACPClient) async {
+        let sessionID = (params?["sessionId"] as? String)
+            ?? hosted.first(where: { $0.value.client === client })?.key
+        guard let sessionID, hosted[sessionID] != nil else {
+            client.respondError(id: id, code: -32602, message: "unknown session")
+            return
+        }
+        switch method {
+        case "session/request_permission":
+            await permission(id: id, sessionID: sessionID, params: params ?? [:], client: client)
+        case "cursor/ask_question":
+            await askQuestion(id: id, sessionID: sessionID, params: params ?? [:], client: client)
+        case "cursor/create_plan":
+            await createPlan(id: id, sessionID: sessionID, params: params ?? [:], client: client)
+        case "cursor/update_todos":
+            let todos = params?["todos"] ?? []
+            client.respond(id: id, result: ["outcome": ["outcome": "accepted", "todos": todos]])
+        case "cursor/task":
+            // The subagent runs on Cursor's side; vibebuddy only shows the row.
+            let callID = (params?["toolCallId"] as? String) ?? UUID().uuidString
+            let childID = "subagent:\(callID)"
+            if var entry = hosted[sessionID] { entry.children.append(childID); hosted[sessionID] = entry }
+            let type = Self.subagentType(params?["subagentType"])
+            await store.ingest(HookEvent(kind: .childLifecycle, sessionID: sessionID, agent: .cursor,
+                                         message: params?["description"] as? String,
+                                         observationSource: .acp, timestamp: Date(),
+                                         childID: childID, childKind: .subagent,
+                                         childName: type, childType: type, childAction: .started))
+            client.respond(id: id, result: ["outcome": ["outcome": "completed"]])
+        case "cursor/generate_image":
+            client.respond(id: id, result: ["outcome": ["outcome": "rejected", "reason": "vibebuddy does not generate images"]])
+        default:
+            // `fs/*` and `terminal/*` were declared unsupported at initialize;
+            // anything else is a method this client does not know.
+            client.respondError(id: id, code: -32601, message: "method not supported by vibebuddy: \(method)")
+        }
+    }
+
+    // MARK: - Permission
+
+    private func permission(id: JSONRPCID, sessionID: String, params: [String: Any], client: CursorACPClient) async {
+        guard let entry = hosted[sessionID] else { return }
+        let toolCall = params["toolCall"] as? [String: Any] ?? [:]
+        let callID = toolCall["toolCallId"] as? String ?? ""
+        let title = toolCall["title"] as? String
+        let tool = entry.tools[callID]
+            ?? Self.canonicalTool(kind: toolCall["kind"] as? String, title: title)
+        var input = CursorToolVocabulary.canonicalInput(toolCall["rawInput"] as? [String: Any] ?? [:])
+        if tool == "Bash", input["command"] == nil, let title { input["command"] = title }
+        let options = Self.permissionOptions(params["options"])
+
+        // Native deny always wins (ADR-0010); an exact vibebuddy always-allow
+        // or a session-wide allow answers without a card.
+        let r = rules(.cursor)
+        if PermissionMatcher.decide(tool: tool, input: input, allow: [], deny: r.deny) == .deny {
+            client.respond(id: id, result: Self.selected(options.reject))
+            return
+        }
+        let storeRules = await allowStore.all()
+        if await sessionAllow.contains(sessionID)
+            || storeRules.contains(where: { AllowRule.matchesExactly($0, tool: tool, input: input) }) {
+            client.respond(id: id, result: Self.selected(options.allow))
+            return
+        }
+
+        let approvalID = makeID()
+        let details = ApprovalDetails.from(tool: tool, input: input)
+        await approvalContext.set(id: approvalID, sessionID: sessionID,
+                                  rule: AllowRule.forApproval(tool: tool, input: input))
+        await approvals.prepare(id: approvalID)
+        if var live = hosted[sessionID] { live.openApprovals[approvalID] = id; hosted[sessionID] = live }
+        await store.beginApproval(sessionID: sessionID,
+            PendingApproval(id: approvalID, tool: tool,
+                            commandPreview: details.commandPreview.isEmpty ? (title ?? tool) : details.commandPreview,
+                            command: details.command, filePath: details.filePath,
+                            oldText: details.oldText, newText: details.newText), at: Date(), source: .acp)
+        let outcome = await approvals.wait(id: approvalID, timeout: Self.decisionTimeout)
+        guard var live = hosted[sessionID], live.openApprovals.removeValue(forKey: approvalID) != nil else {
+            return   // Withdrawn by a cancel, which already answered the agent.
+        }
+        hosted[sessionID] = live
+        await store.endApproval(sessionID: sessionID, approvalID: approvalID, at: Date(), source: .acp)
+        switch outcome {
+        case .allow: client.respond(id: id, result: Self.selected(options.allow))
+        case .deny: client.respond(id: id, result: Self.selected(options.reject))
+        case .pass: client.respond(id: id, result: ["outcome": ["outcome": "cancelled"]])
+        }
+    }
+
+    // MARK: - Questions and plans
+
+    private func askQuestion(id: JSONRPCID, sessionID: String, params: [String: Any], client: CursorACPClient) async {
+        // Cursor's ACP question is the same shape as its `AskQuestion` tool
+        // input, so the hook path's adapter reads it unchanged.
+        guard let question = CursorAskQuestionInput.pendingQuestion(from: params, id: makeID()) else {
+            client.respond(id: id, result: ["outcome": ["outcome": "skipped", "reason": "no questions"]])
+            return
+        }
+        if var live = hosted[sessionID] { live.openQuestions[question.id] = id; hosted[sessionID] = live }
+        await store.beginQuestion(sessionID: sessionID, question, at: Date(), source: .acp)
+        let answers = await questions.wait(sessionID: sessionID, questionID: question.id, timeout: Self.decisionTimeout)
+        guard var live = hosted[sessionID], live.openQuestions.removeValue(forKey: question.id) != nil else { return }
+        hosted[sessionID] = live
+        await store.endQuestion(sessionID: sessionID, questionID: question.id, at: Date(), source: .acp)
+        guard let answers else {
+            client.respond(id: id, result: ["outcome": ["outcome": "cancelled"]])
+            return
+        }
+        client.respond(id: id, result: Self.questionResponse(question: question, answers: answers))
+    }
+
+    private func createPlan(id: JSONRPCID, sessionID: String, params: [String: Any], client: CursorACPClient) async {
+        let name = (params["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let overview = (params["overview"] as? String) ?? (params["plan"] as? String) ?? ""
+        let options = [QuestionOption(id: "accept", label: "Accept"), QuestionOption(id: "reject", label: "Reject")]
+        let item = QuestionItem(id: "plan", header: name.flatMap { $0.isEmpty ? nil : $0 } ?? "Plan",
+                                text: overview.isEmpty ? "Approve this plan?" : String(overview.prefix(600)),
+                                options: options, multiSelect: false, allowsOther: false)
+        let question = PendingQuestion(id: makeID(), prompt: item.text, options: options,
+                                       questions: [item], isBlocking: true)
+        if var live = hosted[sessionID] { live.openQuestions[question.id] = id; hosted[sessionID] = live }
+        await store.beginQuestion(sessionID: sessionID, question, at: Date(), source: .acp)
+        let answers = await questions.wait(sessionID: sessionID, questionID: question.id, timeout: Self.decisionTimeout)
+        guard var live = hosted[sessionID], live.openQuestions.removeValue(forKey: question.id) != nil else { return }
+        hosted[sessionID] = live
+        await store.endQuestion(sessionID: sessionID, questionID: question.id, at: Date(), source: .acp)
+        guard let answers else {
+            client.respond(id: id, result: ["outcome": ["outcome": "cancelled"]])
+            return
+        }
+        let chosen = (answers["plan"] ?? answers.values.first ?? []).joined(separator: " ").lowercased()
+        let accepted = chosen.contains("accept")
+        client.respond(id: id, result: ["outcome": accepted
+            ? ["outcome": "accepted"]
+            : ["outcome": "rejected", "reason": chosen.isEmpty ? "rejected from vibebuddy" : chosen]])
+    }
+
+    private func withdrawOpenRequests(sessionID: String) async {
+        guard var entry = hosted[sessionID] else { return }
+        let approvalsOpen = entry.openApprovals
+        let questionsOpen = entry.openQuestions
+        entry.openApprovals = [:]
+        entry.openQuestions = [:]
+        hosted[sessionID] = entry
+        let now = Date()
+        for (approvalID, rpcID) in approvalsOpen {
+            entry.client.respond(id: rpcID, result: ["outcome": ["outcome": "cancelled"]])
+            _ = await approvalContext.take(id: approvalID)
+            await approvals.resolve(id: approvalID, with: .pass)
+            await store.endApproval(sessionID: sessionID, approvalID: approvalID, at: now, source: .acp)
+        }
+        for (questionID, rpcID) in questionsOpen {
+            entry.client.respond(id: rpcID, result: ["outcome": ["outcome": "cancelled"]])
+            await questions.cancelExact(sessionID: sessionID, questionID: questionID)
+            await store.endQuestion(sessionID: sessionID, questionID: questionID, at: now, source: .acp)
+        }
+    }
+
+    // MARK: - Shapes
+
+    /// ACP's `kind` is the reliable signal; Cursor's `title` is prose. The
+    /// canonical names are the ones `PermissionMatcher` and the allow store
+    /// already understand.
+    static func canonicalTool(kind: String?, title: String?) -> String {
+        switch kind {
+        case "execute": return "Bash"
+        case "read": return "Read"
+        case "edit": return "Edit"
+        case "delete": return "Delete"
+        case "move": return "Move"
+        case "search": return "Grep"
+        case "fetch": return "WebFetch"
+        case "think": return "Thinking"
+        default:
+            guard let title = title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty else { return "tool" }
+            return CursorToolVocabulary.canonicalTool(title)
+        }
+    }
+
+    struct PermissionOptions { var allow: String; var reject: String }
+
+    /// Which `optionId` means allow-once and which reject-once. The ids are
+    /// the agent's to choose; the `kind` says what they mean. Missing kinds
+    /// fall back to the ids Cursor documents.
+    static func permissionOptions(_ raw: Any?) -> PermissionOptions {
+        let options = (raw as? [[String: Any]]) ?? []
+        func find(kind: String, fallback: String) -> String {
+            if let match = options.first(where: { ($0["kind"] as? String) == kind }),
+               let id = match["optionId"] as? String { return id }
+            if let match = options.first(where: { (($0["optionId"] as? String) ?? "") == fallback }),
+               let id = match["optionId"] as? String { return id }
+            return fallback
+        }
+        return PermissionOptions(allow: find(kind: "allow_once", fallback: "allow-once"),
+                                 reject: find(kind: "reject_once", fallback: "reject-once"))
+    }
+
+    static func selected(_ optionID: String) -> [String: Any] {
+        ["outcome": ["outcome": "selected", "optionId": optionID]]
+    }
+
+    /// The phone answers with option values (their labels); Cursor wants the
+    /// option ids. Free text has no place in Cursor's schema, so a typed answer
+    /// travels as the reason on a `skipped` outcome — the model still reads it.
+    static func questionResponse(question: PendingQuestion, answers: QuestionAnswers) -> [String: Any] {
+        var selected: [[String: Any]] = []
+        var typed: [String] = []
+        for item in question.items {
+            let values = (answers[item.id] ?? []).filter { !$0.isEmpty }
+            guard !values.isEmpty else { continue }
+            let ids = values.compactMap { value in
+                item.options.first { $0.id == value || $0.value == value || $0.label == value }?.id
+            }
+            if ids.isEmpty { typed.append("\(item.text): \(values.joined(separator: ", "))") }
+            else { selected.append(["questionId": item.id, "selectedOptionIds": ids]) }
+        }
+        if selected.isEmpty, !typed.isEmpty {
+            return ["outcome": ["outcome": "skipped", "reason": "The user answered from vibebuddy: " + typed.joined(separator: "; ")]]
+        }
+        return ["outcome": ["outcome": "answered", "answers": selected]]
+    }
+
+    static func subagentType(_ raw: Any?) -> String? {
+        if let text = raw as? String { return text }
+        if let custom = (raw as? [String: Any])?["custom"] as? String { return custom }
+        return nil
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorACPMonitor.swift
@@ -289,6 +289,7 @@ public actor CursorACPMonitor {
         // the next prompt — the same moment the hooks' `stop` would have
         // handed it to Cursor.
         if !cancelled, let next = await followups.take(conversationID: sessionID, now: now) {
+            await store.noteCursorFollowupHandoff(sessionID: sessionID, loopCount: nil, source: .acp, at: now)
             startTurn(sessionID: sessionID, text: next)
         }
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorAskQuestionInput.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorAskQuestionInput.swift
@@ -35,8 +35,10 @@ public enum CursorAskQuestionInput {
             return QuestionItem(id: nonEmpty(q["id"] as? String) ?? "q\(index + 1)",
                                 header: nonEmpty(input["title"] as? String),
                                 text: text, options: options,
+                                // `allowMultiple` is the ACP spelling (cursor/ask_question).
                                 multiSelect: (q["multiSelect"] as? Bool)
-                                    ?? (q["multiple"] as? Bool) ?? false,
+                                    ?? (q["multiple"] as? Bool)
+                                    ?? (q["allowMultiple"] as? Bool) ?? false,
                                 allowsOther: true)
         }
         guard let first = items.first else { return nil }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorCLI.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorCLI.swift
@@ -8,6 +8,91 @@ import VibeBuddyKit
 /// Cursor turn has output worth watching and prompts worth answering, and a
 /// detached `--print` run would put both somewhere nobody can see. This mirrors
 /// how a Claude background session is re-entered (`TerminalLauncher.attach`).
+/// The three choices a dispatch may make for a Cursor task, as the CLI's own
+/// global options (cursor.com/docs/cli/reference/parameters, checked
+/// 2026-09-12): `--model <model>`, `--mode plan|ask` (agent mode is the
+/// default and has no flag), and `-w` for a fresh Git worktree the CLI creates
+/// under `~/.cursor/worktrees/<reponame>/<name>`. Global options apply to
+/// every command, so the same arguments go in front of `acp` for a hosted
+/// conversation and in front of `--` for a terminal run.
+///
+/// Both strings come from the phone, so they are checked before they reach an
+/// argv: a token of letters, digits and `. - _ / :`, which every model id and
+/// mode uses, optionally followed by the bracket overrides `--help` documents
+/// for parameterized models (`claude-opus-4-8[context=1m,effort=high]`).
+public struct CursorLaunchOptions: Sendable, Equatable {
+    public var model: String?
+    /// `plan` or `ask`. Nil is agent mode.
+    public var mode: String?
+    public var worktree: Bool
+
+    public static let modes: Set<String> = ["plan", "ask"]
+
+    public init(model: String? = nil, mode: String? = nil, worktree: Bool = false) {
+        self.model = model
+        self.mode = mode
+        self.worktree = worktree
+    }
+
+    /// The options a request asks for, or why it must be refused. `agent` and
+    /// an empty string read as "the default", the way the phone sends them.
+    public static func from(_ request: DispatchRequest) -> Result<CursorLaunchOptions, Rejection> {
+        var options = CursorLaunchOptions(worktree: request.worktree == true)
+        if let model = request.model?.trimmingCharacters(in: .whitespacesAndNewlines), !model.isEmpty {
+            guard isModelToken(model) else { return .failure(.invalidModel(model)) }
+            options.model = model
+        }
+        if let mode = request.mode?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           !mode.isEmpty, mode != "agent" {
+            guard modes.contains(mode) else { return .failure(.invalidMode(mode)) }
+            options.mode = mode
+        }
+        return .success(options)
+    }
+
+    public enum Rejection: Error, Equatable {
+        case invalidModel(String)
+        case invalidMode(String)
+
+        public var message: String {
+            switch self {
+            case .invalidModel(let model): return "\"\(model)\" is not a model id the Cursor CLI would accept"
+            case .invalidMode(let mode): return "\"\(mode)\" is not a Cursor mode (agent, plan or ask)"
+            }
+        }
+    }
+
+    /// The argv fragment: `--model X --mode plan -w`, in that order, only
+    /// what was chosen.
+    public var arguments: [String] {
+        var parts: [String] = []
+        if let model { parts += ["--model", model] }
+        if let mode { parts += ["--mode", mode] }
+        if worktree { parts.append("-w") }
+        return parts
+    }
+
+    private static let tokenScalars: Set<Unicode.Scalar> = Set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_/:".unicodeScalars)
+
+    static func isPlainToken(_ value: String) -> Bool {
+        guard !value.isEmpty, value.utf8.count <= 128 else { return false }
+        return value.unicodeScalars.allSatisfy(tokenScalars.contains)
+    }
+
+    /// A plain token, or a plain token with one `[key=value,...]` suffix.
+    static func isModelToken(_ value: String) -> Bool {
+        guard let open = value.firstIndex(of: "[") else { return isPlainToken(value) }
+        guard value.last == "]", isPlainToken(String(value[..<open])) else { return false }
+        let inner = value[value.index(after: open)..<value.index(before: value.endIndex)]
+        guard !inner.isEmpty else { return false }
+        return inner.split(separator: ",", omittingEmptySubsequences: false).allSatisfy { pair in
+            let sides = pair.split(separator: "=", omittingEmptySubsequences: false)
+            return sides.count == 2 && sides.allSatisfy { isPlainToken(String($0)) }
+        }
+    }
+}
+
 public enum CursorCLI {
 
     /// The conversation-id shape Cursor uses for composers and CLI chats: a
@@ -57,6 +142,46 @@ public enum CursorCLI {
         return text.contains("logged in") || text.contains("@") || text.contains("email")
     }
 
+    /// The models this account may pick from: `cursor-agent --list-models`
+    /// (the same list as `agent models`), one per line. A signed-out CLI
+    /// answers with an authentication error, which reads as no models — the
+    /// caller decides when to ask again, since every call is a subprocess.
+    public static func listModels(
+        executable: URL? = resolveExecutable(),
+        timeout: TimeInterval = 15
+    ) async -> [String] {
+        guard let executable else { return [] }
+        let result = await run(executable, ["--list-models"], cwd: nil, timeout: timeout)
+        guard result.status == 0 else { return [] }
+        return parseModelList(result.stdout)
+    }
+
+    /// One model id per non-empty line: the first whitespace-separated token,
+    /// with a leading bullet or table bar stripped. The output's shape is not
+    /// documented, so this reads a plain list, a bulleted one and a table the
+    /// same way and drops what cannot be an id: a header ("Available
+    /// models:", "MODEL  DESCRIPTION") is capitalised, an id is not.
+    static func parseModelList(_ text: String) -> [String] {
+        var seen = Set<String>()
+        var models: [String] = []
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            var line = Substring(rawLine).trimmingCharacters(in: .whitespaces)
+            while let first = line.first, "-*•|".contains(first) {
+                line = String(line.dropFirst()).trimmingCharacters(in: .whitespaces)
+            }
+            guard let token = line.split(whereSeparator: \.isWhitespace).first else { continue }
+            var candidate = String(token)
+            while let last = candidate.last, ",:|".contains(last) { candidate.removeLast() }
+            guard CursorLaunchOptions.isPlainToken(candidate),
+                  candidate.contains(where: \.isLetter),
+                  candidate == candidate.lowercased(),
+                  seen.insert(candidate).inserted
+            else { continue }
+            models.append(candidate)
+        }
+        return models
+    }
+
     /// Continue an existing conversation in a terminal: `cursor-agent --resume
     /// <id> -- <text>`. The id is validated first; the text is passed as the
     /// prompt argument.
@@ -78,18 +203,20 @@ public enum CursorCLI {
                                            preferring: termProgram)
     }
 
-    /// Start a new Cursor task in a terminal: `cursor-agent -- <prompt>` in the
-    /// requested directory.
+    /// Start a new Cursor task in a terminal: `cursor-agent [--model X]
+    /// [--mode plan|ask] [-w] -- <prompt>` in the requested directory.
     public static func start(
         prompt: String,
         executable: URL? = resolveExecutable(),
         cwd: String,
+        options: CursorLaunchOptions = CursorLaunchOptions(),
         preferring termProgram: String? = nil
     ) async -> Bool {
         guard let executable else { return false }
         let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return false }
-        let parts = [shellQuoted(executable.path), "--", shellQuoted(text)]
+        let parts = [shellQuoted(executable.path)] + options.arguments.map(shellQuoted)
+            + ["--", shellQuoted(text)]
         return await TerminalLauncher.open(command: command(parts, cwd: cwd),
                                            preferring: termProgram)
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorCloudAgentMonitor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorCloudAgentMonitor.swift
@@ -1,0 +1,174 @@
+import Foundation
+import VibeBuddyKit
+
+/// Polls Cursor's Cloud Agents API, which is where a cloud agent exists.
+///
+/// A cloud agent runs on Cursor's machines against a **GitHub repository**, not
+/// on this Mac against a folder: no hook fires for it, no transcript is written
+/// for it, and — checked against this machine's own Cursor database on
+/// 2026-09-12 — no row appears for it in `composerHeaders` either. It has the
+/// shape a Codex Desktop thread has (ADR-0011): a session with no local anchor,
+/// whose only address is a URL. So the API does not *enrich* a local row here;
+/// it is the row's only source.
+///
+/// ADR-0016's layer order is untouched for local Cursor conversations. It simply
+/// has nothing to say about a conversation that never touches this Mac.
+///
+/// Two rules keep it honest:
+///
+/// - **It is a tail, not an import.** An agent already `IDLE` when vibebuddy
+///   starts rings nothing — it finished before anyone was watching. It still
+///   gets a quiet history row, the way an imported Copilot session does. An
+///   agent already `ACTIVE` *is* reported live, because a run happening right
+///   now is not history.
+/// - **It is bounded.** Archived agents stay out and the list is capped, for the
+///   same reason `cursorHistoryLimit` exists: a dashboard is the work in hand,
+///   not an account archive.
+public actor CursorCloudAgentMonitor {
+    private let client: CursorCloudAgentClient
+    private let interval: Duration
+    private let limit: Int
+    /// Last status seen per agent id. Absent means never seen by this process.
+    private var seen: [String: CursorCloudAgentStatus] = [:]
+    /// Repository per agent id. Only the per-agent endpoint carries it, and it
+    /// cannot change for a given agent, so it is fetched once and kept.
+    private var repositories: [String: String] = [:]
+    private var started = false
+
+    /// 20 seconds: fast enough that a cloud turn's end reaches the phone while
+    /// the person still cares, slow enough to be three calls a minute on an
+    /// endpoint Cursor documents no rate limit for. One list call covers every
+    /// agent; run and agent detail are fetched only on a change.
+    public init(client: CursorCloudAgentClient = CursorCloudAgentClient(),
+                interval: Duration = .seconds(20),
+                limit: Int = 50) {
+        self.client = client
+        self.interval = interval
+        self.limit = limit
+    }
+
+    public func run(store: SessionStore) async {
+        while !Task.isCancelled {
+            await poll(store: store, now: Date())
+            do { try await Task.sleep(for: interval) } catch { return }
+        }
+    }
+
+    /// One deterministic pass: hand the store every agent it should know about,
+    /// then the lifecycle events this pass justifies.
+    public func poll(store: SessionStore, now: Date) async {
+        let (agents, events) = await pass(now: now)
+        guard let agents else { return }
+        await store.applyCursorCloudAgents(agents)
+        for event in events { await store.ingest(event) }
+    }
+
+    /// The pure half, for tests: what this pass saw and what it justifies.
+    /// A nil agent list means the pass failed and nothing should be applied —
+    /// an unreachable API is not evidence that an agent stopped existing.
+    public func pass(now: Date) async -> ([CursorCloudAgent]?, [HookEvent]) {
+        guard client.isConfigured else { return ([], []) }
+        let listed: [CursorCloudAgent]
+        do {
+            listed = try await client.agents(limit: limit)
+        } catch {
+            // A refused key, a rate limit or a dropped connection is not
+            // evidence that anything finished. Rows keep the state this monitor
+            // last established and the next pass retries.
+            return (nil, [])
+        }
+        let first = !started
+        started = true
+
+        var agents: [CursorCloudAgent] = []
+        var events: [HookEvent] = []
+        var present: Set<String> = []
+        for listing in listed {
+            present.insert(listing.id)
+            let agent = await withRepository(listing)
+            agents.append(agent)
+            let before = seen[agent.id]
+            seen[agent.id] = agent.status
+            guard before != agent.status else { continue }
+            switch agent.status {
+            case .active:
+                events.append(base(agent, kind: .userPromptSubmit, at: now, message: agent.name))
+            case .idle:
+                // Only a *transition* into idle is a completion. One that was
+                // already idle when this process started finished before
+                // vibebuddy was watching; it gets a history row instead, and
+                // replaying it would ring for a run long since read.
+                guard !first, before != nil else { continue }
+                events.append(await completion(for: agent, at: now))
+            case .archived:
+                events.append(base(agent, kind: .sessionEnd, at: now))
+            }
+        }
+        // An agent that left the list was archived or deleted in Cursor.
+        for (id, status) in seen where !present.contains(id) {
+            seen.removeValue(forKey: id)
+            repositories.removeValue(forKey: id)
+            guard status != .archived else { continue }
+            events.append(HookEvent(kind: .sessionEnd, sessionID: id, agent: .cursor,
+                                    observationSource: .cloud, timestamp: now))
+        }
+        return (agents, events)
+    }
+
+    /// The repository an agent works on, fetched once. A failure is not worth a
+    /// retry storm or a lost row: the agent simply keeps no repository until a
+    /// later pass gets one.
+    private func withRepository(_ agent: CursorCloudAgent) async -> CursorCloudAgent {
+        if let known = repositories[agent.id] { return agent.naming(repository: known) }
+        guard let detail = try? await client.agent(id: agent.id),
+              let repository = detail.repository else { return agent }
+        repositories[agent.id] = repository
+        return agent.naming(repository: repository)
+    }
+
+    /// The end of a cloud turn, with whatever the run itself reported.
+    ///
+    /// The run detail is a second call, so failing to read it must not cost the
+    /// completion: an unreadable run still ends the turn, just without the final
+    /// text. `FINISHED` is the only run status that counts as success — `ERROR`,
+    /// `CANCELLED` and `EXPIRED` all ended the turn without producing what was
+    /// asked for.
+    private func completion(for agent: CursorCloudAgent, at now: Date) async -> HookEvent {
+        guard let runID = agent.latestRunID,
+              let run = try? await client.run(agentID: agent.id, runID: runID) else {
+            return base(agent, kind: .stop, at: now)
+        }
+        let succeeded = run.status == .finished
+        let event = base(agent, kind: .stop, at: now,
+                         message: run.result.map { String($0.prefix(220)) }
+                            ?? (succeeded ? nil : "Run \(run.status.rawValue.lowercased())"),
+                         completionText: succeeded ? run.result : nil,
+                         completionSucceeded: succeeded,
+                         enrichment: run.branch.map { TranscriptInfo(branch: $0) })
+        // A run the person cancelled from here is an ending they asked for, not
+        // a break — the same distinction the hook adapter draws for an aborted
+        // Cursor turn.
+        return run.status == .cancelled ? event.markingUserStop() : event
+    }
+
+    private func base(_ agent: CursorCloudAgent, kind: HookEvent.Kind, at now: Date,
+                      message: String? = nil,
+                      completionText: String? = nil,
+                      completionSucceeded: Bool? = nil,
+                      enrichment: TranscriptInfo? = nil) -> HookEvent {
+        HookEvent(kind: kind, sessionID: agent.id, agent: .cursor,
+                  cwd: agent.repository, sessionName: agent.name, message: message,
+                  observationSource: .cloud, timestamp: now,
+                  enrichment: enrichment,
+                  completionText: completionText,
+                  completionSucceeded: completionSucceeded)
+    }
+}
+
+extension CursorCloudAgent {
+    func naming(repository: String) -> CursorCloudAgent {
+        CursorCloudAgent(id: id, name: name, status: status, environment: environment,
+                         url: url, repository: repository, latestRunID: latestRunID,
+                         updatedAt: updatedAt)
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorCloudAgents.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorCloudAgents.swift
@@ -1,0 +1,572 @@
+import Foundation
+import Security
+import VibeBuddyKit
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Transport seam for `https://api.cursor.com`, shaped like
+/// `CursorUsageTransport` so tests never reach the network.
+public protocol CursorCloudTransport: Sendable {
+    func cursorCloudData(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: CursorCloudTransport {
+    public func cursorCloudData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await data(for: request)
+    }
+}
+
+/// Keychain slot for the Cursor Cloud Agents API key.
+///
+/// Three Cursor credentials exist and none of them substitutes for another: the
+/// app's `WorkosCursorSessionToken` cookie (quota, `CursorSessionCookieStore`),
+/// the `cursor-agent` CLI's own login (kept by the CLI in the login keychain,
+/// never read here), and this key — minted at cursor.com/dashboard/api and the
+/// only credential the Cloud Agents API accepts. So it gets its own account,
+/// beside the two cookie slots rather than inside them.
+public enum CursorCloudAPIKeyStore {
+    public static let keychainAccount = "cursorCloudAPIKey"
+
+    public static func load(read: (String) -> String? = { KeychainStore.get($0) }) -> String? {
+        read(keychainAccount)?.trimmingCharacters(in: .whitespacesAndNewlines).nilWhenEmpty
+    }
+
+    @discardableResult
+    public static func save(
+        _ value: String?,
+        write: (String?, String) -> OSStatus = { KeychainStore.set($0, for: $1) }
+    ) -> OSStatus {
+        write(value?.trimmingCharacters(in: .whitespacesAndNewlines).nilWhenEmpty, keychainAccount)
+    }
+
+    /// Whether a key is stored, **without decrypting it**. Settings uses this to
+    /// print "saved" without ever raising a Keychain authorization prompt — and
+    /// without the key passing through the UI layer at all.
+    public static func isConfigured(exists: (String) -> Bool = { KeychainStore.exists($0) }) -> Bool {
+        exists(keychainAccount)
+    }
+}
+
+private extension String {
+    var nilWhenEmpty: String? { isEmpty ? nil : self }
+}
+
+/// Cursor's agent-level state. Three values, and only three
+/// (`cursor.com/docs/cloud-agent/api/endpoints`, checked 2026-09-12).
+public enum CursorCloudAgentStatus: String, Codable, Sendable {
+    /// A turn is running, waiting on background work, or about to start.
+    case active = "ACTIVE"
+    /// The last turn finished and follow-ups are accepted.
+    case idle = "IDLE"
+    /// Archived or expired. Terminal.
+    case archived = "ARCHIVED"
+}
+
+/// One cloud agent as the API reports it.
+public struct CursorCloudAgent: Equatable, Sendable {
+    public let id: String
+    public let name: String?
+    public let status: CursorCloudAgentStatus
+    /// Where it runs: `cloud` for Cursor's own VMs, `pool` / `machine` for a
+    /// self-hosted worker.
+    public let environment: String?
+    /// Cursor's web page for this agent — the only place the conversation can
+    /// actually be opened, since it runs nowhere on this Mac.
+    public let url: String?
+    /// The repository it works on (`github.com/org/repo`). A cloud agent has no
+    /// local folder, so this is what stands in for a project. Only the per-agent
+    /// endpoint carries it, so it arrives a beat after the row does.
+    public let repository: String?
+    public let latestRunID: String?
+    public let updatedAt: Date?
+
+    public init(id: String, name: String? = nil, status: CursorCloudAgentStatus,
+                environment: String? = nil, url: String? = nil,
+                repository: String? = nil,
+                latestRunID: String? = nil, updatedAt: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.status = status
+        self.environment = environment
+        self.url = url
+        self.repository = repository
+        self.latestRunID = latestRunID
+        self.updatedAt = updatedAt
+    }
+}
+
+/// One run — a single prompt and everything it produced.
+public struct CursorCloudRun: Equatable, Sendable {
+    public enum Status: String, Codable, Sendable {
+        case creating = "CREATING"
+        case running = "RUNNING"
+        case finished = "FINISHED"
+        case error = "ERROR"
+        case cancelled = "CANCELLED"
+        case expired = "EXPIRED"
+
+        /// Whether Cursor still considers this run live. Only one run can be
+        /// active per agent, which is what makes a follow-up land or bounce.
+        public var isLive: Bool { self == .creating || self == .running }
+    }
+
+    public let id: String
+    public let agentID: String
+    public let status: Status
+    /// The final assistant reply. Present on a terminal run only.
+    public let result: String?
+    public let branch: String?
+    public let pullRequestURL: String?
+    public let updatedAt: Date?
+
+    public init(id: String, agentID: String, status: Status, result: String? = nil,
+                branch: String? = nil, pullRequestURL: String? = nil, updatedAt: Date? = nil) {
+        self.id = id
+        self.agentID = agentID
+        self.status = status
+        self.result = result
+        self.branch = branch
+        self.pullRequestURL = pullRequestURL
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Why a Cloud Agents call did not produce an answer.
+///
+/// Deliberately closed and deliberately textual only in `message`, which carries
+/// Cursor's own `code` — never a URL, a header or any part of the key. A leaked
+/// credential in a log line is exactly what the separate Keychain slot is for.
+public enum CursorCloudError: Error, Equatable, Sendable {
+    /// No key in the Keychain. The user has not set this up.
+    case missingKey
+    /// 401 / 403 — the key is wrong, revoked, or lacks the scope.
+    case unauthorized
+    /// 409 `agent_busy`: a run is already `CREATING` or `RUNNING`. Cursor allows
+    /// exactly one live run per agent, so a follow-up must wait for it.
+    case busy
+    case notFound
+    case rateLimited
+    /// Anything else Cursor answered, reduced to its status and `code`.
+    case service(status: Int, code: String?)
+    case transport
+    case undecodable
+}
+
+/// The Cursor Cloud Agents API, v1.
+///
+/// v1 is the current surface and is in public beta; v0 is legacy. The two are
+/// shaped differently and the difference matters here: v0 had a flat
+/// `POST /v0/agents/{id}/followup`, while v1 splits the work into a **durable
+/// agent plus one run per prompt**, so a follow-up *is* `POST /v1/agents/{id}/runs`.
+/// The agent id is the `bc-…` id vibebuddy already reads out of Cursor's own
+/// composer database, so no second identity has to be kept.
+public struct CursorCloudAgentClient: Sendable {
+    public static let defaultBaseURL = URL(string: "https://api.cursor.com")!
+
+    private let baseURL: URL
+    private let apiKey: @Sendable () -> String?
+    private let transport: CursorCloudTransport
+    private let timeout: TimeInterval
+
+    public init(baseURL: URL = defaultBaseURL,
+                apiKey: @escaping @Sendable () -> String? = { CursorCloudAPIKeyStore.load() },
+                transport: CursorCloudTransport = URLSession.shared,
+                timeout: TimeInterval = 15) {
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        self.transport = transport
+        self.timeout = timeout
+    }
+
+    public var isConfigured: Bool { apiKey() != nil }
+
+    /// Every agent on the account, following `nextCursor` to the end.
+    ///
+    /// `includeArchived=false`: an archived agent is one the person filed away,
+    /// and ADR-0016 already keeps Cursor's archived conversations out of the
+    /// buckets. `pages` bounds an account with a very long history — a dashboard
+    /// is work in progress, not an archive.
+    public func agents(limit: Int = 100, pages: Int = 5) async throws -> [CursorCloudAgent] {
+        var collected: [CursorCloudAgent] = []
+        var cursor: String?
+        for _ in 0..<max(1, pages) {
+            var items = [URLQueryItem(name: "limit", value: String(limit)),
+                         URLQueryItem(name: "includeArchived", value: "false")]
+            if let cursor { items.append(URLQueryItem(name: "cursor", value: cursor)) }
+            let page: AgentListDTO = try await send("/v1/agents", method: "GET", query: items)
+            collected += page.items.compactMap(Self.agent(from:))
+            guard let next = page.nextCursor, !next.isEmpty else { break }
+            cursor = next
+        }
+        return collected
+    }
+
+    public func run(agentID: String, runID: String) async throws -> CursorCloudRun {
+        let dto: RunDTO = try await send("/v1/agents/\(encoded(agentID))/runs/\(encoded(runID))",
+                                        method: "GET")
+        guard let run = Self.run(from: dto) else { throw CursorCloudError.undecodable }
+        return run
+    }
+
+    /// Start a new run on an existing agent — v1's follow-up.
+    ///
+    /// Throws `.busy` on Cursor's `409 agent_busy`, which is what an agent with a
+    /// live run answers. Callers refuse *before* sending too; this is the race
+    /// that beats the check.
+    public func startRun(agentID: String, text: String) async throws -> CursorCloudRun {
+        let prompt = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { throw CursorCloudError.undecodable }
+        let body = try? JSONSerialization.data(withJSONObject: ["prompt": ["text": prompt]])
+        let dto: CreateRunDTO = try await send("/v1/agents/\(encoded(agentID))/runs",
+                                               method: "POST", body: body)
+        guard let run = Self.run(from: dto.run) else { throw CursorCloudError.undecodable }
+        return run
+    }
+
+    /// The per-agent record, which is the only place `repos` appears — the list
+    /// endpoint carries identity fields only.
+    public func agent(id: String) async throws -> CursorCloudAgent {
+        let dto: AgentDTO = try await send("/v1/agents/\(encoded(id))", method: "GET")
+        guard let agent = Self.agent(from: dto) else { throw CursorCloudError.undecodable }
+        return agent
+    }
+
+    /// Every run on one agent, newest first — v1's stand-in for v0's
+    /// `/conversation`, which v1 does not have. One run is one turn, and its
+    /// `result` is what that turn finally said.
+    public func runs(agentID: String, limit: Int = 20) async throws -> [CursorCloudRun] {
+        let page: RunListDTO = try await send("/v1/agents/\(encoded(agentID))/runs", method: "GET",
+                                              query: [URLQueryItem(name: "limit", value: String(limit))])
+        return page.items.compactMap(Self.run(from:))
+    }
+
+    /// Cancel a live run. Cursor answers `409 run_not_cancellable` for a run
+    /// that already reached a terminal state or never started, which is a
+    /// refusal rather than a failure — the turn the person was looking at is
+    /// already over.
+    public func cancelRun(agentID: String, runID: String) async throws {
+        let _: CancelDTO = try await send(
+            "/v1/agents/\(encoded(agentID))/runs/\(encoded(runID))/cancel", method: "POST")
+    }
+
+    /// Start the next run and say, in the person's terms, what happened.
+    ///
+    /// `busy` is the one worth its own sentence: the phone was looking at an
+    /// idle agent, a run started in between, and Cursor allows only one at a
+    /// time. Nothing was queued and nothing will be — Cursor has no waiting
+    /// room for a follow-up, so saying "try again when it finishes" is the whole
+    /// truth. Every other failure names what the person can fix, and none of
+    /// them repeats the key.
+    public func continueAgent(id: String, text: String) async -> SessionActionDelivery {
+        do {
+            _ = try await startRun(agentID: id, text: text)
+            return .accepted
+        } catch CursorCloudError.busy {
+            return .failed(String(localized: "This cloud agent started another run. Try again once it finishes."))
+        } catch CursorCloudError.missingKey {
+            return .failed(String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here."))
+        } catch CursorCloudError.unauthorized {
+            return .failed(String(localized: "Cursor refused the API key. Check it in Settings on your Mac."))
+        } catch CursorCloudError.notFound {
+            return .failed(String(localized: "Cursor no longer has this cloud agent."))
+        } catch CursorCloudError.rateLimited {
+            return .failed(String(localized: "Cursor is rate-limiting this Mac. Try again in a moment."))
+        } catch {
+            // The request may well have reached Cursor. `unknown` is the answer
+            // that tells the person to look rather than to send again.
+            return .unknown
+        }
+    }
+
+    /// The recent dialogue for a cloud agent, as `/recent-output` wants it.
+    ///
+    /// v1 has no `/conversation` endpoint — v0 did, and the agent/run split
+    /// replaced it. One run is one turn, so the runs list *is* the conversation:
+    /// each terminal run's `result` is what that turn finally said. A run still
+    /// going has no result yet and says so rather than showing nothing.
+    ///
+    /// Read-only and bounded, like every other recent-output source: fetching it
+    /// acknowledges no completion and moves no state.
+    public func recentOutput(agentID: String, limit: Int = 8,
+                             perEntryLimit: Int = 2000) async -> RecentOutput {
+        let runs: [CursorCloudRun]
+        do {
+            runs = try await self.runs(agentID: agentID, limit: limit)
+        } catch CursorCloudError.missingKey {
+            // No key is not an unreadable source; it is no source at all.
+            return .unavailable(sessionId: agentID, reason: .noSource, source: .cloud)
+        } catch {
+            return .unavailable(sessionId: agentID, reason: .unreadable, source: .cloud)
+        }
+        var entries: [RecentOutputEntry] = []
+        var truncated = false
+        // Oldest first, the way a conversation reads.
+        for run in runs.reversed() {
+            guard let text = run.result ?? Self.pendingText(for: run.status) else { continue }
+            if text.count > perEntryLimit { truncated = true }
+            entries.append(RecentOutputEntry(role: "assistant", text: String(text.prefix(perEntryLimit))))
+        }
+        return RecentOutput(sessionId: agentID, source: .cloud,
+                            updatedAt: runs.compactMap(\.updatedAt).max(),
+                            truncated: truncated, entries: entries)
+    }
+
+    /// What to show for a run with no `result`. A live run genuinely has no text
+    /// yet; a terminal one that produced none says how it ended instead of
+    /// vanishing from the conversation.
+    static func pendingText(for status: CursorCloudRun.Status) -> String? {
+        switch status {
+        case .creating, .running: return nil
+        case .finished: return nil
+        case .error: return "This run ended with an error."
+        case .cancelled: return "This run was cancelled."
+        case .expired: return "This run expired."
+        }
+    }
+
+    /// Cancel the live run and say which of the three things happened, in the
+    /// same vocabulary a Codex interrupt answers in — the phone already knows
+    /// how to read `sent` / `notSent` / `unconfirmed`.
+    ///
+    /// `run_not_cancellable` is `notSent`, not a failure: the turn the person
+    /// was looking at has already ended, and saying so is the honest answer.
+    public func cancel(agentID: String, runID: String) async -> CodexAppServerMonitor.InterruptOutcome {
+        do {
+            try await cancelRun(agentID: agentID, runID: runID)
+            return .sent
+        } catch CursorCloudError.service(_, let code) where code == "run_not_cancellable" {
+            return .notSent(String(localized: "This run has already finished."))
+        } catch CursorCloudError.missingKey {
+            return .notSent(String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here."))
+        } catch CursorCloudError.unauthorized {
+            return .notSent(String(localized: "Cursor refused the API key. Check it in Settings on your Mac."))
+        } catch CursorCloudError.notFound {
+            return .notSent(String(localized: "Cursor no longer has this run."))
+        } catch {
+            // It may have reached Cursor. Never retried, never followed by
+            // another method: the same rule the Codex interrupt follows.
+            return .unconfirmed
+        }
+    }
+
+    // MARK: - Wire
+
+    private func encoded(_ component: String) -> String {
+        component.addingPercentEncoding(withAllowedCharacters: .alphanumerics.union(CharacterSet(charactersIn: "-._~")))
+            ?? component
+    }
+
+    private func send<T: Decodable>(_ path: String, method: String,
+                                    query: [URLQueryItem] = [],
+                                    body: Data? = nil) async throws -> T {
+        guard let key = apiKey() else { throw CursorCloudError.missingKey }
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(path),
+                                             resolvingAgainstBaseURL: false) else {
+            throw CursorCloudError.transport
+        }
+        if !query.isEmpty { components.queryItems = query }
+        guard let url = components.url else { throw CursorCloudError.transport }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.setValue("VibeBuddy", forHTTPHeaderField: "User-Agent")
+        if let body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await transport.cursorCloudData(for: request)
+        } catch {
+            // The URLError's own description can name the request. Nothing from
+            // it is carried forward — the key travels in a header on that
+            // request, and no diagnostic is worth the risk of echoing it.
+            throw CursorCloudError.transport
+        }
+        guard let http = response as? HTTPURLResponse else { throw CursorCloudError.transport }
+        switch http.statusCode {
+        case 200..<300:
+            guard let decoded = try? Self.decoder.decode(T.self, from: data) else {
+                throw CursorCloudError.undecodable
+            }
+            return decoded
+        case 401, 403:
+            throw CursorCloudError.unauthorized
+        case 404:
+            throw CursorCloudError.notFound
+        case 409:
+            // `agent_busy` is the one 409 with its own meaning for us; any other
+            // conflict stays a plain service error so it is not mis-explained.
+            throw Self.errorCode(data) == "agent_busy"
+                ? CursorCloudError.busy
+                : CursorCloudError.service(status: 409, code: Self.errorCode(data))
+        case 429:
+            throw CursorCloudError.rateLimited
+        default:
+            throw CursorCloudError.service(status: http.statusCode, code: Self.errorCode(data))
+        }
+    }
+
+    /// Cursor's error body is `{"code":…,"message":…}`. Only `code` is kept:
+    /// `message` is free text from the service and has no place in a log.
+    static func errorCode(_ data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let code = object["code"] as? String, !code.isEmpty else { return nil }
+        return code
+    }
+
+    static let decoder = JSONDecoder()
+
+    struct AgentListDTO: Decodable {
+        var items: [AgentDTO]
+        var nextCursor: String?
+    }
+
+    struct AgentDTO: Decodable {
+        var id: String?
+        var name: String?
+        var status: String?
+        var env: EnvDTO?
+        var url: String?
+        var updatedAt: String?
+        var latestRunId: String?
+        var repos: [RepoDTO]?
+    }
+
+    struct EnvDTO: Decodable { var type: String? }
+
+    struct RepoDTO: Decodable {
+        var url: String?
+        var startingRef: String?
+        var prUrl: String?
+    }
+
+    struct CreateRunDTO: Decodable { var run: RunDTO }
+
+    struct RunListDTO: Decodable {
+        var items: [RunDTO]
+        var nextCursor: String?
+    }
+
+    struct CancelDTO: Decodable { var id: String? }
+
+    struct RunDTO: Decodable {
+        var id: String?
+        var agentId: String?
+        var status: String?
+        var result: String?
+        var updatedAt: String?
+        var git: GitDTO?
+    }
+
+    struct GitDTO: Decodable {
+        var branches: [BranchDTO]?
+        struct BranchDTO: Decodable {
+            var repoUrl: String?
+            var branch: String?
+            var prUrl: String?
+        }
+    }
+
+    /// An agent whose `status` this build does not recognize is dropped rather
+    /// than guessed at: a status vibebuddy cannot read must not become a state
+    /// in the three buckets. Same rule the hook parser follows.
+    static func agent(from dto: AgentDTO) -> CursorCloudAgent? {
+        guard let id = dto.id, !id.isEmpty,
+              let raw = dto.status, let status = CursorCloudAgentStatus(rawValue: raw) else { return nil }
+        return CursorCloudAgent(id: id, name: dto.name?.nilWhenBlank, status: status,
+                                environment: dto.env?.type, url: dto.url?.nilWhenBlank,
+                                repository: dto.repos?.compactMap { $0.url?.nilWhenBlank }.first,
+                                latestRunID: dto.latestRunId?.nilWhenBlank,
+                                updatedAt: dto.updatedAt.flatMap(Self.date(from:)))
+    }
+
+    static func run(from dto: RunDTO) -> CursorCloudRun? {
+        guard let id = dto.id, !id.isEmpty, let agentID = dto.agentId, !agentID.isEmpty,
+              let raw = dto.status, let status = CursorCloudRun.Status(rawValue: raw) else { return nil }
+        let branch = dto.git?.branches?.compactMap { $0.branch?.nilWhenBlank }.first
+        let pr = dto.git?.branches?.compactMap { $0.prUrl?.nilWhenBlank }.first
+        return CursorCloudRun(id: id, agentID: agentID, status: status,
+                              result: dto.result?.nilWhenBlank, branch: branch,
+                              pullRequestURL: pr, updatedAt: dto.updatedAt.flatMap(Self.date(from:)))
+    }
+
+    /// ISO 8601, with and without fractional seconds — Cursor sends both.
+    static func date(from value: String) -> Date? {
+        let withFraction = ISO8601DateFormatter()
+        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFraction.date(from: value) { return date }
+        return ISO8601DateFormatter().date(from: value)
+    }
+}
+
+private extension String {
+    var nilWhenBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+/// Jump into a Cursor cloud agent.
+///
+/// It runs on Cursor's machines, so there is no window to raise and no terminal
+/// to focus — only the page Cursor hosts for it, which the API hands back as the
+/// agent's `url`. This is the Codex Desktop shape (ADR-0011), and it follows
+/// `CodexDesktopJumper`'s rule: the value arrives from a network response, so it
+/// is checked against a closed allowlist rather than escaped. Nothing that is not
+/// recognisably a Cursor agent page is handed to a browser.
+public enum CursorCloudJumper {
+    /// `https://cursor.com/...` and nothing else: no other scheme, no other
+    /// host, no userinfo. A redirected `url` field must not become an open-redirect
+    /// through the user's default browser.
+    static func validated(_ page: String) -> URL? {
+        guard let url = URL(string: page.trimmingCharacters(in: .whitespacesAndNewlines)),
+              url.scheme?.lowercased() == "https",
+              url.user == nil, url.password == nil,
+              let host = url.host?.lowercased(),
+              host == "cursor.com" || host.hasSuffix(".cursor.com") else { return nil }
+        return url
+    }
+
+    public static func jump(page: String,
+                            open: @Sendable (URL) async -> Bool = { await openInBrowser($0) }) async -> JumpOutcome {
+        guard let url = validated(page) else { return .unsupported }
+        return await open(url) ? .focused : .unsupported
+    }
+
+    public static func openInBrowser(_ url: URL) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            process.arguments = [url.absoluteString]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            let once = Once(continuation)
+            process.terminationHandler = { once.finish($0.terminationStatus == 0) }
+            do { try process.run() } catch { once.finish(false); return }
+            DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
+                if process.isRunning { process.terminate(); once.finish(false) }
+            }
+        }
+    }
+
+    /// Resumes a continuation exactly once, whichever of the termination handler
+    /// and the timeout fires first.
+    private final class Once: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Bool, Never>?
+        init(_ continuation: CheckedContinuation<Bool, Never>) { self.continuation = continuation }
+        func finish(_ ok: Bool) {
+            lock.lock(); defer { lock.unlock() }
+            continuation?.resume(returning: ok)
+            continuation = nil
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorLauncher.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorLauncher.swift
@@ -19,7 +19,7 @@ public actor CursorLauncher {
     private let projectsRoot: URL
     private let executable: URL?
     private let terminalProgram: @Sendable () async -> String?
-    private let start: @Sendable (String, String, String?) async -> Bool
+    private let start: @Sendable (String, String, CursorLaunchOptions, String?) async -> Bool
     private let identifyTimeout: TimeInterval
     private var signedIn: Bool?
 
@@ -27,14 +27,14 @@ public actor CursorLauncher {
                 executable: URL? = CursorCLI.resolveExecutable(),
                 terminalProgram: @escaping @Sendable () async -> String? = { nil },
                 identifyTimeout: TimeInterval = 8,
-                start: (@Sendable (String, String, String?) async -> Bool)? = nil) {
+                start: (@Sendable (String, String, CursorLaunchOptions, String?) async -> Bool)? = nil) {
         self.projectsRoot = projectsRoot
         self.executable = executable
         self.terminalProgram = terminalProgram
         self.identifyTimeout = identifyTimeout
         let resolved = executable
-        self.start = start ?? { prompt, cwd, term in
-            await CursorCLI.start(prompt: prompt, executable: resolved, cwd: cwd, preferring: term)
+        self.start = start ?? { prompt, cwd, options, term in
+            await CursorCLI.start(prompt: prompt, executable: resolved, cwd: cwd, options: options, preferring: term)
         }
     }
 
@@ -63,8 +63,13 @@ public actor CursorLauncher {
         guard await isSupported() else {
             return .unavailable("The Cursor CLI is not signed in — run `cursor-agent login` on this Mac")
         }
+        let options: CursorLaunchOptions
+        switch CursorLaunchOptions.from(request) {
+        case .success(let parsed): options = parsed
+        case .failure(let why): return .rejected(why.message)
+        }
         let before = conversationIDs(inProject: request.cwd)
-        guard await start(request.prompt, request.cwd, await terminalProgram()) else {
+        guard await start(request.prompt, request.cwd, options, await terminalProgram()) else {
             return .unavailable("Couldn't open a terminal running cursor-agent")
         }
         let deadline = Date().addingTimeInterval(identifyTimeout)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorParser.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorParser.swift
@@ -45,6 +45,12 @@ public enum CursorParser {
         let aborted = event == "stop" && status == "aborted"
         let succeeded: Bool? = event == "stop" ? (status == nil || status == "completed") : nil
 
+        // `postToolUseFailure` also names a cause. `is_interrupt` is the person
+        // cancelling in Cursor and `permission_denied` is Cursor's own gate (or
+        // the phone) saying no; neither is the tool breaking, so neither may
+        // ring the error cue. `error` and `timeout` remain real failures.
+        let interrupted = event == "postToolUseFailure" && raw.isInterrupt == true
+
         let base = HookEvent(
             kind: kind,
             sessionID: sessionID,
@@ -53,7 +59,7 @@ public enum CursorParser {
             toolName: toolName(for: event, raw: raw),
             message: message(for: event, raw: raw),
             transcriptPath: nonEmpty(raw.transcriptPath),
-            model: nonEmpty(raw.model) ?? nonEmpty(raw.modelId),
+            model: modelDisplay(raw),
             toolError: kind == .postToolUse && isToolFailure(event, raw: raw, data: data),
             timestamp: receivedAt,
             // No `turnID`: Cursor's `generation_id` names one model generation,
@@ -62,9 +68,117 @@ public enum CursorParser {
             // unconditionally, as Claude's and Codex's do.
             enrichment: enrichment(for: event, raw: raw),
             completionText: nil,
-            completionSucceeded: succeeded
+            completionSucceeded: succeeded,
+            // `composer_mode` is `agent`, `ask` or `edit`. Ask and Edit chats are
+            // a question and an answer, not a task with an ending: they must not
+            // enter the three states or ring a cue, so the store drops them.
+            observeOnly: event == "sessionStart" && isObserveOnlyMode(raw.composerMode),
+            toolOutput: toolOutput(for: event, raw: raw, data: data)
         )
-        return .event(aborted ? base.markingUserStop() : base)
+        return .event(aborted || interrupted ? base.markingUserStop() : base)
+    }
+
+    /// `ask` and `edit` are Cursor's non-agentic composer modes.
+    static func isObserveOnlyMode(_ mode: String?) -> Bool {
+        switch nonEmpty(mode) {
+        case "ask", "edit": return true
+        default: return false
+        }
+    }
+
+    // MARK: - Model display
+
+    /// `model_id` is the stable identifier (`claude-opus-4-7`); `model` is the
+    /// display label Cursor shows in its picker and may change wording between
+    /// releases, so the id wins when both are present. `model_params` carries
+    /// the picker's toggles as `[{id, value}]` — `context` (`"1m"`), `effort`
+    /// (`"max"`) and `thinking` (`"true"`) — which are part of what the person
+    /// chose and worth a suffix: `claude-opus-4-7 (1m, max, thinking)`.
+    static func modelDisplay(_ raw: RawCursor) -> String? {
+        guard let name = nonEmpty(raw.modelId) ?? nonEmpty(raw.model) else { return nil }
+        var parts: [String] = []
+        let params = raw.modelParams ?? []
+        func value(_ id: String) -> String? {
+            nonEmpty(params.first { $0.id == id }?.value)
+        }
+        if let context = value("context") { parts.append(context) }
+        if let effort = value("effort") { parts.append(effort) }
+        if value("thinking")?.lowercased() == "true" { parts.append("thinking") }
+        return parts.isEmpty ? name : "\(name) (\(parts.joined(separator: ", ")))"
+    }
+
+    // MARK: - Tool output
+
+    /// How much of a tool result the recent-output pane keeps per entry —
+    /// the same bound `RecentOutputReader` applies to the Claude transcript.
+    static let toolOutputLimit = 600
+
+    /// The result text a tool hook carried. `postToolUse.tool_output` is a
+    /// JSON-*stringified* result payload (`"{\"exitCode\":0,\"stdout\":…}"`)
+    /// for shell tools and free text for others; `afterShellExecution.output`
+    /// is the full terminal output. A structured payload is rendered as
+    /// `exit <code>` / stdout / stderr so the pane reads like a terminal; any
+    /// other string is used as is. Bounded, because a hook must never hand the
+    /// phone a whole build log.
+    static func toolOutput(for event: String, raw: RawCursor, data: Data) -> String? {
+        let text: String?
+        switch event {
+        case "afterShellExecution":
+            text = nonEmpty(raw.output)
+        case "postToolUse":
+            // Read the raw JSON: `tool_output` is a string for some tools and an
+            // object for others, and `Decodable` cannot hold both.
+            let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            switch obj?["tool_output"] {
+            case let string as String:
+                text = normalizedToolOutput(string)
+            case let object as [String: Any]:
+                text = renderedToolOutput(object)
+            default:
+                text = nil
+            }
+        default:
+            return nil
+        }
+        guard let text = nonEmpty(text) else { return nil }
+        return truncatedToolOutput(text)
+    }
+
+    /// The string form: if it parses as a result object with `stdout` /
+    /// `stderr` / `exitCode` (or `exit_code`), render that; else the raw text.
+    static func normalizedToolOutput(_ string: String) -> String? {
+        if let object = (try? JSONSerialization.jsonObject(with: Data(string.utf8))) as? [String: Any],
+           let rendered = renderedToolOutput(object) {
+            return rendered
+        }
+        return string
+    }
+
+    /// `exit <code>\n<stdout>[\n<stderr>]`, the exit line omitted when the
+    /// payload carries no code. Nil when the object is not a result payload.
+    static func renderedToolOutput(_ object: [String: Any]) -> String? {
+        let stdout = (object["stdout"] as? String).flatMap(nonEmpty)
+        let stderr = (object["stderr"] as? String).flatMap(nonEmpty)
+        let code = (object["exitCode"] ?? object["exit_code"]).flatMap(exitCode)
+        guard stdout != nil || stderr != nil || code != nil else { return nil }
+        var lines: [String] = []
+        if let code { lines.append("exit \(code)") }
+        if let stdout { lines.append(stdout) }
+        if let stderr { lines.append(stderr) }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func exitCode(_ value: Any) -> Int? {
+        switch value {
+        case let n as NSNumber: return n.intValue
+        case let s as String: return Int(s)
+        default: return nil
+        }
+    }
+
+    static func truncatedToolOutput(_ text: String) -> String {
+        guard text.count > toolOutputLimit else { return text }
+        return String(text.prefix(toolOutputLimit)) + "…"
     }
 
     // MARK: - Event mapping
@@ -121,6 +235,13 @@ public enum CursorParser {
         case "afterAgentResponse":
             return nonEmpty(raw.text).map { String($0.prefix(220)) }
         case "postToolUseFailure":
+            // The row's line for a failure names the cause. An interrupt is the
+            // person's own doing, so it says so rather than quoting Cursor's
+            // generic "interrupted" text.
+            if raw.isInterrupt == true { return "Stopped by you" }
+            if nonEmpty(raw.failureType) == "permission_denied" {
+                return nonEmpty(raw.errorMessage) ?? "Denied"
+            }
             return nonEmpty(raw.errorMessage) ?? nonEmpty(raw.failureType)
         case "stop":
             switch nonEmpty(raw.status) {
@@ -146,12 +267,19 @@ public enum CursorParser {
         return TranscriptInfo(contextTokens: used, contextWindow: window)
     }
 
-    /// Did this tool call fail? `postToolUseFailure` is explicit; a plain
-    /// `postToolUse` can still carry an error marker inside `tool_output`, and an
+    /// Did this tool call fail? `postToolUseFailure` is explicit, with two
+    /// documented exceptions: `is_interrupt` (the person cancelled) and
+    /// `failure_type == "permission_denied"` (a gate said no) are not the tool
+    /// breaking, so only `error` and `timeout` count. A plain `postToolUse` can
+    /// still carry an error marker inside `tool_output`, and an
     /// `afterShellExecution` can report a non-zero exit. Read `tool_output`
     /// defensively — it is a string for some tools and an object for others.
     static func isToolFailure(_ event: String, raw: RawCursor, data: Data) -> Bool {
-        if event == "postToolUseFailure" { return true }
+        if event == "postToolUseFailure" {
+            if raw.isInterrupt == true { return false }
+            if nonEmpty(raw.failureType) == "permission_denied" { return false }
+            return true
+        }
         guard let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { return false }
         if let output = obj["tool_output"] as? [String: Any] {
             if isTruthy(output["is_error"]) { return true }
@@ -210,6 +338,8 @@ public enum CursorParser {
         let generationId: String?
         let model: String?
         let modelId: String?
+        /// `[{id, value}]`: the picker's toggles (`thinking`, `context`, `effort`).
+        let modelParams: [ModelParam]?
         let transcriptPath: String?
         let workspaceRoots: [String]?
         let cursorVersion: String?
@@ -228,6 +358,8 @@ public enum CursorParser {
         let isInterrupt: Bool?
         // shell / MCP / file gates
         let command: String?
+        /// `afterShellExecution`: the full terminal output.
+        let output: String?
         let filePath: String?
         let mcpServerName: String?
         // prompt / response
@@ -248,5 +380,29 @@ public enum CursorParser {
         let description: String?
         let summary: String?
         let agentTranscriptPath: String?
+    }
+
+    /// One `model_params` entry. Cursor sends the value as a string
+    /// (`"true"`, `"1m"`, `"max"`); anything else decodes as nil rather than
+    /// failing the envelope.
+    struct ModelParam: Decodable {
+        let id: String?
+        let value: String?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try? container.decode(String.self, forKey: .id)
+            if let string = try? container.decode(String.self, forKey: .value) {
+                value = string
+            } else if let bool = try? container.decode(Bool.self, forKey: .value) {
+                value = bool ? "true" : "false"
+            } else if let number = try? container.decode(Double.self, forKey: .value) {
+                value = number == number.rounded() ? String(Int(number)) : String(number)
+            } else {
+                value = nil
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey { case id, value }
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorParser.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/CursorParser.swift
@@ -197,13 +197,16 @@ public enum CursorParser {
         case "postToolUse", "postToolUseFailure", "afterShellExecution",
              "afterMCPExecution", "afterFileEdit": return .postToolUse
         case "afterAgentResponse": return .sessionMetadataChanged
+        // A finished thinking block is activity the way a tool call is: the row
+        // reads "Thinking…" until the next tool or the agent's reply replaces
+        // it. It carries no progress transition and never a tool error.
+        case "afterAgentThought": return .preToolUse
         case "stop": return .stop
         case "sessionEnd": return .sessionEnd
-        // Thought deltas, Tab completions and workspace open are understood and
-        // deliberately dropped: they say nothing about the three states and
-        // would only churn the snapshot.
-        case "afterAgentThought", "workspaceOpen",
-             "beforeTabFileRead", "afterTabFileEdit": return nil
+        // Tab completions and workspace open are understood and deliberately
+        // dropped: they say nothing about the three states and would only
+        // churn the snapshot.
+        case "workspaceOpen", "beforeTabFileRead", "afterTabFileEdit": return nil
         default: return nil
         }
     }
@@ -212,6 +215,8 @@ public enum CursorParser {
     /// they borrow the canonical name the vocabulary gives them.
     static func toolName(for event: String, raw: RawCursor) -> String? {
         switch event {
+        case "afterAgentThought":
+            return "Thinking"
         case "beforeShellExecution", "afterShellExecution":
             return "Bash"
         case "beforeMCPExecution", "afterMCPExecution":

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookDecoder.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookDecoder.swift
@@ -47,8 +47,46 @@ public enum HookDecoder {
             // (BeforeTool/AfterAgent/…), plus the Antigravity-2.0 spelling.
             return result(AntigravityParser.parse(data, receivedAt: receivedAt))
         default:
+            // Cursor calls Claude Code hooks with its *own* payload once the
+            // person enables "Include third-party Plugins, Skills, and other
+            // configs" (cursor.com/docs/reference/third-party-hooks): the
+            // command registered in ~/.claude/settings.json runs with
+            // `cursor_version`, `conversation_id` and a camelCase
+            // `hook_event_name`, tagged `?agent=claude-code` by the forwarder.
+            // Without this sniff one Cursor chat would appear twice — once from
+            // ~/.cursor/hooks.json as a Cursor session and once here as a Claude
+            // session keyed on a `session_id` Cursor does not send.
+            if isCursorEnvelope(data) {
+                return CursorParser.parse(data, receivedAt: receivedAt)
+            }
             return result(HookParser.parse(data, agent: agent, receivedAt: receivedAt))
         }
+    }
+
+    /// Cursor's camelCase hook names (cursor.com/docs/hooks). A Claude-shape
+    /// CLI spells its events in PascalCase (`PreToolUse`), so a match here is
+    /// unambiguous even when `cursor_version` is absent.
+    static let cursorEventNames: Set<String> = [
+        "sessionStart", "sessionEnd", "preToolUse", "postToolUse", "postToolUseFailure",
+        "beforeShellExecution", "afterShellExecution", "beforeMCPExecution",
+        "afterMCPExecution", "beforeReadFile", "afterFileEdit", "beforeSubmitPrompt",
+        "preCompact", "stop", "afterAgentResponse", "afterAgentThought",
+        "subagentStart", "subagentStop", "workspaceOpen",
+    ]
+
+    /// A cheap look at two envelope fields, so the sniff costs a tiny decode
+    /// rather than a full parse on every Claude hook.
+    static func isCursorEnvelope(_ data: Data) -> Bool {
+        struct Sniff: Decodable {
+            let cursorVersion: String?
+            let hookEventName: String?
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        guard let sniff = try? decoder.decode(Sniff.self, from: data) else { return false }
+        if let version = sniff.cursorVersion, !version.isEmpty { return true }
+        if let name = sniff.hookEventName, cursorEventNames.contains(name) { return true }
+        return false
     }
 
     private static func result(_ event: HookEvent?) -> Result {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HookEvent.swift
@@ -85,6 +85,16 @@ public struct HookEvent: Sendable, Equatable {
     /// nil for progress-only endings with no result evidence.
     public let completionSucceeded: Bool?
     public let sourceCompletionID: String?
+    /// True when the source says this session is a conversation to read, not a
+    /// task to track: a Cursor chat whose `composer_mode` is `ask` or `edit`
+    /// (cursor.com/docs/hooks, `sessionStart`). Such a session must not enter
+    /// the three states or ring a cue; the store drops it before the reducer.
+    public let observeOnly: Bool
+    /// The tool's result text when the hook carried one (Cursor's
+    /// `postToolUse.tool_output`, `afterShellExecution.output`), already
+    /// normalised and bounded. Feeds the recent-output pane only; the
+    /// reducer never reads it.
+    public let toolOutput: String?
 
     public init(
         kind: Kind,
@@ -112,7 +122,9 @@ public struct HookEvent: Sendable, Equatable {
         userStopped: Bool = false,
         completionText: String? = nil,
         completionSucceeded: Bool? = nil,
-        sourceCompletionID: String? = nil
+        sourceCompletionID: String? = nil,
+        observeOnly: Bool = false,
+        toolOutput: String? = nil
     ) {
         self.kind = kind
         self.sessionID = sessionID
@@ -140,6 +152,8 @@ public struct HookEvent: Sendable, Equatable {
         self.completionText = completionText
         self.completionSucceeded = completionSucceeded
         self.sourceCompletionID = sourceCompletionID
+        self.observeOnly = observeOnly
+        self.toolOutput = toolOutput
     }
 
     /// Mark this ending as the answer to a stop the user asked for.
@@ -153,7 +167,7 @@ public struct HookEvent: Sendable, Equatable {
             childAction: childAction, turnID: turnID, enrichment: enrichment,
             desktopThreadID: desktopThreadID, probeRetirement: probeRetirement, userStopped: true,
             completionText: completionText, completionSucceeded: completionSucceeded,
-            sourceCompletionID: sourceCompletionID)
+            sourceCompletionID: sourceCompletionID, observeOnly: observeOnly, toolOutput: toolOutput)
     }
 
     /// Stamp the rollout file this event was tailed from, so a later read-only
@@ -167,6 +181,7 @@ public struct HookEvent: Sendable, Equatable {
             childKind: childKind, childName: childName, childType: childType,
             childAction: childAction, turnID: turnID, enrichment: enrichment,
             desktopThreadID: desktopThreadID, probeRetirement: probeRetirement, userStopped: userStopped,
-            completionText: completionText, completionSucceeded: completionSucceeded, sourceCompletionID: sourceCompletionID)
+            completionText: completionText, completionSucceeded: completionSucceeded, sourceCompletionID: sourceCompletionID,
+            observeOnly: observeOnly, toolOutput: toolOutput)
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/QuestionRegistry.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/QuestionRegistry.swift
@@ -145,6 +145,16 @@ public struct AnswerDispatch: Sendable {
     /// Continue a finished Cursor chat by resuming it in a terminal
     /// (`cursor-agent --resume <id>`). False when the CLI is unavailable.
     public let resumeCursor: @Sendable (AgentSession, String) async -> Bool
+    /// Continue a Cursor **cloud** agent by starting its next run over the Cloud
+    /// Agents API. Returns the delivery verdict directly because the interesting
+    /// failure is Cursor's own `409 agent_busy` — a run started between the
+    /// snapshot the phone saw and this call — and that is a different sentence
+    /// from "the key is missing".
+    public let continueCursorCloud: @Sendable (String, String) async -> SessionActionDelivery
+    /// Cancel the live run on a Cursor cloud agent. Answers in the same three
+    /// outcomes a Codex interrupt does, because they mean the same three things
+    /// to the person who tapped Stop.
+    public let cancelCursorCloud: @Sendable (String) async -> CodexAppServerMonitor.InterruptOutcome
     public let requests: ActionRequestLog
 
     public init(store: SessionStore, questions: QuestionRegistry,
@@ -155,6 +165,10 @@ public struct AnswerDispatch: Sendable {
                     = { _ in .notSent(String(localized: "This Mac cannot stop Codex tasks.")) },
                 queueCursorFollowup: @escaping @Sendable (String, String) async -> Bool = { _, _ in false },
                 resumeCursor: @escaping @Sendable (AgentSession, String) async -> Bool = { _, _ in false },
+                continueCursorCloud: @escaping @Sendable (String, String) async -> SessionActionDelivery
+                    = { _, _ in .failed(String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here.")) },
+                cancelCursorCloud: @escaping @Sendable (String) async -> CodexAppServerMonitor.InterruptOutcome
+                    = { _ in .notSent(String(localized: "Add a Cursor API key on your Mac to reach cloud agents from here.")) },
                 requests: ActionRequestLog = ActionRequestLog()) {
         self.store = store
         self.questions = questions
@@ -164,6 +178,8 @@ public struct AnswerDispatch: Sendable {
         self.interrupt = interrupt
         self.queueCursorFollowup = queueCursorFollowup
         self.resumeCursor = resumeCursor
+        self.continueCursorCloud = continueCursorCloud
+        self.cancelCursorCloud = cancelCursorCloud
         self.requests = requests
     }
 
@@ -253,6 +269,13 @@ public struct AnswerDispatch: Sendable {
                 guard session.status == .done else {
                     return .failed("This session is still running")
                 }
+                // A cloud agent has no terminal to resume into and no local
+                // conversation for the CLI to open. Continuing it means asking
+                // Cursor to start the next run on the same agent, which is what
+                // v1 replaced the old `followup` verb with.
+                if SessionActionSupport.isCursorCloudAgent(session) {
+                    return await continueCursorCloud(session.id, typed)
+                }
                 guard await resumeCursor(session, typed) else {
                     return .failed("This Mac can't resume Cursor chats — the Cursor CLI isn't available.")
                 }
@@ -310,7 +333,12 @@ public struct AnswerDispatch: Sendable {
         guard abs(session.statusSince.timeIntervalSince1970 - expected) < 0.001 else {
             return .refused("This task has changed")
         }
-        switch await interrupt(request.sessionID) {
+        // A cloud run is cancelled through Cursor's own API; a local Codex turn
+        // through the app-server daemon. Both answer the same three outcomes.
+        let outcome = SessionActionSupport.isCursorCloudAgent(session)
+            ? await cancelCursorCloud(request.sessionID)
+            : await interrupt(request.sessionID)
+        switch outcome {
         case .sent: return .accepted
         case .notSent(let why): return .failed(why)
         case .unconfirmed: return .unknown

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/RecentOutputReader.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/RecentOutputReader.swift
@@ -180,8 +180,10 @@ public enum RecentOutputReader {
 
     // MARK: - Shared
 
-    private static func bound(_ entries: [TranscriptEntry], limit: Int,
-                              perEntryLimit: Int) -> RecentOutputSlice {
+    /// Shared bounding for every adapter and for the store's Cursor hook log,
+    /// so a hook-fed slice obeys the same limits as a transcript-fed one.
+    static func bound(_ entries: [TranscriptEntry], limit: Int,
+                      perEntryLimit: Int) -> RecentOutputSlice {
         var truncated = entries.count > limit
         let clipped = entries.suffix(limit).map { entry -> TranscriptEntry in
             if entry.text.count > perEntryLimit {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -16,6 +16,59 @@ public actor SessionStore {
     /// rows read facts out of it; conversations with no live evidence become
     /// history rows.
     private var cursorComposers: [String: CursorComposer] = [:]
+    /// Cursor conversations whose `sessionStart` said `composer_mode` is `ask`
+    /// or `edit`. Such a chat is a question and an answer, not a task: it must
+    /// not enter the three states, mint a completion or ring a cue, so every
+    /// event for it — from the hook *and* from the transcript tailer, since
+    /// both key on the same conversation id — is dropped before the reducer.
+    /// `sessionEnd` releases the id. The set is memory-only: a chat that was
+    /// Ask before a daemon restart re-announces its mode on its next start.
+    private var cursorObserveOnly: Set<String> = []
+    /// Per Cursor conversation, the dialogue the hooks themselves carried —
+    /// prompts, replies, tool markers and tool *results*. The agent transcript
+    /// records no tool results, so while the hooks are live this is the richer
+    /// recent-output source; bounded like every other slice.
+    private var cursorHookLog: [String: [TranscriptEntry]] = [:]
+    static let cursorHookLogLimit = 24
+    /// Cursor conversations the ACP host is carrying right now. While one is,
+    /// that pipe is the live source and the write path: hook and transcript
+    /// events for the same id only corroborate, the hook gate says nothing, and
+    /// the row is stamped `ControlChannel.acp`. Memory-only: the processes die
+    /// with the daemon, so nothing here outlives it either.
+    private var acpHosted: Set<String> = []
+
+    /// The ACP host took over (or let go of) a conversation.
+    public func setACPHosted(sessionID: String, _ hosted: Bool) {
+        let changed = hosted ? acpHosted.insert(sessionID).inserted : acpHosted.remove(sessionID) != nil
+        if changed { broadcast() }
+    }
+
+    public func isACPHosted(_ sessionID: String) -> Bool { acpHosted.contains(sessionID) }
+
+    /// The write path the daemon would use for this session, stamped on every
+    /// snapshot so the phone and the Watch decide availability from one fact
+    /// (ADR-0016, second amendment). Codex: the app-server while it is fresh.
+    /// Cursor: the ACP host it lives on, else the cloud API that reports it,
+    /// else its hooks while they are fresh, else nothing reachable. Other
+    /// agents carry no stamp and keep their agent-based rules.
+    func controlChannel(for session: AgentSession, now: Date) -> ControlChannel? {
+        func fresh(_ source: ObservationSource, within window: TimeInterval) -> Bool {
+            guard let evidence = session.observations?.first(where: { $0.source == source }),
+                  evidence.health.isHealthy else { return false }
+            return now.timeIntervalSince(evidence.lastObservedAt) < window
+        }
+        switch session.agent {
+        case .codex:
+            return fresh(.appserver, within: Self.appServerAuthorityWindow) ? .appserver : nil
+        case .cursor:
+            if acpHosted.contains(session.id) { return .acp }
+            if session.observations?.contains(where: { $0.source == .cloud && $0.health.isHealthy }) == true { return .cloud }
+            if fresh(.hook, within: Self.cursorHookAuthorityWindow) { return .hook }
+            return ControlChannel.none
+        default:
+            return nil
+        }
+    }
 
     /// History bypasses the lifecycle reducer: imports never earn completion cues.
     public func refreshCopilotHistory() {
@@ -308,6 +361,7 @@ public actor SessionStore {
             completionResults.runs[id] = nil
             completionResults.candidates[id] = nil
             transcriptPaths[id] = nil
+            cursorHookLog[id] = nil
             grokDirectories[id] = nil
             lastInteractionAt[id] = nil
         }
@@ -445,6 +499,16 @@ public actor SessionStore {
         return true
     }
 
+    /// While the ACP host carries a Cursor conversation, the hooks Cursor still
+    /// fires for it and the transcript it still writes describe the same turn
+    /// a beat later; they may corroborate but must not move the three states
+    /// or mint a second completion. `sessionEnd` passes: a process that has
+    /// really gone is a fact the pipe reports by closing, not by an event.
+    private func acpOutranks(_ event: HookEvent, from source: ObservationSource) -> Bool {
+        event.agent == .cursor && source != .acp && event.kind != .sessionEnd
+            && acpHosted.contains(event.sessionID)
+    }
+
     private func appServerOutranks(_ event: HookEvent, from source: ObservationSource) -> Bool {
         guard event.agent == .codex, source != .appserver, event.kind != .sessionEnd,
               let session = reducer.sessions[event.sessionID],
@@ -461,9 +525,12 @@ public actor SessionStore {
         recordsEvidence: Bool = true,
         announcesWait: Bool = true
     ) {
+        if dropsCursorObserveOnly(event) { return }
+        recordCursorHookLog(event, from: observationSource)
         // A corroborating source may supply the menu's read-only round evidence.
         if let path = event.transcriptPath { transcriptPaths[event.sessionID] = path }
         if appServerOutranks(event, from: observationSource)
+            || acpOutranks(event, from: observationSource)
             || cursorHooksOutrank(event, from: observationSource) {
             // Corroboration cannot drive progress, but evidence of a newer run
             // must prevent returning an older result while authority catches up.
@@ -509,6 +576,7 @@ public actor SessionStore {
         if reducer.sessions[event.sessionID] == nil {
             // Session was removed (e.g. SessionEnd) — forget its side data.
             transcriptPaths[event.sessionID] = nil
+            cursorHookLog[event.sessionID] = nil
             pendingTerminalRefs[event.sessionID] = nil
             grokDirectories[event.sessionID] = nil
             lastInteractionAt[event.sessionID] = nil
@@ -546,6 +614,66 @@ public actor SessionStore {
            session.status == .needsResponse, let handler = needsResponseHandler {
             Task { await handler(session) }
         }
+    }
+
+    /// An Ask or Edit chat in Cursor (`composer_mode` on `sessionStart`,
+    /// cursor.com/docs/hooks) never becomes a row: its `sessionStart` enrols the
+    /// id and is dropped, every later event for that id is dropped, and its
+    /// `sessionEnd` releases the id and is dropped too. Nothing is reduced,
+    /// recorded as evidence or broadcast, so the chat cannot enter the three
+    /// states or ring a cue. Keyed on the conversation id, so the transcript
+    /// tailer's events for the same chat are held back as well.
+    private func dropsCursorObserveOnly(_ event: HookEvent) -> Bool {
+        guard event.agent == .cursor else { return false }
+        if event.kind == .sessionStart, event.observeOnly {
+            cursorObserveOnly.insert(event.sessionID)
+            cursorHookLog[event.sessionID] = nil
+            return true
+        }
+        guard cursorObserveOnly.contains(event.sessionID) else { return false }
+        if event.kind == .sessionEnd { cursorObserveOnly.remove(event.sessionID) }
+        return true
+    }
+
+    /// Append what a Cursor hook said to the conversation's hook log: the
+    /// prompt, the agent's reply, a "⚙ tool" marker for each tool it reaches
+    /// for, and the tool's result when the hook carried one. Only the hook
+    /// source writes here — the transcript has its own reader.
+    private func recordCursorHookLog(_ event: HookEvent, from source: ObservationSource) {
+        guard event.agent == .cursor, source == .hook else { return }
+        let entry: TranscriptEntry?
+        switch event.kind {
+        case .userPromptSubmit:
+            entry = event.message.map { TranscriptEntry(role: "user", text: $0) }
+        case .sessionMetadataChanged:
+            entry = event.message.map { TranscriptEntry(role: "assistant", text: $0) }
+        case .preToolUse:
+            entry = event.toolName.map { TranscriptEntry(role: "assistant", text: "⚙ \($0)") }
+        case .postToolUse:
+            entry = event.toolOutput.map { TranscriptEntry(role: "assistant", text: $0) }
+        case .sessionEnd:
+            cursorHookLog[event.sessionID] = nil
+            return
+        default:
+            entry = nil
+        }
+        guard let entry else { return }
+        var log = cursorHookLog[event.sessionID] ?? []
+        log.append(entry)
+        if log.count > Self.cursorHookLogLimit {
+            log.removeFirst(log.count - Self.cursorHookLogLimit)
+        }
+        cursorHookLog[event.sessionID] = log
+    }
+
+    /// Whether Cursor's hooks reported this conversation within
+    /// `cursorHookAuthorityWindow` — the same freshness that lets a hook
+    /// outrank the transcript on progress (`cursorHooksOutrank`).
+    private func hasFreshCursorHookEvidence(sessionID: String, now: Date) -> Bool {
+        guard let session = reducer.sessions[sessionID],
+              let evidence = session.observations?.first(where: { $0.source == .hook }),
+              evidence.health.isHealthy else { return false }
+        return now.timeIntervalSince(evidence.lastObservedAt) < Self.cursorHookAuthorityWindow
     }
 
     /// Wait at most until two seconds after the original ending. Results are
@@ -854,6 +982,7 @@ public actor SessionStore {
             session.attention = attention[session.id]
                 ?? AutoAttention.level(lastInteractionAt: lastInteractionAt[session.id], now: now)
             session.completionNotice = completionNotice(for: session, now: now)
+            session.controlChannel = controlChannel(for: session, now: now)
             return session
         }
         let active = Set(snapshot.sessions.compactMap { $0.completionNotice?.id })
@@ -940,6 +1069,23 @@ public actor SessionStore {
                 sessionID: sessionID, source: .appserver, path: nil,
                 RecentOutputReader.codexAppServer(
                     items: items, limit: limit, perEntryLimit: perEntryLimit))
+        }
+        // Cursor has two dialogue sources and one rule for choosing between
+        // them: the hooks are the live source while their evidence is fresh
+        // within `cursorHookAuthorityWindow`, the transcript otherwise. It is
+        // the same window that decides which source drives progress
+        // (`cursorHooksOutrank`), so the pane and the row never disagree about
+        // who is speaking for the session. The hook log is also the only place
+        // tool *results* exist — the agent transcript records none.
+        if session.agent == .cursor,
+           let log = cursorHookLog[sessionID], !log.isEmpty,
+           hasFreshCursorHookEvidence(sessionID: sessionID, now: Date()) {
+            let bounded = RecentOutputReader.bound(log, limit: limit, perEntryLimit: perEntryLimit)
+            return RecentOutput(
+                sessionId: sessionID, source: .hook,
+                updatedAt: session.observations?.first(where: { $0.source == .hook })?.lastObservedAt,
+                truncated: bounded.truncated,
+                entries: bounded.entries.map { RecentOutputEntry(role: $0.role, text: $0.text) })
         }
         let path = rolloutPath ?? transcriptPaths[sessionID]
         guard let path else {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -296,6 +296,8 @@ public actor SessionStore {
     public let sourceID: String?
     /// Account allowance, kept beside the reducer rather than inside it.
     private var providerQuota: [ProviderQuota] = []
+    /// Models the signed-in Cursor CLI lists, for a Cursor dispatch.
+    private var cursorModels: [String] = []
     private var subscribers: [UUID: AsyncStream<Snapshot>.Continuation] = [:]
     private var needsResponseHandler: (@Sendable (AgentSession) async -> Void)?
     private var staleAfter: TimeInterval
@@ -1023,6 +1025,15 @@ public actor SessionStore {
         broadcast()
     }
 
+    /// Replace the Cursor model list the phone may choose from. Account
+    /// state like quota: composed into every snapshot, never near the reducer,
+    /// broadcast on change so a fresh sign-in reaches the sheet.
+    public func setCursorModels(_ models: [String]) {
+        guard models != cursorModels else { return }
+        cursorModels = models
+        broadcast()
+    }
+
     /// The one place a runtime snapshot is assembled: sessions and diagnostics
     /// from the reducer, allowance from beside it.
     private func currentSnapshot(now: Date) -> Snapshot {
@@ -1046,6 +1057,7 @@ public actor SessionStore {
         snapshot.providerQuota = providerQuota.isEmpty ? nil : providerQuota
         let directories = recentDirectories()
         snapshot.recentDirectories = directories.isEmpty ? nil : directories
+        snapshot.cursorModels = cursorModels.isEmpty ? nil : cursorModels
         snapshot.sessions = snapshot.sessions.map { session in
             var session = session
             session.attentionOverride = attention[session.id]

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -138,6 +138,64 @@ public actor SessionStore {
         return changed
     }
 
+    /// Cursor's cloud agents, keyed by agent id, as the Cloud Agents API last
+    /// reported them. Unlike the composer store this *is* the source for these
+    /// conversations: they run on Cursor's machines and appear nowhere on this
+    /// Mac — not in `composerHeaders`, not as a transcript, not as a hook.
+    private var cursorCloudAgents: [String: CursorCloudAgent] = [:]
+
+    /// Take the monitor's view of the account. Rows with no live session become
+    /// quiet history rows; rows the monitor has moved into the three states keep
+    /// whatever the reducer holds.
+    public func applyCursorCloudAgents(_ agents: [CursorCloudAgent]) {
+        let next = Dictionary(agents.filter { $0.status != .archived }.map { ($0.id, $0) },
+                              uniquingKeysWith: { _, last in last })
+        guard next != cursorCloudAgents else { return }
+        cursorCloudAgents = next
+        broadcast()
+    }
+
+    /// Where a cloud agent can actually be opened. It has no window on this Mac
+    /// and no terminal, so its Cursor web page is the only honest jump — the
+    /// same shape as a Codex Desktop thread's.
+    public func cursorCloudAgentURL(for sessionID: String) -> String? {
+        cursorCloudAgents[sessionID]?.url
+    }
+
+    /// The run a stop would cancel. Nil when the agent is not live, which is
+    /// also when there is nothing to cancel.
+    public func cursorCloudLatestRun(for sessionID: String) -> String? {
+        guard let agent = cursorCloudAgents[sessionID], agent.status == .active else { return nil }
+        return agent.latestRunID
+    }
+
+    /// How many cloud agents get a history row, for the same reason
+    /// `cursorHistoryLimit` exists.
+    static let cursorCloudHistoryLimit = 50
+
+    /// A cloud agent vibebuddy has only ever seen finished: a quiet history row
+    /// that never earns a completion cue, exactly like an imported Copilot
+    /// session. Its repository stands in for a project, because it has no folder.
+    private func cursorCloudHistorySessions() -> [AgentSession] {
+        cursorCloudAgents.values
+            .filter { reducer.sessions[$0.id] == nil }
+            .sorted { lhs, rhs in
+                let left = lhs.updatedAt ?? .distantPast, right = rhs.updatedAt ?? .distantPast
+                return left == right ? lhs.id < rhs.id : left > right
+            }
+            .prefix(Self.cursorCloudHistoryLimit)
+            .map { agent in
+                let when = agent.updatedAt ?? Date()
+                var session = AgentSession(
+                    id: agent.id, agent: .cursor,
+                    project: agent.repository ?? String(localized: "Cursor cloud agent"),
+                    status: .done, name: agent.name,
+                    statusSince: when, updatedAt: when)
+                session.historyOnly = true
+                return session
+            }
+    }
+
     /// How many of Cursor's stored conversations get a history row. Cursor keeps
     /// every chat until its own cleanup prunes them, and a dashboard is a list of
     /// work in progress, not an archive.
@@ -964,6 +1022,7 @@ public actor SessionStore {
         snapshot.sessions += cursorHistorySessions().sorted {
             $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt > $1.updatedAt
         }
+        snapshot.sessions += cursorCloudHistorySessions()
         if copilotReadFailed || !copilotHistory.isEmpty {
             var diagnostics = snapshot.observationDiagnostics ?? []
             diagnostics.removeAll { $0.agent == .copilot }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionStore.swift
@@ -45,6 +45,15 @@ public actor SessionStore {
 
     public func isACPHosted(_ sessionID: String) -> Bool { acpHosted.contains(sessionID) }
 
+    /// A queued follow-up left for Cursor: through its `stop` hook (which says
+    /// how many automatic follow-ups this conversation has already taken, so a
+    /// silent drop past a `loop_limit` can be seen in the journal) or as the
+    /// ACP host's next prompt.
+    public func noteCursorFollowupHandoff(sessionID: String, loopCount: Int?, source: ObservationSource, at date: Date) {
+        let event = loopCount.map { "cursorFollowupHandedOver(loop \($0))" } ?? "cursorFollowupHandedOver"
+        _ = appendJournal(sessionID: sessionID, agent: .cursor, event: event, source: source, at: date)
+    }
+
     /// The write path the daemon would use for this session, stamped on every
     /// snapshot so the phone and the Watch decide availability from one fact
     /// (ADR-0016, second amendment). Codex: the app-server while it is fresh.
@@ -706,7 +715,9 @@ public actor SessionStore {
         case .sessionMetadataChanged:
             entry = event.message.map { TranscriptEntry(role: "assistant", text: $0) }
         case .preToolUse:
-            entry = event.toolName.map { TranscriptEntry(role: "assistant", text: "⚙ \($0)") }
+            // Thinking blocks are activity, not dialogue: one per model
+            // generation would drown the prompts and results this log is for.
+            entry = event.toolName.flatMap { $0 == "Thinking" ? nil : TranscriptEntry(role: "assistant", text: "⚙ \($0)") }
         case .postToolUse:
             entry = event.toolOutput.map { TranscriptEntry(role: "assistant", text: $0) }
         case .sessionEnd:

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -58,6 +58,9 @@ public struct VibeBuddyServer: Sendable {
     /// And the third: a Cursor chat lives inside Cursor's own sidebar, which no
     /// deeplink addresses, so the jump brings Cursor (and its workspace) forward.
     public let onJumpToCursor: @Sendable (String?) async -> JumpOutcome
+    /// And the fourth: a Cursor **cloud** agent has no window here at all, so
+    /// the jump opens the page Cursor hosts for it.
+    public let onJumpToCursorCloud: @Sendable (String) async -> JumpOutcome
     public let onAnswer: @Sendable (TerminalRef, String) -> Void
     public let onDevicePaired: @Sendable (DeviceRegistrationPayload) -> Void
     /// Claude background sessions on this Mac, for jumps into them.
@@ -80,6 +83,13 @@ public struct VibeBuddyServer: Sendable {
     /// Tails Cursor's agent transcripts. Optional so route tests consume no
     /// host state, exactly like the Codex rollout source.
     public let cursorTranscriptMonitor: CursorTranscriptMonitor?
+    /// Cursor's Cloud Agents API: the live source for `bc-` conversations, which
+    /// run on Cursor's machines and so reach no hook and write no transcript.
+    /// Doing nothing until an API key is stored is the client's own business, so
+    /// this is always present.
+    public let cursorCloud: CursorCloudAgentClient
+    /// Polls that API. Optional for the same reason the transcript monitor is.
+    public let cursorCloudMonitor: CursorCloudAgentMonitor?
     /// Deliver one completion reminder for a followed, unread, done session.
     /// Returns whether any channel actually took it, so a reminder every
     /// channel suppressed does not spend one of the session's slots. The
@@ -115,6 +125,7 @@ public struct VibeBuddyServer: Sendable {
                 onJump: @escaping @Sendable (TerminalRef) async -> JumpOutcome = { await TerminalJumper.jump($0) },
                 onJumpToDesktopThread: @escaping @Sendable (String) async -> JumpOutcome = { await CodexDesktopJumper.jump(threadID: $0) },
                 onJumpToCursor: @escaping @Sendable (String?) async -> JumpOutcome = { await CursorJumper.jump(project: $0) },
+                onJumpToCursorCloud: @escaping @Sendable (String) async -> JumpOutcome = { await CursorCloudJumper.jump(page: $0) },
                 onAnswer: @escaping @Sendable (TerminalRef, String) -> Void = { ref, answer in TerminalInjector.inject(answer, into: ref) },
                 onDevicePaired: @escaping @Sendable (DeviceRegistrationPayload) -> Void = { _ in },
                 backgroundSessions: @escaping @Sendable () -> [ClaudeBackgroundSession] = { ClaudeBackgroundSessions.load() },
@@ -126,6 +137,8 @@ public struct VibeBuddyServer: Sendable {
                 cursorLauncher: CursorLauncher = CursorLauncher(),
                 cursorACP: CursorACPMonitor? = nil,
                 cursorTranscriptMonitor: CursorTranscriptMonitor? = nil,
+                cursorCloud: CursorCloudAgentClient = CursorCloudAgentClient(),
+                cursorCloudMonitor: CursorCloudAgentMonitor? = nil,
                 onCompletionReminder: (@Sendable (AgentSession) async -> Bool)? = nil,
                 actionRequests: ActionRequestLog = ActionRequestLog(),
                 cursorFollowups: CursorFollowupQueue = CursorFollowupQueue()) {
@@ -154,6 +167,7 @@ public struct VibeBuddyServer: Sendable {
         self.onJump = onJump
         self.onJumpToDesktopThread = onJumpToDesktopThread
         self.onJumpToCursor = onJumpToCursor
+        self.onJumpToCursorCloud = onJumpToCursorCloud
         self.onAnswer = onAnswer
         self.backgroundSessions = backgroundSessions
         self.onAttach = onAttach
@@ -162,6 +176,8 @@ public struct VibeBuddyServer: Sendable {
         self.cursorLauncher = cursorLauncher
         self.cursorACP = cursorACP
         self.cursorTranscriptMonitor = cursorTranscriptMonitor
+        self.cursorCloud = cursorCloud
+        self.cursorCloudMonitor = cursorCloudMonitor
         self.onDevicePaired = onDevicePaired
         self.onCompletionReminder = onCompletionReminder
         self.actionRequests = actionRequests
@@ -205,6 +221,10 @@ public struct VibeBuddyServer: Sendable {
             Task { await monitor.run(store: store) }
         }
         defer { cursorTask?.cancel() }
+        let cursorCloudTask = cursorCloudMonitor.map { monitor in
+            Task { await monitor.run(store: store) }
+        }
+        defer { cursorCloudTask?.cancel() }
         let monitorTask = codexRolloutMonitor.map { monitor in
             Task { await monitor.run(store: store) }
         }
@@ -520,9 +540,19 @@ public struct VibeBuddyServer: Sendable {
         // fetching never acknowledges a completion or moves Session state.
         let rolloutMonitor = self.codexRolloutMonitor
         let cursorMonitor = self.cursorTranscriptMonitor
+        let cursorCloudReader = self.cursorCloud
         authed.get("recent-output") { request, _ -> Response in
             guard let sessionID = request.uri.queryParameters["sessionId"].map(String.init),
                   !sessionID.isEmpty else { throw HTTPError(.badRequest) }
+            // A cloud agent has no file to read: its conversation lives in
+            // Cursor's runs, one run per turn. v1 dropped v0's `/conversation`,
+            // so the runs list is the conversation.
+            if await store.cursorCloudAgentURL(for: sessionID) != nil {
+                let output = await cursorCloudReader.recentOutput(agentID: sessionID)
+                let data = try JSONEncoder().encode(output)
+                return Response(status: .ok, headers: [.contentType: "application/json"],
+                                body: .init(byteBuffer: ByteBuffer(bytes: data)))
+            }
             var path = await rolloutMonitor?.rolloutPath(for: sessionID)
             if path == nil { path = await cursorMonitor?.transcriptPath(for: sessionID) }
             let output = await store.recentOutput(sessionID: sessionID, rolloutPath: path)
@@ -929,6 +959,12 @@ public struct VibeBuddyServer: Sendable {
                 // Codex Desktop runs no hook, so this session will never have a
                 // ref; its thread id is the target instead.
                 outcome = await onJumpToDesktopThread(thread)
+            } else if let page = await store.cursorCloudAgentURL(for: sid) {
+                // A cloud agent has no window on this Mac and no terminal: it
+                // runs on Cursor's machines. Its own page is the only place the
+                // conversation can be opened — the Codex Desktop shape, with the
+                // URL checked before it is handed to a browser.
+                outcome = await onJumpToCursorCloud(page)
             } else if session?.agent == .cursor {
                 // Cursor publishes no deeplink that opens a chat by id, so the
                 // honest jump is: Cursor forward, with this session's workspace
@@ -1005,6 +1041,7 @@ public struct VibeBuddyServer: Sendable {
         // become steer, and stop is only ever explicit.
         let monitor = self.codexAppServerMonitor
         let cursorTerminal: @Sendable () async -> String? = { await store.preferredTerminalProgram() }
+        let cursorCloud = self.cursorCloud
         let dispatch = AnswerDispatch(store: store, questions: questionRegistry, inject: self.onAnswer,
                                       steer: { sessionID, text in
                                           await monitor?.steer(threadID: sessionID, text: text) ?? false
@@ -1031,6 +1068,15 @@ public struct VibeBuddyServer: Sendable {
                                           return await CursorCLI.resume(conversationID: session.id, text: text,
                                                                         cwd: session.project,
                                                                         preferring: await cursorTerminal())
+                                      },
+                                      continueCursorCloud: { id, text in
+                                          await cursorCloud.continueAgent(id: id, text: text)
+                                      },
+                                      cancelCursorCloud: { id in
+                                          guard let run = await store.cursorCloudLatestRun(for: id) else {
+                                              return .notSent(String(localized: "This run has already finished."))
+                                          }
+                                          return await cursorCloud.cancel(agentID: id, runID: run)
                                       },
                                       requests: self.actionRequests)
         authed.post("answer") { request, _ -> Response in

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -194,6 +194,9 @@ public struct VibeBuddyServer: Sendable {
         if await claudeLauncher.isSupported() { agents.append(.claudeCode) }
         if let monitor = codexAppServerMonitor, await monitor.diagnostics().connected { agents.append(.codex) }
         var cursor = await cursorACPSupported()
+        // The model list rides with the sign-in verdict: the host caches it,
+        // so this costs a subprocess once per verdict, not once per snapshot.
+        await store.setCursorModels(cursor ? await cursorACP?.models() ?? [] : [])
         if !cursor { cursor = await cursorLauncher.isSupported() }
         if cursor { agents.append(.cursor) }
         return agents
@@ -526,8 +529,11 @@ public struct VibeBuddyServer: Sendable {
         // Full snapshot — bearer-token gated.
         authed.get("snapshot") { request, _ -> Response in
             await store.applyBackgroundSessions(backgroundSessions())
+            // Agents first: it also refreshes the store's Cursor model list,
+            // which the snapshot taken next composes in.
+            let agents = await dispatchAgents()
             var snapshot = await store.snapshot(now: Date())
-            snapshot.dispatchAgents = await dispatchAgents()
+            snapshot.dispatchAgents = agents
             let data = try JSONEncoder().encode(Self.snapshotForPeer(snapshot, request: request))
             return Response(
                 status: .ok,
@@ -1009,8 +1015,13 @@ public struct VibeBuddyServer: Sendable {
             guard await store.isKnownDirectory(cwd) else {
                 return reply(.badRequest, ["error": "not a directory a session has run in"])
             }
-            let req = DispatchRequest(agent: agent, cwd: cwd, prompt: text,
-                                      name: (o["name"] as? String).flatMap { $0.isEmpty ? nil : $0 })
+            func optionalString(_ key: String) -> String? {
+                (o[key] as? String).flatMap { $0.isEmpty ? nil : $0 }
+            }
+            // Cursor's `--model`, `--mode` and `-w`; other agents ignore them.
+            let req = DispatchRequest(agent: agent, cwd: cwd, prompt: text, name: optionalString("name"),
+                                      model: optionalString("model"), mode: optionalString("mode"),
+                                      worktree: o["worktree"] as? Bool)
             let outcome: DispatchOutcome
             if let dispatcher {
                 outcome = await dispatcher(req)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -69,8 +69,14 @@ public struct VibeBuddyServer: Sendable {
     public let onDispatch: (@Sendable (DispatchRequest) async -> DispatchOutcome)?
     /// Starts Claude Code background sessions for dispatches.
     public let claudeLauncher: ClaudeBackgroundLauncher
-    /// Starts Cursor CLI sessions for dispatches.
+    /// Starts Cursor CLI sessions for dispatches in a terminal — the fallback
+    /// when no ACP host is configured.
     public let cursorLauncher: CursorLauncher
+    /// Hosts Cursor CLI conversations over ACP: dispatch, continue, stop,
+    /// permission and question all through one process per conversation.
+    /// Nil (route tests, an older wiring) leaves the terminal launcher in
+    /// charge and Cursor sessions on their hooks.
+    public let cursorACP: CursorACPMonitor?
     /// Tails Cursor's agent transcripts. Optional so route tests consume no
     /// host state, exactly like the Codex rollout source.
     public let cursorTranscriptMonitor: CursorTranscriptMonitor?
@@ -118,6 +124,7 @@ public struct VibeBuddyServer: Sendable {
                 onDispatch: (@Sendable (DispatchRequest) async -> DispatchOutcome)? = nil,
                 claudeLauncher: ClaudeBackgroundLauncher = ClaudeBackgroundLauncher(),
                 cursorLauncher: CursorLauncher = CursorLauncher(),
+                cursorACP: CursorACPMonitor? = nil,
                 cursorTranscriptMonitor: CursorTranscriptMonitor? = nil,
                 onCompletionReminder: (@Sendable (AgentSession) async -> Bool)? = nil,
                 actionRequests: ActionRequestLog = ActionRequestLog(),
@@ -153,6 +160,7 @@ public struct VibeBuddyServer: Sendable {
         self.onDispatch = onDispatch
         self.claudeLauncher = claudeLauncher
         self.cursorLauncher = cursorLauncher
+        self.cursorACP = cursorACP
         self.cursorTranscriptMonitor = cursorTranscriptMonitor
         self.onDevicePaired = onDevicePaired
         self.onCompletionReminder = onCompletionReminder
@@ -169,8 +177,17 @@ public struct VibeBuddyServer: Sendable {
         var agents: [AgentKind] = []
         if await claudeLauncher.isSupported() { agents.append(.claudeCode) }
         if let monitor = codexAppServerMonitor, await monitor.diagnostics().connected { agents.append(.codex) }
-        if await cursorLauncher.isSupported() { agents.append(.cursor) }
+        var cursor = await cursorACPSupported()
+        if !cursor { cursor = await cursorLauncher.isSupported() }
+        if cursor { agents.append(.cursor) }
         return agents
+    }
+
+    /// Whether a Cursor dispatch would be hosted over ACP rather than opened
+    /// in a terminal: an ACP host is wired and the CLI is installed and signed in.
+    func cursorACPSupported() async -> Bool {
+        guard let cursorACP else { return false }
+        return await cursorACP.isSupported()
     }
 
     public func runService() async throws {
@@ -638,6 +655,12 @@ public struct VibeBuddyServer: Sendable {
             // denied and the person's choice travels to the model in
             // `agent_message`, which is exactly what Cursor documents that field
             // for. Silence still prints nothing, so Cursor shows its own picker.
+            // A conversation vibebuddy hosts over ACP gets its permission and
+            // question requests on that pipe; the hook gate for the same call
+            // says nothing, so one request never raises two cards.
+            if agent == .cursor, await store.isACPHosted(sessionID) {
+                return Response(status: .ok)
+            }
             if agent == .cursor, tool == CursorToolVocabulary.askQuestionTool {
                 guard let question = CursorAskQuestionInput.pendingQuestion(from: input, id: makeID()) else {
                     return Response(status: .ok)
@@ -764,7 +787,10 @@ public struct VibeBuddyServer: Sendable {
             let obj = (try? JSONSerialization.jsonObject(with: Data(buffer: buffer))) as? [String: Any] ?? [:]
             let id = (obj["conversation_id"] as? String) ?? (obj["session_id"] as? String)
                 ?? request.uri.queryParameters["conversationId"].map(String.init) ?? ""
-            guard !id.isEmpty, let text = await cursorFollowups.take(conversationID: id) else {
+            // A hosted conversation's follow-up goes out as the next ACP
+            // prompt; handing it to the hook as well would send it twice.
+            guard !id.isEmpty, !(await store.isACPHosted(id)),
+                  let text = await cursorFollowups.take(conversationID: id) else {
                 return Response(status: .ok)
             }
             let body: [String: Any] = ["followup_message": text]
@@ -928,6 +954,7 @@ public struct VibeBuddyServer: Sendable {
         let dispatcher = self.onDispatch
         let dispatchMonitor = self.codexAppServerMonitor
         let claudeLauncher = self.claudeLauncher
+        let cursorACP = self.cursorACP
         authed.post("dispatch") { request, _ -> Response in
             let buffer = try await request.body.collect(upTo: 64 * 1024)
             guard let o = try? JSONSerialization.jsonObject(with: Data(buffer: buffer)) as? [String: Any],
@@ -954,7 +981,13 @@ public struct VibeBuddyServer: Sendable {
             } else if agent == .claudeCode {
                 outcome = await claudeLauncher.dispatch(req)
             } else if agent == .cursor {
-                outcome = await cursorLauncher.dispatch(req)
+                // Hosted over ACP when the CLI is signed in — the phone can
+                // then stop, continue and answer it — else a terminal window.
+                if let cursorACP, await cursorACP.isSupported() {
+                    outcome = await cursorACP.dispatch(req)
+                } else {
+                    outcome = await cursorLauncher.dispatch(req)
+                }
             } else {
                 outcome = .unsupported("vibebuddy cannot start \(agent.displayName) sessions yet")
             }
@@ -980,16 +1013,24 @@ public struct VibeBuddyServer: Sendable {
                                           await monitor?.startTurn(threadID: sessionID, text: text) ?? false
                                       },
                                       interrupt: { sessionID in
-                                          await monitor?.interrupt(threadID: sessionID)
+                                          // A hosted Cursor conversation is cancelled on its
+                                          // own pipe; everything else is Codex's interrupt.
+                                          if let cursorACP, await cursorACP.hosts(sessionID) {
+                                              return await cursorACP.cancel(sessionID: sessionID)
+                                          }
+                                          return await monitor?.interrupt(threadID: sessionID)
                                               ?? .notSent(String(localized: "This Mac isn't watching Codex."))
                                       },
                                       queueCursorFollowup: { sessionID, text in
                                           await cursorFollowups.queue(conversationID: sessionID, text: text) != nil
                                       },
                                       resumeCursor: { session, text in
-                                          await CursorCLI.resume(conversationID: session.id, text: text,
-                                                                 cwd: session.project,
-                                                                 preferring: await cursorTerminal())
+                                          if let cursorACP, await cursorACP.hosts(session.id) {
+                                              return await cursorACP.prompt(sessionID: session.id, text: text)
+                                          }
+                                          return await CursorCLI.resume(conversationID: session.id, text: text,
+                                                                        cwd: session.project,
+                                                                        preferring: await cursorTerminal())
                                       },
                                       requests: self.actionRequests)
         authed.post("answer") { request, _ -> Response in

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/VibeBuddyServer.swift
@@ -823,6 +823,8 @@ public struct VibeBuddyServer: Sendable {
                   let text = await cursorFollowups.take(conversationID: id) else {
                 return Response(status: .ok)
             }
+            await store.noteCursorFollowupHandoff(sessionID: id, loopCount: (obj["loop_count"] as? NSNumber)?.intValue,
+                                                  source: .hook, at: Date())
             let body: [String: Any] = ["followup_message": text]
             guard let data = try? JSONSerialization.data(withJSONObject: body) else {
                 return Response(status: .ok)

--- a/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
+++ b/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
@@ -85,6 +85,7 @@ struct VibeBuddyDaemon {
             questionRegistry: questionRegistry,
             cursorACP: cursorACP,
             cursorTranscriptMonitor: CursorTranscriptMonitor(),
+            cursorCloudMonitor: CursorCloudAgentMonitor(),
             cursorFollowups: cursorFollowups)
         FileHandle.standardError.write(Data(
             "vibebuddyd: listening on 0.0.0.0:\(port) (apns: \(pusher != nil ? "on" : "off"), token: \(tokenSource))\n".utf8))

--- a/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
+++ b/VibeBuddyMac/Sources/vibebuddyd/VibeBuddyDaemon.swift
@@ -55,15 +55,23 @@ struct VibeBuddyDaemon {
         let sessionAllow = SessionAllowList()
         let approvalContext = ApprovalContextStore()
         let questionRegistry = QuestionRegistry()
+        let store = SessionStore(
+            sourceID: DaemonIdentity.load(),
+            diagnosticsHome: FileManager.default.homeDirectoryForCurrentUser,
+            journalURL: journalURL,
+            attentionURL: AttentionOverrides.defaultURL(),
+            missedURL: env["VIBEBUDDY_MISSED_PATH"].map { URL(fileURLWithPath: $0) }
+                ?? MissedLedgerLocation.defaultURL()
+        )
+        // One follow-up queue for Cursor: the hooks' `stop` drains it for IDE
+        // chats, the ACP host for the conversations it carries.
+        let cursorFollowups = CursorFollowupQueue()
+        let cursorACP = CursorACPMonitor(
+            store: store, approvals: approvalRegistry, approvalContext: approvalContext,
+            questions: questionRegistry, allowStore: allowStore, sessionAllow: sessionAllow,
+            followups: cursorFollowups)
         let server = VibeBuddyServer(
-            store: SessionStore(
-                sourceID: DaemonIdentity.load(),
-                diagnosticsHome: FileManager.default.homeDirectoryForCurrentUser,
-                journalURL: journalURL,
-                attentionURL: AttentionOverrides.defaultURL(),
-                missedURL: env["VIBEBUDDY_MISSED_PATH"].map { URL(fileURLWithPath: $0) }
-                    ?? MissedLedgerLocation.defaultURL()
-            ),
+            store: store,
             token: token, port: port, pusher: pusher, phoneReceipts: phoneReceipts,
             deliveryRecorder: deliveryRecorder,
             deviceTokens: deviceTokens,
@@ -75,7 +83,9 @@ struct VibeBuddyDaemon {
             approvalRegistry: approvalRegistry, allowStore: allowStore,
             sessionAllow: sessionAllow, approvalContext: approvalContext,
             questionRegistry: questionRegistry,
-            cursorTranscriptMonitor: CursorTranscriptMonitor())
+            cursorACP: cursorACP,
+            cursorTranscriptMonitor: CursorTranscriptMonitor(),
+            cursorFollowups: cursorFollowups)
         FileHandle.standardError.write(Data(
             "vibebuddyd: listening on 0.0.0.0:\(port) (apns: \(pusher != nil ? "on" : "off"), token: \(tokenSource))\n".utf8))
         try await server.runService()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorACPTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorACPTests.swift
@@ -114,6 +114,18 @@ private final class FakeACPAgent: @unchecked Sendable {
     }
 }
 
+/// What the monitor asked to spawn, and how often it asked for the model
+/// list — the two seams a dispatch's options and the cache show through.
+private final class LaunchLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [CursorACPLaunch] = []
+    private var listed = 0
+    var launches: [CursorACPLaunch] { lock.lock(); defer { lock.unlock() }; return stored }
+    var modelListings: Int { lock.lock(); defer { lock.unlock() }; return listed }
+    func record(_ launch: CursorACPLaunch) { lock.lock(); stored.append(launch); lock.unlock() }
+    func recordListing() { lock.lock(); listed += 1; lock.unlock() }
+}
+
 /// Poll until `condition` holds. Bounded so a wrong implementation fails
 /// instead of hanging; the bound is liveness, never the assertion.
 private func eventually(_ what: String, _ condition: @Sendable () async -> Bool) async {
@@ -135,10 +147,13 @@ struct CursorACPTests {
         let sessionAllow = SessionAllowList()
         let followups = CursorFollowupQueue()
         let agent: FakeACPAgent
+        let log = LaunchLog()
         let monitor: CursorACPMonitor
 
-        init(agent: FakeACPAgent = FakeACPAgent(), signedIn: Bool = true, deny: [String] = []) {
+        init(agent: FakeACPAgent = FakeACPAgent(), signedIn: Bool = true, deny: [String] = [],
+             models: [String] = ["gpt-5", "sonnet-4.5"]) {
             self.agent = agent
+            let log = self.log
             allowStore = VibeBuddyAllowStore(url: FileManager.default.temporaryDirectory
                 .appendingPathComponent("vbacp-\(UUID().uuidString).json"))
             monitor = CursorACPMonitor(store: store, approvals: approvals, approvalContext: approvalContext,
@@ -148,7 +163,8 @@ struct CursorACPTests {
                                        makeID: { UUID().uuidString },
                                        executable: URL(fileURLWithPath: "/usr/bin/true"),
                                        signInProbe: { signedIn },
-                                       spawn: { _ in agent.client() })
+                                       modelsProbe: { log.recordListing(); return models },
+                                       spawn: { launch in log.record(launch); return agent.client() })
         }
 
         func session() async -> AgentSession? {
@@ -338,6 +354,62 @@ struct CursorACPTests {
         #expect(session?.controlChannel == .acp)
     }
 
+    @Test func aPlainDispatchStartsTheCLIWithNoOptions() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        #expect(rig.log.launches == [CursorACPLaunch(cwd: "/x/p")])
+        #expect(rig.log.launches.first?.leadingArguments == [])
+    }
+
+    @Test func modelModeAndWorktreeBecomeTheCLIsGlobalOptionsInFrontOfACP() async throws {
+        let rig = Rig()
+        var chosen = request
+        chosen.model = "gpt-5"
+        chosen.mode = "plan"
+        chosen.worktree = true
+        let outcome = await rig.monitor.dispatch(chosen)
+        #expect(outcome == .started(sessionID: "acp-1"))
+        #expect(rig.log.launches.count == 1)
+        #expect(rig.log.launches.first?.cwd == "/x/p")
+        #expect(rig.log.launches.first?.leadingArguments == ["--model", "gpt-5", "--mode", "plan", "-w"])
+        // Agent mode is the CLI's default and needs no flag.
+        await eventually("the row carries the chosen model") { await rig.session()?.model == "gpt-5" }
+        var agentMode = request
+        agentMode.mode = "agent"
+        agentMode.model = "sonnet-4.5"
+        let second = Rig(agent: FakeACPAgent(sessionID: "acp-2"))
+        _ = await second.monitor.dispatch(agentMode)
+        #expect(second.log.launches.first?.leadingArguments == ["--model", "sonnet-4.5"])
+    }
+
+    @Test func aModelOrModeThatIsNotAPlainTokenIsRefusedBeforeAnythingIsSpawned() async throws {
+        let rig = Rig()
+        var bad = request
+        bad.model = "gpt-5; rm -rf ~"
+        guard case .rejected(let why) = await rig.monitor.dispatch(bad) else { Issue.record("expected rejected"); return }
+        #expect(why.contains("model"))
+        var badMode = request
+        badMode.mode = "yolo"
+        guard case .rejected(let modeWhy) = await rig.monitor.dispatch(badMode) else { Issue.record("expected rejected"); return }
+        #expect(modeWhy.contains("mode"))
+        #expect(rig.log.launches.isEmpty)
+        #expect(await rig.session() == nil)
+    }
+
+    @Test func theModelListIsProbedOncePerSignInVerdict() async throws {
+        let rig = Rig()
+        #expect(await rig.monitor.models() == ["gpt-5", "sonnet-4.5"])
+        #expect(await rig.monitor.models() == ["gpt-5", "sonnet-4.5"])
+        #expect(rig.log.modelListings == 1)
+        await rig.monitor.invalidate()
+        #expect(await rig.monitor.models() == ["gpt-5", "sonnet-4.5"])
+        #expect(rig.log.modelListings == 2)
+        // Signed out: no models, and no subprocess to ask for them.
+        let signedOut = Rig(signedIn: false)
+        #expect(await signedOut.monitor.models() == [])
+        #expect(signedOut.log.modelListings == 0)
+    }
+
     @Test func anUnexpectedProtocolVersionIsRefusedNotGuessed() async throws {
         let agent = FakeACPAgent()
         agent.protocolVersion = 2
@@ -398,5 +470,61 @@ struct CursorACPShapeTests {
         #expect((outcome?["reason"] as? String)?.contains("something else") == true)
         let picked = CursorACPMonitor.questionResponse(question: question, answers: ["q1": ["A"]])
         #expect(((picked["outcome"] as? [String: Any])?["outcome"] as? String) == "answered")
+    }
+}
+
+@Suite("Cursor launch options")
+struct CursorLaunchOptionTests {
+    @Test func theListIsOneIDPerLineWhateverDecorationTheCLIPrints() {
+        let fixture = """
+        Available models:
+        MODEL          DESCRIPTION
+        * gpt-5        OpenAI GPT-5 (current)
+        - sonnet-4.5   Anthropic
+        | composer-1 | Cursor |
+        claude-opus-4.1, the big one
+        auto
+        gpt-5
+
+        Run `agent --model <model>` to pick one.
+        """
+        #expect(CursorCLI.parseModelList(fixture) == ["gpt-5", "sonnet-4.5", "composer-1", "claude-opus-4.1", "auto"])
+        #expect(CursorCLI.parseModelList("Error: Authentication required. Run 'agent login'.") == [])
+        #expect(CursorCLI.parseModelList("") == [])
+    }
+
+    @Test func onlyPlainTokensAndDocumentedBracketOverridesPass() {
+        for ok in ["gpt-5", "sonnet-4-thinking", "claude-opus-4.1", "vendor/model:latest",
+                   "claude-opus-4-8[context=1m,effort=high,fast=false]"] {
+            #expect(CursorLaunchOptions.isModelToken(ok), "\(ok)")
+        }
+        for bad in ["", "gpt 5", "gpt-5; rm -rf ~", "$(id)", "gpt-5[", "gpt-5[context]", "gpt-5[a=b]x", "模型"] {
+            #expect(!CursorLaunchOptions.isModelToken(bad), "\(bad)")
+        }
+    }
+
+    @Test func aRequestBecomesArgumentsOrARejection() throws {
+        var request = DispatchRequest(agent: .cursor, cwd: "/x/p", prompt: "go")
+        #expect(try CursorLaunchOptions.from(request).get().arguments == [])
+        request.mode = "Ask"
+        request.worktree = true
+        #expect(try CursorLaunchOptions.from(request).get().arguments == ["--mode", "ask", "-w"])
+        request.mode = "agent"
+        request.worktree = false
+        request.model = " gpt-5 "
+        #expect(try CursorLaunchOptions.from(request).get().arguments == ["--model", "gpt-5"])
+        request.model = "gpt 5"
+        #expect(CursorLaunchOptions.from(request) == .failure(.invalidModel("gpt 5")))
+        request.model = nil
+        request.mode = "edit"
+        #expect(CursorLaunchOptions.from(request) == .failure(.invalidMode("edit")))
+    }
+
+    @Test func theTerminalFallbackPutsTheSameFlagsBeforeTheDoubleDash() {
+        let options = CursorLaunchOptions(model: "gpt-5", mode: "plan", worktree: true)
+        let parts = [CursorCLI.shellQuoted("/usr/local/bin/cursor-agent")] + options.arguments.map(CursorCLI.shellQuoted)
+            + ["--", CursorCLI.shellQuoted("fix it")]
+        #expect(CursorCLI.command(parts, cwd: "/x/p")
+                == "cd '/x/p' && '/usr/local/bin/cursor-agent' '--model' 'gpt-5' '--mode' 'plan' '-w' -- 'fix it'")
     }
 }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorACPTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorACPTests.swift
@@ -1,0 +1,402 @@
+import Testing
+import Foundation
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+/// A scripted `agent acp` on a pair of pipes. It answers the handshake the way
+/// Cursor's CLI does (cursor.com/docs/cli/acp) and leaves `session/prompt`
+/// open until the test ends the turn, so the test can push notifications and
+/// server requests in between exactly as the real process would.
+private final class FakeACPAgent: @unchecked Sendable {
+    private let toAgent = Pipe()      // client writes, agent reads
+    private let toClient = Pipe()     // agent writes, client reads
+    private let lock = NSLock()
+    private var buffer = Data()
+    private var requests: [(id: Int, method: String, params: [String: Any])] = []
+    private var responses: [Int: [String: Any]] = [:]
+    private var nextID = 100
+    let sessionID: String
+    var protocolVersion = 1
+
+    init(sessionID: String = "acp-1") {
+        self.sessionID = sessionID
+        toAgent.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            guard let self else { return }
+            let data = handle.availableData
+            guard !data.isEmpty else { handle.readabilityHandler = nil; return }
+            self.consume(data)
+        }
+    }
+
+    func client() -> CursorACPClient {
+        CursorACPClient(reading: toClient.fileHandleForReading, writing: toAgent.fileHandleForWriting)
+    }
+
+    private func consume(_ data: Data) {
+        lock.lock()
+        buffer.append(data)
+        var lines: [Data] = []
+        while let nl = buffer.firstIndex(of: 0x0A) {
+            lines.append(buffer.subdata(in: buffer.startIndex..<nl))
+            buffer.removeSubrange(buffer.startIndex...nl)
+        }
+        lock.unlock()
+        for line in lines {
+            guard let obj = (try? JSONSerialization.jsonObject(with: line)) as? [String: Any] else { continue }
+            if let method = obj["method"] as? String {
+                let params = obj["params"] as? [String: Any] ?? [:]
+                guard let id = (obj["id"] as? NSNumber)?.intValue else {
+                    lock.lock(); requests.append((id: -1, method: method, params: params)); lock.unlock()
+                    continue
+                }
+                lock.lock(); requests.append((id: id, method: method, params: params)); lock.unlock()
+                // The handshake answers itself; prompts wait for the test.
+                switch method {
+                case "initialize": respond(id, ["protocolVersion": protocolVersion, "agentCapabilities": ["loadSession": true]])
+                case "authenticate": respond(id, [:])
+                case "session/new": respond(id, ["sessionId": sessionID])
+                default: break
+                }
+            } else if let id = (obj["id"] as? NSNumber)?.intValue {
+                lock.lock(); responses[id] = obj; lock.unlock()
+            }
+        }
+    }
+
+    private func write(_ json: [String: Any]) {
+        var data = try! JSONSerialization.data(withJSONObject: json)
+        data.append(0x0A)
+        try? toClient.fileHandleForWriting.write(contentsOf: data)
+    }
+
+    func respond(_ id: Int, _ result: [String: Any]) {
+        write(["jsonrpc": "2.0", "id": id, "result": result])
+    }
+
+    func update(_ update: [String: Any]) {
+        write(["jsonrpc": "2.0", "method": "session/update", "params": ["sessionId": sessionID, "update": update]])
+    }
+
+    /// A server-initiated request; returns its id so the test can await the answer.
+    @discardableResult
+    func ask(_ method: String, _ params: [String: Any]) -> Int {
+        lock.lock(); let id = nextID; nextID += 1; lock.unlock()
+        var full = params
+        full["sessionId"] = sessionID
+        write(["jsonrpc": "2.0", "id": id, "method": method, "params": full])
+        return id
+    }
+
+    func endTurn(_ stopReason: String) {
+        guard let prompt = request(named: "session/prompt", after: promptsEnded) else { return }
+        promptsEnded += 1
+        respond(prompt.id, ["stopReason": stopReason])
+    }
+    private var promptsEnded = 0
+
+    func request(named method: String, after skip: Int = 0) -> (id: Int, method: String, params: [String: Any])? {
+        lock.lock(); defer { lock.unlock() }
+        return requests.filter { $0.method == method }.dropFirst(skip).first
+    }
+
+    func requests(named method: String) -> [[String: Any]] {
+        lock.lock(); defer { lock.unlock() }
+        return requests.filter { $0.method == method }.map(\.params)
+    }
+
+    func response(to id: Int) -> [String: Any]? {
+        lock.lock(); defer { lock.unlock() }
+        return responses[id]
+    }
+
+    func close() {
+        try? toClient.fileHandleForWriting.close()
+    }
+}
+
+/// Poll until `condition` holds. Bounded so a wrong implementation fails
+/// instead of hanging; the bound is liveness, never the assertion.
+private func eventually(_ what: String, _ condition: @Sendable () async -> Bool) async {
+    for _ in 0..<600 {
+        if await condition() { return }
+        try? await Task.sleep(for: .milliseconds(5))
+    }
+    Issue.record("never happened: \(what)")
+}
+
+@Suite("Cursor ACP host")
+struct CursorACPTests {
+    private struct Rig {
+        let store = SessionStore()
+        let approvals = ApprovalRegistry()
+        let approvalContext = ApprovalContextStore()
+        let questions = QuestionRegistry()
+        let allowStore: VibeBuddyAllowStore
+        let sessionAllow = SessionAllowList()
+        let followups = CursorFollowupQueue()
+        let agent: FakeACPAgent
+        let monitor: CursorACPMonitor
+
+        init(agent: FakeACPAgent = FakeACPAgent(), signedIn: Bool = true, deny: [String] = []) {
+            self.agent = agent
+            allowStore = VibeBuddyAllowStore(url: FileManager.default.temporaryDirectory
+                .appendingPathComponent("vbacp-\(UUID().uuidString).json"))
+            monitor = CursorACPMonitor(store: store, approvals: approvals, approvalContext: approvalContext,
+                                       questions: questions, allowStore: allowStore, sessionAllow: sessionAllow,
+                                       followups: followups,
+                                       rules: { _ in PermissionRules(allow: [], deny: deny) },
+                                       makeID: { UUID().uuidString },
+                                       executable: URL(fileURLWithPath: "/usr/bin/true"),
+                                       signInProbe: { signedIn },
+                                       spawn: { _ in agent.client() })
+        }
+
+        func session() async -> AgentSession? {
+            await store.snapshot(now: Date()).sessions.first { $0.id == agent.sessionID }
+        }
+    }
+
+    private let request = DispatchRequest(agent: .cursor, cwd: "/x/p", prompt: "fix the tests", name: nil)
+
+    @Test func aDispatchBecomesAWorkingSessionOnTheACPChannel() async throws {
+        let rig = Rig()
+        let outcome = await rig.monitor.dispatch(request)
+        #expect(outcome == .started(sessionID: "acp-1"))
+        await eventually("the prompt reached the agent") { rig.agent.request(named: "session/prompt") != nil }
+        let prompt = rig.agent.request(named: "session/prompt")?.params
+        #expect(((prompt?["prompt"] as? [[String: Any]])?.first?["text"] as? String) == "fix the tests")
+        await eventually("the session is working") { await rig.session()?.status == .working }
+        let session = await rig.session()
+        #expect(session?.agent == .cursor)
+        #expect(session?.controlChannel == .acp)
+        #expect(session?.observations?.contains { $0.source == .acp } == true)
+        #expect(await rig.store.isACPHosted("acp-1"))
+        // Steer / continue / stop all read as available on this row.
+        #expect(SessionActionSupport.resolve(for: session!).isAvailable)
+        #expect(SessionActionSupport.resolveStop(for: session!).isAvailable)
+    }
+
+    @Test func toolCallsAndTheEndingFlowThrough() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("prompt") { rig.agent.request(named: "session/prompt") != nil }
+        rig.agent.update(["sessionUpdate": "tool_call", "toolCallId": "c1", "title": "Running tests", "kind": "execute", "status": "pending"])
+        await eventually("active tool") { await rig.session()?.activeTool == "Bash" }
+        rig.agent.update(["sessionUpdate": "tool_call_update", "toolCallId": "c1", "status": "completed"])
+        rig.agent.update(["sessionUpdate": "agent_message_chunk", "content": ["type": "text", "text": "All green."]])
+        rig.agent.update(["sessionUpdate": "usage_update", "used": 53000, "size": 200000])
+        await eventually("context") { await rig.session()?.contextTokens == 53000 }
+        rig.agent.endTurn("end_turn")
+        await eventually("done") { await rig.session()?.status == .done }
+        let session = await rig.session()
+        #expect(session?.contextWindow == 200000)
+        #expect(session?.failed != true)
+        #expect(session?.userStopped != true)
+        #expect(session?.summary?.contains("All green") == true)
+    }
+
+    @Test func aPermissionRequestBecomesACardAndThePhonesAnswerGoesBack() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("prompt") { rig.agent.request(named: "session/prompt") != nil }
+        rig.agent.update(["sessionUpdate": "tool_call", "toolCallId": "c1", "title": "rm -rf build", "kind": "execute",
+                          "rawInput": ["command": "rm -rf build"]])
+        let rpc = rig.agent.ask("session/request_permission", [
+            "toolCall": ["toolCallId": "c1", "title": "rm -rf build", "kind": "execute", "rawInput": ["command": "rm -rf build"]],
+            "options": [["optionId": "allow-once", "name": "Allow once", "kind": "allow_once"],
+                        ["optionId": "allow-always", "name": "Always", "kind": "allow_always"],
+                        ["optionId": "reject-once", "name": "Reject", "kind": "reject_once"]],
+        ])
+        await eventually("card") { await rig.session()?.pendingApproval != nil }
+        let card = await rig.session()?.pendingApproval
+        #expect(card?.tool == "Bash")
+        #expect(card?.command == "rm -rf build")
+        #expect(card?.answerable != false)
+        #expect(await rig.session()?.status == .needsResponse)
+        // The phone taps Allow: the same registry `/decision` resolves.
+        #expect(await rig.approvals.claim(id: card!.id))
+        await rig.approvals.resolve(id: card!.id, with: .allow)
+        await eventually("answer") { rig.agent.response(to: rpc) != nil }
+        let outcome = (rig.agent.response(to: rpc)?["result"] as? [String: Any])?["outcome"] as? [String: Any]
+        #expect(outcome?["outcome"] as? String == "selected")
+        #expect(outcome?["optionId"] as? String == "allow-once")
+        await eventually("card gone") { await rig.session()?.pendingApproval == nil }
+    }
+
+    @Test func aDenyRuleAnswersWithoutACard() async throws {
+        let rig = Rig(deny: ["Bash(rm -rf:*)"])
+        _ = await rig.monitor.dispatch(request)
+        await eventually("prompt") { rig.agent.request(named: "session/prompt") != nil }
+        let rpc = rig.agent.ask("session/request_permission", [
+            "toolCall": ["toolCallId": "c9", "title": "rm -rf /", "kind": "execute", "rawInput": ["command": "rm -rf /"]],
+            "options": [["optionId": "allow-once", "kind": "allow_once"], ["optionId": "reject-once", "kind": "reject_once"]],
+        ])
+        await eventually("answer") { rig.agent.response(to: rpc) != nil }
+        let outcome = (rig.agent.response(to: rpc)?["result"] as? [String: Any])?["outcome"] as? [String: Any]
+        #expect(outcome?["optionId"] as? String == "reject-once")
+        #expect(await rig.session()?.pendingApproval == nil)
+    }
+
+    @Test func aQuestionIsAnsweredWithCursorsOwnOptionIDs() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("prompt") { rig.agent.request(named: "session/prompt") != nil }
+        let rpc = rig.agent.ask("cursor/ask_question", [
+            "toolCallId": "q1", "title": "Need input",
+            "questions": [["id": "mode", "prompt": "Which mode?",
+                           "options": [["id": "agent", "label": "Agent"], ["id": "plan", "label": "Plan"]]],
+                          ["id": "scope", "prompt": "Which files?", "allowMultiple": true,
+                           "options": [["id": "a", "label": "a.swift"], ["id": "b", "label": "b.swift"]]]],
+        ])
+        await eventually("question") { await rig.session()?.pendingQuestion != nil }
+        let question = await rig.session()!.pendingQuestion!
+        #expect(question.items.count == 2)
+        #expect(question.items[1].multiSelect)
+        #expect(await rig.questions.resolveExact(sessionID: "acp-1", questionID: question.id,
+                                                  answers: ["mode": ["Plan"], "scope": ["a.swift", "b.swift"]]))
+        await eventually("answer") { rig.agent.response(to: rpc) != nil }
+        let outcome = (rig.agent.response(to: rpc)?["result"] as? [String: Any])?["outcome"] as? [String: Any]
+        #expect(outcome?["outcome"] as? String == "answered")
+        let answers = outcome?["answers"] as? [[String: Any]]
+        #expect(answers?.first { $0["questionId"] as? String == "mode" }?["selectedOptionIds"] as? [String] == ["plan"])
+        #expect(answers?.first { $0["questionId"] as? String == "scope" }?["selectedOptionIds"] as? [String] == ["a", "b"])
+        await eventually("question gone") { await rig.session()?.pendingQuestion == nil }
+    }
+
+    @Test func aPlanIsAcceptedFromTheCard() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("prompt") { rig.agent.request(named: "session/prompt") != nil }
+        let rpc = rig.agent.ask("cursor/create_plan", ["toolCallId": "p1", "name": "Refactor tabs",
+                                                        "overview": "Tighten layout.", "plan": "1. …", "todos": []])
+        await eventually("question") { await rig.session()?.pendingQuestion != nil }
+        let question = await rig.session()!.pendingQuestion!
+        #expect(question.options.map(\.id) == ["accept", "reject"])
+        _ = await rig.questions.resolveExact(sessionID: "acp-1", questionID: question.id, answers: ["plan": ["Accept"]])
+        await eventually("answer") { rig.agent.response(to: rpc) != nil }
+        let outcome = (rig.agent.response(to: rpc)?["result"] as? [String: Any])?["outcome"] as? [String: Any]
+        #expect(outcome?["outcome"] as? String == "accepted")
+    }
+
+    @Test func aStopCancelsTheTurnAndIsMarkedAsTheUsers() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("prompt") { rig.agent.request(named: "session/prompt") != nil }
+        // An open permission request must be answered `cancelled` on the way.
+        let rpc = rig.agent.ask("session/request_permission", [
+            "toolCall": ["toolCallId": "c1", "title": "npm test", "kind": "execute"],
+            "options": [["optionId": "allow-once", "kind": "allow_once"], ["optionId": "reject-once", "kind": "reject_once"]],
+        ])
+        await eventually("card") { await rig.session()?.pendingApproval != nil }
+        let outcome = await rig.monitor.cancel(sessionID: "acp-1")
+        #expect(outcome == .sent)
+        await eventually("cancel notified") { rig.agent.request(named: "session/cancel") != nil }
+        await eventually("permission cancelled") {
+            ((rig.agent.response(to: rpc)?["result"] as? [String: Any])?["outcome"] as? [String: Any])?["outcome"] as? String == "cancelled"
+        }
+        rig.agent.endTurn("cancelled")
+        await eventually("done") { await rig.session()?.status == .done }
+        let session = await rig.session()
+        #expect(session?.userStopped == true)
+        #expect(session?.failed != true)
+        #expect(session?.pendingApproval == nil)
+        // Nothing left to stop.
+        #expect(await rig.monitor.cancel(sessionID: "acp-1") != .sent)
+    }
+
+    @Test func aSupplementQueuedDuringATurnGoesOutAsTheNextPrompt() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("prompt") { rig.agent.request(named: "session/prompt") != nil }
+        #expect(await rig.followups.queue(conversationID: "acp-1", text: "also bump the version") != nil)
+        rig.agent.endTurn("end_turn")
+        await eventually("second prompt") { rig.agent.request(named: "session/prompt", after: 1) != nil }
+        let second = rig.agent.request(named: "session/prompt", after: 1)?.params
+        #expect(((second?["prompt"] as? [[String: Any]])?.first?["text"] as? String) == "also bump the version")
+        #expect(await rig.followups.peek(conversationID: "acp-1") == nil)
+        await eventually("working again") { await rig.session()?.status == .working }
+        // A continue on a running turn is refused; once idle it is the next prompt.
+        #expect(await rig.monitor.prompt(sessionID: "acp-1", text: "and lint") == false)
+        rig.agent.endTurn("end_turn")
+        await eventually("done") { await rig.session()?.status == .done }
+        #expect(await rig.monitor.prompt(sessionID: "acp-1", text: "and lint"))
+        await eventually("third prompt") { rig.agent.request(named: "session/prompt", after: 2) != nil }
+    }
+
+    @Test func hookEventsForAHostedConversationOnlyCorroborate() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("working") { await rig.session()?.status == .working }
+        // Cursor's own hooks still fire for a CLI turn; a `stop` from them must
+        // not end a turn the pipe says is running.
+        let stop = HookEvent(kind: .stop, sessionID: "acp-1", agent: .cursor, cwd: "/x/p",
+                             observationSource: .hook, timestamp: Date(), completionSucceeded: true)
+        await rig.store.ingest(stop)
+        let session = await rig.session()
+        #expect(session?.status == .working)
+        #expect(session?.observations?.contains { $0.source == .hook } == true)
+        #expect(session?.controlChannel == .acp)
+    }
+
+    @Test func anUnexpectedProtocolVersionIsRefusedNotGuessed() async throws {
+        let agent = FakeACPAgent()
+        agent.protocolVersion = 2
+        let rig = Rig(agent: agent)
+        let outcome = await rig.monitor.dispatch(request)
+        guard case .unavailable(let why) = outcome else { Issue.record("expected unavailable, got \(outcome)"); return }
+        #expect(why.contains("version 2"))
+        #expect(await rig.session() == nil)
+        #expect(await rig.store.isACPHosted("acp-1") == false)
+    }
+
+    @Test func aSignedOutCLIIsNotOffered() async throws {
+        let rig = Rig(signedIn: false)
+        #expect(await rig.monitor.isSupported() == false)
+        guard case .unavailable(let why) = await rig.monitor.dispatch(request) else { Issue.record("expected unavailable"); return }
+        #expect(why.contains("login"))
+    }
+
+    @Test func theProcessGoingAwayEndsTheTurnAsAFailureAndReleasesTheRow() async throws {
+        let rig = Rig()
+        _ = await rig.monitor.dispatch(request)
+        await eventually("working") { await rig.session()?.status == .working }
+        rig.agent.close()
+        await eventually("done") { await rig.session()?.status == .done }
+        let session = await rig.session()
+        #expect(session?.failed == true)
+        #expect(session?.userStopped != true)
+        await eventually("released") { await rig.store.isACPHosted("acp-1") == false }
+        #expect(await rig.session()?.controlChannel != .acp)
+    }
+}
+
+@Suite("Cursor ACP shapes")
+struct CursorACPShapeTests {
+    @Test func toolKindsBecomeCanonicalNames() {
+        #expect(CursorACPMonitor.canonicalTool(kind: "execute", title: "Running tests") == "Bash")
+        #expect(CursorACPMonitor.canonicalTool(kind: "read", title: nil) == "Read")
+        #expect(CursorACPMonitor.canonicalTool(kind: "edit", title: nil) == "Edit")
+        #expect(CursorACPMonitor.canonicalTool(kind: "search", title: nil) == "Grep")
+        #expect(CursorACPMonitor.canonicalTool(kind: nil, title: "Shell") == "Bash")
+        #expect(CursorACPMonitor.canonicalTool(kind: nil, title: nil) == "tool")
+    }
+
+    @Test func permissionOptionsFollowTheKindNotTheID() {
+        let options = CursorACPMonitor.permissionOptions([
+            ["optionId": "yes", "kind": "allow_once"], ["optionId": "no", "kind": "reject_once"]])
+        #expect(options.allow == "yes" && options.reject == "no")
+        let documented = CursorACPMonitor.permissionOptions(nil)
+        #expect(documented.allow == "allow-once" && documented.reject == "reject-once")
+    }
+
+    @Test func aTypedAnswerTravelsAsASkipReason() {
+        let question = PendingQuestion(id: "q", prompt: "Which?", options: [QuestionOption(id: "a", label: "A")],
+                                       questions: [QuestionItem(id: "q1", text: "Which?", options: [QuestionOption(id: "a", label: "A")])])
+        let typed = CursorACPMonitor.questionResponse(question: question, answers: ["q1": ["something else"]])
+        let outcome = typed["outcome"] as? [String: Any]
+        #expect(outcome?["outcome"] as? String == "skipped")
+        #expect((outcome?["reason"] as? String)?.contains("something else") == true)
+        let picked = CursorACPMonitor.questionResponse(question: question, answers: ["q1": ["A"]])
+        #expect(((picked["outcome"] as? [String: Any])?["outcome"] as? String) == "answered")
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorAdapterTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorAdapterTests.swift
@@ -147,6 +147,234 @@ struct CursorHookAdapterTests {
         // Metadata never manufactures progress.
         #expect(session?.status == .working)
     }
+
+    // MARK: - postToolUseFailure causes (cursor.com/docs/hooks)
+
+    /// `is_interrupt` is the person pressing stop in Cursor. The tool did not
+    /// break, so the error cue must stay silent.
+    @Test func anInterruptedToolIsNotAFailure() async {
+        let result = CursorParser.parse(cursorHook("postToolUseFailure",
+            extra: #","tool_name":"Shell","tool_input":{"command":"swift test"},"error_message":"Command was interrupted","failure_type":"error","duration":812,"is_interrupt":true"#),
+            receivedAt: Date())
+        #expect(result.event?.kind == .postToolUse)
+        #expect(result.event?.toolError == false)
+        #expect(result.event?.userStopped == true)
+        #expect(result.event?.message == "Stopped by you")
+
+        let store = SessionStore()
+        let now = Date()
+        await store.ingest(cursorHook("beforeSubmitPrompt", extra: #","prompt":"go""#),
+                           agent: .cursor, receivedAt: now)
+        await store.ingest(cursorHook("postToolUseFailure",
+            extra: #","tool_name":"Shell","tool_input":{},"error_message":"Command was interrupted","failure_type":"error","duration":812,"is_interrupt":true"#),
+            agent: .cursor, receivedAt: now.addingTimeInterval(1))
+        let session = await store.snapshot(now: now).sessions.first { $0.id == "c1" }
+        #expect(session?.failed != true)
+    }
+
+    /// A gate saying no (Cursor's own, or the phone's Deny) is a decision, not
+    /// a breakage.
+    @Test func aDeniedToolIsNotAFailure() {
+        let denied = CursorParser.parse(cursorHook("postToolUseFailure",
+            extra: #","tool_name":"Shell","tool_input":{"command":"rm -rf build"},"error_message":"Permission denied by user","failure_type":"permission_denied","duration":3,"is_interrupt":false"#),
+            receivedAt: Date())
+        #expect(denied.event?.toolError == false)
+        #expect(denied.event?.userStopped == false)
+        #expect(denied.event?.message == "Permission denied by user")
+
+        let bare = CursorParser.parse(cursorHook("postToolUseFailure",
+            extra: #","tool_name":"Shell","tool_input":{},"failure_type":"permission_denied","duration":3,"is_interrupt":false"#),
+            receivedAt: Date())
+        #expect(bare.event?.message == "Denied")
+    }
+
+    @Test func aTimedOutToolIsStillAFailure() {
+        let result = CursorParser.parse(cursorHook("postToolUseFailure",
+            extra: #","tool_name":"Shell","tool_input":{"command":"sleep 999"},"error_message":"Timed out after 600s","failure_type":"timeout","duration":600000,"is_interrupt":false"#),
+            receivedAt: Date())
+        #expect(result.event?.toolError == true)
+        #expect(result.event?.message == "Timed out after 600s")
+    }
+
+    // MARK: - composer_mode
+
+    /// An Ask or Edit chat is a Q&A, not a task: it never becomes a row, never
+    /// enters the three states, and its later events do not open one either —
+    /// from the hook or from the transcript tailer, which keys on the same id.
+    @Test func anAskModeChatNeverBecomesASession() async {
+        let ask = CursorParser.parse(cursorHook("sessionStart",
+            extra: #","session_id":"s1","is_background_agent":false,"composer_mode":"ask""#), receivedAt: Date())
+        #expect(ask.event?.observeOnly == true)
+        let edit = CursorParser.parse(cursorHook("sessionStart",
+            extra: #","session_id":"s1","is_background_agent":false,"composer_mode":"edit""#), receivedAt: Date())
+        #expect(edit.event?.observeOnly == true)
+
+        let store = SessionStore()
+        let now = Date()
+        await store.ingest(cursorHook("sessionStart",
+            extra: #","session_id":"s1","is_background_agent":false,"composer_mode":"ask""#),
+            agent: .cursor, receivedAt: now)
+        #expect(await store.snapshot(now: now).sessions.contains { $0.id == "c1" } == false)
+
+        await store.ingest(cursorHook("beforeSubmitPrompt", extra: #","prompt":"what does this do?""#),
+                           agent: .cursor, receivedAt: now.addingTimeInterval(1))
+        await store.ingest(cursorHook("preToolUse", extra: #","tool_name":"ReadFile","tool_input":{"path":"/a"},"cwd":"/x/p""#),
+                           agent: .cursor, receivedAt: now.addingTimeInterval(2))
+        await store.ingest(HookEvent(kind: .userPromptSubmit, sessionID: "c1", agent: .cursor,
+                                     cwd: "/x/p", message: "go", observationSource: .transcript,
+                                     timestamp: now.addingTimeInterval(3)))
+        await store.ingest(cursorHook("stop", extra: #","status":"completed","loop_count":0"#),
+                           agent: .cursor, receivedAt: now.addingTimeInterval(4))
+        #expect(await store.snapshot(now: now).sessions.contains { $0.id == "c1" } == false)
+        // Nothing was recorded as hook evidence for it either.
+        #expect(await store.hasSession("c1") == false)
+
+        // An Agent-mode chat in the same store is tracked as usual.
+        let agent = cursorHook("sessionStart",
+            extra: #","session_id":"s2","is_background_agent":false,"composer_mode":"agent""#)
+            .replacingConversation(with: "c2")
+        await store.ingest(agent, agent: .cursor, receivedAt: now)
+        await store.ingest(cursorHook("preToolUse", extra: #","tool_name":"Shell","tool_input":{"command":"ls"},"cwd":"/x/p""#)
+                               .replacingConversation(with: "c2"),
+                           agent: .cursor, receivedAt: now.addingTimeInterval(1))
+        let session = await store.snapshot(now: now).sessions.first { $0.id == "c2" }
+        #expect(session?.status == .working)
+        #expect(session?.activeTool == "Bash")
+
+        // `sessionEnd` releases the id; a fresh Agent-mode start is tracked again.
+        await store.ingest(cursorHook("sessionEnd", extra: #","session_id":"s1","reason":"user_closed""#),
+                           agent: .cursor, receivedAt: now.addingTimeInterval(5))
+        await store.ingest(cursorHook("sessionStart",
+            extra: #","session_id":"s3","is_background_agent":false,"composer_mode":"agent""#),
+            agent: .cursor, receivedAt: now.addingTimeInterval(6))
+        #expect(await store.snapshot(now: now).sessions.contains { $0.id == "c1" })
+    }
+
+    // MARK: - model display
+
+    /// `model_id` is the stable id, `model` the picker label; the picker's
+    /// toggles ride in `model_params` and are worth a suffix.
+    @Test func modelIDAndParamsRender() {
+        let full = CursorParser.parse(cursorHook("beforeSubmitPrompt",
+            extra: #","prompt":"go","model_id":"claude-opus-4-7","model_params":[{"id":"thinking","value":"true"},{"id":"context","value":"1m"},{"id":"effort","value":"max"}]"#),
+            receivedAt: Date())
+        #expect(full.event?.model == "claude-opus-4-7 (1m, max, thinking)")
+
+        let some = CursorParser.parse(cursorHook("beforeSubmitPrompt",
+            extra: #","prompt":"go","model_id":"gpt-5.5","model_params":[{"id":"thinking","value":"false"},{"id":"effort","value":"high"}]"#),
+            receivedAt: Date())
+        #expect(some.event?.model == "gpt-5.5 (high)")
+
+        // No id and no params: the label alone, no parentheses.
+        let bare = CursorParser.parse(cursorHook("beforeSubmitPrompt", extra: #","prompt":"go""#), receivedAt: Date())
+        #expect(bare.event?.model == "Claude Fable 5")
+    }
+
+    // MARK: - tool output into recent output
+
+    /// `tool_output` is a JSON-stringified result payload for shell tools; the
+    /// pane shows it as exit / stdout, and while the hooks are fresh it is what
+    /// `/recent-output` serves — the transcript has no tool results at all.
+    @Test func toolOutputRendersAndReachesRecentOutput() async {
+        let result = CursorParser.parse(cursorHook("postToolUse",
+            extra: #","tool_name":"Shell","tool_input":{"command":"swift test"},"tool_output":"{\"exitCode\":0,\"stdout\":\"All tests passed\"}","tool_use_id":"t1","cwd":"/x/p","duration":812"#),
+            receivedAt: Date())
+        #expect(result.event?.toolOutput == "exit 0\nAll tests passed")
+        #expect(result.event?.toolError == false)
+
+        let withErr = CursorParser.parse(cursorHook("postToolUse",
+            extra: #","tool_name":"Shell","tool_input":{},"tool_output":"{\"exit_code\":1,\"stdout\":\"\",\"stderr\":\"boom\"}","tool_use_id":"t2","cwd":"/x/p","duration":1"#),
+            receivedAt: Date())
+        #expect(withErr.event?.toolOutput == "exit 1\nboom")
+
+        let plain = CursorParser.parse(cursorHook("postToolUse",
+            extra: #","tool_name":"ReadFile","tool_input":{"path":"/a"},"tool_output":"line one","tool_use_id":"t3","cwd":"/x/p","duration":1"#),
+            receivedAt: Date())
+        #expect(plain.event?.toolOutput == "line one")
+
+        let long = String(repeating: "x", count: 700)
+        let cut = CursorParser.parse(cursorHook("postToolUse",
+            extra: #","tool_name":"ReadFile","tool_input":{},"tool_output":"\#(long)","tool_use_id":"t4","cwd":"/x/p","duration":1"#),
+            receivedAt: Date())
+        #expect(cut.event?.toolOutput?.count == 601)
+        #expect(cut.event?.toolOutput?.hasSuffix("…") == true)
+
+        let store = SessionStore()
+        let now = Date()
+        await store.ingest(cursorHook("beforeSubmitPrompt", extra: #","prompt":"run the tests""#),
+                           agent: .cursor, receivedAt: now)
+        await store.ingest(cursorHook("preToolUse", extra: #","tool_name":"Shell","tool_input":{"command":"swift test"},"cwd":"/x/p""#),
+                           agent: .cursor, receivedAt: now.addingTimeInterval(1))
+        await store.ingest(cursorHook("postToolUse",
+            extra: #","tool_name":"Shell","tool_input":{"command":"swift test"},"tool_output":"{\"exitCode\":0,\"stdout\":\"All tests passed\"}","tool_use_id":"t1","cwd":"/x/p","duration":812"#),
+            agent: .cursor, receivedAt: now.addingTimeInterval(2))
+        await store.ingest(cursorHook("afterAgentResponse", extra: #","text":"Green.""#),
+                           agent: .cursor, receivedAt: now.addingTimeInterval(3))
+        let output = await store.recentOutput(sessionID: "c1")
+        #expect(output.source == .hook)
+        #expect(output.entries.map(\.role) == ["user", "assistant", "assistant", "assistant"])
+        #expect(output.entries.map(\.text) == ["run the tests", "⚙ Bash", "exit 0\nAll tests passed", "Green."])
+    }
+
+    @Test func shellOutputReachesRecentOutput() async {
+        let result = CursorParser.parse(cursorHook("afterShellExecution",
+            extra: #","command":"git status","output":"On branch main\nnothing to commit","duration":40,"sandbox":false"#),
+            receivedAt: Date())
+        #expect(result.event?.toolOutput == "On branch main\nnothing to commit")
+
+        let store = SessionStore()
+        let now = Date()
+        await store.ingest(cursorHook("beforeSubmitPrompt", extra: #","prompt":"status?""#),
+                           agent: .cursor, receivedAt: now)
+        await store.ingest(cursorHook("afterShellExecution",
+            extra: #","command":"git status","output":"On branch main\nnothing to commit","duration":40,"sandbox":false"#),
+            agent: .cursor, receivedAt: now.addingTimeInterval(1))
+        let output = await store.recentOutput(sessionID: "c1")
+        #expect(output.entries.last?.text == "On branch main\nnothing to commit")
+    }
+}
+
+private extension Data {
+    /// The same documented payload for a second conversation.
+    func replacingConversation(with id: String) -> Data {
+        Data(String(decoding: self, as: UTF8.self)
+            .replacingOccurrences(of: #""conversation_id":"c1""#, with: #""conversation_id":"\#(id)""#).utf8)
+    }
+}
+
+@Suite("Cursor through Claude hooks")
+struct CursorThroughClaudeHooksTests {
+    /// With "Include third-party Plugins, Skills, and other configs" on, Cursor
+    /// runs the Claude Code hooks in ~/.claude/settings.json with its own
+    /// payload (cursor.com/docs/reference/third-party-hooks). The forwarder tags
+    /// it `claude-code`; the decoder must still see one Cursor session.
+    @Test func aCursorPayloadOnTheClaudeRouteIsACursorSession() {
+        let payload = Data(#"{"hook_event_name":"preToolUse","conversation_id":"c1","generation_id":"g1","#
+            .appending(#""model":"Claude Fable 5","cursor_version":"3.20.17","workspace_roots":["/x/p"],"#)
+            .appending(#""tool_name":"Shell","tool_input":{"command":"ls"},"cwd":"/x/p"}"#).utf8)
+        let result = HookDecoder.decode(payload, agent: .claudeCode, receivedAt: Date())
+        #expect(result.event?.agent == .cursor)
+        #expect(result.event?.sessionID == "c1")
+        #expect(result.event?.kind == .preToolUse)
+        #expect(result.event?.toolName == "Bash")
+    }
+
+    /// A camelCase event name alone is enough: no Claude-shape CLI spells its
+    /// events that way.
+    @Test func aCamelCaseEventNameWithoutAVersionStillRoutes() {
+        let payload = Data(#"{"hook_event_name":"beforeSubmitPrompt","conversation_id":"c1","prompt":"go"}"#.utf8)
+        let result = HookDecoder.decode(payload, agent: .claudeCode, receivedAt: Date())
+        #expect(result.event?.agent == .cursor)
+        #expect(result.event?.kind == .userPromptSubmit)
+    }
+
+    @Test func aGenuineClaudePayloadIsUnchanged() {
+        let payload = Data(#"{"hook_event_name":"PreToolUse","session_id":"s1","cwd":"/x/p","tool_name":"Bash","tool_input":{"command":"ls"}}"#.utf8)
+        let result = HookDecoder.decode(payload, agent: .claudeCode, receivedAt: Date())
+        #expect(result.event?.agent == .claudeCode)
+        #expect(result.event?.sessionID == "s1")
+        #expect(result.event?.kind == .preToolUse)
+    }
 }
 
 @Suite("Cursor tool vocabulary")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorAdapterTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorAdapterTests.swift
@@ -122,9 +122,22 @@ struct CursorHookAdapterTests {
     /// Cursor fires events that say nothing about progress on every session.
     /// Treating those as an unknown envelope would report the hook source as an
     /// unrecognised Cursor version after every turn.
+    @Test func aThoughtIsActivityNotAToolError() async {
+        let result = CursorParser.parse(cursorHook("afterAgentThought", extra: #","text":"hm","duration_ms":10"#),
+                                        receivedAt: Date())
+        #expect(result.event?.kind == .preToolUse)
+        #expect(result.event?.toolName == "Thinking")
+        #expect(result.event?.toolError == false)
+        let store = SessionStore()
+        await store.ingest(result.event!)
+        let session = await store.snapshot(now: Date()).sessions.first { $0.id == "c1" }
+        #expect(session?.status == .working)
+        #expect(ToolActivity.label(for: session!) == "Thinking…")
+        // A heartbeat, not dialogue: the hook log stays empty.
+        #expect(await store.recentOutput(sessionID: "c1", rolloutPath: nil).entries.isEmpty)
+    }
+
     @Test func understoodButSilentEventsAreIgnoredNotUndecodable() {
-        #expect(CursorParser.parse(cursorHook("afterAgentThought", extra: #","text":"hm","duration_ms":10"#),
-                                   receivedAt: Date()) == .ignored)
         #expect(CursorParser.parse(cursorHook("workspaceOpen"), receivedAt: Date()) == .ignored)
         #expect(CursorParser.parse(cursorHook("beforeTabFileRead", extra: #","file_path":"/a""#),
                                    receivedAt: Date()) == .ignored)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorCloudAgentTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/CursorCloudAgentTests.swift
@@ -1,0 +1,541 @@
+import Foundation
+import Testing
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+/// A pass counter the scripted transport can bump from a `@Sendable` closure.
+final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func next() -> Int { lock.withLock { defer { value += 1 }; return value } }
+}
+
+/// Scripted `api.cursor.com`. Records every request so a test can assert what
+/// was — and was not — sent.
+final class ScriptedCursorCloudTransport: CursorCloudTransport, @unchecked Sendable {
+    private let handler: @Sendable (URLRequest) throws -> (Data, URLResponse)
+    private let lock = NSLock()
+    private var recorded: [URLRequest] = []
+
+    init(handler: @escaping @Sendable (URLRequest) throws -> (Data, URLResponse)) {
+        self.handler = handler
+    }
+
+    var requests: [URLRequest] { lock.withLock { recorded } }
+
+    func cursorCloudData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lock.withLock { recorded.append(request) }
+        return try handler(request)
+    }
+
+    static func json(_ body: String, status: Int = 200, for request: URLRequest) -> (Data, URLResponse) {
+        (Data(body.utf8), HTTPURLResponse(url: request.url!, statusCode: status,
+                                          httpVersion: nil, headerFields: nil)!)
+    }
+}
+
+@Suite("Cursor Cloud Agents API")
+struct CursorCloudAgentTests {
+    static let agentID = "bc-00000000-0000-0000-0000-000000000001"
+    static let runID = "run-00000000-0000-0000-0000-000000000001"
+    static let key = "key_supersecret_value"
+
+    static func client(_ transport: ScriptedCursorCloudTransport,
+                       apiKey: String? = key) -> CursorCloudAgentClient {
+        CursorCloudAgentClient(baseURL: URL(string: "https://api.cursor.example")!,
+                               apiKey: { apiKey }, transport: transport)
+    }
+
+    // MARK: - Wire
+
+    @Test("list reads v1 agents, sends the key as a bearer token and skips archived")
+    func listAgents() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            let body = """
+            {"items":[{"id":"\(Self.agentID)","name":"Fix the parser","status":"ACTIVE",
+            "env":{"type":"cloud"},"url":"https://cursor.com/agents/x",
+            "updatedAt":"2026-09-12T10:00:00Z","latestRunId":"\(Self.runID)"}]}
+            """
+            return ScriptedCursorCloudTransport.json(body, for: request)
+        }
+        let agents = try await Self.client(transport).agents()
+        #expect(agents.count == 1)
+        #expect(agents[0].id == Self.agentID)
+        #expect(agents[0].status == .active)
+        #expect(agents[0].name == "Fix the parser")
+        #expect(agents[0].environment == "cloud")
+        #expect(agents[0].latestRunID == Self.runID)
+
+        let request = try #require(transport.requests.first)
+        #expect(request.url?.path == "/v1/agents")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(Self.key)")
+        let query = try #require(request.url?.query)
+        #expect(query.contains("includeArchived=false"))
+    }
+
+    @Test("list follows nextCursor to the end")
+    func listPaginates() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            let cursor = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first { $0.name == "cursor" }?.value
+            let body = cursor == nil
+                ? #"{"items":[{"id":"bc-1","status":"IDLE"}],"nextCursor":"page2"}"#
+                : #"{"items":[{"id":"bc-2","status":"ACTIVE"}]}"#
+            return ScriptedCursorCloudTransport.json(body, for: request)
+        }
+        let agents = try await Self.client(transport).agents()
+        #expect(agents.map(\.id) == ["bc-1", "bc-2"])
+        #expect(transport.requests.count == 2)
+    }
+
+    @Test("an agent status this build does not know is dropped, not guessed at")
+    func unknownStatusDropped() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json(
+                #"{"items":[{"id":"bc-1","status":"HIBERNATING"},{"id":"bc-2","status":"IDLE"}]}"#,
+                for: request)
+        }
+        let agents = try await Self.client(transport).agents()
+        #expect(agents.map(\.id) == ["bc-2"])
+    }
+
+    @Test("a follow-up is POST /v1/agents/{id}/runs with the documented prompt body")
+    func startRunShape() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json(
+                #"{"run":{"id":"run-9","agentId":"bc-1","status":"CREATING"}}"#, for: request)
+        }
+        let run = try await Self.client(transport).startRun(agentID: "bc-1", text: "  keep going  ")
+        #expect(run.status == .creating)
+
+        let request = try #require(transport.requests.first)
+        #expect(request.httpMethod == "POST")
+        #expect(request.url?.path == "/v1/agents/bc-1/runs")
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let prompt = try #require(json["prompt"] as? [String: Any])
+        #expect(prompt["text"] as? String == "keep going")
+    }
+
+    @Test("a terminal run carries its result and branch")
+    func runDetail() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            let body = """
+            {"id":"\(Self.runID)","agentId":"\(Self.agentID)","status":"FINISHED",
+            "result":"Renamed the field and updated both call sites.",
+            "git":{"branches":[{"repoUrl":"github.com/a/b","branch":"cursor/fix-1","prUrl":"https://github.com/a/b/pull/3"}]}}
+            """
+            return ScriptedCursorCloudTransport.json(body, for: request)
+        }
+        let run = try await Self.client(transport).run(agentID: Self.agentID, runID: Self.runID)
+        #expect(run.status == .finished)
+        #expect(run.result == "Renamed the field and updated both call sites.")
+        #expect(run.branch == "cursor/fix-1")
+        #expect(run.pullRequestURL == "https://github.com/a/b/pull/3")
+    }
+
+    // MARK: - Refusals
+
+    @Test("409 agent_busy is its own error, and any other 409 is not mistaken for it")
+    func busyIsDistinct() async throws {
+        let busy = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json(#"{"code":"agent_busy","message":"A run is active"}"#,
+                                              status: 409, for: request)
+        }
+        await #expect(throws: CursorCloudError.busy) {
+            try await Self.client(busy).startRun(agentID: "bc-1", text: "hi")
+        }
+        let other = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json(#"{"code":"repo_locked"}"#, status: 409, for: request)
+        }
+        await #expect(throws: CursorCloudError.service(status: 409, code: "repo_locked")) {
+            try await Self.client(other).startRun(agentID: "bc-1", text: "hi")
+        }
+    }
+
+    @Test("no key means no request is ever sent")
+    func missingKey() async throws {
+        let transport = ScriptedCursorCloudTransport { _ in
+            Issue.record("Must not call Cursor without a key")
+            throw CursorCloudError.transport
+        }
+        await #expect(throws: CursorCloudError.missingKey) {
+            try await Self.client(transport, apiKey: nil).agents()
+        }
+        #expect(transport.requests.isEmpty)
+    }
+
+    @Test("a busy agent is told to wait, and every refusal keeps the key out of its text",
+          arguments: [(409, #"{"code":"agent_busy"}"#), (401, "{}"), (404, "{}"), (429, "{}"), (500, "{}")])
+    func refusalCopyNeverEchoesTheKey(status: Int, body: String) async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json(body, status: status, for: request)
+        }
+        let outcome = await Self.client(transport).continueAgent(id: "bc-1", text: "go")
+        guard case let .failed(message) = outcome else {
+            #expect(status == 500, "only an unclassified failure may answer `unknown`")
+            return
+        }
+        #expect(!message.contains(Self.key))
+        #expect(!message.isEmpty)
+        if status == 409 { #expect(message.contains("finishes")) }
+    }
+
+    @Test("a started run reports accepted")
+    func continueAccepted() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json(
+                #"{"run":{"id":"run-9","agentId":"bc-1","status":"CREATING"}}"#, for: request)
+        }
+        let outcome = await Self.client(transport).continueAgent(id: "bc-1", text: "go")
+        #expect(outcome == .accepted)
+    }
+
+    // MARK: - Monitor
+
+    /// A scripted account: one list response per pass, plus agent detail and run
+    /// detail for whatever is asked.
+    static func monitorTransport(_ statuses: [[String: String]],
+                                 runStatus: String = "FINISHED",
+                                 result: String? = "Done.",
+                                 repo: String? = "github.com/org/repo") -> ScriptedCursorCloudTransport {
+        let passes = Counter()
+        return ScriptedCursorCloudTransport { request in
+            let path = request.url!.path
+            if path.contains("/runs/") {
+                let body = """
+                {"id":"\(Self.runID)","agentId":"\(Self.agentID)","status":"\(runStatus)"
+                \(result.map { ",\"result\":\"\($0)\"" } ?? "")}
+                """
+                return ScriptedCursorCloudTransport.json(body, for: request)
+            }
+            // Per-agent detail: /v1/agents/{id} with nothing after it.
+            if path.hasPrefix("/v1/agents/") {
+                let id = String(path.dropFirst("/v1/agents/".count))
+                let repos = repo.map { #","repos":[{"url":"\#($0)"}]"# } ?? ""
+                return ScriptedCursorCloudTransport.json(
+                    #"{"id":"\#(id)","status":"IDLE"\#(repos)}"#, for: request)
+            }
+            let index = min(passes.next(), statuses.count - 1)
+            let items = statuses[index].map { id, status in
+                #"{"id":"\#(id)","status":"\#(status)","latestRunId":"\#(Self.runID)","updatedAt":"2026-09-12T10:00:00Z"}"#
+            }.joined(separator: ",")
+            return ScriptedCursorCloudTransport.json("{\"items\":[\(items)]}", for: request)
+        }
+    }
+
+    static func monitor(_ transport: ScriptedCursorCloudTransport,
+                        apiKey: String? = key) -> CursorCloudAgentMonitor {
+        CursorCloudAgentMonitor(client: client(transport, apiKey: apiKey))
+    }
+
+    @Test("an agent nothing on this Mac has ever seen still gets a row")
+    func rowsComeFromTheAPI() async throws {
+        // The decisive case: this Mac's Cursor database holds no bc- rows at
+        // all, so a design that waited for one would show nothing, ever.
+        let transport = Self.monitorTransport([[Self.agentID: "ACTIVE"]])
+        let (agents, events) = await Self.monitor(transport).pass(now: Date())
+        #expect(agents?.map(\.id) == [Self.agentID])
+        #expect(agents?.first?.repository == "github.com/org/repo")
+        #expect(events.map(\.kind) == [.userPromptSubmit])
+        // The repository stands in for a project: a cloud agent has no folder.
+        #expect(events.first?.cwd == "github.com/org/repo")
+        #expect(events.first?.observationSource == .cloud)
+    }
+
+    @Test("an agent already idle at launch replays nothing but is still reported")
+    func idleAtLaunchIsSilentNotInvisible() async throws {
+        let transport = Self.monitorTransport([[Self.agentID: "IDLE"]])
+        let monitor = Self.monitor(transport)
+        let (agents, events) = await monitor.pass(now: Date())
+        #expect(events.isEmpty)
+        // Silent, but present — it becomes a quiet history row.
+        #expect(agents?.map(\.id) == [Self.agentID])
+        let (_, again) = await monitor.pass(now: Date())
+        #expect(again.isEmpty)
+    }
+
+    @Test("running then idle ends the turn with the run's own result")
+    func activeToIdleCompletes() async throws {
+        let transport = Self.monitorTransport([[Self.agentID: "ACTIVE"], [Self.agentID: "IDLE"]])
+        let monitor = Self.monitor(transport)
+        _ = await monitor.pass(now: Date())
+        let (_, events) = await monitor.pass(now: Date())
+        #expect(events.map(\.kind) == [.stop])
+        #expect(events.first?.completionSucceeded == true)
+        #expect(events.first?.completionText == "Done.")
+    }
+
+    @Test("a run that errored ends the turn without claiming success")
+    func erroredRunIsNotSuccess() async throws {
+        let transport = Self.monitorTransport([[Self.agentID: "ACTIVE"], [Self.agentID: "IDLE"]],
+                                              runStatus: "ERROR", result: nil)
+        let monitor = Self.monitor(transport)
+        _ = await monitor.pass(now: Date())
+        let (_, events) = await monitor.pass(now: Date())
+        #expect(events.first?.kind == .stop)
+        #expect(events.first?.completionSucceeded == false)
+        #expect(events.first?.completionText == nil)
+    }
+
+    @Test("a cancelled run reads as an ending the person asked for")
+    func cancelledRunIsAUserStop() async throws {
+        let transport = Self.monitorTransport([[Self.agentID: "ACTIVE"], [Self.agentID: "IDLE"]],
+                                              runStatus: "CANCELLED", result: nil)
+        let monitor = Self.monitor(transport)
+        _ = await monitor.pass(now: Date())
+        let (_, events) = await monitor.pass(now: Date())
+        #expect(events.first?.userStopped == true)
+        #expect(events.first?.completionSucceeded == false)
+    }
+
+    @Test("the repository is fetched once and then reused")
+    func repositoryIsCached() async throws {
+        let transport = Self.monitorTransport([[Self.agentID: "ACTIVE"], [Self.agentID: "ACTIVE"]])
+        let monitor = Self.monitor(transport)
+        _ = await monitor.pass(now: Date())
+        _ = await monitor.pass(now: Date())
+        let details = transport.requests.filter {
+            $0.url!.path.hasPrefix("/v1/agents/") && !$0.url!.path.contains("/runs")
+        }
+        #expect(details.count == 1)
+    }
+
+    @Test("without a key the monitor never reaches the network")
+    func monitorNeedsAKey() async throws {
+        let transport = ScriptedCursorCloudTransport { _ in
+            Issue.record("Must not poll Cursor without a key")
+            throw CursorCloudError.transport
+        }
+        let (agents, events) = await Self.monitor(transport, apiKey: nil).pass(now: Date())
+        #expect(agents?.isEmpty == true)
+        #expect(events.isEmpty)
+        #expect(transport.requests.isEmpty)
+    }
+
+    @Test("a failed poll applies nothing — an unreachable API is not an empty account")
+    func failedPollAppliesNothing() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json("{}", status: 500, for: request)
+        }
+        let (agents, events) = await Self.monitor(transport).pass(now: Date())
+        // nil, not [] — [] would wipe every row the last good pass established.
+        #expect(agents == nil)
+        #expect(events.isEmpty)
+    }
+
+    @Test("an agent that leaves the list ends, once")
+    func vanishedAgentEnds() async throws {
+        let transport = Self.monitorTransport([[Self.agentID: "ACTIVE"], [:]])
+        let monitor = Self.monitor(transport)
+        _ = await monitor.pass(now: Date())
+        let (_, events) = await monitor.pass(now: Date())
+        #expect(events.map(\.kind) == [.sessionEnd])
+        let (_, again) = await monitor.pass(now: Date())
+        #expect(again.isEmpty)
+    }
+
+    // MARK: - Jump
+
+    @Test("only a Cursor page is ever handed to a browser",
+          arguments: ["http://cursor.com/agents/x",
+                      "https://evil.com/agents/x",
+                      "https://cursor.com.evil.com/x",
+                      "https://user:pw@cursor.com/x",
+                      "javascript:alert(1)",
+                      "not a url at all"])
+    func jumpRejectsAnythingElse(_ page: String) async {
+        #expect(CursorCloudJumper.validated(page) == nil)
+        let outcome = await CursorCloudJumper.jump(page: page) { _ in
+            Issue.record("Must not open \(page)")
+            return true
+        }
+        #expect(outcome == .unsupported)
+    }
+
+    @Test("a Cursor agent page opens", arguments: ["https://cursor.com/agents/bc-1",
+                                                  "https://www.cursor.com/agents/bc-1"])
+    func jumpOpensTheAgentPage(_ page: String) async {
+        let outcome = await CursorCloudJumper.jump(page: page) { url in
+            #expect(url.absoluteString == page)
+            return true
+        }
+        #expect(outcome == .focused)
+    }
+
+    // MARK: - Cancel
+
+    @Test("cancelling a live run is sent")
+    func cancelSent() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            #expect(request.httpMethod == "POST")
+            #expect(request.url?.path == "/v1/agents/bc-1/runs/run-1/cancel")
+            return ScriptedCursorCloudTransport.json(#"{"id":"run-1"}"#, for: request)
+        }
+        let outcome = await Self.client(transport).cancel(agentID: "bc-1", runID: "run-1")
+        #expect(outcome == .sent)
+    }
+
+    @Test("a run that already finished is refused, not reported as failure")
+    func cancelNotCancellable() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json(#"{"code":"run_not_cancellable"}"#,
+                                              status: 409, for: request)
+        }
+        let outcome = await Self.client(transport).cancel(agentID: "bc-1", runID: "run-1")
+        #expect(outcome == .notSent("This run has already finished."))
+    }
+
+    @Test("a cancel that never reached Cursor is unconfirmed, never retried")
+    func cancelUnconfirmed() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json("{}", status: 500, for: request)
+        }
+        let outcome = await Self.client(transport).cancel(agentID: "bc-1", runID: "run-1")
+        #expect(outcome == .unconfirmed)
+        #expect(transport.requests.count == 1)
+    }
+
+    // MARK: - Conversation
+
+    @Test("the runs list is the conversation v1 has no endpoint for")
+    func recentOutputFromRuns() async throws {
+        let transport = ScriptedCursorCloudTransport { request in
+            #expect(request.url?.path == "/v1/agents/bc-1/runs")
+            let body = """
+            {"items":[
+              {"id":"run-3","agentId":"bc-1","status":"RUNNING"},
+              {"id":"run-2","agentId":"bc-1","status":"ERROR"},
+              {"id":"run-1","agentId":"bc-1","status":"FINISHED","result":"Renamed the field."}
+            ]}
+            """
+            return ScriptedCursorCloudTransport.json(body, for: request)
+        }
+        let output = await Self.client(transport).recentOutput(agentID: "bc-1")
+        #expect(output.source == .cloud)
+        #expect(output.unavailable == nil)
+        // Oldest first, the way a conversation reads. The still-running run has
+        // nothing to say yet and contributes no line.
+        #expect(output.entries.map(\.text) == ["Renamed the field.", "This run ended with an error."])
+    }
+
+    @Test("no key is no source, and an unreachable API is an unreadable one")
+    func recentOutputUnavailability() async throws {
+        let none = ScriptedCursorCloudTransport { _ in
+            Issue.record("Must not call Cursor without a key")
+            throw CursorCloudError.transport
+        }
+        let missing = await Self.client(none, apiKey: nil).recentOutput(agentID: "bc-1")
+        #expect(missing.unavailable == .noSource)
+
+        let broken = ScriptedCursorCloudTransport { request in
+            ScriptedCursorCloudTransport.json("{}", status: 500, for: request)
+        }
+        let unreadable = await Self.client(broken).recentOutput(agentID: "bc-1")
+        #expect(unreadable.unavailable == .unreadable)
+    }
+
+    // MARK: - What the composer may send
+
+    static func cloudSession(status: SessionStatus,
+                             observations: [ObservationEvidence]?) -> AgentSession {
+        let now = Date()
+        var session = AgentSession(id: agentID, agent: .cursor, project: "/tmp/repo",
+                                   status: status, statusSince: now, updatedAt: now)
+        session.observations = observations
+        return session
+    }
+
+    static let cloudEvidence = [ObservationEvidence(source: .cloud, lastObservedAt: Date(),
+                                                    health: .healthy)]
+
+    @Test("a running cloud agent refuses a supplement — Cursor allows one run at a time")
+    func runningCloudAgentRefusesSteer() {
+        let support = SessionActionSupport.resolve(
+            for: Self.cloudSession(status: .working, observations: Self.cloudEvidence))
+        #expect(support.intent == .steer)
+        #expect(!support.isAvailable)
+        #expect(support.unsupportedReason?.contains("busy") == true)
+    }
+
+    @Test("an idle cloud agent takes the next run, and says where it lands")
+    func idleCloudAgentContinues() {
+        let support = SessionActionSupport.resolve(
+            for: Self.cloudSession(status: .done, observations: Self.cloudEvidence))
+        #expect(support.intent == .continue)
+        #expect(support.isAvailable)
+        #expect(support.note?.contains("cloud agent") == true)
+    }
+
+    @Test("a cloud agent with no reachable API asks for the key, not for Cursor's hooks")
+    func unreachableCloudAgentAsksForTheKey() {
+        for status: SessionStatus in [.working, .done] {
+            let support = SessionActionSupport.resolve(
+                for: Self.cloudSession(status: status, observations: nil))
+            #expect(!support.isAvailable)
+            #expect(support.unsupportedReason?.contains("API key") == true)
+            // The local-Cursor copy would send the person to the hook installer,
+            // which does nothing for an agent that never runs on this Mac.
+            #expect(support.unsupportedReason?.contains("hooks") != true)
+        }
+    }
+
+    @Test("a hooked local Cursor chat is unaffected by any of this")
+    func localCursorUnchanged() {
+        let now = Date()
+        var session = AgentSession(id: "11111111-2222-3333-4444-555555555555", agent: .cursor,
+                                   project: "/tmp/repo", status: .working,
+                                   statusSince: now, updatedAt: now)
+        session.observations = [ObservationEvidence(source: .hook, lastObservedAt: Date(),
+                                                    health: .healthy)]
+        let support = SessionActionSupport.resolve(for: session)
+        #expect(support.intent == .steer)
+        #expect(support.isAvailable)
+        #expect(support.note?.contains("queued") == true)
+    }
+
+    @Test("a live cloud run can be stopped — Cursor's API cancels it")
+    func stopAvailableForLiveCloudRun() {
+        let support = SessionActionSupport.resolveStop(
+            for: Self.cloudSession(status: .working, observations: Self.cloudEvidence))
+        #expect(support.isAvailable)
+    }
+
+    @Test("a finished or unreachable cloud agent says why stop is not on offer")
+    func stopRefusedWhenThereIsNothingToCancel() {
+        let done = SessionActionSupport.resolveStop(
+            for: Self.cloudSession(status: .done, observations: Self.cloudEvidence))
+        #expect(!done.isAvailable)
+        #expect(done.unsupportedReason?.contains("already finished") == true)
+
+        let noKey = SessionActionSupport.resolveStop(
+            for: Self.cloudSession(status: .working, observations: nil))
+        #expect(!noKey.isAvailable)
+        #expect(noKey.unsupportedReason?.contains("API key") == true)
+    }
+
+    @Test("a local Cursor chat is still refused — it has no interrupt")
+    func stopStillRefusedForLocalCursor() {
+        let now = Date()
+        let local = AgentSession(id: "11111111-2222-3333-4444-555555555555", agent: .cursor,
+                                 project: "/tmp/repo", status: .working,
+                                 statusSince: now, updatedAt: now)
+        let support = SessionActionSupport.resolveStop(for: local)
+        #expect(!support.isAvailable)
+        #expect(support.unsupportedReason?.contains("Cursor on your Mac") == true)
+    }
+
+    @Test("only a bc- id is a cloud agent")
+    func cloudIdentity() {
+        #expect(SessionActionSupport.isCursorCloudAgent(
+            Self.cloudSession(status: .done, observations: nil)))
+        let now = Date()
+        var local = AgentSession(id: "11111111-2222-3333-4444-555555555555", agent: .cursor,
+                                 project: "/tmp/repo", status: .done,
+                                 statusSince: now, updatedAt: now)
+        #expect(!SessionActionSupport.isCursorCloudAgent(local))
+        local = AgentSession(id: "bc-1", agent: .codex, project: "/tmp/repo",
+                             status: .done, statusSince: now, updatedAt: now)
+        #expect(!SessionActionSupport.isCursorCloudAgent(local))
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/DispatchTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/DispatchTests.swift
@@ -43,9 +43,22 @@ struct DispatchRouteTests {
                 #expect(res.status == .ok)
                 #expect(String(buffer: res.body).contains(#""sessionId":"thr-new""#))
             }
+            // Cursor's model, mode and worktree ride the same body; an empty
+            // model is no model.
+            try await client.execute(uri: "/dispatch", method: .post, headers: [.authorization: "Bearer t0k"],
+                                     body: ByteBuffer(string: #"{"agent":"cursor","cwd":"/x/one","prompt":"fix it","model":"gpt-5","mode":"plan","worktree":true}"#)) { res in
+                #expect(res.status == .ok)
+            }
+            try await client.execute(uri: "/dispatch", method: .post, headers: [.authorization: "Bearer t0k"],
+                                     body: ByteBuffer(string: #"{"agent":"cursor","cwd":"/x/one","prompt":"fix it","model":"","worktree":false}"#)) { res in
+                #expect(res.status == .ok)
+            }
         }
-        #expect(box.requests.count == 1)
+        #expect(box.requests.count == 3)
         #expect(box.requests.first == DispatchRequest(agent: .codex, cwd: "/x/one", prompt: "list files", name: "listing"))
+        #expect(box.requests[1] == DispatchRequest(agent: .cursor, cwd: "/x/one", prompt: "fix it",
+                                                   model: "gpt-5", mode: "plan", worktree: true))
+        #expect(box.requests[2] == DispatchRequest(agent: .cursor, cwd: "/x/one", prompt: "fix it", worktree: false))
         // The snapshot tells the phone where it may start tasks.
         #expect(await store.snapshot(now: Date()).recentDirectories == ["/x/two", "/x/one"])
     }

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -470,6 +470,7 @@ final class MenuBarModel: ObservableObject {
                 if await self.claudeLauncher.isSupported() { agents.append(.claudeCode) }
                 if self.codexAppServerDiagnostics.connected { agents.append(.codex) }
                 var cursorReady = await self.cursorACP.isSupported()
+                await self.store.setCursorModels(cursorReady ? await self.cursorACP.models() : [])
                 if !cursorReady { cursorReady = await self.cursorLauncher.isSupported() }
                 if cursorReady { agents.append(.cursor) }
                 self.dispatchAgents = agents

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -112,6 +112,15 @@ final class MenuBarModel: ObservableObject {
     private let approvalContext = ApprovalContextStore()
     private let questionRegistry = QuestionRegistry()
     private let codexAppServerMonitor: CodexAppServerMonitor
+    /// Follow-ups queued for Cursor conversations; the hooks' `stop` collects
+    /// them for an IDE chat, the ACP host for one it carries. One queue so a
+    /// supplement can never be delivered twice.
+    private let cursorFollowups = CursorFollowupQueue()
+    /// Hosts `cursor-agent acp` conversations (ticket cursor-integration/11):
+    /// the phone's dispatch, stop, continue, permission and question for a
+    /// Cursor task all travel this pipe. Given no executable during isolated
+    /// acceptance, so it reports unsupported and spawns nothing.
+    private let cursorACP: CursorACPMonitor
     private let grokBotMonitor: GrokBotMonitor
     /// Live account usage from Claude's status line and the Codex daemon,
     /// consumed by the usage coordinator ahead of its spawning collectors.
@@ -244,6 +253,11 @@ final class MenuBarModel: ObservableObject {
         openDashboardHotkey = Hotkey.loadOpenDashboard()
         toggleGlanceHotkey = Hotkey.loadToggleGlance()
         usage = AccountUsageCoordinator(store: store, notifier: notifier, liveFeed: usageFeed)
+        cursorACP = CursorACPMonitor(
+            store: store, approvals: approvalRegistry, approvalContext: approvalContext,
+            questions: questionRegistry, allowStore: allowStore, sessionAllow: sessionAllow,
+            followups: cursorFollowups,
+            executable: E2ERunConfiguration.current == nil ? CursorCLI.resolveExecutable() : nil)
         let apnsConfig = APNsConfig.load()
         let deliveryURL = (E2ERunConfiguration.current == nil ? ProcessInfo.processInfo.environment["VIBEBUDDY_DELIVERY_LOG_PATH"] : nil).map {
             URL(fileURLWithPath: $0)
@@ -394,11 +408,13 @@ final class MenuBarModel: ObservableObject {
                                      },
                                      claudeLauncher: claudeLauncher,
                                      cursorLauncher: cursorLauncher,
+                                     cursorACP: cursorACP,
                                      cursorTranscriptMonitor: cursorTranscriptMonitor,
                                      onCompletionReminder: { [weak self] session in
                                          guard let self else { return false }
                                          return await self.deliverCompletionReminder(session)
-                                     })
+                                     },
+                                     cursorFollowups: cursorFollowups)
         Task.detached(priority: .utility) {
             do {
                 try await server.runService()
@@ -445,7 +461,9 @@ final class MenuBarModel: ObservableObject {
                 var agents: [AgentKind] = []
                 if await self.claudeLauncher.isSupported() { agents.append(.claudeCode) }
                 if self.codexAppServerDiagnostics.connected { agents.append(.codex) }
-                if await self.cursorLauncher.isSupported() { agents.append(.cursor) }
+                var cursorReady = await self.cursorACP.isSupported()
+                if !cursorReady { cursorReady = await self.cursorLauncher.isSupported() }
+                if cursorReady { agents.append(.cursor) }
                 self.dispatchAgents = agents
                 self.lifecycleTimeline = await self.store.recentLifecycle()
                 self.missedThisWeek = await self.store.missedCounts()
@@ -914,6 +932,10 @@ final class MenuBarModel: ObservableObject {
         }
     }
 
+    /// End every `cursor-agent acp` process this app is hosting. Called on quit:
+    /// the CLI has no detached mode over ACP, so a turn cannot outlive the host.
+    func shutdownCursorHosts() async { await cursorACP.shutdown() }
+
     /// Start a new task from the Mac, the same way `/dispatch` does for the
     /// phone: Codex through the app-server daemon; other agents once they have
     /// a launcher. The directory must be one a session has run in.
@@ -924,7 +946,11 @@ final class MenuBarModel: ObservableObject {
         switch request.agent {
         case .codex: return await codexAppServerMonitor.dispatch(request)
         case .claudeCode: return await claudeLauncher.dispatch(request)
-        case .cursor: return await cursorLauncher.dispatch(request)
+        case .cursor:
+            // Hosted over ACP when the CLI is signed in, so the task can be
+            // stopped and answered from the phone; a terminal window otherwise.
+            if await cursorACP.isSupported() { return await cursorACP.dispatch(request) }
+            return await cursorLauncher.dispatch(request)
         default: return .unsupported("vibebuddy cannot start \(request.agent.displayName) sessions yet.")
         }
     }

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -49,6 +49,13 @@ final class MenuBarModel: ObservableObject {
         guard let run = E2ERunConfiguration.current else { return CursorTranscriptMonitor() }
         return CursorTranscriptMonitor(root: run.file("agents").appendingPathComponent("cursor/projects", isDirectory: true))
     }()
+    /// Cursor's Cloud Agents API poller. A cloud agent runs on Cursor's
+    /// machines, so it reaches no hook and writes no transcript; this is the
+    /// only live source it has. It does nothing at all until an API key is
+    /// stored, and it is skipped entirely during isolated acceptance so a run
+    /// never talks to Cursor's service.
+    private let cursorCloudMonitor: CursorCloudAgentMonitor? =
+        E2ERunConfiguration.current == nil ? CursorCloudAgentMonitor() : nil
     /// The Codex app-server daemon connection (ADR-0011): on by default, and
     /// the rollout tailer + hooks keep covering Codex whenever it is off or
     /// the daemon is not running.
@@ -410,6 +417,7 @@ final class MenuBarModel: ObservableObject {
                                      cursorLauncher: cursorLauncher,
                                      cursorACP: cursorACP,
                                      cursorTranscriptMonitor: cursorTranscriptMonitor,
+                                     cursorCloudMonitor: cursorCloudMonitor,
                                      onCompletionReminder: { [weak self] session in
                                          guard let self else { return false }
                                          return await self.deliverCompletionReminder(session)

--- a/VibeBuddyMacApp/Sources/UsageView.swift
+++ b/VibeBuddyMacApp/Sources/UsageView.swift
@@ -138,6 +138,10 @@ struct AccountUsageSettings: View {
     @State private var cursorCookie: String = CursorSessionCookieStore.loadManual() ?? ""
     @State private var cursorCookieMode: CursorCookieSourceMode = CursorCookieSourceSettings.mode()
     @State private var cursorImportMessage: String?
+    /// What the user is typing right now — never the stored key, which is
+    /// written once and never read back.
+    @State private var cloudAPIKeyDraft: String = ""
+    @State private var cloudAPIKeySaved = false
     @State private var grokBotAuthorization: String?
     @State private var isAuthorizingGrokBot = false
     @FocusState private var cursorCookieFocused: Bool
@@ -256,6 +260,40 @@ struct AccountUsageSettings: View {
                     .foregroundStyle(.secondary)
             }
 
+            // The third Cursor credential (ADR-0017): a Cloud Agents API key,
+            // separate from the session Cookie above and from the CLI's own
+            // login. Written once, never read back into the field.
+            Section {
+                HStack(spacing: 8) {
+                    SecureField("Cursor API key", text: $cloudAPIKeyDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .labelsHidden()
+                        .frame(width: 170)
+                        .accessibilityLabel("Cursor API key")
+                        .onSubmit { saveCloudAPIKey() }
+                    Button("Save") { saveCloudAPIKey() }
+                        .disabled(cloudAPIKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .accessibilityIdentifier("save-cursorCloudAPIKey")
+                    Button("Remove") {
+                        CursorCloudAPIKeyStore.save(nil)
+                        cloudAPIKeyDraft = ""
+                        cloudAPIKeySaved = CursorCloudAPIKeyStore.isConfigured()
+                    }
+                    .disabled(!cloudAPIKeySaved)
+                    .accessibilityIdentifier("remove-cursorCloudAPIKey")
+                }
+                Text(cloudKeyDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("Cursor cloud agents")
+            } footer: {
+                Text("A Cloud Agents API key from cursor.com/dashboard/api. Separate from the session Cookie above and from the cursor-agent CLI's own login — none of the three substitutes for another. Stored in its own Keychain slot and used only to read the live state of cloud agents (bc-… chats), start their next run and cancel one. Without it, cloud agents stay stored-history rows.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .onAppear { cloudAPIKeySaved = CursorCloudAPIKeyStore.isConfigured() }
+
             Section("Quota alert") {
                 Picker("Quota alert", selection: $alertThreshold) {
                     Text("Off").tag(0)
@@ -281,5 +319,27 @@ struct AccountUsageSettings: View {
                 }
             }
         }
+    }
+}
+
+extension AccountUsageSettings {
+    /// Whether a key is stored — asked of the Keychain by **metadata only**, so
+    /// reading this page never decrypts the key and never raises an
+    /// authorization prompt. The key itself is never read back into the field:
+    /// it is written once and thereafter only replaced or removed.
+    var cloudKeyDetail: String {
+        cloudAPIKeySaved
+            ? String(localized: "A key is saved. Type a new one to replace it.")
+            : String(localized: "No key saved. Cloud agents show as stored history only.")
+    }
+
+    func saveCloudAPIKey() {
+        let trimmed = cloudAPIKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        CursorCloudAPIKeyStore.save(trimmed)
+        // Drop the draft the moment it is stored: nothing keeps the key in the
+        // view hierarchy, and nothing prints it.
+        cloudAPIKeyDraft = ""
+        cloudAPIKeySaved = CursorCloudAPIKeyStore.isConfigured()
     }
 }

--- a/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
+++ b/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
@@ -160,7 +160,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         Self.log.notice("applicationShouldTerminate (someone asked us to quit)")
-        return .terminateNow
+        // Hosted `cursor-agent acp` processes end with the app: their turns
+        // cannot outlive it, and a child left behind would keep its pipes.
+        Task { @MainActor in
+            await MenuBarModel.shared?.shutdownCursorHosts()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/docs/adr/0016-cursor-observation-and-control.md
+++ b/docs/adr/0016-cursor-observation-and-control.md
@@ -116,3 +116,46 @@ a terminal keeps the ordinary terminal jump.
   changes the `composerHeaders` schema degrades one layer at a time rather than
   all three: the parser answers `.undecodable` (reported as an unknown version),
   the tailer finds no files, or the store reports `sourceUnreadable`.
+
+## Amendment 1 (2026-09-13): a hosted CLI conversation is controlled over ACP
+
+**Context.** The decision above says "Stop is refused — Cursor exposes no
+interrupt". That is true of a chat in the IDE, whose only write path is its
+hooks. It is not true of `cursor-agent acp`: the CLI runs as an Agent Client
+Protocol server over stdio (cursor.com/docs/cli/acp) and offers
+`session/prompt`, `session/cancel`, `session/request_permission`
+(`allow-once` / `allow-always` / `reject-once`) and Cursor's own
+`cursor/ask_question` (structured answers by option id), `cursor/create_plan`,
+`cursor/update_todos` and `cursor/task`. The CLI and the IDE share one agent
+runtime and one tool set, so the vocabulary and the question shapes are the
+same on both.
+
+**Decision.** A Cursor conversation vibebuddy starts itself is hosted by
+`CursorACPMonitor`: one `agent acp` process per conversation, alive as long as
+the daemon, observed through its `session/update` notifications
+(`ObservationSource.acp`) and answered on the same pipe. For such a
+conversation stop is `session/cancel` and the ending it produces is marked
+`userStopped`; continue is the next `session/prompt`; a supplement for a
+running turn is still queued (ACP has no mid-turn steer) and sent as the next
+prompt the moment the current one returns — the same `CursorFollowupQueue` the
+hooks drain, and the hook route steps aside for a hosted id so nothing is
+delivered twice. Permission requests become cards through the same
+`ApprovalRegistry` as the hooks; a deny rule or an exact always-allow answers
+without one. Questions and plans are cards whose answers travel back in ACP's
+own shapes; a typed answer Cursor's schema cannot carry travels as the reason
+on a `skipped` outcome. While the host carries a conversation, Cursor's hooks
+and transcript for the same id only corroborate.
+
+Every session now carries a **control channel** (`ControlChannel`: `hook`,
+`acp`, `appserver`, `cloud`, `none`), stamped by the daemon on each snapshot,
+and `SessionActionSupport` decides availability and wording from it before the
+agent kind. So an IDE chat (`hook`) still says "Stop this in Cursor on your
+Mac", a hosted CLI conversation (`acp`) offers Stop on the phone and the Watch,
+and a cloud agent (`cloud`, ADR-0017) cancels its run.
+
+**Consequences.** A hosted turn ends when vibebuddy quits, and the phone is
+told so at dispatch time. A request nobody answers blocks the turn, as the
+protocol says; the card stays until answered or the turn is cancelled. Whether
+`session/load` can take over a conversation the IDE created is still an open
+probe (ticket cursor-integration/11); until it is answered, continuing a
+finished IDE chat keeps going through `cursor-agent --resume` in a terminal.

--- a/docs/adr/0017-cursor-cloud-agents-api.md
+++ b/docs/adr/0017-cursor-cloud-agents-api.md
@@ -1,0 +1,174 @@
+# ADR-0017: A Cursor cloud agent is observed and continued through Cursor's Cloud Agents API
+
+- Status: accepted
+- Date: 2026-09-12
+- Supersedes / amends: amends ADR-0016 (Cursor observation and control), whose
+  "Alternatives rejected" deferred this to its own decision and its own ticket.
+  Sits beside ADR-0009 (daemon security) and ADR-0011 (Codex through the
+  app-server daemon).
+
+## Context
+
+ADR-0016 left the Cloud Agents API out on purpose: it needs a `CURSOR_API_KEY`
+separate from both the Cursor app's cookie and the `cursor-agent` CLI's own
+login, "so it is its own decision and its own ticket". This is that decision.
+
+**ADR-0016 says cloud agents "are already *visible*" because "they carry
+`bc-`-prefixed ids and appear in the composer store like any other
+conversation". That is not true on this Mac.** Cursor's
+`globalStorage/state.vscdb` here holds 16 conversations, every one of them a
+plain UUID with `agentLocation.type` either `local` or absent, and not one
+`bc-`-prefixed row in `composerHeaders` or `cursorDiskKV` (checked 2026-09-12).
+Whether that is because no cloud agent has ever been launched from this machine
+or because the desktop app does not sync them at all, the conclusion is the same:
+**the local database cannot be relied on to know that a cloud agent exists.**
+
+That matters because everything else about a cloud agent points the same way. It
+runs on Cursor's machines against a **GitHub repository**, not on this Mac
+against a folder. No hook fires for it. No transcript is written for it. It has
+no local branch checkout, no terminal and no window. All three of ADR-0016's
+layers are silent — not merely quiet, but structurally inapplicable.
+
+The API was re-read on 2026-09-12 against `cursor.com/docs/cloud-agent/api/*`,
+and two things in ADR-0016's own description of it are now out of date:
+
+1. **`POST /v0/agents/{id}/followup` is not the current shape.** v1 is the
+   current surface (public beta; Cursor says it may change before GA) and v0 is
+   legacy. v1 splits the work into a **durable agent plus one run per prompt**,
+   so a follow-up is `POST /v1/agents/{id}/runs` with `{"prompt":{"text":…}}`.
+2. **An agent takes a follow-up when it is *idle*, not while it is running.**
+   Agent status is exactly `ACTIVE` / `IDLE` / `ARCHIVED`, `IDLE` is documented
+   as "the last turn finished and follow-ups are accepted", and
+   `POST …/runs` answers `409 agent_busy` when a run is already `CREATING` or
+   `RUNNING`. Forum answers describing the opposite are about v0.
+
+The agent id in the API is the same `bc-…` id the composer store already holds,
+so the two views join on an identity vibebuddy keeps anyway.
+
+## Decision
+
+**A cloud agent is not a local conversation with a remote status. It is a
+session with no local anchor, and the API is its only source — of its state and
+of its existence.** This is the shape the codebase already has a place for:
+ADR-0011's Codex Desktop threads, which run no hook, keep no terminal, and are
+addressed by a URL rather than a window.
+
+ADR-0016's layer order is unchanged and its rules still hold where they applied —
+it simply has nothing to say about a conversation that never touches this Mac:
+
+- **Hooks** remain the live, answerable source for conversations that run on
+  this Mac. They never fire for a cloud agent, so nothing competes.
+- **The agent transcript** remains the fallback tail for local conversations.
+  None is written for a cloud agent.
+- **The composer store** still never moves the three states, for either kind. It
+  names the conversation, its project, its branch and its model, and it is what
+  decides a cloud agent exists at all.
+- **The Cloud Agents API** supplies `bc-` rows outright and moves their three
+  states. `ACTIVE` is `working`; `IDLE` is `done`; `ARCHIVED` ends the session.
+
+So the layering forks on *where the conversation runs*, rather than stacking a
+fourth authority on top of every row. Two sources never describe one
+conversation, which is why no authority window like ADR-0016's two-minute
+transcript rule is needed here.
+
+**The repository stands in for the project**, since there is no folder: `repos[]`
+from the per-agent endpoint, fetched once per agent and kept, because it cannot
+change. **The row is bounded** the way `cursorHistoryLimit` bounds the composer
+store — archived agents excluded at the query, the list capped — for the same
+reason: a dashboard is the work in hand, not an account archive.
+
+**It is a tail, not an import — with one deliberate difference.** An agent
+already `IDLE` when vibebuddy starts produces nothing, so launching the app never
+rings a completion for a run that finished yesterday. An agent already `ACTIVE`
+*is* reported, because unlike a transcript already on disk, a run that is live
+right now is not history.
+
+**The key lives in its own Keychain slot.** `cursorCloudAPIKey`, beside
+`cursorSessionCookie` and `cursorSessionCookie.imported` rather than inside
+them: three Cursor credentials exist and none substitutes for another. Settings
+writes it once and never reads it back — "a key is saved" is answered by a
+metadata-only Keychain lookup, which cannot raise an authorization prompt and
+cannot decrypt anything. No error message, log line or snapshot carries the key
+or any part of it, which is why the client reduces a failure to Cursor's status
+and `code` and discards its `message`.
+
+**A follow-up is refused when Cursor would refuse it, and the refusal is the
+mirror image of the local one.** A local Cursor turn can take a supplement
+*while* it runs (queued for its `stop` hook) but needs a terminal to reopen a
+finished chat. A cloud agent is the other way round: a running one is refused up
+front — one run at a time, per Cursor — and a finished one is continued directly
+by starting its next run. The refusal is worded from the live snapshot, and the
+`409 agent_busy` that beats the check answers "try again once it finishes", not
+a generic failure: nothing was queued, and Cursor has no waiting room for a
+follow-up, so implying one would be a lie.
+
+**Availability is read off the `.cloud` observation, not off the key.** The
+phone cannot see the Mac's Keychain. A `.cloud` evidence entry appears only when
+the Mac actually reached the API, so its absence covers a missing key, a rejected
+key and an unreachable service in one honest sentence — and the local wording,
+which sends the person to the Cursor hook installer, is never shown for an agent
+that does not run on this Mac.
+
+## Alternatives rejected
+
+- **Using the API as a control path only**, leaving the rows as stored history.
+  It would keep a row that says "finished" next to a Send button that starts a
+  run, which is precisely the kind of mismatch ADR-0016 exists to prevent.
+- **Reporting only on cloud agents the local composer store already lists.** This
+  was the first decision taken here, on ADR-0016's word that such rows exist. The
+  database says otherwise, and the rule would have made the whole feature render
+  nothing. Anchoring a session that has no local folder, branch or transcript to a
+  local database row was the wrong model regardless of what the query returned.
+- **The SSE run stream** (`…/runs/{runId}/stream`). It is the better fit for
+  live tool activity and is the only real-time option Cursor offers today
+  (webhooks exist on v0 only and are "coming soon" for v1). It also needs a
+  long-lived connection and `Last-Event-ID` resume, and polling already answers
+  the question the three buckets ask. Left for when tool-level activity is wanted.
+- **Leaving stop refused.** ADR-0016 says "Stop is refused, not attempted —
+  Cursor exposes no interrupt". That is true of a local chat and **false of a
+  cloud run**, which `POST /v1/agents/{id}/runs/{runId}/cancel` ends. Refusing
+  would have been inventing a limitation Cursor does not have, so this ADR
+  amends that sentence: stop is offered for a live cloud run and refused
+  everywhere else it was refused before. Cursor's `409 run_not_cancellable`
+  answers `notSent` ("this run has already finished"), not a failure, and a
+  cancel is never retried — the rule ADR-0011 set for the Codex interrupt.
+- **`POST /v1/agents` to start new cloud work.** Dispatch needs a repository and
+  a starting ref, which is a separate surface from anything vibebuddy shows now.
+
+**The jump opens the agent's own page.** There is no window to raise and no
+terminal to focus, so `agent.url` is the only honest target — the Codex Desktop
+answer to the same problem. The URL arrives from a network response, so it is
+checked against a closed allowlist (`https`, a `cursor.com` host, no userinfo)
+rather than escaped, on `CodexDesktopJumper`'s principle: nothing that is not
+recognisably a Cursor agent page is handed to a browser.
+
+**The runs list is the conversation.** v0 had `GET /v0/agents/{id}/conversation`;
+v1 replaced it with the agent/run split and offers no equivalent. One run is one
+turn, so `/recent-output` for a cloud agent reads the runs list and shows each
+terminal run's `result`, oldest first. A run still going has no result yet and
+contributes no line rather than a blank one.
+
+## Consequences
+
+- A cloud agent appears whether or not this Mac's Cursor has ever heard of it,
+  with the repository it works on, the state it is actually in, its final text
+  when a run ends, a jump to its page, a follow-up when it is idle, and a stop
+  while it runs. A completion cue rings for a cloud run that finishes while
+  vibebuddy is watching.
+- Without an API key nothing changes and nothing is attempted: cloud agents stay
+  stored-history rows, exactly as they are today.
+- The API is in public beta. A renamed field or a new `status` value degrades
+  one layer: an unrecognized status drops that agent from the pass rather than
+  guessing a state, a failed poll ends nothing, and the composer store's row
+  survives underneath either way.
+- Two Cursor credentials now exist in vibebuddy's Keychain, and a person who
+  configures only one gets exactly the capability that one buys — quota from the
+  cookie, cloud agents from the key.
+- Polling costs one list call per interval (20s), one agent call the first time
+  an agent is seen, and one run call when an agent has just finished. Cursor
+  documents no rate limit on `/v1/agents`; if one appears, the interval is the
+  single knob.
+- Rows now come from an account rather than from this machine, so a second Mac
+  running vibebuddy against the same Cursor account will show the same cloud
+  agents. That is correct — the work is genuinely the same work — but it is a
+  new property, and the completion cue fires on whichever Mac is watching.

--- a/hooks/install-cursor-hooks.py
+++ b/hooks/install-cursor-hooks.py
@@ -27,7 +27,17 @@ Event set (Cursor's own camelCase names; `CursorParser` maps them):
 
 `stop` always runs `hooks/cursor-followup.sh`, which forwards the ending *and*
 hands Cursor any follow-up the phone queued for a running turn
-(`{"followup_message": …}`) — the one remote write Cursor documents.
+(`{"followup_message": …}`) — the one remote write Cursor documents. That entry
+is written with `"loop_limit": null`: Cursor caps the automatic follow-ups it
+accepts from one stop hook per conversation at 5 by default, and `null` removes
+the cap (cursor.com/docs/hooks). Without it the sixth queued message from the
+phone would be silently dropped.
+
+If `~/.claude/settings.json` also carries vibebuddy's Claude Code hooks, Cursor
+calls those too once "Include third-party Plugins, Skills, and other configs" is
+on — with Cursor's own payload (cursor.com/docs/reference/third-party-hooks).
+The daemon recognises that payload and keeps one session identity, so the
+installer only says so; it never edits the Claude file.
 
 `sessionStart` also runs `hooks/capture-terminal.sh cursor`, so a `cursor-agent`
 session started in a terminal can be jumped back to. (An IDE chat has no
@@ -86,8 +96,8 @@ STATUS_EVENTS = [
 ]
 
 
-def entry(command, timeout=5):
-    return {"command": command, "timeout": timeout}
+def entry(command, timeout=5, **options):
+    return {"command": command, "timeout": timeout, **options}
 
 
 def desired(approval=False):
@@ -97,8 +107,10 @@ def desired(approval=False):
     # on its own. In status-only mode the same event is a plain progress report.
     hooks["preToolUse"] = [entry(APPROVAL_COMMAND, timeout=30)] if approval else [entry(COMMAND)]
     # The follow-up collector must finish inside Cursor's patience for a `stop`
-    # hook; it only reads a local queue, so 5 s is generous.
-    hooks["stop"] = [entry(FOLLOWUP_COMMAND)]
+    # hook; it only reads a local queue, so 5 s is generous. `loop_limit: null`
+    # lifts Cursor's default cap of 5 automatic follow-ups per conversation, so
+    # every message the phone queues is handed over, not just the first five.
+    hooks["stop"] = [entry(FOLLOWUP_COMMAND, loop_limit=None)]
     hooks["sessionStart"].append(entry(CAPTURE_COMMAND, timeout=10))
     return hooks
 
@@ -190,6 +202,23 @@ def write(document):
         f.write("\n")
 
 
+def note_third_party_overlap():
+    """One line when Claude Code's settings also carry vibebuddy hooks. Cursor
+    calls Claude Code hooks with its own payload once third-party hooks are
+    enabled; the daemon routes that payload to the Cursor parser, so this is
+    information, not a conflict, and the Claude file is left alone."""
+    path = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
+    try:
+        with open(path) as f:
+            content = f.read()
+    except OSError:
+        return
+    if "vibebuddy" in content:
+        print("note: ~/.claude/settings.json also carries vibebuddy hooks; if Cursor's "
+              "third-party hooks are enabled, Cursor will call them too — vibebuddy "
+              "recognises the Cursor payload and keeps one session identity.")
+
+
 def main():
     args = sys.argv[1:]
     approval = "--approval" in args
@@ -216,6 +245,7 @@ def main():
         merged = merge(json.loads(json.dumps(document)), desired(approval))
         print("would write:", TARGET)
         print(json.dumps(merged, indent=2))
+        note_third_party_overlap()
         return
 
     if mode == "--install":
@@ -230,6 +260,7 @@ def main():
         if approval:
             print("phone approvals answer Cursor's own permission contract; a timeout "
                   "prints nothing and Cursor asks in its own UI.")
+        note_third_party_overlap()
         return
 
     if mode == "--uninstall":

--- a/hooks/install-cursor-hooks.py
+++ b/hooks/install-cursor-hooks.py
@@ -91,7 +91,7 @@ STATUS_EVENTS = [
     "sessionStart", "sessionEnd",
     "beforeSubmitPrompt",
     "postToolUse", "postToolUseFailure", "afterFileEdit",
-    "afterAgentResponse", "preCompact",
+    "afterAgentResponse", "afterAgentThought", "preCompact",
     "subagentStart", "subagentStop",
 ]
 

--- a/hooks/test_install_agent_hooks.py
+++ b/hooks/test_install_agent_hooks.py
@@ -437,9 +437,15 @@ def main():
             commands = [entry.get("command", "") for entry in cursor_hooks.get(event, [])]
             if not any('vibebuddy-forward.sh" cursor' in command for command in commands):
                 fails.append(f"install missed the vibebuddy cursor {event} hook")
-        if not any("cursor-followup.sh" in entry.get("command", "")
-                   for entry in cursor_hooks.get("stop", [])):
+        followups = [entry for entry in cursor_hooks.get("stop", [])
+                     if "cursor-followup.sh" in entry.get("command", "")]
+        if not followups:
             fails.append("install missed the cursor stop follow-up collector")
+        # Cursor accepts at most 5 automatic follow-ups per conversation from a
+        # stop hook unless the entry says `loop_limit: null`; the sixth message
+        # the phone queues would otherwise be dropped.
+        if not all("loop_limit" in entry and entry["loop_limit"] is None for entry in followups):
+            fails.append("cursor stop follow-up entry must carry loop_limit: null")
         if not any("capture-terminal.sh" in entry.get("command", "")
                    for entry in cursor_hooks.get("sessionStart", [])):
             fails.append("install missed the cursor sessionStart terminal capture")

--- a/hooks/test_install_agent_hooks.py
+++ b/hooks/test_install_agent_hooks.py
@@ -43,7 +43,7 @@ USER_CURSOR_HOOK = "./hooks/my-own-audit.sh"
 CURSOR_EVENTS = [
     "sessionStart", "sessionEnd", "beforeSubmitPrompt",
     "postToolUse", "postToolUseFailure", "afterFileEdit",
-    "afterAgentResponse", "preCompact", "subagentStart", "subagentStop",
+    "afterAgentResponse", "afterAgentThought", "preCompact", "subagentStart", "subagentStop",
 ]
 # The grok 1.0.13 event set install-grok-hooks.py registers.
 GROK_EVENTS = [


### PR DESCRIPTION
Stacked on #159 (`claude/cursor-sessions`); merge that first. Every ticket in `.scratch/cursor-integration/issues/07–17` except real-device acceptance (18), against the current Cursor docs (hooks, cli/acp, cli/reference/parameters, third-party-hooks, cloud-agent/api, fetched 2026-09-12/13).

**Control channel (Kit).** Every session carries the write path the daemon would actually use — `hook` / `acp` / `appserver` / `cloud` / `none` — stamped by the Mac on each snapshot. `SessionActionSupport` and the Watch's stop gate decide from it before the agent kind, so an IDE chat still says "Stop this in Cursor on your Mac" while a hosted CLI conversation or a cloud agent offers a real Stop. Older snapshots infer the channel the way clients always did; Codex and Claude behaviour is unchanged.

**Hooks read in full.** `stop` installs with `loop_limit: null`; interrupted or permission-denied tool calls are not failures; ask/edit chats stay out of the three states; `model_id` plus context/effort/thinking; `tool_output` and shell output reach recent output; `afterAgentThought` shows as the row's "Thinking…" activity; a Cursor payload arriving through Claude Code hooks (third-party hooks enabled) keeps one session identity; the follow-up hand-over is journaled with Cursor's `loop_count`.

**ACP host.** `CursorACPMonitor` runs one `agent acp` per conversation vibebuddy starts, reduces `session/update` into the three states and answers `session/request_permission`, `cursor/ask_question` (option ids) and `cursor/create_plan` through the same registries as the hook cards. `session/cancel` is the user's stop; a mid-turn supplement goes out as the next prompt from the shared follow-up queue and the hook routes step aside for a hosted id. Dispatch from the phone can pick the model (`--list-models`, cached beside the sign-in verdict), plan/ask mode and a fresh worktree (`-w`).

**Cloud agents.** Ported from the Cloud Agents session's branch and reconciled with the channel: `bc-` conversations are polled through `api.cursor.com` once a key is saved (own Keychain slot, Settings → Usage), an idle agent is continued with a new run, a running one is cancelled through the API. ADR-0017.

**Watch.** A multi-question `AskQuestion` is walked one question per screen and sent once as a complete answer set; the gate refuses partial or forged sets; single questions look as before.

Validation on the branch head: `VibeBuddyMac` 990 tests / 118 suites pass; `VibeBuddyKit` 462 pass; hook installer self-test passes; Mac app builds; iPhone scheme including the Watch target builds (watchOS runtime is present on this Mac). ADR-0016 amendment 1, ADR-0017 and CONTEXT.md record the decisions.

Not done: real acceptance (ticket 18) — needs `cursor-agent login` on the Mac and this build on :9876; that login also gates the `session/load` probe (continue for a finished IDE chat still goes through `cursor-agent --resume` in a terminal) and a look at the real `--list-models` output format. `is_background_agent` was deliberately not modelled (the `bc-` prefix already identifies cloud conversations).
