### PR TITLE
Merge reviewed Dynamic Island status-dot PR with integration fixes

### DIFF
--- a/VibeBuddyApp/Shared/IslandDecisionIntent.swift
+++ b/VibeBuddyApp/Shared/IslandDecisionIntent.swift
@@ -58,7 +58,10 @@ enum IslandActivity {
         where activity.content.state.approvalId == approvalId {
             var state = activity.content.state
             state.decisionSent = outcome
-            await activity.update(ActivityContent(state: state, staleDate: nil))
+            await activity.update(ActivityContent(
+                state: state,
+                staleDate: nil,
+                relevanceScore: LiveActivityPresentation.relevanceScore(for: state.summary.primaryState)))
         }
     }
 }

--- a/VibeBuddyApp/Sources/LiveActivityManager.swift
+++ b/VibeBuddyApp/Sources/LiveActivityManager.swift
@@ -72,7 +72,13 @@ final class LiveActivityManager {
             // A decision already sent from the island stays shown while the Mac
             // still reports the same request; a new request starts clean.
             decisionSent: target != nil && previous?.approvalId == target?.approvalID ? previous?.decisionSent : nil)
-        let content = ActivityContent(state: state, staleDate: nil)
+        // Needs-you sessions outrank quieter ones when several Live Activities compete
+        // (ActivityKit `relevanceScore`; Apple Adventure / Live Activities docs).
+        let leadingState = LiveActivityPresentation.compactTrailingState(leading: leading)
+        let content = ActivityContent(
+            state: state,
+            staleDate: nil,
+            relevanceScore: LiveActivityPresentation.relevanceScore(for: leadingState))
 
         if let activity {
             await activity.update(content)   // local update (foreground); push covers background

--- a/VibeBuddyApp/Tests/LiveActivityRecoveryTests.swift
+++ b/VibeBuddyApp/Tests/LiveActivityRecoveryTests.swift
@@ -25,6 +25,7 @@ final class LiveActivityRecoveryTests: XCTestCase {
         XCTAssertEqual(activity.content.state.approvalId, expected?.approvalID)
         XCTAssertEqual(activity.content.state.approvalTitle, expected?.title)
         XCTAssertEqual(activity.content.state.approvalDetail, expected?.detail)
+        XCTAssertEqual(activity.content.relevanceScore, 80)
         await IslandActivity.markSent(approvalId: "valid-request", outcome: "allow")
         valid.pendingApproval = PendingApproval(id: "valid-request", tool: "Bash", commandPreview: "ls", answerable: false)
         await manager.sync(sessions: [readOnly, valid])
@@ -60,6 +61,7 @@ final class LiveActivityRecoveryTests: XCTestCase {
         XCTAssertEqual(original.activityState, .active)
         XCTAssertEqual(original.content.state.topProject, "Dashboard Recovery QA",
                        "Dashboard.start must preserve and update the original activity")
+        XCTAssertEqual(original.content.relevanceScore, 40)
         await store.stop().value
     }
 

--- a/VibeBuddyApp/Widget/VibeBuddyWidget.swift
+++ b/VibeBuddyApp/Widget/VibeBuddyWidget.swift
@@ -174,30 +174,28 @@ struct VibeBuddyLiveActivity: Widget {
                 }
             } compactLeading: {
                 ActivityCat(state: context.state.summary.primaryState, size: 22)
+                    .widgetURL(tapTarget(context.state))
             } compactTrailing: {
-                NeedsYouBadge(summary: context.state.summary)
+                CompactTrailingStatus(project: context.state.topProject, summary: context.state.summary)
+                    .widgetURL(tapTarget(context.state))
             } minimal: {
-                TaskStatusIndicator(context.state.summary.primaryState, size: 10)
+                CompactTrailingStatus(project: context.state.topProject, summary: context.state.summary)
+                    .widgetURL(tapTarget(context.state))
             }
         }
     }
 }
 
-/// Round 5, compact: only the needs-you count, in the state colour that
-/// earns it; a quiet snapshot shows the working count in blue instead.
-private struct NeedsYouBadge: View {
+/// Compact / minimal island: the leading session's status mark, not a count.
+private struct CompactTrailingStatus: View {
+    let project: String?
     let summary: TaskPresentationSummary
 
     var body: some View {
-        let needs = CompanionCopy.needsYou(summary)
-        let value = needs > 0 ? needs : summary.thinking
-        let state: TaskPresentationState = summary.error > 0 ? .error : (needs > 0 ? .requiresInput : .thinking)
-        Text("\(value)")
-            .font(CompanionType.font(12, .black).monospacedDigit())
-            .foregroundStyle(.white)
-            .padding(.horizontal, 7).padding(.vertical, 1)
-            .background(CompanionPalette.status(state), in: Capsule())
-            .accessibilityLabel(needs > 0 ? "\(needs) need you" : "\(value) working")
+        let state = LiveActivityPresentation.compactTrailingState(summary: summary)
+        TaskStatusIndicator(state, size: 10)
+            .accessibilityLabel(LiveActivityPresentation.compactAccessibilityLabel(
+                project: project, state: state))
     }
 }
 

--- a/VibeBuddyKit/Sources/VibeBuddyKit/TaskPresentation.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/TaskPresentation.swift
@@ -209,3 +209,49 @@ public extension Array where Element == AgentSession {
         }
     }
 }
+
+/// Compact Dynamic Island trailing slot and Live Activity ranking for the
+/// single highest-attention session. Aggregate counts stay on expanded /
+/// lock-screen copy — they must not occupy `compactTrailing`.
+public enum LiveActivityPresentation {
+    /// Trailing indicator: the leading session's state, or `unassigned` when none.
+    public static func compactTrailingState(leading: AgentSession?) -> TaskPresentationState {
+        leading?.presentationState ?? .unassigned
+    }
+
+    /// Same selection from the already-reduced summary. `primaryState` matches
+    /// `leadingPresentationSession` because both use the same attention order.
+    public static func compactTrailingState(summary: TaskPresentationSummary) -> TaskPresentationState {
+        summary.primaryState
+    }
+
+    /// ActivityKit `relevanceScore`: needs-you states outrank quieter ones so
+    /// this activity wins the Dynamic Island when several compete.
+    public static func relevanceScore(for state: TaskPresentationState) -> Double {
+        switch state {
+        case .error: return 100
+        case .requiresInput: return 80
+        case .thinking: return 40
+        case .completeUnread: return 20
+        case .idle: return 10
+        case .unassigned: return 0
+        }
+    }
+
+    /// VoiceOver for the compact mark: project + state, never a bare count.
+    public static func compactAccessibilityLabel(project: String?, state: TaskPresentationState) -> String {
+        let spoken: String
+        switch state {
+        case .error: spoken = String(localized: "error")
+        case .requiresInput: spoken = String(localized: "needs input")
+        case .thinking: spoken = String(localized: "thinking")
+        case .completeUnread: spoken = String(localized: "complete, unread update")
+        case .idle: spoken = String(localized: "idle")
+        case .unassigned: return String(localized: "All quiet")
+        }
+        if let project, !project.isEmpty {
+            return "\(project), \(spoken)"
+        }
+        return spoken
+    }
+}

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/TaskPresentationTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/TaskPresentationTests.swift
@@ -10,12 +10,13 @@ struct TaskPresentationTests {
         waitKind: WaitKind? = nil,
         failed: Bool = false,
         unread: Bool = false,
+        project: String? = nil,
         updatedAt: TimeInterval = 0
     ) -> AgentSession {
         AgentSession(
             id: id,
             agent: .codex,
-            project: id,
+            project: project ?? id,
             status: status,
             waitKind: waitKind,
             failed: failed,
@@ -96,5 +97,65 @@ struct TaskPresentationTests {
         #expect(TaskPresentationSummary().primaryState == .unassigned)
         #expect(TaskPresentationSnapshot(sessions: sessions).summary == summary)
         #expect(TaskPresentationSnapshot(sessions: sessions).topSessionId == "error")
+    }
+
+    @Test("compact trailing follows the leading session, not an aggregate count")
+    func compactTrailingFollowsLeadingSession() {
+        let sessions = [
+            session("idle", status: .done, updatedAt: 9),
+            session("thinking", status: .working, updatedAt: 7),
+            session("input", status: .needsResponse, waitKind: .permission, updatedAt: 6),
+            session("error", status: .done, failed: true, project: "build-fail", updatedAt: 5),
+        ]
+        let leading = sessions.leadingPresentationSession
+        let summary = TaskPresentationSummary(sessions: sessions)
+        #expect(leading?.id == "error")
+        #expect(LiveActivityPresentation.compactTrailingState(leading: leading) == .error)
+        #expect(LiveActivityPresentation.compactTrailingState(summary: summary) == .error)
+        #expect(LiveActivityPresentation.compactAccessibilityLabel(
+            project: leading?.project, state: .error) == "build-fail, error")
+
+        let inputOnly = [
+            session("quiet", status: .done, updatedAt: 2),
+            session("release-check", status: .needsResponse, waitKind: .question, updatedAt: 1),
+        ]
+        let inputLeading = inputOnly.leadingPresentationSession
+        #expect(inputLeading?.id == "release-check")
+        #expect(LiveActivityPresentation.compactTrailingState(leading: inputLeading) == .requiresInput)
+        #expect(LiveActivityPresentation.compactTrailingState(
+            summary: TaskPresentationSummary(sessions: inputOnly)) == .requiresInput)
+        #expect(LiveActivityPresentation.compactAccessibilityLabel(
+            project: inputLeading?.project, state: .requiresInput) == "release-check, needs input")
+    }
+
+    @Test("relevanceScore is higher when the leading session needs you")
+    func relevanceScoreNeedsYouOutranksQuiet() {
+        let needsYou: [TaskPresentationState] = [.error, .requiresInput]
+        let quieter: [TaskPresentationState] = [.thinking, .completeUnread, .idle, .unassigned]
+        for urgent in needsYou {
+            for quiet in quieter {
+                #expect(LiveActivityPresentation.relevanceScore(for: urgent)
+                        > LiveActivityPresentation.relevanceScore(for: quiet))
+            }
+        }
+        #expect(LiveActivityPresentation.relevanceScore(for: .error)
+                > LiveActivityPresentation.relevanceScore(for: .requiresInput))
+        #expect(LiveActivityPresentation.relevanceScore(for: .thinking)
+                > LiveActivityPresentation.relevanceScore(for: .idle))
+    }
+
+    @Test("empty and idle compact trailing stay quiet and unlabeled as a count")
+    func compactTrailingQuietAndEmpty() {
+        #expect(LiveActivityPresentation.compactTrailingState(leading: nil) == .unassigned)
+        #expect(LiveActivityPresentation.compactTrailingState(summary: TaskPresentationSummary()) == .unassigned)
+        #expect(LiveActivityPresentation.relevanceScore(for: .unassigned) == 0)
+        #expect(LiveActivityPresentation.compactAccessibilityLabel(project: nil, state: .unassigned) == "All quiet")
+
+        let idle = [session("release-check", status: .done, updatedAt: 1)]
+        #expect(LiveActivityPresentation.compactTrailingState(leading: idle.leadingPresentationSession) == .idle)
+        #expect(LiveActivityPresentation.relevanceScore(for: .idle) == 10)
+        #expect(LiveActivityPresentation.compactAccessibilityLabel(
+            project: "release-check", state: .idle) == "release-check, idle")
+        #expect(LiveActivityPresentation.compactAccessibilityLabel(project: nil, state: .thinking) == "thinking")
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/APNs.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/APNs.swift
@@ -350,6 +350,8 @@ public actor APNsPusher {
 
     /// The `liveactivity` push body. `content-state` keys mirror
     /// `VibeBuddyActivityAttributes.ContentState`; optional strings are omitted when nil.
+    /// `relevance-score` follows the leading session so a needs-you update wins
+    /// the Dynamic Island the same way a local `ActivityContent` update does.
     nonisolated static func activityPayload(summary: TaskPresentationSummary,
                                             topProject: String?, topSessionId: String?,
                                             approvalId: String? = nil, approvalTitle: String? = nil,
@@ -363,7 +365,8 @@ public actor APNsPusher {
         if let a = approvalId { state += #","approvalId":"\#(escape(a))""# }
         if let t = approvalTitle { state += #","approvalTitle":"\#(escape(t))""# }
         if let d = approvalDetail { state += #","approvalDetail":"\#(escape(d))""# }
-        return #"{"aps":{"timestamp":\#(timestamp),"event":"update","content-state":{\#(state)}}}"#
+        let score = Int(LiveActivityPresentation.relevanceScore(for: summary.primaryState))
+        return #"{"aps":{"timestamp":\#(timestamp),"event":"update","relevance-score":\#(score),"content-state":{\#(state)}}}"#
     }
 
     private func providerToken(now: Date) throws -> String {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ActivityPushTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/ActivityPushTests.swift
@@ -33,6 +33,7 @@ struct ActivityPushTests {
         #expect(p.contains(#""event":"update""#))
         #expect(p.contains(#""timestamp":1700"#))
         #expect(p.contains(#""summary":{"idle":0,"thinking":1,"completeUnread":0,"requiresInput":2,"error":0}"#))
+        #expect(p.contains(#""relevance-score":80"#))
         #expect(!p.contains("topProject"))   // omitted when nil
     }
 
@@ -95,6 +96,23 @@ struct ActivityPushTests {
                                            topProject: #"my "proj""#, topSessionId: "s1", timestamp: 1)
         #expect(p.contains(#""topProject":"my \"proj\"""#))
         #expect(p.contains(#""topSessionId":"s1""#))
+        #expect(p.contains(#""relevance-score":20"#))
+    }
+
+    @Test("activity payload ranks needs-you above a quiet working snapshot")
+    func payloadRelevanceFollowsLeadingState() {
+        let needsYou = APNsPusher.activityPayload(
+            summary: TaskPresentationSummary(error: 1, thinking: 3),
+            topProject: "build-fail", topSessionId: "e1", timestamp: 2)
+        let quiet = APNsPusher.activityPayload(
+            summary: TaskPresentationSummary(thinking: 3),
+            topProject: "ok", topSessionId: "w1", timestamp: 2)
+        let empty = APNsPusher.activityPayload(
+            summary: TaskPresentationSummary(),
+            topProject: nil, topSessionId: nil, timestamp: 2)
+        #expect(needsYou.contains(#""relevance-score":100"#))
+        #expect(quiet.contains(#""relevance-score":40"#))
+        #expect(empty.contains(#""relevance-score":0"#))
     }
 
     // MARK: /activity route


### PR DESCRIPTION
Integrates #158 using the reviewed local merge ead840d3. The compact trailing and minimal Dynamic Island regions show the leading session status dot, with localized project/state VoiceOver labels and consistent relevance scores for local updates, decisions and APNs.

The local integration resolved the visual-language conflict and corrected the argument order in the APNs regression test. Verified evidence: 7 Kit presentation tests and 10 Live Activity push tests pass; iOS/Watch build passes. The failed first Mac test compile was corrected before the successful retry. This merge adds no further application changes. Real-device Dynamic Island/APNs delivery remains unverified; no app installation or release is included.
