### PR TITLE
feat(mac): Cursor-style dashboard sidebar, always-on New task

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -152,7 +152,7 @@ code, and tests — don't drift to synonyms.
   the live sessions and can **approve / answer** for you. Started by the same
   **mic circle** on every surface (ADR-0017 §3): the iPhone composer (always
   visible, explained once), the Mac panel's command row, the Mac dashboard's
-  top bar and the expanded Glance. Its glyph follows the voice phase.
+  sidebar (its Voice row) and the expanded Glance. Its glyph follows the voice phase.
 - **VoiceProvider** — a vendor the companion talks to: `qwen`, `openai`,
   `gemini`, `doubao` or `deepseek`. Each has its own key. The realtime backends
   also have a model, voice and input sample rate; `supportsVoice` says which

--- a/VibeBuddyKit/Sources/VibeBuddyKit/SessionFilter.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/SessionFilter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Pure filtering for the dashboard: by status, by agent, and a text query over
-/// project/summary. nil status/agent = no filter; empty query = match all.
+/// name/project/summary. nil status/agent = no filter; empty query = match all.
 public enum SessionFilter {
     public static func apply(_ sessions: [AgentSession], status: SessionStatus?,
                              agent: AgentKind?, query: String) -> [AgentSession] {
@@ -10,7 +10,8 @@ public enum SessionFilter {
             if let status, s.status != status { return false }
             if let agent, s.agent != agent { return false }
             if !q.isEmpty {
-                let hay = (s.project + " " + (s.summary ?? "")).lowercased()
+                // The name is the row's title, so a search must find it.
+                let hay = ((s.name ?? "") + " " + s.project + " " + (s.summary ?? "")).lowercased()
                 if !hay.contains(q) { return false }
             }
             return true

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/SessionFilterTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/SessionFilterTests.swift
@@ -32,6 +32,14 @@ struct SessionFilterTests {
         #expect(SessionFilter.apply(all, status: nil, agent: nil, query: "bug").map(\.id) == ["b"])
     }
 
+    @Test("query matches the task name, which is the row's title")
+    func byQueryName() {
+        var named = s("a", .working, project: "/Users/me/Projects/duetsub")
+        named.name = "Otty hook cleanup"
+        let all = [named, s("b", .working, project: "other")]
+        #expect(SessionFilter.apply(all, status: nil, agent: nil, query: "hook").map(\.id) == ["a"])
+    }
+
     @Test("nil filters + empty query return everything")
     func noFilter() {
         let all = [s("a", .working), s("b", .done)]

--- a/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -870,3 +870,26 @@
 "An honest assessment: verdict, what went well, problems and risks, and advice for next time." = "坦率评估：结论、做对了什么、问题与风险，以及下次的建议。";
 
 "Neutral notes: goal, key decisions, results and verification, open work." = "中性记录：目标、关键决策、结果与验证、未完成工作。";
+
+/* MARK: Dashboard sidebar and New task (Cursor layout) */
+"Errors" = "错误";
+"Unassigned" = "未分配";
+"All" = "全部";
+"Reset" = "重置";
+"Message matches" = "消息匹配";
+"Open Settings" = "打开设置";
+"Close" = "关闭";
+"Thinking…" = "思考中…";
+"Connecting…" = "连接中…";
+"Recovering…" = "恢复中…";
+"Choose folder…" = "选择文件夹…";
+"Choose" = "选择";
+"What should the agent do?" = "让代理做什么？";
+"No agent can start from this Mac yet." = "这台 Mac 上还没有可启动的代理。";
+"needs a `claude` that supports background sessions." = "需要支持后台会话的 `claude`。";
+"needs the app-server connection from Settings › Agent CLIs." = "需要在设置 › 代理命令行中连接 app-server。";
+"needs the Cursor CLI, or ACP, on this Mac." = "需要这台 Mac 上有 Cursor 命令行或 ACP。";
+"Pick a task on the left to see its details." = "从左侧选择任务查看详情。";
+"Pick a conversation on the left to read it." = "从左侧选择会话阅读。";
+"Expanded" = "已展开";
+"Collapsed" = "已收起";

--- a/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyMacApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -893,3 +893,4 @@
 "Pick a conversation on the left to read it." = "从左侧选择会话阅读。";
 "Expanded" = "已展开";
 "Collapsed" = "已收起";
+"That folder is no longer available." = "该文件夹已不可用。";

--- a/VibeBuddyMacApp/Sources/DashboardSidebar.swift
+++ b/VibeBuddyMacApp/Sources/DashboardSidebar.swift
@@ -1,0 +1,334 @@
+import SwiftUI
+import VibeBuddyKit
+import VibeBuddyMacCore
+
+/// The dashboard's one sidebar, in the shape of Cursor's main window: the
+/// actions on top (New task, Search, Voice), the four libraries, the project
+/// filter for whichever library is showing, and at the bottom the account
+/// quota and Settings. It replaces the segmented library picker, the buddy
+/// header and the window toolbar, so nothing sits in the title bar any more.
+struct DashboardSidebar: View {
+    @ObservedObject var model: MenuBarModel
+    @ObservedObject var voice: VoiceChat
+    @Binding var library: String
+    @Binding var projectScope: DashboardSessionList.ProjectScope
+    @Binding var historyProject: String?
+    let liveProjects: [DashboardSessionList.Project]
+    /// History's projects by path, with how many conversations each holds.
+    let historyProjects: [(path: String, count: Int)]
+    var onNewTask: () -> Void
+    var onSearch: () -> Void
+    @AppStorage(VoiceSettings.companionEnabledKey) private var companionEnabled = false
+    /// The one-line "where voice lives" note shows until the dashboard has been
+    /// closed once with it on screen (ADR-0017 §3).
+    @AppStorage("dashboard.voiceHintSeen") private var voiceHintSeen = false
+
+    static let width: CGFloat = 216
+
+    private var waiting: Int { model.sessions.filter { $0.status == .needsResponse }.count }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // The actions and the libraries never scroll away; only the
+            // project list does, so New task stays reachable in any project count.
+            VStack(alignment: .leading, spacing: 1) {
+                SidebarRow(systemName: "plus.square", title: "New task", shortcut: "⌘N", action: onNewTask)
+                SidebarRow(systemName: "magnifyingglass", title: "Search", shortcut: "⌘F", action: onSearch)
+                voiceRow
+
+                SidebarHeading(title: "Library")
+                SidebarRow(systemName: "rectangle.stack", title: "Current tasks",
+                           count: waiting, countTint: MacTheme.status(.requiresInput),
+                           selected: library == "live") { library = "live" }
+                SidebarRow(systemName: "clock", title: "History", selected: library == "history") { library = "history" }
+                SidebarRow(systemName: "star", title: "Favorites", selected: library == "favorites") { library = "favorites" }
+                SidebarRow(systemName: "chart.bar", title: "Usage", selected: library == "usage") { library = "usage" }
+                if library != "usage" { SidebarHeading(title: "Projects") }
+            }
+            .padding(.horizontal, 8).padding(.top, 10)
+            if library != "usage" {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 1) { projectRows }
+                        .padding(.horizontal, 8).padding(.bottom, 8)
+                }
+            }
+            Spacer(minLength: 0)
+            QuotaPlinth(model: model)
+            Divider()
+            SidebarRow(systemName: "gearshape", title: "Settings", shortcut: "⌘,") {
+                NotificationCenter.default.post(name: .openAppSettings, object: nil)
+            }
+            .padding(.horizontal, 8).padding(.vertical, 6)
+        }
+        .frame(width: Self.width).frame(maxHeight: .infinity)
+        .background(MacTheme.bg2)
+        .sheet(isPresented: $voice.showConsent) { VoiceConsentSheet(voice: voice) }
+        .onDisappear { if !companionEnabled { voiceHintSeen = true } }
+    }
+
+    // MARK: Voice
+
+    /// The mic is Cursor's small round button, here on its own row: the row
+    /// toggles the conversation, the trailing word is its state, and a second
+    /// line carries the last exchange or the error. The cat sits beside the
+    /// mic only while a conversation is live (ADR-0017 §2–3).
+    private var voiceRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button { voice.toggle() } label: {
+                HStack(spacing: 8) {
+                    MicGlyph(phase: voice.phase, enabled: companionEnabled)
+                    if voice.isActive {
+                        PetFace(state: model.buddyState, voice: .init(voice.phase), plain: true, scale: 0.36)
+                            .frame(width: 18, height: 18)
+                    }
+                    Text("Voice").font(MacTheme.font(12, .medium)).foregroundStyle(MacTheme.ink)
+                    Spacer(minLength: 4)
+                    Text(stateWord).font(MacTheme.mono(10)).foregroundStyle(stateTint).lineLimit(1)
+                }
+                .padding(.horizontal, 8).padding(.vertical, 5)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            }
+            .buttonStyle(SidebarRowStyle(selected: voice.isActive))
+            .help(voice.phase == .idle ? "Start voice conversation" : "End voice conversation")
+            .accessibilityLabel("Toggle voice companion")
+            if let line = secondLine {
+                Text(line.text).font(MacTheme.font(10.5))
+                    .foregroundStyle(line.isError ? MacTheme.status(.error) : MacTheme.ink2)
+                    .lineLimit(2).padding(.horizontal, 8).padding(.bottom, 4)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var stateWord: LocalizedStringKey {
+        if !companionEnabled { return "Off" }
+        switch voice.phase {
+        case .idle: return ""
+        case .listening: return "Listening…"
+        case .speaking: return "Speaking…"
+        case .thinking: return "Thinking…"
+        case .connecting: return "Connecting…"
+        case .recovering: return "Recovering…"
+        }
+    }
+
+    private var stateTint: Color { voice.phase == .idle ? MacTheme.ink3 : MacTheme.accent }
+
+    private var secondLine: (text: String, isError: Bool)? {
+        if let err = voice.errorText { return (err, true) }
+        if !voice.lastReply.isEmpty { return (voice.lastReply, false) }
+        if !voice.lastUserText.isEmpty { return (voice.lastUserText, false) }
+        if !companionEnabled {
+            return voiceHintSeen ? nil : (String(localized: "Enable it in Settings › Voice, or tap the mic."), false)
+        }
+        if voice.phase == .connecting { return (String(localized: "Connecting — wait to speak"), false) }
+        if voice.phase == .recovering { return (String(localized: "Recovering audio… tap the mic to end"), false) }
+        let n = model.buddySessionIDs.count
+        return (n == 0 ? String(localized: "Buddy: all sessions") : String(localized: "Buddy: \(n) selected"), false)
+    }
+
+    // MARK: Projects
+
+    @ViewBuilder private var projectRows: some View {
+        if library == "live" {
+            ForEach(liveProjects) { project in
+                // Live projects are named by their path; the row shows the
+                // folder, as Cursor does, and keeps the path in the tooltip.
+                let full = Self.title(project.id)
+                ProjectRow(title: full.hasPrefix("/") ? URL(fileURLWithPath: full).lastPathComponent : full,
+                           count: project.count,
+                           selected: projectScope == project.id) { projectScope = project.id }
+                    .help(full)
+            }
+        } else {
+            ProjectRow(title: String(localized: "All projects"),
+                       count: historyProjects.reduce(0) { $0 + $1.count },
+                       selected: historyProject == nil) { historyProject = nil }
+            ForEach(historyProjects, id: \.path) { project in
+                ProjectRow(title: project.path.isEmpty ? String(localized: "Unknown project")
+                                                       : URL(fileURLWithPath: project.path).lastPathComponent,
+                           count: project.count, selected: historyProject == project.path) { historyProject = project.path }
+                    .help(project.path)
+            }
+        }
+    }
+
+    static func title(_ scope: DashboardSessionList.ProjectScope) -> String {
+        switch scope {
+        case .all: String(localized: "All projects")
+        case .unknown: String(localized: "Unknown project (unassigned)")
+        case .project(let name): name
+        }
+    }
+}
+
+// MARK: - Pieces
+
+/// Cursor's sidebar row: a line glyph, the name, and on the right a count or a
+/// shortcut in the mono face. Selection is a soft ink wash, never the accent.
+struct SidebarRow: View {
+    let systemName: String
+    let title: LocalizedStringKey
+    var count: Int = 0
+    var countTint: Color = MacTheme.ink3
+    var shortcut: String? = nil
+    var selected = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: systemName).font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(selected ? MacTheme.ink : MacTheme.ink2).frame(width: 14)
+                Text(title).font(MacTheme.font(12, .medium)).foregroundStyle(MacTheme.ink).lineLimit(1)
+                Spacer(minLength: 4)
+                if count > 0 {
+                    Text("\(count)").font(MacTheme.mono(10, .medium)).foregroundStyle(countTint)
+                } else if let shortcut {
+                    Text(shortcut).font(MacTheme.mono(10)).foregroundStyle(MacTheme.ink3)
+                }
+            }
+            .padding(.horizontal, 8).padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .buttonStyle(SidebarRowStyle(selected: selected))
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+}
+
+struct ProjectRow: View {
+    let title: String
+    let count: Int
+    let selected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(title).font(MacTheme.font(12)).foregroundStyle(selected ? MacTheme.ink : MacTheme.ink2)
+                    .lineLimit(1).truncationMode(.middle)
+                Spacer(minLength: 4)
+                Text("\(count)").font(MacTheme.mono(10)).foregroundStyle(MacTheme.ink3)
+            }
+            .padding(.horizontal, 8).padding(.vertical, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .buttonStyle(SidebarRowStyle(selected: selected))
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+}
+
+/// Section label in the mono face, uppercase and tracked, as Cursor sets
+/// "Projects" and "Repositories".
+struct SidebarHeading: View {
+    let title: LocalizedStringKey
+    var body: some View {
+        Text(title).font(MacTheme.mono(10, .medium)).foregroundStyle(MacTheme.ink3)
+            .textCase(.uppercase).kerning(0.6)
+            .padding(.horizontal, 8).padding(.top, 14).padding(.bottom, 4)
+    }
+}
+
+/// Hover lifts the row a shade; selection holds it there.
+struct SidebarRowStyle: ButtonStyle {
+    var selected: Bool
+    @State private var hovering = false
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background(ground(configuration.isPressed), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .onHover { hovering = $0 }
+    }
+    private func ground(_ pressed: Bool) -> Color {
+        if selected || pressed { return MacTheme.ink.opacity(0.07) }
+        return hovering ? MacTheme.ink.opacity(0.04) : .clear
+    }
+}
+
+/// The mic as Cursor draws it in the composer: a 20pt disc, filled with ink
+/// while a conversation is live, quiet ground otherwise.
+struct MicGlyph: View {
+    let phase: VoiceChat.Phase
+    let enabled: Bool
+    var body: some View {
+        Image(systemName: glyph)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(phase == .idle ? MacTheme.ink2 : MacTheme.bg)
+            .frame(width: 20, height: 20)
+            .background(phase == .idle ? MacTheme.bg3 : MacTheme.ink, in: Circle())
+            .overlay(Circle().strokeBorder(MacTheme.line, lineWidth: CompanionType.hairline))
+    }
+    private var glyph: String {
+        if !enabled { return "mic.slash" }
+        switch phase {
+        case .idle: return "mic"
+        case .listening: return "mic.fill"
+        case .speaking: return "waveform"
+        case .connecting, .recovering, .thinking: return "ellipsis"
+        }
+    }
+}
+
+/// Cursor's filter chip: outlined at rest, ink-filled when on.
+struct FilterChip: View {
+    let title: LocalizedStringKey
+    let selected: Bool
+    let action: () -> Void
+    var body: some View {
+        Button(action: action) {
+            Text(title).font(MacTheme.font(10.5, .medium))
+                .foregroundStyle(selected ? MacTheme.bg : MacTheme.ink2)
+                .padding(.horizontal, 9).padding(.vertical, 3)
+                .background(selected ? MacTheme.ink : .clear, in: Capsule())
+                .overlay(Capsule().strokeBorder(selected ? .clear : MacTheme.line, lineWidth: CompanionType.hairline))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+}
+
+/// The "iOS-vibebuddy ⌄" kind of dropdown pill Cursor uses for model and
+/// project pickers: outlined, quiet, a chevron at the end.
+struct MenuPill<Content: View>: View {
+    let title: String
+    @ViewBuilder var content: () -> Content
+    var body: some View {
+        Menu(content: content) {
+            HStack(spacing: 4) {
+                Text(title).font(MacTheme.font(10.5, .medium)).foregroundStyle(MacTheme.ink2).lineLimit(1)
+                Image(systemName: "chevron.down").font(.system(size: 7, weight: .bold)).foregroundStyle(MacTheme.ink3)
+            }
+            .padding(.horizontal, 9).padding(.vertical, 3)
+            .overlay(Capsule().strokeBorder(MacTheme.line, lineWidth: CompanionType.hairline))
+            .contentShape(Capsule())
+        }
+        .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden)
+        .fixedSize()
+    }
+}
+
+/// An empty pane that stays out of the way: a small glyph, a title at body
+/// size and one line of guidance, centred, with no card behind it. Replaces
+/// the system `ContentUnavailableView`, whose display-size title outweighed
+/// the list beside it.
+struct QuietEmptyState: View {
+    let title: LocalizedStringKey
+    let message: LocalizedStringKey
+    var systemName = "sidebar.right"
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: systemName).font(.system(size: 22, weight: .light)).foregroundStyle(MacTheme.ink3)
+                .padding(.bottom, 4)
+            Text(title).font(MacTheme.font(13, .semibold)).foregroundStyle(MacTheme.ink)
+            Text(message).font(MacTheme.font(11)).foregroundStyle(MacTheme.ink2)
+                .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: 280)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -52,6 +52,13 @@ struct DashboardView: View {
         DashboardSidebar.title(scope)
     }
 
+    /// The search field lives in the live and history list heads; Usage has
+    /// none, so searching from there lands on Current tasks.
+    private func focusSearch() {
+        if libraryScope == "usage" { libraryScope = "live" }
+        searchFocused = true
+    }
+
     /// History's projects with a conversation count each, for the sidebar.
     private var historyProjects: [(path: String, count: Int)] {
         let counts = Dictionary(grouping: history.snapshot.sessions, by: \.projectPath).mapValues(\.count)
@@ -64,10 +71,7 @@ struct DashboardView: View {
                              projectScope: $projectScope, historyProject: $historyProject,
                              liveProjects: projection.projects, historyProjects: historyProjects,
                              onNewTask: { showNewTask = true },
-                             onSearch: {
-                                 if libraryScope == "usage" { libraryScope = "live" }
-                                 searchFocused = true
-                             })
+                             onSearch: focusSearch)
             Rectangle().fill(MacTheme.line).frame(width: CompanionType.hairline)
             Group {
                 if libraryScope == "live" {
@@ -115,8 +119,8 @@ struct DashboardView: View {
                 Button("") { statusFilter = .completeUnread }.keyboardShortcut("4", modifiers: .command)
                 Button("") { statusFilter = .idle }.keyboardShortcut("5", modifiers: .command)
                 Button("") { statusFilter = nil }.keyboardShortcut("0", modifiers: .command)
-                // ⌘F focuses the sessions search field.
-                Button("") { searchFocused = true }.keyboardShortcut("f", modifiers: .command)
+                // ⌘F focuses the search field, leaving Usage first if needed.
+                Button("", action: focusSearch).keyboardShortcut("f", modifiers: .command)
                 // ⏎ jumps to the selected session's terminal. Ignored while typing in
                 // search so it doesn't shadow the field's own Return.
                 Button("") {

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -30,6 +30,9 @@ struct DashboardView: View {
     @State private var query: String = ""
     @State private var showNewTask = false
     @State private var libraryScope = "live"
+    /// History and Favorites filter by project path; the sidebar owns the
+    /// choice so both libraries share one project list.
+    @State private var historyProject: String?
     @StateObject private var history = HistoryLibraryModel()
     // Demo instance pre-selects the approval session so the detail pane (diff +
     // Approve/Deny) is shown for screenshots; nil in normal use.
@@ -46,51 +49,41 @@ struct DashboardView: View {
     private var selectedSession: AgentSession? { projection.selected }
 
     private func projectTitle(_ scope: DashboardSessionList.ProjectScope) -> String {
-        switch scope {
-        case .all: String(localized: "All projects")
-        case .unknown: String(localized: "Unknown project (unassigned)")
-        case .project(let name): name
-        }
+        DashboardSidebar.title(scope)
+    }
+
+    /// History's projects with a conversation count each, for the sidebar.
+    private var historyProjects: [(path: String, count: Int)] {
+        let counts = Dictionary(grouping: history.snapshot.sessions, by: \.projectPath).mapValues(\.count)
+        return counts.keys.sorted().map { (path: $0, count: counts[$0] ?? 0) }
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            MacBuddyBar(model: model, voice: model.voiceChat, query: $query, searchFocused: $searchFocused)
-            HStack(spacing: 12) {
-                Picker("Library", selection: $libraryScope) {
-                    Text("Current tasks").tag("live")
-                    Text("History").tag("history")
-                    Text("Favorites").tag("favorites")
-                    Text("Usage").tag("usage")
-                }
-                .pickerStyle(.segmented).frame(maxWidth: 460)
-                Spacer()
-                if libraryScope != "live" {
-                    let waiting = model.sessions.filter { $0.status == .needsResponse }.count
-                    if waiting > 0 {
-                        Button("\(waiting) need a response") {
-                            libraryScope = "live"
-                            statusFilter = .requiresInput
-                            projectScope = .all
-                            query = ""
-                        }
+        HStack(spacing: 0) {
+            DashboardSidebar(model: model, voice: model.voiceChat, library: $libraryScope,
+                             projectScope: $projectScope, historyProject: $historyProject,
+                             liveProjects: projection.projects, historyProjects: historyProjects,
+                             onNewTask: { showNewTask = true },
+                             onSearch: {
+                                 if libraryScope == "usage" { libraryScope = "live" }
+                                 searchFocused = true
+                             })
+            Rectangle().fill(MacTheme.line).frame(width: CompanionType.hairline)
+            Group {
+                if libraryScope == "live" {
+                    HSplitView {
+                        sessionsColumn
+                        detailColumn
                     }
+                } else if libraryScope == "usage" {
+                    UsageWorkbenchView(model: model)
+                } else {
+                    HistoryWorkbenchView(history: history, model: model, query: $query,
+                                         favoritesOnly: libraryScope == "favorites",
+                                         project: $historyProject, searchFocused: $searchFocused)
                 }
             }
-            .padding(.horizontal, 16).padding(.bottom, 8)
-            Divider()
-            if libraryScope == "live" {
-                HSplitView {
-                    projectSidebar
-                    sessionsColumn
-                    detailColumn
-                }
-            } else if libraryScope == "usage" {
-                UsageWorkbenchView(model: model)
-            } else {
-                HistoryWorkbenchView(history: history, model: model, query: query,
-                                     favoritesOnly: libraryScope == "favorites")
-            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(MacTheme.bg)
         .onReceive(DashboardRoute.shared.$requested) { library in
@@ -100,20 +93,22 @@ struct DashboardView: View {
             // publisher is not re-entered from inside its own delivery.
             DispatchQueue.main.async { DashboardRoute.shared.requested = nil }
         }
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button { showNewTask = true } label: { Image(systemName: "plus.bubble") }
-                    .help("Start a new task in a directory a session has run in")
-                    .disabled(model.recentDirectories.isEmpty || model.dispatchAgents.isEmpty)
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Button { NotificationCenter.default.post(name: .openAppSettings, object: nil) } label: { Image(systemName: "gearshape") }
-                    .help("Settings")
+        .sheet(isPresented: $showNewTask) { NewTaskSheet(model: model) }
+        .onAppear {
+            // `VIBEBUDDY_DEMO_PAGE=dashboard/<live|history|favorites|usage|newtask>`
+            // lands on that library, or opens New task, for screenshots and QA.
+            guard let page = ProcessInfo.processInfo.environment["VIBEBUDDY_DEMO_PAGE"],
+                  page.hasPrefix("dashboard/") else { return }
+            let target = String(page.dropFirst("dashboard/".count))
+            if target == "newtask" { showNewTask = true } else if let library = DashboardRoute.Library(rawValue: target) {
+                libraryScope = library.rawValue
             }
         }
-        .sheet(isPresented: $showNewTask) { NewTaskSheet(model: model) }
         .background {
             Group {
+                // ⌘N opens New task; the sheet itself explains when no agent
+                // can start yet, so the entry is never disabled.
+                Button("") { showNewTask = true }.keyboardShortcut("n", modifiers: .command)
                 Button("") { statusFilter = .error }.keyboardShortcut("1", modifiers: .command)
                 Button("") { statusFilter = .requiresInput }.keyboardShortcut("2", modifiers: .command)
                 Button("") { statusFilter = .thinking }.keyboardShortcut("3", modifiers: .command)
@@ -142,85 +137,48 @@ struct DashboardView: View {
         }
     }
 
-    private var projectSidebar: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Projects").font(MacTheme.font(12, .semibold))
-                Text("Counts include all sessions")
-                    .font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2)
-                    .fixedSize(horizontal: false, vertical: true)
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 4) {
-                        ForEach(projection.projects) { project in
-                            Button { projectScope = project.id } label: {
-                                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                                    Text(projectTitle(project.id))
-                                        .fixedSize(horizontal: false, vertical: true)
-                                    Spacer(minLength: 0)
-                                    Text("\(project.count)").monospacedDigit()
-                                        .foregroundStyle(MacTheme.ink2)
-                                }
-                                .padding(8)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(projectScope == project.id ? MacTheme.accent.opacity(0.12) : .clear,
-                                            in: RoundedRectangle(cornerRadius: 8))
-                                .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityAddTraits(projectScope == project.id ? .isSelected : [])
-                        }
-                    }
-                }
-            }
-            .padding(12)
-            // Account quota is account-level: it stays put while the selection
-            // and the session list change underneath it.
-            QuotaPlinth(model: model)
-        }
-        .font(MacTheme.font(12))
-        .foregroundStyle(MacTheme.ink)
-        .frame(minWidth: 160, idealWidth: 204, maxWidth: 280, maxHeight: .infinity)
-        .background(MacTheme.bg2)
-    }
-
+    /// The list column's head, as Cursor lays out a list page: the scope as
+    /// the title, the search field, then a row of filter chips. ⌘1–5 and ⌘0
+    /// still drive the same filter.
     private var sessionsColumn: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(projectTitle(projectScope)).font(MacTheme.font(13, .semibold))
-                    .fixedSize(horizontal: false, vertical: true)
-                HStack {
-                    Picker("State", selection: $statusFilter) {
-                        Text("All states").tag(TaskPresentationState?.none)
-                        ForEach([TaskPresentationState.error, .requiresInput, .thinking, .completeUnread, .idle], id: \.self) { state in
-                            Text(LocalizedStringKey(state.label)).tag(TaskPresentationState?.some(state))
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(projectTitle(projectScope)).font(MacTheme.font(13, .semibold)).foregroundStyle(MacTheme.ink)
+                        .lineLimit(1).truncationMode(.middle)
+                    Spacer(minLength: 8)
+                    Text(filtered.count == 1 ? String(localized: "1 session") : String(localized: "\(filtered.count) sessions"))
+                        .font(MacTheme.mono(10)).foregroundStyle(MacTheme.ink3)
+                }
+                SearchPill(query: $query, focused: $searchFocused)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        FilterChip(title: "All", selected: statusFilter == nil) { statusFilter = nil }
+                        ForEach([TaskPresentationState.requiresInput, .error, .thinking, .completeUnread, .idle], id: \.self) { state in
+                            FilterChip(title: Self.chipTitle(state), selected: statusFilter == state) { statusFilter = state }
+                        }
+                        if projectScope != .all || !query.isEmpty {
+                            Button("Reset") {
+                                projectScope = .all
+                                statusFilter = nil
+                                query = ""
+                            }
+                            .buttonStyle(.plain).font(MacTheme.font(10.5)).foregroundStyle(MacTheme.ink3)
                         }
                     }
-                    .labelsHidden()
-                    .accessibilityLabel("Filter sessions by state")
-                    Spacer(minLength: 0)
-                    Text(filtered.count == 1 ? String(localized: "1 session") : String(localized: "\(filtered.count) sessions"))
-                        .font(MacTheme.font(11)).foregroundStyle(MacTheme.ink2)
                 }
-                if projectScope != .all || statusFilter != nil || !query.isEmpty {
-                    Button("Reset view filters") {
-                        projectScope = .all
-                        statusFilter = nil
-                        query = ""
-                    }
-                    .buttonStyle(.borderless)
-                    .font(MacTheme.font(11))
-                }
+                .accessibilityLabel("Filter sessions by state")
             }
             .padding(.horizontal, 12).padding(.top, 12)
             ScrollView {
                 LazyVStack(spacing: 8) {
                     if filtered.isEmpty {
-                        ContentUnavailableView(
-                            model.sessions.isEmpty ? "No sessions reporting" : "No matching sessions",
-                            systemImage: "waveform.path.ecg",
-                            description: Text(model.sessions.isEmpty
-                                ? "Start a Claude Code or Codex turn. If nothing appears, repair hooks in Settings."
-                                : "Clear a filter or try another search."))
+                        QuietEmptyState(title: model.sessions.isEmpty ? "No sessions reporting" : "No matching sessions",
+                                        message: model.sessions.isEmpty
+                                            ? "Start a Claude Code or Codex turn. If nothing appears, repair hooks in Settings."
+                                            : "Clear a filter or try another search.",
+                                        systemName: "waveform.path.ecg")
+                            .padding(.top, 40)
                     } else {
                         ForEach(filtered) { session in
                             SummaryRow(session: session, isSelected: selection == session.id,
@@ -234,118 +192,44 @@ struct DashboardView: View {
                 .padding(.horizontal, 12).padding(.bottom, 12)
             }
         }
-        .frame(minWidth: 220, idealWidth: 280, maxWidth: 360, maxHeight: .infinity)
+        .frame(minWidth: 240, idealWidth: 300, maxWidth: 380, maxHeight: .infinity)
     }
 
-    private var detailColumn: some View {
-        ScrollView {
-            VStack(spacing: 12) {
-                Group {
-                    if let s = selectedSession {
-                        VStack(spacing: 0) {
-                            DetailCard(session: s, model: model)
-                            Divider()
-                            RecentOutputPane(session: s, model: model)
-                        }.id(s.id)
-                    } else {
-                        ContentUnavailableView("Select a session", systemImage: "sidebar.right")
-                            .frame(maxWidth: .infinity, minHeight: 200)
-                    }
+    /// The chips use the menu panel's group words (Needs you / Working / Done),
+    /// not the long state labels, so six of them fit on one line.
+    static func chipTitle(_ state: TaskPresentationState) -> LocalizedStringKey {
+        switch state {
+        case .requiresInput: "Needs you"
+        case .error: "Errors"
+        case .thinking: "Working"
+        case .completeUnread: "Done"
+        case .idle: "Idle"
+        case .unassigned: "Unassigned"
+        }
+    }
+
+    @ViewBuilder private var detailColumn: some View {
+        if let s = selectedSession {
+            ScrollView {
+                VStack(spacing: 0) {
+                    DetailCard(session: s, model: model)
+                    Divider()
+                    RecentOutputPane(session: s, model: model)
                 }
+                .id(s.id)
                 .companionCard(radius: MacTheme.panelRadius)
+                .padding(12)
             }
-            .padding(12)
+            .frame(minWidth: 340, idealWidth: 380, maxWidth: .infinity)
+        } else {
+            QuietEmptyState(title: "Select a session", message: "Pick a task on the left to see its details.")
+                .frame(minWidth: 340, idealWidth: 380, maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(minWidth: 340, idealWidth: 380, maxWidth: .infinity)
     }
 
 }
 
-/// The top bar: the voice companion's mic and its status line on the left,
-/// search on the right. The cat appears beside the mic only while a
-/// conversation is live (ADR-0017 §2–3).
-private struct MacBuddyBar: View {
-    @ObservedObject var model: MenuBarModel
-    @ObservedObject var voice: VoiceChat
-    @Binding var query: String
-    var searchFocused: FocusState<Bool>.Binding
-    @AppStorage(VoiceSettings.companionEnabledKey) private var companionEnabled = false
-
-    /// The buddy header reads "off" until the companion is opted in; otherwise the
-    /// live Listening/Speaking/idle status.
-    private var headline: LocalizedStringKey {
-        if !companionEnabled { return "Voice companion off" }
-        if voice.phase == .recovering { return "Recovering audio… tap the mic to end" }
-        if voice.phase == .connecting { return "Connecting — wait to speak" }
-        if voice.phase == .thinking { return "Thinking…" }
-        if voice.isListening { return "Listening…" }
-        if voice.isSpeaking { return "Speaking…" }
-        return "Tap the mic to talk"
-    }
-
-    /// "Buddy: all sessions" when nothing is scoped, else "Buddy: N selected".
-    private var scopeLine: LocalizedStringKey {
-        let n = model.buddySessionIDs.count
-        return n == 0 ? "Buddy: all sessions" : "Buddy: \(n) selected"
-    }
-
-    var body: some View {
-        HStack(spacing: 12) {
-            MenuCircleButton(systemName: micGlyph, size: 30,
-                             tint: voice.phase == .idle ? MacTheme.ink2 : .onAccent,
-                             ground: voice.phase == .idle ? MacTheme.bg3 : MacTheme.accent) {
-                voice.toggle()
-            }
-            .help(voice.phase == .idle ? "Start voice conversation" : "End voice conversation")
-            .accessibilityLabel("Toggle voice companion")
-            if voice.isActive {
-                PetFace(state: model.buddyState, voice: .init(voice.phase), plain: true, scale: 0.5)
-            }
-            Group {
-                VStack(alignment: .leading, spacing: 1) {
-                    HStack(spacing: 6) {
-                        if !companionEnabled {
-                            Image(systemName: "mic.slash").font(.system(size: 10)).foregroundStyle(MacTheme.ink2)
-                        }
-                        Text(headline).font(MacTheme.font(13, .heavy)).foregroundStyle(MacTheme.ink)
-                        if companionEnabled {
-                            Text((voice.activeProvider ?? VoiceSettings.provider).display)
-                                .font(MacTheme.font(10, .heavy))
-                                .foregroundStyle(MacTheme.ink2)
-                                .padding(.horizontal, 6).padding(.vertical, 2)
-                                .background(MacTheme.bg2, in: Capsule())
-                        }
-                    }
-                    if let err = voice.errorText {
-                        Text(err).font(MacTheme.font(11)).foregroundStyle(MacTheme.status(.error)).lineLimit(2)
-                    } else if !voice.lastReply.isEmpty {
-                        Text(voice.lastReply).font(MacTheme.font(11)).foregroundStyle(MacTheme.ink2).lineLimit(2)
-                    } else if !voice.lastUserText.isEmpty {
-                        Text(voice.lastUserText).font(MacTheme.font(11)).foregroundStyle(MacTheme.ink2).lineLimit(1)
-                    } else {
-                        Text(companionEnabled ? scopeLine : "Enable it in Settings › Voice, or tap the mic.")
-                            .font(MacTheme.font(11, .semibold)).foregroundStyle(MacTheme.ink2)
-                    }
-                }
-            }
-            Spacer(minLength: 12)
-            SearchPill(query: $query, focused: searchFocused)
-        }
-        .padding(.horizontal, 16).padding(.vertical, 6)
-        .sheet(isPresented: $voice.showConsent) { VoiceConsentSheet(voice: voice) }
-    }
-
-    private var micGlyph: String {
-        switch voice.phase {
-        case .idle: "mic"
-        case .listening: "mic.fill"
-        case .speaking: "waveform"
-        case .connecting, .recovering, .thinking: "ellipsis"
-        }
-    }
-}
-
-private struct SearchPill: View {
+struct SearchPill: View {
     @Binding var query: String
     var focused: FocusState<Bool>.Binding
     var body: some View {
@@ -362,8 +246,8 @@ private struct SearchPill: View {
                     .buttonStyle(.plain)
             }
         }
-        .padding(.horizontal, 12).frame(width: 220, height: 30)
-        .companionCard(radius: 15)
+        .padding(.horizontal, 10).frame(maxWidth: .infinity).frame(height: 28)
+        .companionCard(radius: 14)
     }
 }
 
@@ -439,11 +323,11 @@ private struct SummaryRow: View {
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .companionCard()
+        .companionCard(isSelected ? MacTheme.bg2 : MacTheme.bg3)
         .overlay {
             if isSelected {
                 RoundedRectangle(cornerRadius: MacTheme.cardRadius, style: .continuous)
-                    .strokeBorder(MacTheme.accent, lineWidth: 2)
+                    .strokeBorder(MacTheme.ink.opacity(0.28), lineWidth: CompanionType.hairline)
                     .allowsHitTesting(false)
             }
         }
@@ -622,7 +506,7 @@ private struct RequestCard: View {
 
 }
 
-private struct VoiceConsentSheet: View {
+struct VoiceConsentSheet: View {
     @ObservedObject var voice: VoiceChat
     @Environment(\.dismiss) private var dismiss
 
@@ -679,12 +563,10 @@ private struct TranscriptSheet: View {
         if !loaded {
             ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let output, output.entries.isEmpty {
-            ContentUnavailableView(
-                "No recent output", systemImage: "text.alignleft",
-                description: Text(output.statusLine.isEmpty
-                                  ? "This session hasn't reported a transcript yet."
-                                  : output.statusLine))
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            QuietEmptyState(title: "No recent output",
+                            message: output.statusLine.isEmpty
+                                ? "This session hasn't reported a transcript yet." : LocalizedStringKey(output.statusLine),
+                            systemName: "text.alignleft")
         } else if let output {
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {

--- a/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
+++ b/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
@@ -150,9 +150,11 @@ final class HistoryLibraryModel: ObservableObject {
 struct HistoryWorkbenchView: View {
     @ObservedObject var history: HistoryLibraryModel
     @ObservedObject var model: MenuBarModel
-    let query: String
+    @Binding var query: String
     let favoritesOnly: Bool
-    @State private var project: String?
+    /// The sidebar owns the project choice (shared with the live library).
+    @Binding var project: String?
+    var searchFocused: FocusState<Bool>.Binding
     @State private var agent: SessionHistoryAgent?
     @State private var archiveScope = "all"
     private var archived: Bool? { archiveScope == "all" ? nil : archiveScope == "archived" }
@@ -160,15 +162,19 @@ struct HistoryWorkbenchView: View {
     @State private var targetMessage: String?
     @State private var exportError: String?
 
+    private var archiveTitle: String {
+        switch archiveScope {
+        case "unarchived": String(localized: "Unarchived")
+        case "archived": String(localized: "Archived")
+        default: String(localized: "All history")
+        }
+    }
     private var isSearching: Bool { !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     private var sessions: [SessionHistorySession] {
         history.snapshot.sessions.filter {
             (project == nil || $0.projectPath == project) && (!favoritesOnly || $0.isFavorite)
                 && (agent == nil || $0.agent == agent) && (archived == nil || $0.isArchived == archived)
         }
-    }
-    private var projects: [String] {
-        Array(Set(history.snapshot.sessions.map(\.projectPath))).sorted()
     }
     private var selected: SessionHistorySession? {
         guard let selection else { return nil }
@@ -184,7 +190,6 @@ struct HistoryWorkbenchView: View {
 
     var body: some View {
         HSplitView {
-            sidebar
             sessionList
             readingPane
         }
@@ -210,74 +215,56 @@ struct HistoryWorkbenchView: View {
         } message: { Text(exportError ?? "") }
     }
 
-    private var sidebar: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Local library").font(MacTheme.font(13, .semibold))
-            Text("Claude Code · Codex\nIncludes archived Codex sessions")
-                .font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2)
-            Picker("Agent", selection: $agent) {
-                Text("All agents").tag(nil as SessionHistoryAgent?)
-                ForEach(SessionHistoryAgent.allCases, id: \.self) { value in
-                    Text(value.displayName).tag(Optional(value))
-                }
-            }
-            Picker("Archive", selection: $archiveScope) {
-                Text("All history").tag("all")
-                Text("Unarchived").tag("unarchived")
-                Text("Archived").tag("archived")
-            }
-            Button { project = nil } label: {
-                Label("All projects", systemImage: "tray.full")
-                    .frame(maxWidth: .infinity, alignment: .leading).padding(8)
-                    .background(project == nil ? Color.accentColor.opacity(0.12) : .clear, in: RoundedRectangle(cornerRadius: 6))
-            }.buttonStyle(.plain)
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 4) {
-                    ForEach(projects, id: \.self) { path in
-                        Button { project = path } label: {
-                            VStack(alignment: .leading, spacing: 3) {
-                                Label(path.isEmpty ? "Unknown project" : URL(fileURLWithPath: path).lastPathComponent,
-                                      systemImage: "folder")
-                                Text(path).font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2).lineLimit(2)
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading).padding(8)
-                            .background(project == path ? Color.accentColor.opacity(0.12) : .clear, in: RoundedRectangle(cornerRadius: 6))
-                        }.buttonStyle(.plain).help(path)
-                    }
-                }
-            }
-            Divider()
-            if history.loading { ProgressView("Updating library…").font(MacTheme.font(10)) }
-            if let date = history.snapshot.refreshedAt {
-                Text("Updated \(date.formatted(date: .omitted, time: .shortened))")
-                    .font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2)
-            }
-            HStack {
-                Button("Refresh") { Task { await history.refresh() } }
-                Menu {
-                    Button("Rebuild index") { Task { await history.refresh(rebuild: true) } }
-                } label: { Image(systemName: "ellipsis.circle") }
-                .menuStyle(.borderlessButton).frame(width: 24)
-            }.disabled(history.loading)
-            if let error = history.error { Text(error).font(MacTheme.font(10)).foregroundStyle(.red).textSelection(.enabled) }
-            if !history.snapshot.issues.isEmpty {
-                DisclosureGroup("Source notices (\(history.snapshot.issues.count))") {
-                    ScrollView { Text(history.snapshot.issues.joined(separator: "\n")).font(MacTheme.font(10)).textSelection(.enabled) }
-                        .frame(maxHeight: 130)
-                }.font(MacTheme.font(10))
-            }
-        }
-        .padding(12).frame(minWidth: 170, idealWidth: 210, maxWidth: 270)
-        .frame(maxHeight: .infinity).background(Color(nsColor: .controlBackgroundColor))
-    }
-
     private var sessionList: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(isSearching ? "Message matches" : favoritesOnly ? "Favorites" : "History").font(MacTheme.font(13, .semibold))
-                Spacer()
-                Text("\(isSearching ? history.results.count : sessions.count)").foregroundStyle(MacTheme.ink2)
-            }.padding(12)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(isSearching ? "Message matches" : favoritesOnly ? "Favorites" : "History")
+                        .font(MacTheme.font(13, .semibold)).foregroundStyle(MacTheme.ink)
+                    Spacer(minLength: 8)
+                    Text("\(isSearching ? history.results.count : sessions.count)")
+                        .font(MacTheme.mono(10)).foregroundStyle(MacTheme.ink3)
+                }
+                // The dashboard's one query; the sidebar's Search row and ⌘F
+                // land here while a history library is showing.
+                SearchPill(query: $query, focused: searchFocused)
+                HStack(spacing: 6) {
+                    MenuPill(title: agent?.displayName ?? String(localized: "All agents")) {
+                        Button("All agents") { agent = nil }
+                        ForEach(SessionHistoryAgent.allCases, id: \.self) { value in
+                            Button(value.displayName) { agent = value }
+                        }
+                    }
+                    MenuPill(title: archiveTitle) {
+                        Button("All history") { archiveScope = "all" }
+                        Button("Unarchived") { archiveScope = "unarchived" }
+                        Button("Archived") { archiveScope = "archived" }
+                    }
+                    Spacer(minLength: 4)
+                    if history.loading {
+                        ProgressView().controlSize(.mini)
+                    } else if let date = history.snapshot.refreshedAt {
+                        Text(date, style: .time).font(MacTheme.mono(10)).foregroundStyle(MacTheme.ink3)
+                            .help(String(localized: "Updated \(date.formatted(date: .omitted, time: .shortened))"))
+                    }
+                    MenuPill(title: "···") {
+                        Button("Refresh") { Task { await history.refresh() } }
+                        Button("Rebuild index") { Task { await history.refresh(rebuild: true) } }
+                        if !history.snapshot.issues.isEmpty {
+                            Divider()
+                            Section("Source notices (\(history.snapshot.issues.count))") {
+                                ForEach(history.snapshot.issues, id: \.self) { issue in Text(issue) }
+                            }
+                        }
+                    }
+                    .disabled(history.loading)
+                }
+                if let error = history.error {
+                    Text(error).font(MacTheme.font(10)).foregroundStyle(MacTheme.status(.error)).textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.horizontal, 12).padding(.top, 12)
             if isSearching && history.searching { ProgressView("Searching…") }
             if isSearching, let error = history.searchError {
                 Text("Search could not complete: \(error)").font(MacTheme.font(10)).foregroundStyle(.red).padding(12)
@@ -302,8 +289,10 @@ struct HistoryWorkbenchView: View {
                         }
                     }
                     if !history.loading && !(isSearching && history.searching) && (isSearching ? history.results.isEmpty && history.searchError == nil : sessions.isEmpty) {
-                        ContentUnavailableView(isSearching ? "No matching messages" : "No sessions in this view", systemImage: "text.magnifyingglass",
-                                               description: Text("Check the project filter and source notices, or refresh the library."))
+                        QuietEmptyState(title: isSearching ? "No matching messages" : "No sessions in this view",
+                                        message: "Check the project filter and source notices, or refresh the library.",
+                                        systemName: "text.magnifyingglass")
+                            .padding(.top, 40)
                     }
                 }.padding(.horizontal, 8)
             }
@@ -328,7 +317,7 @@ struct HistoryWorkbenchView: View {
             else if !session.warnings.isEmpty { Label("Partial or limited record", systemImage: "info.circle").font(MacTheme.font(10)) }
         }
         .frame(maxWidth: .infinity, alignment: .leading).padding(10)
-        .background(active ? Color.accentColor.opacity(0.12) : .clear, in: RoundedRectangle(cornerRadius: 8))
+        .background(active ? MacTheme.ink.opacity(0.07) : .clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .contentShape(Rectangle())
     }
 
@@ -370,8 +359,8 @@ struct HistoryWorkbenchView: View {
             .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
             .id(session.id)
         } else {
-            ContentUnavailableView("Select a conversation", systemImage: "text.book.closed",
-                                   description: Text("Read local history without changing a task's live state."))
+            QuietEmptyState(title: "Select a conversation", message: "Pick a conversation on the left to read it.",
+                            systemName: "text.book.closed")
                 .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
         }
     }

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -993,9 +993,19 @@ final class MenuBarModel: ObservableObject {
 
     /// Start a new task from the Mac, the same way `/dispatch` does for the
     /// phone: Codex through the app-server daemon; other agents once they have
-    /// a launcher. The directory must be one a session has run in.
-    func dispatch(_ request: DispatchRequest) async -> DispatchOutcome {
-        guard await store.isKnownDirectory(request.cwd) else {
+    /// a launcher. The directory must be one a session has run in, unless the
+    /// user picked it in this Mac's open panel just now (`userChoseDirectory`):
+    /// that choice is the authorization the known-directory rule stands in
+    /// for when a request arrives from the phone.
+    func dispatch(_ request: DispatchRequest, userChoseDirectory: Bool = false) async -> DispatchOutcome {
+        if userChoseDirectory {
+            var isDirectory: ObjCBool = false
+            guard request.cwd.hasPrefix("/"),
+                  FileManager.default.fileExists(atPath: request.cwd, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                return .rejected("That folder is no longer available.")
+            }
+        } else if !(await store.isKnownDirectory(request.cwd)) {
             return .rejected("Pick a directory a session has already run in.")
         }
         switch request.agent {

--- a/VibeBuddyMacApp/Sources/NewTaskSheet.swift
+++ b/VibeBuddyMacApp/Sources/NewTaskSheet.swift
@@ -1,57 +1,157 @@
 import SwiftUI
+import AppKit
 import VibeBuddyKit
 
-/// Start a new agent task from the Mac: pick one of the directories a session
-/// has already run in, write the prompt, optionally name it. Claude Code
-/// starts as a `claude --bg` background session, Codex as a thread on the
-/// app-server daemon; only agents the Mac can start right now are offered.
+/// Start a new agent task from the Mac: pick the agent, the directory, write
+/// the prompt, optionally name it. Claude Code starts as a `claude --bg`
+/// background session, Codex as a thread on the app-server daemon, Cursor
+/// through its CLI. The sheet always opens; when no agent can start from this
+/// Mac it says which one needs what, instead of a greyed-out button.
 struct NewTaskSheet: View {
     @ObservedObject var model: MenuBarModel
     @Environment(\.dismiss) private var dismiss
     @State private var agent: AgentKind = .claudeCode
     @State private var directory = ""
+    /// Folders picked with the open panel, on top of the ones sessions ran in.
+    @State private var chosenDirectories: [String] = []
     @State private var prompt = ""
     @State private var name = ""
     @State private var feedback: String?
     @State private var busy = false
 
+    private var directories: [String] {
+        var seen = Set<String>()
+        return (chosenDirectories + model.recentDirectories).filter { seen.insert($0).inserted }
+    }
+    private var canStart: Bool {
+        !busy && model.dispatchAgents.contains(agent) && !directory.isEmpty
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("New task").font(MacTheme.font(15, .bold))
-            Picker("Agent", selection: $agent) {
-                ForEach(model.dispatchAgents, id: \.self) { kind in
-                    Text(kind.displayName).tag(kind)
-                }
-            }
-            .pickerStyle(.segmented)
-            Picker("Directory", selection: $directory) {
-                ForEach(model.recentDirectories, id: \.self) { path in
-                    Text(path).tag(path)
-                }
-            }
-            TextField("Task name (optional)", text: $name).textFieldStyle(.roundedBorder)
-            TextEditor(text: $prompt)
-                .font(MacTheme.font(13))
-                .frame(minHeight: 120)
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
-            if let feedback {
-                Label(feedback, systemImage: "info.circle").font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2)
-            }
             HStack {
+                Text("New task").font(MacTheme.font(15, .semibold)).foregroundStyle(MacTheme.ink)
                 Spacer()
-                Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
+                MenuCircleButton(systemName: "xmark", size: 22, tint: MacTheme.ink2) { dismiss() }
+                    .accessibilityLabel("Close")
+            }
+
+            if model.dispatchAgents.isEmpty {
+                unavailable
+            } else {
+                HStack(spacing: 6) {
+                    ForEach(model.dispatchAgents, id: \.self) { kind in
+                        FilterChip(title: LocalizedStringKey(kind.displayName), selected: agent == kind) { agent = kind }
+                    }
+                    Spacer(minLength: 8)
+                    MenuPill(title: directory.isEmpty ? String(localized: "Choose folder…")
+                                                      : URL(fileURLWithPath: directory).lastPathComponent) {
+                        ForEach(directories, id: \.self) { path in
+                            Button(path) { directory = path }
+                        }
+                        if !directories.isEmpty { Divider() }
+                        Button("Choose folder…") { chooseFolder() }
+                    }
+                    .help(directory.isEmpty ? String(localized: "Directory") : directory)
+                }
+                .accessibilityLabel("Agent")
+            }
+
+            // Without an agent there is nothing to type for; `.disabled` alone
+            // still lets the editor take focus and swallow Escape.
+            if !model.dispatchAgents.isEmpty {
+                VStack(alignment: .leading, spacing: 0) {
+                    TextField("Task name (optional)", text: $name)
+                        .textFieldStyle(.plain).font(MacTheme.font(12, .medium)).foregroundStyle(MacTheme.ink)
+                        .padding(.horizontal, 12).padding(.vertical, 9)
+                    Divider()
+                    TextEditor(text: $prompt)
+                        .font(MacTheme.font(13)).foregroundStyle(MacTheme.ink)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 120)
+                        .padding(.horizontal, 8).padding(.vertical, 6)
+                        .overlay(alignment: .topLeading) {
+                            if prompt.isEmpty {
+                                Text("What should the agent do?").font(MacTheme.font(13)).foregroundStyle(MacTheme.ink3)
+                                    .padding(.horizontal, 13).padding(.vertical, 6).allowsHitTesting(false)
+                            }
+                        }
+                }
+                .companionCard()
+            }
+
+            if let feedback {
+                Label(feedback, systemImage: "info.circle").font(MacTheme.font(11)).foregroundStyle(MacTheme.ink2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
+                if model.dispatchAgents.isEmpty {
+                    Button("Open Settings") {
+                        NotificationCenter.default.post(name: .openAppSettings, object: nil)
+                        dismiss()
+                    }
+                    .buttonStyle(PillButtonStyle(kind: .ghost, size: .small))
+                }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .buttonStyle(PillButtonStyle(kind: .ghost, size: .small))
+                    .keyboardShortcut(.cancelAction)
                 Button(busy ? "Starting…" : "Start") { start() }
+                    .buttonStyle(PillButtonStyle(kind: .filled(MacTheme.accent), size: .small))
                     .keyboardShortcut(.defaultAction)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(busy || !model.dispatchAgents.contains(agent) || directory.isEmpty
-                              || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(!canStart)
+                    .opacity(canStart ? 1 : 0.5)
             }
         }
         .padding(20)
         .frame(width: 520)
+        .background(MacTheme.bg)
+        .onExitCommand { dismiss() }
         .onAppear {
             if directory.isEmpty { directory = model.recentDirectories.first ?? "" }
             if !model.dispatchAgents.contains(agent), let first = model.dispatchAgents.first { agent = first }
+        }
+    }
+
+    /// What each agent needs before the Mac can start it; the same three
+    /// checks `MenuBarModel` runs to fill `dispatchAgents`.
+    private var unavailable: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("No agent can start from this Mac yet.").font(MacTheme.font(12, .semibold)).foregroundStyle(MacTheme.ink)
+            requirement("Claude Code", "needs a `claude` that supports background sessions.")
+            requirement("Codex", "needs the app-server connection from Settings › Agent CLIs.")
+            requirement("Cursor", "needs the Cursor CLI, or ACP, on this Mac.")
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .companionCard(MacTheme.bg2)
+    }
+
+    private func requirement(_ agent: String, _ what: LocalizedStringKey) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(agent).font(MacTheme.font(11, .medium)).foregroundStyle(MacTheme.ink)
+            Text(what).font(MacTheme.font(11)).foregroundStyle(MacTheme.ink2)
+        }
+    }
+
+    private func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = String(localized: "Choose")
+        let completion: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .OK, let url = panel.url else { return }
+            let path = url.path
+            if !chosenDirectories.contains(path) { chosenDirectories.insert(path, at: 0) }
+            directory = path
+        }
+        if let window = NSApp.keyWindow {
+            panel.beginSheetModal(for: window, completionHandler: completion)
+        } else {
+            panel.begin(completionHandler: completion)
         }
     }
 

--- a/VibeBuddyMacApp/Sources/NewTaskSheet.swift
+++ b/VibeBuddyMacApp/Sources/NewTaskSheet.swift
@@ -161,7 +161,7 @@ struct NewTaskSheet: View {
                                       prompt: prompt.trimmingCharacters(in: .whitespacesAndNewlines),
                                       name: name.isEmpty ? nil : name)
         Task {
-            let outcome = await model.dispatch(request)
+            let outcome = await model.dispatch(request, userChoseDirectory: chosenDirectories.contains(directory))
             busy = false
             switch outcome {
             case .started: dismiss()

--- a/VibeBuddyMacApp/Sources/UsageWorkbenchView.swift
+++ b/VibeBuddyMacApp/Sources/UsageWorkbenchView.swift
@@ -9,6 +9,9 @@ import VibeBuddyMacCore
 /// window, credits, spend and the local token estimate.
 struct QuotaPlinth: View {
     @ObservedObject var model: MenuBarModel
+    /// Collapsed by default: one line says whether you can keep working, the
+    /// detail is a click away, and the choice is remembered.
+    @AppStorage("dashboard.quotaExpanded") private var expanded = false
 
     private var providers: [AccountUsageProvider] {
         AccountUsageProvider.allCases.filter { model.isUsageCollectionEnabled($0) }
@@ -19,31 +22,78 @@ struct QuotaPlinth: View {
             TimelineView(.periodic(from: .now, by: 30)) { context in
                 VStack(alignment: .leading, spacing: 9) {
                     Divider()
-                    HStack(alignment: .firstTextBaseline) {
-                        Text("Account quota")
-                            .font(MacTheme.font(10, .semibold)).foregroundStyle(MacTheme.ink3)
-                            .textCase(.uppercase).kerning(0.6)
-                        Spacer(minLength: 4)
-                        if let updated = latestFetch {
-                            Text(updated, style: .time)
-                                .font(MacTheme.mono(9)).foregroundStyle(MacTheme.ink3)
-                        }
-                    }
-                    ForEach(providers, id: \.self) { provider in
-                        row(provider, now: context.date)
-                    }
-                    if let spend = todaySpend {
-                        Divider()
-                        HStack {
-                            Text("Today's spend").font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2)
+                    Button { expanded.toggle() } label: {
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 8, weight: .bold)).foregroundStyle(MacTheme.ink3)
+                                .rotationEffect(.degrees(expanded ? 90 : 0))
+                            Text("Account quota")
+                                .font(MacTheme.font(10, .semibold)).foregroundStyle(MacTheme.ink3)
+                                .textCase(.uppercase).kerning(0.6)
                             Spacer(minLength: 4)
-                            Text(spend).font(MacTheme.mono(10, .semibold)).foregroundStyle(MacTheme.ink)
+                            if expanded, let updated = latestFetch {
+                                Text(updated, style: .time)
+                                    .font(MacTheme.mono(9)).foregroundStyle(MacTheme.ink3)
+                            }
                         }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Account quota")
+                    .accessibilityValue(expanded ? "Expanded" : "Collapsed")
+                    if !expanded, let tight = tightestOverall(now: context.date) {
+                        Text(tight.text).font(MacTheme.mono(10, .semibold)).foregroundStyle(tight.tint)
+                            .lineLimit(1)
+                    }
+                    if expanded {
+                        ForEach(providers, id: \.self) { provider in
+                            row(provider, now: context.date)
+                        }
+                        if let spend = todaySpend {
+                            Divider()
+                            HStack {
+                                Text("Today's spend").font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2)
+                                Spacer(minLength: 4)
+                                Text(spend).font(MacTheme.mono(10, .semibold)).foregroundStyle(MacTheme.ink)
+                            }
+                        }
+                    } else if let issue = anomaly(now: context.date) {
+                        Text(issue).font(MacTheme.font(10)).foregroundStyle(QuotaPresentation.Severity.warning.tint)
+                            .lineLimit(1)
                     }
                 }
                 .padding(.horizontal, 12).padding(.vertical, 10)
+                .animation(.smooth(duration: 0.15), value: expanded)
             }
         }
+    }
+
+    /// The collapsed line: the provider with the least left, its remaining
+    /// share and reset — the one reading that decides whether to keep going.
+    private func tightestOverall(now: Date) -> (text: String, tint: Color)? {
+        var best: (provider: AccountUsageProvider, window: AccountUsageWindow)?
+        for provider in providers {
+            let snapshot = model.usageState(for: provider).snapshot?.excludingExpiredGrokWindows(at: now)
+            if let window = tightest(snapshot), best == nil || window.usedPercent > best!.window.usedPercent {
+                best = (provider, window)
+            }
+        }
+        guard let best else { return nil }
+        var text = "\(best.provider.displayName) \(max(0, 100 - best.window.usedPercent))%"
+        if let reset = best.window.resetsAt { text += " · \(QuotaPresentation.resetCountdown(from: reset, now: now))" }
+        return (text, QuotaPresentation.severity(usedPercent: best.window.usedPercent).tint)
+    }
+
+    /// One provider that cannot be read right now (signed out, offline,
+    /// stale…), so a collapsed plinth never hides a broken source.
+    private func anomaly(now: Date) -> String? {
+        for provider in providers {
+            let state = model.usageState(for: provider)
+            let snapshot = state.snapshot?.excludingExpiredGrokWindows(at: now)
+            if state.isStale { return "\(provider.displayName) · \(String(localized: "stale"))" }
+            if tightest(snapshot) == nil { return "\(provider.displayName) · \(Self.shortReason(state))" }
+        }
+        return nil
     }
 
     /// One provider, one window: the window closest to running out, because

--- a/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
+++ b/VibeBuddyMacApp/Sources/VibeBuddyMenuBarApp.swift
@@ -153,6 +153,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// `VIBEBUDDY_DEMO_PAGE=settings` opens Settings instead of the Dashboard
+    /// (`dashboard/<library|newtask>` is read by `DashboardView` itself);
     /// on launch; `settings/<page>` (a `SettingsPageID` raw value, e.g.
     /// `settings/phone`) opens it on that page — for screenshots and QA.
     private static var demoSettingsPage: SettingsPageID? {

--- a/docs/adr/0017-cursor-visual-language-on-every-surface.md
+++ b/docs/adr/0017-cursor-visual-language-on-every-surface.md
@@ -45,7 +45,8 @@ closed the same way.
    Glance, the Mac dashboard's top bar, the Live Activity and the widgets.
    Empty states use `moon.zzz`.
 3. **The voice companion's entry is a mic circle, everywhere.** The iPhone
-   composer (always visible), the panel's command row, the dashboard's top bar,
+   composer (always visible), the panel's command row, the dashboard's sidebar
+   (Voice row, since 2026-09-13; the top bar before that),
    the expanded Glance and the Watch home carry the same control, whose glyph
    follows the voice phase. It is explained once, the first time it appears.
 4. **Status is a dot and a word.** One status dot per row plus the

--- a/docs/design/mac-companion-redesign.md
+++ b/docs/design/mac-companion-redesign.md
@@ -89,12 +89,29 @@ selection is still a 2 pt accent ring.
 ## Panels
 
 ### Dashboard window
-Top bar: cat (44 pt) + speech bubble (voice headline, provider badge, scope
-line) + search field. Below: groups column (flexible) + detail column (360 pt).
-Groups: three `bg2` panels with the title row; "Needs you" gets a warm tint
-(10 % requiresInput over bg2). Rows are summary-first cards on `bg3`; the
-selected row wears the accent ring. Empty groups are hidden; an empty snapshot
-shows the existing `ContentUnavailableView` text.
+*Revised 2026-09-13 to Cursor's main-window skeleton (`DashboardSidebar.swift`).*
+One sidebar (216 pt, `bg2`) on the left, nothing in the title bar. Top rows:
+**New task** (⌘N, always enabled — the sheet says which agent needs what when
+none can start), **Search** (⌘F, focuses the list's search field) and
+**Voice** (the mic circle from ADR-0017 §3 on its own row; the trailing word is
+the phase, a second line carries the last exchange, the error or the one-time
+hint). Then **Library** — Current tasks (with the needs-a-response count),
+History, Favorites, Usage — and **Projects** with a count per row, shared by the
+live and history libraries; only this list scrolls, the rows above stay put.
+At the bottom the account-quota plinth, collapsed by default to one line (the
+provider with the least left, its reset, and any source that cannot be read)
+and expanded to the per-provider rows on click, remembered across launches;
+under it a **Settings** row, where Cursor keeps its gear. Selection and hover
+are an ink wash (7 % / 4 %), never the accent.
+
+Content: list column (240–380 pt) + detail column. The list head is the scope
+title, the search pill and a row of filter chips (All / Needs you / Errors /
+Working / Done / Idle; the selected chip is ink-filled). Rows are summary-first
+cards on `bg3`; the selected row sits on `bg2` with a hairline. History uses
+the same head with agent / archive dropdown pills and a `···` menu (Refresh,
+Rebuild index, source notices). Empty panes are `QuietEmptyState`: a 22 pt
+glyph, a body-size title and one line of guidance, centred, no card — never
+the system `ContentUnavailableView`.
 
 Detail is one `bg3` card. Approval: request card (agent avatar CC/CX/GK, header,
 path label, diff or command block, then `Approve ▾` split button whose menu


### PR DESCRIPTION
## 做了什么

Dashboard 窗口改成 Cursor 主窗口的骨架（方案 A）：

- **单侧栏**（`DashboardSidebar.swift`）取代 segmented 库切换、语音顶栏和窗口 toolbar。顶部 New task ⌘N / Search ⌘F / Voice 固定不滚动；Library 四行（Current tasks 带待回应计数）；Projects 由当前任务与 History 共用，只有这一段滚动；底部配额底座 + Settings。
- **New task 始终可点**：无可启动代理时表单直接写出 Claude Code / Codex / Cursor 各需要什么并给 Open Settings；目录改为下拉胶囊，新增 Choose folder…。
- **列头**：标题 + 搜索胶囊 + 筛选 chips（All / Needs you / Errors / Working / Done / Idle）；History 的 agent、归档、Refresh、Rebuild index 收进胶囊和 ··· 菜单，旧 "Local library" 左栏并入侧栏。
- **空态**改为 `QuietEmptyState`（小图标、正文字号标题、一句引导，无卡片）。
- **配额底座可折叠**，默认收起：一行"剩余最少的服务商 + 重置时间"，有读不到的来源时再加一行提示；展开为原有明细；`@AppStorage` 记住。
- 选中 / 悬停改为墨色水洗，不再用 accent 描边。
- **搜索匹配任务名**（`SessionFilter` 之前只搜 project / summary，标题搜不到；iPhone 同步受益），补测试。
- `VIBEBUDDY_DEMO_PAGE=dashboard/<library|newtask>` 供截图与 QA。
- 中文文案 21 条；`mac-companion-redesign.md`、`CONTEXT.md`、ADR-0017 与代码对齐。

## 验证

- Mac App Debug 构建通过；`swift test --filter SessionFilterTests` 6/6 通过。
- 隔离 E2E 实例（独立 bundle id，History 软链真实 `~/.claude` / `~/.codex`）在 940×620 最小窗口下：真实 History 79 条加载、点开阅读、项目筛选、⌘N 开表单、⌘. 关表单、⌘F 聚焦并搜到 "Otty hook cleanup"、侧栏项目列表滚动，均通过。
- 演示实例截图：当前任务、History、New task 无代理态、配额底座收起 / 展开。截图存 `.scratch/cursor-visual-language/shots/matrix/mac-dashboard-sidebar-*`。

## 未覆盖

- 本机没有可启动的代理，New task 的目录选择与 Start 未走通真实启动。
- Escape 关表单：代码有 `.cancelAction` 与 `onExitCommand`，自动化按键未触发，⌘. 已验证；需人工按一次 Escape 确认。
- History 阅读面板顶部的旧式按钮组（Favorite / Pin / Export…）不在本次范围（工单 10）。
