### PR TITLE
feat: add read-aloud voice styles for Doubao, Qwen and Gemini

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/DoubaoSpeechSynthesizer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/DoubaoSpeechSynthesizer.swift
@@ -16,10 +16,13 @@ public struct DoubaoSpeechSynthesizer: SpeechSynthesizer {
 
     let model: String
     let voice: String
+    let persona: VoicePersona?
 
-    public init(model: String = defaultModel, voice: String = defaultVoice) {
+    public init(model: String = defaultModel, voice: String = defaultVoice,
+                persona: VoicePersona? = nil) {
         self.model = model.isEmpty ? Self.defaultModel : model
         self.voice = voice.isEmpty ? Self.defaultVoice : voice
+        self.persona = persona
     }
 
     public func synthesize(_ text: String, apiKey: String) async throws -> Data {
@@ -32,9 +35,28 @@ public struct DoubaoSpeechSynthesizer: SpeechSynthesizer {
                       "X-Api-Resource-Id": model,
                       "X-Api-Request-Id": UUID().uuidString,
                       "Accept": "application/json"],
-            body: ["req_params": ["text": text, "speaker": voice,
-                                  "audio_params": ["format": "mp3", "sample_rate": 24_000]]])
+            body: requestBody(text))
         return try Self.audio(from: data)
+    }
+
+    /// Volcengine's style lever is 语音指令 — `additions.context_texts`, which
+    /// the docs describe as an aid to 对话式合成 and illustrate with requests
+    /// ("你可以用特别特别痛心的语气说话吗?"), so the persona goes in as one.
+    /// Only the list's first value takes effect, and its text is not billed.
+    ///
+    /// Two documented limits shape this: `additions` is a **jsonstring**, not
+    /// an object, and `context_texts` is TTS-2.0-only — which the read-aloud
+    /// catalog satisfies (every voice in it is `_uranus_bigtts` / `ICL_uranus_`,
+    /// tagged 指令遵循), but a hand-typed 1.0 voice ID would not. That is left
+    /// to the vendor to ignore rather than guessed at from the ID's shape.
+    func requestBody(_ text: String) -> [String: Any] {
+        var params: [String: Any] = ["text": text, "speaker": voice,
+                                     "audio_params": ["format": "mp3", "sample_rate": 24_000]]
+        if let persona,
+           let additions = try? JSONSerialization.data(withJSONObject: ["context_texts": [persona.request]]) {
+            params["additions"] = String(decoding: additions, as: UTF8.self)
+        }
+        return ["req_params": params]
     }
 
     /// Every frame carries a status: `0` on each audio chunk and `20000000`

--- a/VibeBuddyKit/Sources/VibeBuddyKit/GeminiSpeechSynthesizer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/GeminiSpeechSynthesizer.swift
@@ -11,10 +11,22 @@ public struct GeminiSpeechSynthesizer: SpeechSynthesizer {
 
     let model: String
     let voice: String
+    let persona: VoicePersona?
 
-    public init(model: String = defaultModel, voice: String = defaultVoice) {
+    public init(model: String = defaultModel, voice: String = defaultVoice,
+                persona: VoicePersona? = nil) {
         self.model = model.isEmpty ? Self.defaultModel : model
         self.voice = voice.isEmpty ? Self.defaultVoice : voice
+        self.persona = persona
+    }
+
+    /// Gemini has no instruction field — `speechConfig` carries only the voice
+    /// — so style is controlled from inside the prompt, which is the documented
+    /// way ("Say in a spooky whisper: …"). The lead-in therefore sits ahead of
+    /// the summary, and the model reads it as direction rather than content.
+    func prompt(_ text: String) -> String {
+        guard let persona else { return text }
+        return "\(persona.leadIn)\n\(text)"
     }
 
     public func synthesize(_ text: String, apiKey: String) async throws -> Data {
@@ -24,7 +36,7 @@ public struct GeminiSpeechSynthesizer: SpeechSynthesizer {
         }
         let data = try await SpeechSynthesisHTTP.post(url,
             headers: ["x-goog-api-key": apiKey, "Accept": "application/json"],
-            body: ["contents": [["role": "user", "parts": [["text": text]]]],
+            body: ["contents": [["role": "user", "parts": [["text": prompt(text)]]]],
                    "generationConfig": [
                        "candidateCount": 1,
                        "responseModalities": ["AUDIO"],

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -338,7 +338,7 @@ public enum VoiceSettings {
     /// instruction channel, whatever is stored — the request has nowhere to
     /// carry it, and claiming otherwise would make the setting a lie.
     public static func readAloudStyle(_ p: VoiceProvider, defaults: UserDefaults = .standard) -> VoiceStyle {
-        guard SpeechSynthesis.support(p).supportsStyle else { return .standard }
+        guard SpeechSynthesis.supportsStyle(p) else { return .standard }
         return VoiceStyle(stored: defaults.string(forKey: readAloudStyleKey(p)))
     }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/KeychainStore.swift
@@ -252,6 +252,10 @@ public enum VoiceSettings {
     /// Per-provider read-aloud model / voice, mirroring `modelKey` / `voiceKey`.
     public static func readAloudModelKey(_ p: VoiceProvider) -> String { "readAloud.model.\(p.rawValue)" }
     public static func readAloudVoiceKey(_ p: VoiceProvider) -> String { "readAloud.voice.\(p.rawValue)" }
+    /// Per-provider too, and for the same reason the voice is: a persona is
+    /// phrased for one vendor's instruction channel, so it does not follow the
+    /// user across a provider switch.
+    public static func readAloudStyleKey(_ p: VoiceProvider) -> String { "readAloud.style.\(p.rawValue)" }
     /// The Qwen-only keys read-aloud used before it became a purpose provider.
     public static let legacyReadAloudModelKey = "qwenReadAloudModel"
     public static let legacyReadAloudVoiceKey = "qwenReadAloudVoice"
@@ -330,13 +334,22 @@ public enum VoiceSettings {
         return VoiceCatalog.defaultVoice(purpose, p, language: language) ?? curated
     }
 
+    /// The read-aloud persona for a provider. `.standard` for a vendor with no
+    /// instruction channel, whatever is stored — the request has nowhere to
+    /// carry it, and claiming otherwise would make the setting a lie.
+    public static func readAloudStyle(_ p: VoiceProvider, defaults: UserDefaults = .standard) -> VoiceStyle {
+        guard SpeechSynthesis.support(p).supportsStyle else { return .standard }
+        return VoiceStyle(stored: defaults.string(forKey: readAloudStyleKey(p)))
+    }
+
     public static func readAloudConfiguration(_ p: VoiceProvider,
                                               defaults: UserDefaults = .standard) -> SpeechSynthesisConfiguration {
         let workspace = (defaults.string(forKey: qwenWorkspaceIDKey) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return SpeechSynthesisConfiguration(provider: p,
             model: readAloudModel(p, defaults: defaults), voice: readAloudVoice(p, defaults: defaults),
-            qwenWorkspaceID: workspace.isEmpty ? nil : workspace, qwenUseIntl: defaults.bool(forKey: regionIntlKey))
+            qwenWorkspaceID: workspace.isEmpty ? nil : workspace, qwenUseIntl: defaults.bool(forKey: regionIntlKey),
+            style: readAloudStyle(p, defaults: defaults), language: conversationLanguage(defaults: defaults))
     }
 
     /// The shared conversation language, from an injectable store.

--- a/VibeBuddyKit/Sources/VibeBuddyKit/QwenSpeechSynthesizer.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/QwenSpeechSynthesizer.swift
@@ -9,13 +9,30 @@ public struct QwenSpeechSynthesizer: SpeechSynthesizer {
     let voice: String
     let workspaceID: String?
     let useIntl: Bool
+    let persona: VoicePersona?
 
     public init(model: String = defaultModel, voice: String = defaultVoice,
-                workspaceID: String?, useIntl: Bool) {
+                workspaceID: String?, useIntl: Bool, persona: VoicePersona? = nil) {
         self.model = model.isEmpty ? Self.defaultModel : model
         self.voice = voice.isEmpty ? Self.defaultVoice : voice
         self.workspaceID = workspaceID
         self.useIntl = useIntl
+        self.persona = persona
+    }
+
+    /// `run-task` parameters. Alibaba's style lever is 指令控制 — the
+    /// `instruction` field, which controls 方言、情感或角色 and which
+    /// `qwen-audio-3.0-tts-plus` / `-flash` accept for any voice, system or
+    /// cloned. Their examples are directives ("请用河南话表达。"), so the
+    /// persona goes in as one. The name matters: `instruction` is the
+    /// Qwen-Audio-TTS / CosyVoice spelling, while the older Qwen-TTS family
+    /// spells it `instructions` — the docs warn against mixing them.
+    func parameters() -> [String: Any] {
+        var parameters: [String: Any] = ["text_type": "PlainText", "voice": voice, "format": "mp3",
+                                         "sample_rate": 22050, "volume": 50, "rate": 1, "pitch": 1,
+                                         "enable_ssml": false]
+        if let persona { parameters["instruction"] = persona.directive }
+        return parameters
     }
 
     public func synthesize(_ text: String, apiKey: String) async throws -> Data {
@@ -41,8 +58,7 @@ public struct QwenSpeechSynthesizer: SpeechSynthesizer {
             }
             do {
                 try await send("run-task", ["task_group": "audio", "task": "tts", "function": "SpeechSynthesizer",
-                    "model": model, "parameters": ["text_type": "PlainText", "voice": voice, "format": "mp3",
-                        "sample_rate": 22050, "volume": 50, "rate": 1, "pitch": 1, "enable_ssml": false], "input": [:]])
+                    "model": model, "parameters": parameters(), "input": [:]])
                 var output = Data()
                 var sentText = false
                 while !Task.isCancelled {

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesis.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesis.swift
@@ -8,15 +8,27 @@ public struct SpeechSynthesisConfiguration: Sendable, Equatable {
     public let voice: String
     public let qwenWorkspaceID: String?
     public let qwenUseIntl: Bool
+    /// The persona layered on the voice. `.standard` sends no instruction, so
+    /// the request is byte-for-byte what it was before styles existed.
+    public let style: VoiceStyle
+    /// Which language the style instruction is written in — the summary's own,
+    /// so the vendor reads it as a delivery note and not a language switch.
+    public let language: VoiceLanguage
 
     public init(provider: VoiceProvider, model: String, voice: String,
-                qwenWorkspaceID: String? = nil, qwenUseIntl: Bool = false) {
+                qwenWorkspaceID: String? = nil, qwenUseIntl: Bool = false,
+                style: VoiceStyle = .standard, language: VoiceLanguage = .english) {
         self.provider = provider
         self.model = model
         self.voice = voice
         self.qwenWorkspaceID = qwenWorkspaceID
         self.qwenUseIntl = qwenUseIntl
+        self.style = style
+        self.language = language
     }
+
+    /// The persona each synthesizer frames in its own vendor's words.
+    var persona: VoicePersona? { style.persona(language) }
 }
 
 /// Graded so the UI can say something the user can act on without echoing a
@@ -65,7 +77,19 @@ public enum SpeechSynthesis {
     public struct Support: Sendable {
         public let defaultModel: String
         public let defaultVoice: String
+        /// Whether this vendor documents an instruction channel for delivery.
+        /// The UI offers the style control only where it changes the audio —
+        /// a picker that silently does nothing is worse than no picker.
+        public let supportsStyle: Bool
         let make: @Sendable (SpeechSynthesisConfiguration) -> any SpeechSynthesizer
+
+        init(defaultModel: String, defaultVoice: String, supportsStyle: Bool = false,
+             make: @escaping @Sendable (SpeechSynthesisConfiguration) -> any SpeechSynthesizer) {
+            self.defaultModel = defaultModel
+            self.defaultVoice = defaultVoice
+            self.supportsStyle = supportsStyle
+            self.make = make
+        }
     }
 
     /// Every provider speaks, so this is total — there is no "cannot read
@@ -74,24 +98,30 @@ public enum SpeechSynthesis {
         switch provider {
         case .qwen:
             return Support(defaultModel: QwenSpeechSynthesizer.defaultModel,
-                           defaultVoice: QwenSpeechSynthesizer.defaultVoice) {
+                           defaultVoice: QwenSpeechSynthesizer.defaultVoice,
+                           supportsStyle: true) {
                 QwenSpeechSynthesizer(model: $0.model, voice: $0.voice,
-                                      workspaceID: $0.qwenWorkspaceID, useIntl: $0.qwenUseIntl)
+                                      workspaceID: $0.qwenWorkspaceID, useIntl: $0.qwenUseIntl,
+                                      persona: $0.persona)
             }
         case .openai:
+            // `/v1/audio/speech` does take an `instructions` field; it is left
+            // unwired because this ticket asked for the three vendors below.
             return Support(defaultModel: OpenAISpeechSynthesizer.defaultModel,
                            defaultVoice: OpenAISpeechSynthesizer.defaultVoice) {
                 OpenAISpeechSynthesizer(model: $0.model, voice: $0.voice)
             }
         case .gemini:
             return Support(defaultModel: GeminiSpeechSynthesizer.defaultModel,
-                           defaultVoice: GeminiSpeechSynthesizer.defaultVoice) {
-                GeminiSpeechSynthesizer(model: $0.model, voice: $0.voice)
+                           defaultVoice: GeminiSpeechSynthesizer.defaultVoice,
+                           supportsStyle: true) {
+                GeminiSpeechSynthesizer(model: $0.model, voice: $0.voice, persona: $0.persona)
             }
         case .doubao:
             return Support(defaultModel: DoubaoSpeechSynthesizer.defaultModel,
-                           defaultVoice: DoubaoSpeechSynthesizer.defaultVoice) {
-                DoubaoSpeechSynthesizer(model: $0.model, voice: $0.voice)
+                           defaultVoice: DoubaoSpeechSynthesizer.defaultVoice,
+                           supportsStyle: true) {
+                DoubaoSpeechSynthesizer(model: $0.model, voice: $0.voice, persona: $0.persona)
             }
         }
     }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesis.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SpeechSynthesis.swift
@@ -126,6 +126,14 @@ public enum SpeechSynthesis {
         }
     }
 
+    /// Whether this vendor takes a delivery instruction, as one accessor
+    /// rather than four reads of `Support` — the UI, the stored setting and
+    /// their tests all ask the same question, and a vendor that gains or
+    /// loses a speech API should change one line here, not hunt call sites.
+    public static func supportsStyle(_ provider: VoiceProvider) -> Bool {
+        support(provider).supportsStyle
+    }
+
     public static func synthesizer(_ configuration: SpeechSynthesisConfiguration) -> any SpeechSynthesizer {
         support(configuration.provider).make(configuration)
     }

--- a/VibeBuddyKit/Sources/VibeBuddyKit/VoiceStyle.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/VoiceStyle.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// A persona for read-aloud, layered on top of whichever voice is chosen.
+///
+/// No vendor takes a style *flag*: Volcengine, Alibaba and Google all control
+/// delivery with a natural-language instruction, so a tier is a sentence we
+/// send, not an enum they recognise. What differs between them is only the
+/// grammatical form their docs use, so this file owns every word we say and
+/// each vendor's Kit file picks a form and a place to put it. That split is
+/// why adding a fourth vendor never edits this file.
+///
+/// `.standard` is the pre-existing behaviour, kept as a real option rather
+/// than a hidden one: a persona is taste, and someone who wants a summary read
+/// plainly must be able to say so.
+public enum VoiceStyle: String, Sendable, CaseIterable, Equatable {
+    case standard
+    case girlNextDoor
+    case fieryGirl
+
+    /// English source text; the app's string tables translate it.
+    public var display: String {
+        switch self {
+        case .standard: NSLocalizedString("Standard", comment: "Read-aloud voice style")
+        case .girlNextDoor: NSLocalizedString("Girl next door", comment: "Read-aloud voice style")
+        case .fieryGirl: NSLocalizedString("Fiery girl", comment: "Read-aloud voice style")
+        }
+    }
+
+    /// The persona to send, in the language being spoken — the instruction has
+    /// to match the summary's language, or the vendor hears a language switch
+    /// rather than a note about delivery. `nil` for `.standard`, and callers
+    /// must then send the request exactly as they did before styles existed.
+    public func persona(_ language: VoiceLanguage) -> VoicePersona? {
+        switch (self, language) {
+        case (.standard, _):
+            return nil
+        case (.girlNextDoor, .chinese):
+            return .init("像邻家小妹一样亲切甜美、语速自然、尾音轻柔，带点腼腆的笑意", language)
+        case (.girlNextDoor, .english):
+            return .init("like the girl next door — warm, sweet and unhurried, with a shy smile in the voice", language)
+        case (.fieryGirl, .chinese):
+            return .init("像火辣少女一样热情张扬、明快有力，尾音带点撩人的上扬", language)
+        case (.fieryGirl, .english):
+            return .init("like a fiery young woman — bold and playful, brisk and punchy, with a teasing lift at the end", language)
+        }
+    }
+
+    /// A stored value this build cannot parse is `.standard`, for the same
+    /// reason an unknown provider is no pin: inventing a persona is worse than
+    /// reading plainly.
+    public init(stored: String?) {
+        self = VoiceStyle(rawValue: (stored ?? "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? .standard
+    }
+}
+
+/// One persona, ready to be said three ways. Each vendor documents its
+/// instruction channel with a different grammatical form, and matching it
+/// matters — the model was tuned on those examples — so the forms live here
+/// together instead of being re-derived in three Kit files.
+public struct VoicePersona: Sendable, Equatable {
+    /// The adverbial clause every form is built from.
+    public let clause: String
+    let language: VoiceLanguage
+
+    init(_ clause: String, _ language: VoiceLanguage) {
+        self.clause = clause
+        self.language = language
+    }
+
+    /// A conversational request, for a vendor whose examples ask the voice for
+    /// something ("你可以用特别特别痛心的语气说话吗?").
+    public var request: String {
+        switch language {
+        case .chinese: "你能\(clause)地说话吗？"
+        case .english: "Could you speak \(clause)?"
+        }
+    }
+
+    /// A directive, for a vendor whose examples tell the voice what to do
+    /// ("请用河南话表达。").
+    public var directive: String {
+        switch language {
+        case .chinese: "请\(clause)地表达。"
+        case .english: "Please speak \(clause)."
+        }
+    }
+
+    /// A lead-in for a vendor with no instruction field, where the only way in
+    /// is the prompt itself ("Say in a spooky whisper: …"). Ends at the colon;
+    /// the caller joins it to the text.
+    public var leadIn: String {
+        switch language {
+        case .chinese: "请\(clause)地念出下面这段话："
+        case .english: "Say the following \(clause):"
+        }
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceStyleTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceStyleTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import VibeBuddyKit
+
+/// The persona has to reach each vendor through the field that vendor's own
+/// docs name, and `.standard` has to leave the request exactly as it was
+/// before styles existed. Both are wire-format claims, so they are asserted
+/// against the request body rather than the picker.
+@Suite("Read-aloud voice style")
+struct VoiceStyleTests {
+
+    // MARK: The persona itself
+
+    @Test func standardSendsNothingAndEveryTierSpeaksBothLanguages() {
+        for language in VoiceLanguage.allCases {
+            #expect(VoiceStyle.standard.persona(language) == nil)
+            for style in VoiceStyle.allCases where style != .standard {
+                let persona = style.persona(language)
+                #expect(persona != nil)
+                // Each form has to be a whole sentence, not a bare clause: the
+                // vendor is being asked, told, or led in.
+                #expect(persona?.request.contains(persona?.clause ?? "#") == true)
+                #expect(persona?.directive.contains(persona?.clause ?? "#") == true)
+                #expect(persona?.leadIn.contains(persona?.clause ?? "#") == true)
+            }
+        }
+    }
+
+    @Test func unparseableStoredStyleReadsPlainly() {
+        for stored in [nil, "", "   ", "unknown", "GirlNextDoor"] as [String?] {
+            #expect(VoiceStyle(stored: stored) == .standard)
+        }
+        #expect(VoiceStyle(stored: " girlNextDoor ") == .girlNextDoor)
+        #expect(VoiceStyle(stored: "fieryGirl") == .fieryGirl)
+    }
+
+    /// The instruction must be written in the language being read, or the
+    /// vendor hears a language switch instead of a note about delivery.
+    @Test func instructionLanguageFollowsTheSummary() throws {
+        let chinese = try #require(VoiceStyle.girlNextDoor.persona(.chinese))
+        let english = try #require(VoiceStyle.girlNextDoor.persona(.english))
+        #expect(chinese.clause.contains("邻家小妹"))
+        #expect(chinese.request.hasSuffix("？"))
+        #expect(english.clause.allSatisfy { $0.isASCII || $0 == "—" })
+        #expect(english.leadIn.hasSuffix(":"))
+    }
+
+    // MARK: Doubao — additions.context_texts, and `additions` is a jsonstring
+
+    @Test func doubaoCarriesThePersonaInContextTextsAsAJSONString() throws {
+        let persona = try #require(VoiceStyle.fieryGirl.persona(.chinese))
+        let body = DoubaoSpeechSynthesizer(persona: persona).requestBody("摘要")
+        let params = try #require(body["req_params"] as? [String: Any])
+        // A jsonstring per the V3 docs — an object here is a parameter error.
+        let additions = try #require(params["additions"] as? String)
+        let decoded = try #require(try JSONSerialization.jsonObject(with: Data(additions.utf8)) as? [String: Any])
+        #expect(decoded["context_texts"] as? [String] == [persona.request])
+    }
+
+    @Test func doubaoOmitsAdditionsEntirelyWithoutAPersona() throws {
+        let body = DoubaoSpeechSynthesizer().requestBody("摘要")
+        let params = try #require(body["req_params"] as? [String: Any])
+        #expect(params["additions"] == nil)
+        #expect(params["text"] as? String == "摘要")
+        #expect(params["speaker"] as? String == DoubaoSpeechSynthesizer.defaultVoice)
+    }
+
+    // MARK: Qwen — parameters.instruction, not `instructions`
+
+    @Test func qwenCarriesThePersonaInInstruction() throws {
+        let persona = try #require(VoiceStyle.girlNextDoor.persona(.chinese))
+        let styled = QwenSpeechSynthesizer(workspaceID: nil, useIntl: false, persona: persona).parameters()
+        #expect(styled["instruction"] as? String == persona.directive)
+        // The Qwen-TTS spelling is a different family's field; mixing them is
+        // what the docs warn about.
+        #expect(styled["instructions"] == nil)
+
+        let plain = QwenSpeechSynthesizer(workspaceID: nil, useIntl: false).parameters()
+        #expect(plain["instruction"] == nil)
+        #expect(plain["voice"] as? String == QwenSpeechSynthesizer.defaultVoice)
+    }
+
+    // MARK: Gemini — no instruction field, so the prompt leads in
+
+    @Test func geminiLeadsInBeforeTheSummary() throws {
+        let persona = try #require(VoiceStyle.fieryGirl.persona(.english))
+        let prompt = GeminiSpeechSynthesizer(persona: persona).prompt("The task is complete.")
+        #expect(prompt.hasPrefix(persona.leadIn))
+        #expect(prompt.hasSuffix("The task is complete."))
+        // The summary must survive intact — a persona may not rewrite it.
+        #expect(GeminiSpeechSynthesizer().prompt("The task is complete.") == "The task is complete.")
+    }
+
+    // MARK: Which vendors offer it
+
+    @Test func onlyVendorsWithAnInstructionChannelOfferStyle() {
+        #expect(SpeechSynthesis.support(.doubao).supportsStyle)
+        #expect(SpeechSynthesis.support(.qwen).supportsStyle)
+        #expect(SpeechSynthesis.support(.gemini).supportsStyle)
+        #expect(!SpeechSynthesis.support(.openai).supportsStyle)
+    }
+
+    /// A persona stored against one provider must not be claimed by another
+    /// that would silently drop it — the setting would then be a lie.
+    @Test func storedStyleIsPerProviderAndIgnoredWhereUnsupported() throws {
+        let name = "voice-style-tests-\(UUID())"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+
+        defaults.set(VoiceStyle.fieryGirl.rawValue, forKey: VoiceSettings.readAloudStyleKey(.doubao))
+        defaults.set(VoiceStyle.fieryGirl.rawValue, forKey: VoiceSettings.readAloudStyleKey(.openai))
+        #expect(VoiceSettings.readAloudStyle(.doubao, defaults: defaults) == .fieryGirl)
+        #expect(VoiceSettings.readAloudStyle(.gemini, defaults: defaults) == .standard)
+        #expect(VoiceSettings.readAloudStyle(.openai, defaults: defaults) == .standard)
+    }
+
+    @Test func configurationCarriesStyleAndTheSpokenLanguage() throws {
+        let name = "voice-style-tests-\(UUID())"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+        defaults.set(VoiceStyle.girlNextDoor.rawValue, forKey: VoiceSettings.readAloudStyleKey(.doubao))
+        defaults.set(VoiceLanguage.chinese.rawValue, forKey: VoiceSettings.conversationLanguageKey)
+
+        let configuration = VoiceSettings.readAloudConfiguration(.doubao, defaults: defaults)
+        #expect(configuration.style == .girlNextDoor)
+        #expect(configuration.language == .chinese)
+        #expect(configuration.persona?.clause == VoiceStyle.girlNextDoor.persona(.chinese)?.clause)
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceStyleTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/VoiceStyleTests.swift
@@ -94,10 +94,10 @@ struct VoiceStyleTests {
     // MARK: Which vendors offer it
 
     @Test func onlyVendorsWithAnInstructionChannelOfferStyle() {
-        #expect(SpeechSynthesis.support(.doubao).supportsStyle)
-        #expect(SpeechSynthesis.support(.qwen).supportsStyle)
-        #expect(SpeechSynthesis.support(.gemini).supportsStyle)
-        #expect(!SpeechSynthesis.support(.openai).supportsStyle)
+        #expect(SpeechSynthesis.supportsStyle(.doubao))
+        #expect(SpeechSynthesis.supportsStyle(.qwen))
+        #expect(SpeechSynthesis.supportsStyle(.gemini))
+        #expect(!SpeechSynthesis.supportsStyle(.openai))
     }
 
     /// A persona stored against one provider must not be claimed by another

--- a/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -252,6 +252,14 @@
 "Hello, I’m your work companion. The task is complete, and device verification is still pending." = "你好，我是你的工作伙伴。任务已完成，设备验证仍待进行。";
 "Read-aloud voice" = "朗读音色";
 
+/* Read-aloud voice style — a persona sent as a delivery instruction */
+"Voice style" = "语音风格";
+"Standard" = "标准";
+"Girl next door" = "邻家小妹";
+"Fiery girl" = "火辣少女";
+"Reads the summary with no extra direction." = "按音色本身朗读摘要，不附加风格指令。";
+"Sent to %@ as a delivery instruction alongside each reading." = "每次朗读都会把该风格指令一并发给 %@。";
+
 /* Verified wait handling */
 "Review and respond on your iPhone." = "请在 iPhone 上查看并处理。";
 "Approve or deny on your Watch." = "请在 Watch 上批准或拒绝。";

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -547,6 +547,7 @@ private struct ReadAloudFeatureRow: View {
     @AppStorage(VoiceSettings.qwenWorkspaceIDKey) private var workspace = ""
     @AppStorage private var modelID: String
     @AppStorage private var voiceID: String
+    @AppStorage private var styleID: String
 
     init(status: VoiceSettings.ReadAloudStatus, summaryProvider: VoiceProvider?,
          reader: ReadAloud, voiceChat: VoiceChat,
@@ -566,6 +567,8 @@ private struct ReadAloudFeatureRow: View {
         // Deliberately empty: a stored voice wins, and everything else is
         // decided by the language-aware fallback below.
         _voiceID = AppStorage(wrappedValue: "", VoiceSettings.readAloudVoiceKey(keyed))
+        _styleID = AppStorage(wrappedValue: VoiceStyle.standard.rawValue,
+                              VoiceSettings.readAloudStyleKey(keyed))
     }
 
     private var spokenLanguage: VoiceLanguage { VoiceLanguage(rawValue: language) ?? .english }
@@ -578,11 +581,19 @@ private struct ReadAloudFeatureRow: View {
             ? VoiceSettings.readAloudVoice(status.provider ?? .qwen, language: spokenLanguage)
             : voiceID
     }
+    /// `.standard` for a vendor with no instruction channel, so a persona left
+    /// behind by an earlier provider cannot follow the user to one that would
+    /// silently drop it.
+    private var effectiveStyle: VoiceStyle {
+        guard SpeechSynthesis.support(status.provider ?? .qwen).supportsStyle else { return .standard }
+        return VoiceStyle(stored: styleID)
+    }
     private var configuration: SpeechSynthesisConfiguration {
         let value = workspace.trimmingCharacters(in: .whitespacesAndNewlines)
         return .init(provider: status.provider ?? .qwen,
                      model: modelID.trimmingCharacters(in: .whitespacesAndNewlines), voice: effectiveVoice,
-                     qwenWorkspaceID: value.isEmpty ? nil : value, qwenUseIntl: intl)
+                     qwenWorkspaceID: value.isEmpty ? nil : value, qwenUseIntl: intl,
+                     style: effectiveStyle, language: spokenLanguage)
     }
     /// Why preview cannot run — the same order the status pill reports.
     private var previewFailure: String? {
@@ -667,6 +678,26 @@ private struct ReadAloudFeatureRow: View {
                 // No trailing button: the ▶ beside the voice is this row's verification.
                 EmptyView()
             }
+            // Its own line, not a fifth column: the persona applies to whatever
+            // voice is chosen above, and ControlLine's three cells are already
+            // at their minimum widths. Shown only where the vendor documents an
+            // instruction channel — see `Support.supportsStyle`.
+            if case .ready(let provider) = status, SpeechSynthesis.support(provider).supportsStyle {
+                HStack(spacing: 8) {
+                    Text("Voice style").font(.caption).foregroundStyle(.secondary)
+                    Picker("Voice style", selection: styleSelection) {
+                        ForEach(VoiceStyle.allCases, id: \.rawValue) { Text(verbatim: $0.display).tag($0.rawValue) }
+                    }
+                    .labelsHidden().fixedSize()
+                    .accessibilityLabel("Voice style")
+                    .accessibilityIdentifier("readAloudStyle")
+                    Text(effectiveStyle == .standard
+                         ? "Reads the summary with no extra direction."
+                         : "Sent to \(provider.display) as a delivery instruction alongside each reading.")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Spacer(minLength: 0)
+                }
+            }
             // A reading that started on its own is stoppable here; the ▶ owns previews only.
             if reader.automaticBusy || !reader.status.isEmpty {
                 HStack(spacing: 8) {
@@ -683,10 +714,10 @@ private struct ReadAloudFeatureRow: View {
           }
         }
         .onAppear { credential.refresh() }
-        .onChange(of: [modelID, voiceID, workspace, String(intl), String(credential.revision),
+        .onChange(of: [modelID, voiceID, styleID, workspace, String(intl), String(credential.revision),
                        String(enabled)]) { _, _ in tests.invalidate() }
         .onChange(of: enabled) { _, on in if !on { reader.stop() } }
-        .onChange(of: [modelID, voiceID]) { _, _ in reader.stop() }
+        .onChange(of: [modelID, voiceID, styleID]) { _, _ in reader.stop() }
         .onChange(of: voiceChat.isActive) { _, active in
             if active, tests.purpose == .readAloud { tests.cancel() }
         }
@@ -694,6 +725,13 @@ private struct ReadAloudFeatureRow: View {
 
     /// This row owns the running test, so its button reads and acts as Stop.
     private var isPreviewing: Bool { tests.purpose == .readAloud && tests.isBusy }
+
+    /// Reads through the same normalisation the request uses, so a stored
+    /// persona this build cannot parse shows as Standard instead of leaving
+    /// the picker with no matching tag.
+    private var styleSelection: Binding<String> {
+        Binding(get: { effectiveStyle.rawValue }, set: { styleID = $0 })
+    }
 
     private func preview() {
         if isPreviewing { tests.cancel(); return }

--- a/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
+++ b/VibeBuddyMacApp/Sources/VoiceSettingsTab.swift
@@ -585,7 +585,7 @@ private struct ReadAloudFeatureRow: View {
     /// behind by an earlier provider cannot follow the user to one that would
     /// silently drop it.
     private var effectiveStyle: VoiceStyle {
-        guard SpeechSynthesis.support(status.provider ?? .qwen).supportsStyle else { return .standard }
+        guard SpeechSynthesis.supportsStyle(status.provider ?? .qwen) else { return .standard }
         return VoiceStyle(stored: styleID)
     }
     private var configuration: SpeechSynthesisConfiguration {
@@ -681,8 +681,8 @@ private struct ReadAloudFeatureRow: View {
             // Its own line, not a fifth column: the persona applies to whatever
             // voice is chosen above, and ControlLine's three cells are already
             // at their minimum widths. Shown only where the vendor documents an
-            // instruction channel — see `Support.supportsStyle`.
-            if case .ready(let provider) = status, SpeechSynthesis.support(provider).supportsStyle {
+            // instruction channel — see `SpeechSynthesis.supportsStyle`.
+            if case .ready(let provider) = status, SpeechSynthesis.supportsStyle(provider) {
                 HStack(spacing: 8) {
                     Text("Voice style").font(.caption).foregroundStyle(.secondary)
                     Picker("Voice style", selection: styleSelection) {


### PR DESCRIPTION
## Changes

Read-aloud can now apply a style on top of the chosen voice: **Standard** (unchanged behaviour), **Girl next door** (邻家小妹) and **Fiery girl** (火辣少女). Settings › Models & Voice shows a Voice style picker under the read-aloud row for Doubao, Qwen and Gemini. The choice is stored per provider, like the voice.

None of the vendors has a style flag. All three control delivery with a natural-language instruction, so each style is a sentence we send. `VoiceStyle` holds the wording in the summary's language and offers the three sentence forms the vendors' docs use. Each synthesizer puts it where its API documents:

- **Doubao** — `req_params.additions.context_texts` (语音指令, [V3 HTTP docs](https://docs.volcengine.com/docs/6561/1598757?lang=zh)). `additions` is a **JSON string**, not an object. `context_texts` works only with TTS 2.0 voices, and every voice in the read-aloud catalog is one.
- **Qwen** — `run-task` `parameters.instruction` (指令控制, [client events](https://help.aliyun.com/zh/model-studio/cosyvoice-client-events)). The field is `instruction`, not `instructions`; the plural belongs to the separate Qwen-TTS family.
- **Gemini** — a lead-in sentence before the summary text. `speechConfig` has no instruction field, and prompt-based style is the [documented approach](https://ai.google.dev/gemini-api/docs/speech-generation).

Standard sends no instruction, so the request is identical to before. OpenAI reports `supportsStyle == false` and gets no picker. Its `instructions` field was left unwired because this change was scoped to the three vendors above.

## Merging with the DeepSeek work

The DeepSeek text-only provider, which makes `SpeechSynthesis.support(_:)` return an optional, is not in this PR. A trial merge with it had one conflict, in `SpeechSynthesis.swift`. The fix is one line: `SpeechSynthesis.supportsStyle(_:)` becomes `support(provider)?.supportsStyle == true`.

## Validation

- `swift test --package-path VibeBuddyKit`: 465 tests pass at this branch's head, including 10 new ones. They check that each vendor's request body carries the instruction in its documented field (Doubao's as a JSON string), that Standard omits it entirely, and that the stored style is per provider and ignored where unsupported.
- Mac app Debug build succeeds.
- Isolated Mac app run (separate bundle ID, E2E root, port 19876 and preferences; the installed app was not touched): the picker appears for Doubao and Gemini and round-trips a stored style. It is absent for OpenAI even with a style stored. The zh-Hans UI shows 语音风格 / 邻家小妹 / 火辣少女.
- Trial merge with the uncommitted DeepSeek work plus the one-line fix: 467 tests pass and the Mac app builds.

Not verified: how the styles sound through the live APIs. That needs provider keys, is billed, and needs someone to listen.
