### PR TITLE
feat(ios): align the phone's list, composer and sheets with Cursor

### DIFF
--- a/VibeBuddyApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VibeBuddyApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -441,3 +441,28 @@
 "Answer an approval" = "回应审批";
 "Approval" = "审批";
 "Allow" = "允许";
+
+/* Phone chrome (Cursor alignment, 2026-09-13) */
+"now" = "刚刚";
+"%lldm" = "%lld 分钟";
+"%lldh" = "%lld 小时";
+"%lldd" = "%lld 天";
+"Offline · showing last snapshot" = "离线 · 显示上次快照";
+"Reconnecting · showing last snapshot" = "重新连接中 · 显示上次快照";
+"Offline · reconnect to respond" = "离线 · 重新连接后可回应";
+
+/* New task editor (2026-09-13) */
+"your Mac" = "你的 Mac";
+"Couldn't reach your Mac — not started" = "连不上你的 Mac——未启动";
+"Offline · the task can't start until %@ is reachable" = "离线 · 连上 %@ 后才能启动任务";
+"How this runs" = "运行方式";
+"Directory path" = "目录路径";
+"Show the full path" = "显示完整路径";
+"No folder yet" = "还没有目录";
+"Default model" = "默认模型";
+"New worktree" = "新建 worktree";
+"Runs on %@ as a Codex thread with your usual settings." = "在 %@ 上作为 Codex 线程运行，使用你的常规设置。";
+"Runs on %@ over the Cursor CLI, hosted by vibebuddy." = "在 %@ 上通过 Cursor CLI 运行，由 vibebuddy 托管。";
+"Runs on %@ as a Claude Code background session." = "在 %@ 上作为 Claude Code 后台会话运行。";
+"Hosted by vibebuddy on your Mac over the Cursor CLI. It appears in Working here and can be stopped, continued and answered from this phone; it ends if vibebuddy quits. A new worktree is created on your Mac under ~/.cursor/worktrees/<repo>/<name>; Plan and Ask are read-only." = "由 vibebuddy 在你的 Mac 上通过 Cursor CLI 托管。它会出现在这里的“进行中”，可以从这台手机停止、继续和回答；vibebuddy 退出时它随之结束。新 worktree 创建在 Mac 的 ~/.cursor/worktrees/<repo>/<name>；Plan 和 Ask 为只读。";
+"Sends as a new task — you pick the folder and agent next" = "将作为新任务发送——下一步选择目录和 agent";

--- a/VibeBuddyApp/Sources/AccountQuotaView.swift
+++ b/VibeBuddyApp/Sources/AccountQuotaView.swift
@@ -9,6 +9,8 @@ struct AccountQuotaView: View {
 
     var body: some View {
         NavigationStack {
+            VStack(spacing: 0) {
+            PhoneSheetHeader(title: String(localized: "Usage")) { dismiss() }
             TimelineView(.periodic(from: .now, by: 30)) { context in
                 List {
                     Section {
@@ -122,9 +124,9 @@ struct AccountQuotaView: View {
                 }
             }
             .phoneList()
-            .navigationTitle("Usage")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarItem(placement: .confirmationAction) { Button("Done") { dismiss() } } }
+            }
+            .background(CompanionPalette.bg)
+            .toolbar(.hidden, for: .navigationBar)
         }
     }
 

--- a/VibeBuddyApp/Sources/DashboardStore.swift
+++ b/VibeBuddyApp/Sources/DashboardStore.swift
@@ -729,21 +729,33 @@ final class DashboardStore: ObservableObject {
     @Published var toast: String?
     private var toastTask: Task<Void, Never>?
 
-    /// Start a new task on the Mac. Returns the Mac's answer as a toast-ready
-    /// line; nil when it could not be reached.
-    func dispatch(_ request: DispatchRequest) async -> String? {
+    /// What the Mac said to a New task request, for the sheet that asked.
+    struct DispatchFeedback: Equatable {
+        let started: Bool
+        let message: String
+    }
+
+    /// Start a new task on the Mac. A start is announced on the dashboard
+    /// (the sheet closes); a refusal is returned to the sheet, which keeps the
+    /// draft and says why under it.
+    func dispatch(_ request: DispatchRequest) async -> DispatchFeedback {
         if isDemo {
-            showToast(String(localized: "Demo mode: nothing was started"))
-            return nil
+            let message = String(localized: "Demo mode: nothing was started")
+            showToast(message)
+            return DispatchFeedback(started: false, message: message)
         }
-        guard let pairing else { showToast(String(localized: "Couldn't reach your Mac")); return nil }
-        let result = await decisionClient.dispatch(pairing, request: request)
-        switch result {
-        case .started: showToast(String(localized: "Started — it will appear in Working"))
-        case .rejected(let why), .unsupported(let why), .unavailable(let why): showToast(why)
-        case nil: showToast(String(localized: "Couldn't reach your Mac"))
+        guard let pairing else {
+            return DispatchFeedback(started: false, message: String(localized: "Couldn't reach your Mac — not started"))
         }
-        return result.map { "\($0)" }
+        switch await decisionClient.dispatch(pairing, request: request) {
+        case .started:
+            showToast(String(localized: "Started — it will appear in Working"))
+            return DispatchFeedback(started: true, message: "")
+        case .rejected(let why), .unsupported(let why), .unavailable(let why):
+            return DispatchFeedback(started: false, message: why)
+        case nil:
+            return DispatchFeedback(started: false, message: String(localized: "Couldn't reach your Mac — not started"))
+        }
     }
 
     func jump(_ sessionId: String) {

--- a/VibeBuddyApp/Sources/DashboardView.swift
+++ b/VibeBuddyApp/Sources/DashboardView.swift
@@ -48,27 +48,39 @@ struct DashboardView: View {
                 .listRowInsets(.init(top: 2, leading: PhoneMetrics.gutter, bottom: 4, trailing: PhoneMetrics.gutter))
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
+            // The connection is said once, here. Rows only add what the
+            // offline state changes for them (a disabled key), and the
+            // composer only speaks up when there is a draft it cannot send.
             if !dashboard.allSessions.isEmpty && dashboard.state != .connected {
-                Label("Showing last snapshot. Reconnect to update tasks.", systemImage: "wifi.exclamationmark")
-                    .font(CompanionType.font(12)).foregroundStyle(CompanionPalette.ink2)
-                    .listRowInsets(.init(top: 0, leading: PhoneMetrics.gutter, bottom: 12, trailing: PhoneMetrics.gutter))
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
+                PhoneNotice(symbol: "wifi.exclamationmark",
+                            text: dashboard.state == .connecting
+                                ? String(localized: "Reconnecting · showing last snapshot")
+                                : String(localized: "Offline · showing last snapshot"),
+                            tint: CompanionPalette.status(.requiresInput)) {
+                    if case .failed = dashboard.state, let pairing = connection.pairing {
+                        Button("Reconnect") { dashboard.start(pairing) }
+                            .buttonStyle(PhoneButtonStyle(kind: .quiet, size: .small))
+                    }
+                }
+                .listRowInsets(.init(top: 4, leading: PhoneMetrics.gutter, bottom: 10, trailing: PhoneMetrics.gutter))
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
             }
             if dashboard.allSessions.isEmpty {
                 EmptyStateView(state: dashboard.state)
+                    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
             } else if stream.isEmpty {
-                ContentUnavailableView {
-                    Label("No matching tasks", systemImage: "line.3.horizontal.decrease")
-                } description: {
-                    Text(hiddenCount > 0
-                         ? "Nothing has moved in the last 24 hours. Older tasks are in Customize."
-                         : "Try another filter, or reset them to see every task.")
-                } actions: {
+                PhoneEmptyState(symbol: "line.3.horizontal.decrease",
+                                title: String(localized: "No matching tasks"),
+                                text: hiddenCount > 0
+                                    ? String(localized: "Nothing has moved in the last 24 hours. Older tasks are in Customize.")
+                                    : String(localized: "Try another filter, or reset them to see every task.")) {
                     Button("Customize") { showFilters = true }
+                        .buttonStyle(PhoneButtonStyle(kind: .quiet, size: .small))
                 }
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
             }
@@ -77,6 +89,7 @@ struct DashboardView: View {
                     if isExpanded(section.id) {
                         ForEach(Array(section.sessions.enumerated()), id: \.element.id) { index, session in
                             TaskRow(session: session,
+                                    now: now,
                                     isSelected: highlightId == session.id,
                                     isReplyTarget: replyTo == session.id,
                                     showsDivider: index < section.sessions.count - 1,
@@ -159,7 +172,9 @@ struct DashboardView: View {
         .sheet(isPresented: $showQuota) {
             AccountQuotaView().environmentObject(dashboard).environmentObject(connection)
         }
-        .sheet(isPresented: $showNewTask) { NewTaskSheet(dashboard: dashboard, initialPrompt: newTaskDraft) }
+        .sheet(isPresented: $showNewTask) {
+            NewTaskSheet(dashboard: dashboard, macName: connection.pairing?.macName, initialPrompt: newTaskDraft)
+        }
         .sheet(isPresented: $showSettings) {
             // A sheet doesn't inherit the presenter's environment objects, so
             // re-inject `voice` — Settings restarts a live session on change.
@@ -461,11 +476,14 @@ enum ReplyMeaning: Equatable {
     }
 }
 
-/// One task as a row: a state dot, its title, the agent and project under it,
-/// then `ACTIVITY — summary`; a pending approval or question is answered in
-/// place. Rows sit on the page and are told apart by a hairline, not a card.
+/// One task as a row, in Cursor's two-line shape: the state dot and the title,
+/// then one quiet line — the `ToolActivity` word in the state's colour, the
+/// agent, the branch — and, when there is one, the summary under that. A
+/// pending approval or question is answered in place. Rows sit on the page
+/// and are told apart by a hairline, not a card.
 private struct TaskRow: View {
     let session: AgentSession
+    let now: Date
     let isSelected: Bool
     let isReplyTarget: Bool
     let showsDivider: Bool
@@ -474,59 +492,85 @@ private struct TaskRow: View {
     @EnvironmentObject private var dashboard: DashboardStore
 
     private var state: TaskPresentationState { session.presentationState }
+    /// The question card is the answer path when it is shown; a Reply key
+    /// beside it would only be a second way to the same composer.
+    private var showsQuestionCard: Bool {
+        session.pendingQuestion != nil && WaitHandling.resolve(for: session) == .remoteAvailable
+    }
     private var canReply: Bool {
         guard session.agent != .grokBot else { return false }
-        if session.pendingQuestion != nil { return SessionActionSupport.resolve(for: session).isAvailable }
+        if session.pendingQuestion != nil {
+            return !showsQuestionCard && SessionActionSupport.resolve(for: session).isAvailable
+        }
         return session.agent == .codex && session.status != .needsResponse
     }
+    /// Keys this row offers that the offline state has disabled: only then
+    /// does the row say so, in one short line.
+    private var offlineBlocksAction: Bool {
+        guard dashboard.state != .connected, session.status == .needsResponse else { return false }
+        return WaitHandling.resolve(for: session) == .remoteAvailable
+    }
+    private var summaryLineLimit: Int { session.status == .needsResponse ? 3 : 2 }
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 6) {
                 Button(action: onOpen) { headline }
                     .buttonStyle(.plain)
                     .accessibilityElement(children: .ignore)
                     .accessibilityLabel(accessibilityLabel)
                     .accessibilityHint("Open details")
-                activity
+                // The question card carries its own prompt; the row does not
+                // say it twice.
+                if let summary = session.displaySummary, !summary.isEmpty,
+                   !(showsQuestionCard && session.pendingQuestion?.prompt == summary) {
+                    Text(summary)
+                        .font(CompanionType.font(13))
+                        .foregroundStyle(CompanionPalette.ink2)
+                        .lineLimit(summaryLineLimit)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.leading, PhoneRowMetrics.textInset)
+                }
                 if let approval = session.pendingApproval { approvalBlock(approval) }
                 if let question = session.pendingQuestion { questionBlock(question) }
                 if let child = ToolActivity.childSummary(for: session) {
                     Text(child).font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink3)
                         .monospacedDigit().lineLimit(1)
+                        .padding(.leading, PhoneRowMetrics.textInset)
                 }
                 if session.status == .needsResponse && session.pendingApproval == nil && session.pendingQuestion == nil {
-                    Text(WaitHandling.resolve(for: session).message)
-                        .font(CompanionType.font(12)).foregroundStyle(CompanionPalette.ink2)
+                    Label(WaitHandling.resolve(for: session).message, systemImage: "keyboard")
+                        .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink3)
+                        .padding(.leading, PhoneRowMetrics.textInset)
                 }
-                if session.status == .needsResponse && dashboard.state != .connected {
-                    Text("Connection to your Mac is unavailable. Reconnect to verify this request.")
-                        .font(CompanionType.font(12)).foregroundStyle(CompanionPalette.ink2)
+                if offlineBlocksAction {
+                    Label(String(localized: "Offline · reconnect to respond"), systemImage: "wifi.exclamationmark")
+                        .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink3)
+                        .padding(.leading, PhoneRowMetrics.textInset)
                 }
                 actions
             }
             .padding(.horizontal, PhoneMetrics.gutter)
-            .padding(.vertical, 11)
+            .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(isSelected || isReplyTarget ? CompanionPalette.accent.opacity(0.08) : .clear)
-            if showsDivider { PhoneDivider(leading: PhoneMetrics.gutter) }
+            if showsDivider { PhoneDivider(leading: PhoneMetrics.gutter + PhoneRowMetrics.textInset) }
         }
     }
 
     /// Title, state word, activity or summary, and the relative time, read as
     /// one element; the approve / deny / reply keys below stay separate.
     private var accessibilityLabel: String {
-        let when = RelativeDateTimeFormatter().localizedString(for: session.updatedAt, relativeTo: Date())
-        return [session.displayTitle, state.label,
-                session.displaySummary ?? ToolActivity.label(for: session), when]
+        [session.displayTitle, ToolActivity.label(for: session), session.agent.shortName,
+         session.effectiveAttention == .normal ? "" : session.effectiveAttention.stateTitle,
+         session.displaySummary ?? "", PhoneRelativeTime.spoken(session.updatedAt, now: now)]
             .filter { !$0.isEmpty }.joined(separator: ", ")
     }
 
     private var headline: some View {
-        HStack(alignment: .top, spacing: 10) {
-            Circle().fill(CompanionPalette.status(state))
-                .frame(width: 9, height: 9)
-                .padding(.top, 5)
+        HStack(alignment: .top, spacing: PhoneRowMetrics.textInset - PhoneRowMetrics.dot) {
+            StatusDot(state: state, size: PhoneRowMetrics.dot)
+                .padding(.top, 6)
             VStack(alignment: .leading, spacing: 3) {
                 Text(session.displayTitle)
                     .font(CompanionType.font(15, .medium))
@@ -535,46 +579,44 @@ private struct TaskRow: View {
                     .lineLimit(1)
                 metaLine
             }
-            Spacer(minLength: 6)
-            Text(session.updatedAt, style: .relative)
-                .font(CompanionType.font(11)).monospacedDigit()
-                .foregroundStyle(CompanionPalette.ink3)
-                .lineLimit(1)
+            Spacer(minLength: 8)
+            HStack(spacing: 5) {
+                if session.effectiveAttention != .normal {
+                    Image(systemName: session.effectiveAttention == .followed ? "bell.badge" : "bell.slash")
+                        .font(.system(size: 10, weight: .medium))
+                        .accessibilityLabel(session.effectiveAttention.stateTitle)
+                }
+                Text(PhoneRelativeTime.short(session.updatedAt, now: now))
+                    .font(CompanionType.font(11)).monospacedDigit()
+            }
+            .foregroundStyle(CompanionPalette.ink3)
+            .padding(.top, 2)
         }
+        // The whole row, blank space included, opens the task.
+        .contentShape(Rectangle())
     }
 
+    /// `Working · Claude · feat/auth`: the state word first, in its colour,
+    /// then who is doing it and where. One line, always.
     private var metaLine: some View {
         HStack(spacing: 5) {
-            AgentAvatar(agent: session.agent, size: 14)
+            Text(ToolActivity.label(for: session))
+                .foregroundStyle(CompanionPalette.status(state))
+            Text("·")
+            AgentMark(agent: session.agent)
             Text(session.agent.shortName)
             if DashboardFilters.projectTitle(session.project) != session.displayTitle {
                 Text("·")
-                Text(DashboardFilters.projectTitle(session.project))
+                Text(DashboardFilters.projectTitle(session.project)).lineLimit(1)
             }
             if let branch = session.branch {
                 Text("·")
                 Text(branch).font(CompanionType.mono(10)).lineLimit(1).truncationMode(.middle)
             }
-            if session.effectiveAttention != .normal {
-                Image(systemName: session.effectiveAttention == .followed ? "bell.badge.fill" : "bell.slash.fill")
-                    .foregroundStyle(session.effectiveAttention == .followed
-                                     ? CompanionPalette.status(.requiresInput) : CompanionPalette.ink3)
-                    .accessibilityLabel(session.effectiveAttention.stateTitle)
-            }
         }
         .font(CompanionType.font(11))
-        .foregroundStyle(CompanionPalette.ink2)
+        .foregroundStyle(CompanionPalette.ink3)
         .lineLimit(1)
-    }
-
-    private var activity: some View {
-        (Text(ToolActivity.label(for: session)).foregroundStyle(CompanionPalette.status(state))
-         + Text("  ").foregroundStyle(CompanionPalette.ink3)
-         + Text(session.displaySummary ?? "").foregroundStyle(CompanionPalette.ink2))
-            .font(CompanionType.font(13))
-            .lineLimit(3)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.leading, 19)
     }
 
     @ViewBuilder private func approvalKeys(_ approval: PendingApproval) -> some View {
@@ -620,43 +662,56 @@ private struct TaskRow: View {
                 .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink3)
             }
         }
-        .padding(.leading, 19)
+        .padding(.leading, PhoneRowMetrics.textInset)
+        .padding(.top, 2)
     }
 
     @ViewBuilder private func questionBlock(_ question: PendingQuestion) -> some View {
         Group {
-            if WaitHandling.resolve(for: session) == .remoteAvailable {
+            if showsQuestionCard {
                 QuestionCardView(question: question, actionState: dashboard.phoneActionState(for: session)) { answers in
                     await dashboard.answer(session.id, answers: answers, expected: session)
                 }
                 .disabled(dashboard.phoneActionDisabled(for: session))
             } else {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(question.prompt).font(CompanionType.font(14, .medium)).foregroundStyle(CompanionPalette.ink)
+                    if question.prompt != session.displaySummary {
+                        Text(question.prompt).font(CompanionType.font(14, .medium)).foregroundStyle(CompanionPalette.ink)
+                    }
                     Label(WaitHandling.resolve(for: session).message, systemImage: "keyboard")
-                        .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink2)
+                        .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink3)
                 }
             }
         }
-        .padding(.leading, 19)
+        .padding(.leading, PhoneRowMetrics.textInset)
+        .padding(.top, 2)
     }
 
+    /// Small text keys, the way Cursor's `View PR` sits under a message.
     @ViewBuilder private var actions: some View {
         if canReply || session.canJump {
             HStack(spacing: 8) {
                 if canReply {
-                    Button(action: onReply) { Label("Reply", systemImage: "arrowshape.turn.up.left") }
+                    Button("Reply", action: onReply)
                         .buttonStyle(PhoneButtonStyle(
-                            kind: isReplyTarget ? .primary(CompanionPalette.accent) : .quiet, size: .small))
+                            kind: isReplyTarget ? .primary(CompanionPalette.accent) : .soft, size: .small))
                 }
                 if session.canJump {
                     Button(session.agent == .grokBot ? "Open Grok Bot" : session.jumpsToDesktopThread ? "Open thread" : "Jump") { dashboard.jump(session.id) }
-                        .buttonStyle(PhoneButtonStyle(kind: .quiet, size: .small))
+                        .buttonStyle(PhoneButtonStyle(kind: .soft, size: .small))
                 }
             }
-            .padding(.leading, 19)
+            .padding(.leading, PhoneRowMetrics.textInset)
+            .padding(.top, 2)
         }
     }
+}
+
+/// The row's own measures: the dot, and the inset every line under the title
+/// shares so summaries, keys and the divider align on the title's left edge.
+private enum PhoneRowMetrics {
+    static let dot: CGFloat = 8
+    static let textInset: CGFloat = 18
 }
 
 /// The composer says whom the text goes to and what it means. With a reply
@@ -688,17 +743,23 @@ private struct StreamComposer: View {
     var body: some View {
         VStack(spacing: 6) {
             if let target {
-                HStack(spacing: 8) {
-                    RoundedRectangle(cornerRadius: 2).fill(CompanionPalette.status(target.presentationState))
-                        .frame(width: 3)
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(SessionActionSupport.targetCaption(macName: macName, session: target))
-                            .font(CompanionType.font(10)).foregroundStyle(CompanionPalette.ink3)
-                        Text("\(meaning.verbLabel) · \(target.displayTitle) · \(target.presentationState.label)")
-                            .font(CompanionType.font(11, .medium)).foregroundStyle(CompanionPalette.ink2)
-                        Text(unsupported ?? target.displaySummary ?? ToolActivity.label(for: target))
-                            .font(CompanionType.font(12))
-                            .foregroundStyle(unsupported == nil ? CompanionPalette.ink : CompanionPalette.status(.error))
+                // Two lines: what the text will do and to whom, then where
+                // that is. The card takes the height of its text and no more.
+                HStack(alignment: .top, spacing: 8) {
+                    StatusDot(state: target.presentationState, size: PhoneRowMetrics.dot)
+                        .padding(.top, 4)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 5) {
+                            Text(meaning.verbLabel)
+                                .font(CompanionType.font(12, .medium)).foregroundStyle(CompanionPalette.ink)
+                            Text("·").foregroundStyle(CompanionPalette.ink3)
+                            Text(target.displayTitle)
+                                .font(CompanionType.font(12, .medium)).foregroundStyle(CompanionPalette.ink)
+                                .lineLimit(1)
+                        }
+                        Text(unsupported ?? "\(ToolActivity.label(for: target)) · \(SessionActionSupport.targetCaption(macName: macName, session: target))")
+                            .font(CompanionType.font(11))
+                            .foregroundStyle(unsupported == nil ? CompanionPalette.ink3 : CompanionPalette.status(.error))
                             .lineLimit(2)
                     }
                     Spacer(minLength: 0)
@@ -706,12 +767,14 @@ private struct StreamComposer: View {
                         Image(systemName: "xmark").font(.system(size: 11, weight: .semibold))
                             .foregroundStyle(CompanionPalette.ink3)
                             .frame(width: 26, height: 26)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Cancel reply")
                 }
                 .padding(.horizontal, 10).padding(.vertical, 8)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
                 .companionCard()
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
@@ -755,11 +818,18 @@ private struct StreamComposer: View {
                 Text(receipt.message)
                     .font(CompanionType.font(11))
                     .foregroundStyle(receiptColor(receipt))
-            } else if !reachable {
+            } else if !reachable, hasDraft {
+                // The page already says it is offline; the composer only adds
+                // that this draft is staying here.
                 Text("Couldn't reach your Mac — not sent")
                     .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.status(.error))
             } else if unsupported == nil, let note = meaning.note(for: target) {
                 Text(note)
+                    .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink2)
+            } else if target == nil, hasDraft {
+                // Text with no target is a new task. Said here, so a draft
+                // that lost its reply target is not sent somewhere by surprise.
+                Text("Sends as a new task — you pick the folder and agent next")
                     .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink2)
             } else if !micHintSeen, !hasDraft, voice.phase == .idle, voice.errorText == nil {
                 // Said once: the mic is explained the first time it appears,
@@ -833,30 +903,35 @@ private struct SessionDetailSheet: View {
             PhoneSheetHeader(title: String(localized: "Task")) { dismiss() }
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
-                    HStack(spacing: 10) {
+                    HStack(alignment: .top, spacing: 10) {
                         AgentAvatar(agent: session.agent, size: 36)
-                        VStack(alignment: .leading, spacing: 2) {
+                        VStack(alignment: .leading, spacing: 3) {
                             Text(session.displayTitle)
                                 .font(CompanionType.font(22, .semibold))
                                 .tracking(CompanionType.tracking(22))
                                 .foregroundStyle(CompanionPalette.ink)
-                            HStack(spacing: 6) {
-                                Text(DashboardFilters.projectTitle(session.project))
-                                AgentBadge(agent: session.agent)
-                                if let branch = session.branch { Text(branch).font(CompanionType.mono(10)) }
+                                .lineLimit(2)
+                            // The same line the row carries: the state word in
+                            // its colour, then agent, project and branch.
+                            HStack(spacing: 5) {
+                                StatusDot(state: state, size: PhoneRowMetrics.dot)
+                                Text(ToolActivity.label(for: session))
+                                    .foregroundStyle(CompanionPalette.status(state))
+                                Text("·")
+                                Text(session.agent.shortName)
+                                if DashboardFilters.projectTitle(session.project) != session.displayTitle {
+                                    Text("·")
+                                    Text(DashboardFilters.projectTitle(session.project))
+                                }
+                                if let branch = session.branch {
+                                    Text("·")
+                                    Text(branch).font(CompanionType.mono(10)).lineLimit(1).truncationMode(.middle)
+                                }
                             }
-                            .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink2)
+                            .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink3)
+                            .lineLimit(1)
                         }
                     }
-                    HStack(spacing: 6) {
-                        Image(systemName: state.symbolName).font(.system(size: 10, weight: .semibold))
-                        Text(state.label)
-                    }
-                    .font(CompanionType.font(12, .medium))
-                    .foregroundStyle(CompanionPalette.status(state))
-                    .padding(.horizontal, 10).padding(.vertical, 5)
-                    .background(CompanionPalette.status(state).opacity(0.12),
-                                in: RoundedRectangle(cornerRadius: 8, style: .continuous))
                     if session.completionNotice?.state == .pending {
                         Text("Preparing completion summary…")
                             .font(CompanionType.font(12)).foregroundStyle(CompanionPalette.ink2)
@@ -936,7 +1011,7 @@ private struct SessionDetailSheet: View {
             if let observation = session.observationDescription {
                 HStack(spacing: 5) {
                     Label(observation, systemImage: "waveform.path.ecg")
-                    if let last = session.lastObservedAt { Text("· \(last, style: .relative)") }
+                    if let last = session.lastObservedAt { Text("· \(PhoneRelativeTime.short(last))") }
                 }
                 .font(CompanionType.font(11)).foregroundStyle(CompanionPalette.ink3)
             }
@@ -1015,7 +1090,7 @@ private struct RecentOutputCard: View {
             Text(output.sourceLabel)
             if let updatedAt = output.updatedAt {
                 Text("·")
-                Text(updatedAt, style: .relative).monospacedDigit()
+                Text(PhoneRelativeTime.short(updatedAt)).monospacedDigit()
             }
         }
         .font(CompanionType.font(11))
@@ -1123,6 +1198,8 @@ private struct MacTitleMenu: View {
     }
 }
 
+/// The page with nothing on it, in the phone's own type. `moon.zzz` is the
+/// empty glyph on every status surface (ADR-0017 §2).
 private struct EmptyStateView: View {
     @State private var showMacHelp = false
     let state: DashboardStore.ConnectionState
@@ -1130,19 +1207,18 @@ private struct EmptyStateView: View {
     var body: some View {
         switch state {
         case .connecting:
-            ContentUnavailableView("Connecting to your Mac", systemImage: "antenna.radiowaves.left.and.right")
+            PhoneEmptyState(symbol: "antenna.radiowaves.left.and.right",
+                            title: String(localized: "Connecting to your Mac"))
         case .connected:
-            ContentUnavailableView(
-                "No active tasks", systemImage: "moon.zzz",
-                description: Text("Start a Claude Code or Codex session and it'll show up here."))
+            PhoneEmptyState(symbol: "moon.zzz",
+                            title: String(localized: "No active tasks"),
+                            text: String(localized: "Start a Claude Code or Codex session and it'll show up here."))
         case .failed(let message):
-            ContentUnavailableView {
-                Label("Disconnected", systemImage: "wifi.exclamationmark")
-            } description: {
-                Text(message)
-                Text("Check that the Mac app is running, both devices are on the same local network, and Local Network access is enabled in Settings.")
-            } actions: {
+            PhoneEmptyState(symbol: "wifi.exclamationmark",
+                            title: String(localized: "Disconnected"),
+                            text: message + "\n" + String(localized: "Check that the Mac app is running, both devices are on the same local network, and Local Network access is enabled in Settings.")) {
                 Button("Need the Mac companion?") { showMacHelp = true }
+                    .buttonStyle(PhoneButtonStyle(kind: .quiet, size: .small))
             }
             .sheet(isPresented: $showMacHelp) { MacCompanionSetupSheet() }
         }

--- a/VibeBuddyApp/Sources/NewTaskSheet.swift
+++ b/VibeBuddyApp/Sources/NewTaskSheet.swift
@@ -1,25 +1,35 @@
 import SwiftUI
 import VibeBuddyKit
 
-/// Start a new task on the Mac from the phone: a directory the Mac has seen a
-/// session run in, the agent, the prompt, an optional name. Claude Code runs
-/// as a `claude --bg` background session, Codex as a daemon thread, Cursor as
-/// a `cursor-agent` conversation vibebuddy hosts over ACP — for which the
-/// CLI's own global options (model, plan/ask mode, a fresh worktree) are
-/// offered too.
+/// Start a new task on the Mac from the phone. An editor, not a form: the
+/// target (a directory the Mac has seen a session run in, and the agent) sits
+/// on the editor's top edge as two chips, the prompt is the body, the
+/// optional name and — for Cursor — the CLI's own options (model, plan/ask
+/// mode, a fresh worktree) sit on its bottom edge. What "start" means for
+/// each agent is one short line under the editor, with the long version
+/// behind a disclosure. Claude Code runs as a `claude --bg` background
+/// session, Codex as a daemon thread, Cursor as a `cursor-agent` conversation
+/// vibebuddy hosts over ACP.
 struct NewTaskSheet: View {
     @ObservedObject var dashboard: DashboardStore
+    /// The paired Mac's name, for "Runs on <Mac>"; nil says "your Mac".
+    var macName: String? = nil
     @Environment(\.dismiss) private var dismiss
     @State private var agent: AgentKind = .claudeCode
     @State private var directory = ""
     @State private var prompt: String
     @State private var name = ""
     @State private var busy = false
+    @State private var pathExpanded = false
+    @State private var explained = false
+    /// The Mac's refusal, kept under the editor with the draft it refused.
+    @State private var feedback: DashboardStore.DispatchFeedback?
     /// Cursor only. An empty model is the CLI's default; `agent` is the mode
     /// the CLI starts in when no `--mode` is given, so it travels as nil.
     @State private var cursorModel = ""
     @State private var cursorMode: CursorMode = .agent
     @State private var cursorWorktree = false
+    @FocusState private var promptFocused: Bool
 
     /// `cursor-agent --mode` takes `plan` or `ask`; agent mode has no flag
     /// (cursor.com/docs/cli/reference/parameters).
@@ -39,106 +49,262 @@ struct NewTaskSheet: View {
 
     /// `initialPrompt` carries text typed into the dashboard's composer with
     /// no reply target — the composer's "new task" meaning lands here.
-    init(dashboard: DashboardStore, initialPrompt: String = "") {
+    init(dashboard: DashboardStore, macName: String? = nil, initialPrompt: String = "") {
         self.dashboard = dashboard
+        self.macName = macName
         _prompt = State(initialValue: initialPrompt)
     }
 
+    private var reachable: Bool { dashboard.state == .connected }
+    private var trimmedPrompt: String { prompt.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var canStart: Bool { reachable && !busy && !directory.isEmpty && !trimmedPrompt.isEmpty }
+    private var macLabel: String {
+        let mac = macName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return mac.isEmpty ? String(localized: "your Mac") : mac
+    }
+
     var body: some View {
-        NavigationStack {
-            Form {
-                Section("Where") {
-                    if dashboard.recentDirectories.isEmpty {
-                        Text("Your Mac has not seen a session run yet.").foregroundStyle(CompanionPalette.ink2)
-                    } else {
-                        Picker("Directory", selection: $directory) {
-                            ForEach(dashboard.recentDirectories, id: \.self) { path in
-                                Text((path as NSString).lastPathComponent).tag(path)
-                            }
-                        }
-                        if !directory.isEmpty {
-                            Text(directory).font(CompanionType.mono(12)).foregroundStyle(CompanionPalette.ink2)
+        VStack(spacing: 0) {
+            PhoneSheetHeader(title: String(localized: "New task"), close: { dismiss() }) {
+                Button(busy ? "Starting…" : "Start") { start() }
+                    .buttonStyle(PhoneButtonStyle(kind: .primary(CompanionPalette.accent), size: .small))
+                    .disabled(!canStart)
+            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    editor
+                    Text(runLine)
+                        .font(CompanionType.font(11))
+                        .foregroundStyle(CompanionPalette.ink3)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let feedback, !feedback.started {
+                        Label(feedback.message, systemImage: "exclamationmark.circle")
+                            .font(CompanionType.font(12))
+                            .foregroundStyle(CompanionPalette.status(.error))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if !reachable {
+                        PhoneNotice(symbol: "wifi.exclamationmark",
+                                    text: String(localized: "Offline · the task can't start until \(macLabel) is reachable"),
+                                    tint: CompanionPalette.status(.requiresInput))
+                    }
+                    DisclosureGroup(isExpanded: $explained) {
+                        Text(explanation)
+                            .font(CompanionType.font(12))
+                            .foregroundStyle(CompanionPalette.ink2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.top, 6)
+                    } label: {
+                        Text("How this runs")
+                            .font(CompanionType.font(12, .medium))
+                            .foregroundStyle(CompanionPalette.ink2)
+                    }
+                    .tint(CompanionPalette.ink3)
+                }
+                .padding(.horizontal, PhoneMetrics.gutter)
+                .padding(.bottom, 24)
+            }
+            .scrollDismissesKeyboard(.interactively)
+        }
+        .background(CompanionPalette.bg)
+        .tint(CompanionPalette.accent)
+        .onAppear {
+            if directory.isEmpty { directory = dashboard.recentDirectories.first ?? "" }
+            if !dashboard.dispatchAgents.contains(agent), let first = dashboard.dispatchAgents.first { agent = first }
+        }
+        .task {
+            // The sheet is for typing; the keyboard comes up with it.
+            try? await Task.sleep(for: .milliseconds(350))
+            promptFocused = true
+        }
+    }
+
+    // MARK: Editor
+
+    /// Target chips on the top edge, the prompt as the body, the name and the
+    /// agent's own options on the bottom edge — Cursor's editor shape.
+    private var editor: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                directoryChip
+                agentChip
+                Spacer(minLength: 0)
+            }
+            if !directory.isEmpty {
+                // The full path on demand: one middle-truncated line that
+                // opens out when tapped, so a deep path never owns the screen.
+                Button { withAnimation(.smooth(duration: 0.15)) { pathExpanded.toggle() } } label: {
+                    Text(directory)
+                        .font(CompanionType.mono(10))
+                        .foregroundStyle(CompanionPalette.ink3)
+                        .lineLimit(pathExpanded ? nil : 1)
+                        .truncationMode(.middle)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Directory path"))
+                .accessibilityValue(directory)
+                .accessibilityHint(pathExpanded ? "Collapse" : "Show the full path")
+            }
+            TextField(String(localized: "What should \(agent.displayName) do?"), text: $prompt, axis: .vertical)
+                .font(CompanionType.font(15))
+                .foregroundStyle(CompanionPalette.ink)
+                .lineLimit(4...12)
+                .focused($promptFocused)
+                .padding(.vertical, 2)
+            PhoneDivider()
+            HStack(spacing: 8) {
+                TextField(String(localized: "Name (optional)"), text: $name)
+                    .font(CompanionType.font(12))
+                    .foregroundStyle(CompanionPalette.ink2)
+                Spacer(minLength: 0)
+            }
+            if agent == .cursor { cursorOptions }
+        }
+        .padding(12)
+        .companionCard()
+    }
+
+    private var directoryChip: some View {
+        Group {
+            if dashboard.recentDirectories.isEmpty {
+                chip("folder", String(localized: "No folder yet"), menu: false)
+                    .accessibilityHint(String(localized: "Your Mac has not seen a session run yet."))
+            } else {
+                Menu {
+                    Picker("Directory", selection: $directory) {
+                        ForEach(dashboard.recentDirectories, id: \.self) { path in
+                            Text((path as NSString).lastPathComponent).tag(path)
                         }
                     }
+                } label: {
+                    chip("folder", (directory as NSString).lastPathComponent, menu: true)
                 }
-                Section("Task") {
-                    if dashboard.dispatchAgents.count > 1 {
-                        Picker("Agent", selection: $agent) {
-                            ForEach(dashboard.dispatchAgents, id: \.self) { kind in
-                                Text(kind.displayName).tag(kind)
-                            }
-                        }
-                    }
-                    TextField("What should \(agent.displayName) do?", text: $prompt, axis: .vertical).lineLimit(3...8)
-                    TextField("Name (optional)", text: $name)
-                }
-                if agent == .cursor {
-                    cursorSection
-                }
-                Section {
-                    Text(explanation).font(CompanionType.font(12)).foregroundStyle(CompanionPalette.ink2)
-                }
-            }
-            .phoneList()
-            .navigationTitle("New task")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(busy ? "Starting…" : "Start") { start() }
-                        .disabled(busy || directory.isEmpty
-                                  || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                }
-            }
-            .onAppear {
-                if directory.isEmpty { directory = dashboard.recentDirectories.first ?? "" }
-                if !dashboard.dispatchAgents.contains(agent), let first = dashboard.dispatchAgents.first { agent = first }
+                .accessibilityLabel(String(localized: "Directory"))
+                .accessibilityValue((directory as NSString).lastPathComponent)
             }
         }
     }
 
-    /// Cursor's three launch choices. The model list comes from the Mac's
-    /// `cursor-agent --list-models`; when the Mac has none, the row stays
-    /// out and the CLI's default model is used.
-    private var cursorSection: some View {
-        Section {
+    /// One agent is a label; several are a menu. The mark says which.
+    private var agentChip: some View {
+        Group {
+            if dashboard.dispatchAgents.count > 1 {
+                Menu {
+                    Picker("Agent", selection: $agent) {
+                        ForEach(dashboard.dispatchAgents, id: \.self) { kind in
+                            Text(kind.displayName).tag(kind)
+                        }
+                    }
+                } label: {
+                    chip(agent, agent.shortName, menu: true)
+                }
+                .accessibilityLabel(String(localized: "Agent"))
+                .accessibilityValue(agent.displayName)
+            } else {
+                chip(agent, agent.shortName, menu: false)
+            }
+        }
+    }
+
+    /// Cursor's three launch choices as chips. The model list comes from the
+    /// Mac's `cursor-agent --list-models`; when the Mac has none, the chip
+    /// stays out and the CLI's default model is used.
+    private var cursorOptions: some View {
+        HStack(spacing: 6) {
             if !dashboard.cursorModels.isEmpty {
-                Picker("Model", selection: $cursorModel) {
-                    Text("Default").tag("")
-                    ForEach(dashboard.cursorModels, id: \.self) { model in
-                        Text(model).tag(model)
+                Menu {
+                    Picker("Model", selection: $cursorModel) {
+                        Text("Default").tag("")
+                        ForEach(dashboard.cursorModels, id: \.self) { model in
+                            Text(model).tag(model)
+                        }
+                    }
+                } label: {
+                    chip("cpu", cursorModel.isEmpty ? String(localized: "Default model") : cursorModel, menu: true)
+                }
+                .accessibilityLabel(String(localized: "Model"))
+            }
+            Menu {
+                Picker("Mode", selection: $cursorMode) {
+                    ForEach(CursorMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
                     }
                 }
+            } label: {
+                chip("slider.horizontal.3", cursorMode.label, menu: true)
             }
-            Picker("Mode", selection: $cursorMode) {
-                ForEach(CursorMode.allCases) { mode in
-                    Text(mode.label).tag(mode)
-                }
+            .accessibilityLabel(String(localized: "Mode"))
+            Button { cursorWorktree.toggle() } label: {
+                Label(String(localized: "New worktree"), systemImage: cursorWorktree ? "checkmark" : "arrow.triangle.branch")
             }
-            Toggle("Run in a new worktree", isOn: $cursorWorktree)
-        } header: {
-            Text("Cursor")
-        } footer: {
-            Text("A new worktree is created on your Mac under ~/.cursor/worktrees/<repo>/<name>; Plan and Ask are read-only.")
+            .buttonStyle(PhoneButtonStyle(kind: cursorWorktree ? .primary(CompanionPalette.accent) : .soft, size: .small))
+            .accessibilityAddTraits(cursorWorktree ? .isSelected : [])
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func chip(_ symbol: String, _ text: String, menu: Bool) -> some View {
+        chipBody(text: text, menu: menu) {
+            Image(systemName: symbol).font(.system(size: 11, weight: .medium))
+        }
+    }
+
+    private func chip(_ agent: AgentKind, _ text: String, menu: Bool) -> some View {
+        chipBody(text: text, menu: menu) { AgentMark(agent: agent, size: 12) }
+    }
+
+    /// A small soft key that names one part of the target: glyph, word,
+    /// and a chevron when it opens a menu.
+    private func chipBody<Icon: View>(text: String, menu: Bool, @ViewBuilder icon: () -> Icon) -> some View {
+        HStack(spacing: 5) {
+            icon()
+            Text(text).lineLimit(1).truncationMode(.middle)
+            if menu {
+                Image(systemName: "chevron.down").font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(CompanionPalette.ink3)
+            }
+        }
+        .font(CompanionType.font(12, .medium))
+        .foregroundStyle(CompanionPalette.ink)
+        .padding(.horizontal, 9).padding(.vertical, 5)
+        .background(CompanionPalette.bg2, in: RoundedRectangle(cornerRadius: PhoneMetrics.controlRadius, style: .continuous))
+    }
+
+    // MARK: Copy
+
+    /// One line: where it runs and as what.
+    private var runLine: String {
+        switch agent {
+        case .codex:
+            return String(localized: "Runs on \(macLabel) as a Codex thread with your usual settings.")
+        case .cursor:
+            return String(localized: "Runs on \(macLabel) over the Cursor CLI, hosted by vibebuddy.")
+        default:
+            return String(localized: "Runs on \(macLabel) as a Claude Code background session.")
         }
     }
 
     private var explanation: String {
         switch agent {
         case .codex:
-            return "Runs as a new Codex thread on your Mac through the app-server daemon, with your usual model, approval and sandbox settings. It appears in Codex Desktop and in Working here."
+            return String(localized: "Runs as a new Codex thread on your Mac through the app-server daemon, with your usual model, approval and sandbox settings. It appears in Codex Desktop and in Working here.")
         case .cursor:
-            return "Hosted by vibebuddy on your Mac over the Cursor CLI. It appears in Working here and can be stopped, continued and answered from this phone; it ends if vibebuddy quits."
+            return String(localized: "Hosted by vibebuddy on your Mac over the Cursor CLI. It appears in Working here and can be stopped, continued and answered from this phone; it ends if vibebuddy quits. A new worktree is created on your Mac under ~/.cursor/worktrees/<repo>/<name>; Plan and Ask are read-only.")
         default:
-            return "Runs as a Claude Code background session on your Mac (claude --bg) with your usual settings. It appears in Working here; Jump opens a terminal attached to it."
+            return String(localized: "Runs as a Claude Code background session on your Mac (claude --bg) with your usual settings. It appears in Working here; Jump opens a terminal attached to it.")
         }
     }
 
     private func start() {
+        guard canStart else { return }
         busy = true
+        feedback = nil
         let cursor = agent == .cursor
         let request = DispatchRequest(agent: agent, cwd: directory,
-                                      prompt: prompt.trimmingCharacters(in: .whitespacesAndNewlines),
+                                      prompt: trimmedPrompt,
                                       name: name.isEmpty ? nil : name,
                                       model: cursor && !cursorModel.isEmpty ? cursorModel : nil,
                                       mode: cursor ? cursorMode.wireValue : nil,
@@ -146,7 +312,7 @@ struct NewTaskSheet: View {
         Task {
             let result = await dashboard.dispatch(request)
             busy = false
-            if result?.hasPrefix("started") == true { dismiss() }
+            if result.started { dismiss() } else { feedback = result }
         }
     }
 }

--- a/VibeBuddyApp/Sources/PhoneChrome.swift
+++ b/VibeBuddyApp/Sources/PhoneChrome.swift
@@ -58,7 +58,7 @@ struct PhoneSectionHeader: View {
 
     var body: some View {
         CompanionSectionHeader(title: title, count: count, expanded: $expanded,
-                               titleSize: 15, countSize: 13, chevronSize: 11, spacing: 6)
+                               titleSize: 14, countSize: 12, chevronSize: 10, spacing: 6)
             .accessibilityLabel("\(title), \(count)")
     }
 }
@@ -66,7 +66,10 @@ struct PhoneSectionHeader: View {
 /// Rounded-rect buttons, the phone's answer to `PillButtonStyle`: the Kit's
 /// `CompanionButtonStyle` at the phone's control radius.
 struct PhoneButtonStyle: ButtonStyle {
-    enum Kind { case primary(Color), quiet, ghost }
+    /// `soft` is the lightest key: the secondary ground, no edge — for the
+    /// small verbs under a row (Reply, Jump) that must not weigh as much as
+    /// an approval.
+    enum Kind { case primary(Color), quiet, soft, ghost }
     enum Size { case small, regular, wide }
     var kind: Kind = .quiet
     var size: Size = .regular
@@ -80,6 +83,7 @@ struct PhoneButtonStyle: ButtonStyle {
         switch kind {
         case .primary(let c): return .filled(c)
         case .quiet: return .quiet
+        case .soft: return .soft
         case .ghost: return .ghost
         }
     }
@@ -159,10 +163,35 @@ private struct PhoneApproveHalf: ButtonStyle {
 /// The hairline between rows, inset past the status dot like a settings list.
 typealias PhoneDivider = CompanionHairline
 
-/// A sheet's head: a round close button on the left, the title centred.
-struct PhoneSheetHeader: View {
+/// The agent's mark alone, in its brand hue, with no tile behind it: the
+/// Kit's `AgentAvatar` is the product tile for a sheet's head; on a row's
+/// meta line the mark is enough and a tile is one more block.
+struct AgentMark: View {
+    let agent: AgentKind
+    var size: CGFloat = 11
+
+    var body: some View {
+        SVGPathShape(agent.brandMark)
+            .fill(agent.brandColor)
+            .frame(width: size, height: size)
+            .accessibilityLabel(agent.displayName)
+    }
+}
+
+/// A sheet's head: a round close button on the left, the title centred, and
+/// — when the sheet has one action of its own (Start, Done) — that action on
+/// the right as a small key. Every sheet on the phone opens with this head;
+/// none uses the system navigation bar.
+struct PhoneSheetHeader<Trailing: View>: View {
     let title: String
     let close: () -> Void
+    @ViewBuilder var trailing: Trailing
+
+    init(title: String, close: @escaping () -> Void, @ViewBuilder trailing: () -> Trailing) {
+        self.title = title
+        self.close = close
+        self.trailing = trailing()
+    }
 
     var body: some View {
         ZStack {
@@ -170,14 +199,132 @@ struct PhoneSheetHeader: View {
                 .font(CompanionType.font(17, .semibold))
                 .tracking(CompanionType.tracking(17))
                 .foregroundStyle(CompanionPalette.ink)
+                .lineLimit(1)
             HStack {
                 PhoneCircleButton("xmark", size: 32, tint: CompanionPalette.ink2, action: close)
                     .accessibilityLabel("Close")
                 Spacer(minLength: 0)
+                trailing
             }
         }
         .padding(.horizontal, PhoneMetrics.gutter)
         .padding(.top, 14).padding(.bottom, 12)
+    }
+}
+
+extension PhoneSheetHeader where Trailing == EmptyView {
+    init(title: String, close: @escaping () -> Void) {
+        self.init(title: title, close: close) { EmptyView() }
+    }
+}
+
+/// The phone's relative time: `now`, `5m`, `3h`, `2d`. Rows re-cut on the
+/// page's 60-second clock and on every snapshot, so seconds would only
+/// flicker; Cursor's rows say `5m` too.
+enum PhoneRelativeTime {
+    static func short(_ date: Date, now: Date = Date()) -> String {
+        let seconds = max(0, now.timeIntervalSince(date))
+        if seconds < 60 { return String(localized: "now") }
+        let minutes = Int(seconds / 60)
+        if minutes < 60 { return String(localized: "\(minutes)m") }
+        let hours = minutes / 60
+        if hours < 24 { return String(localized: "\(hours)h") }
+        return String(localized: "\(hours / 24)d")
+    }
+
+    /// The spoken form for accessibility (`5 minutes ago`).
+    static func spoken(_ date: Date, now: Date = Date()) -> String {
+        RelativeDateTimeFormatter().localizedString(for: date, relativeTo: now)
+    }
+}
+
+/// One line about the page, above the list: a glyph, a short sentence, and
+/// at most one key. The connection is said here, once; rows only add what
+/// changes for them.
+struct PhoneNotice<Action: View>: View {
+    let symbol: String
+    let text: String
+    var tint: Color = CompanionPalette.ink2
+    @ViewBuilder var action: Action
+
+    init(symbol: String, text: String, tint: Color = CompanionPalette.ink2,
+         @ViewBuilder action: () -> Action) {
+        self.symbol = symbol
+        self.text = text
+        self.tint = tint
+        self.action = action()
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(tint)
+                .frame(width: 16)
+            Text(text)
+                .font(CompanionType.font(12))
+                .foregroundStyle(CompanionPalette.ink2)
+                .lineLimit(2)
+            Spacer(minLength: 8)
+            action
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .companionCard()
+    }
+}
+
+extension PhoneNotice where Action == EmptyView {
+    init(symbol: String, text: String, tint: Color = CompanionPalette.ink2) {
+        self.init(symbol: symbol, text: text, tint: tint) { EmptyView() }
+    }
+}
+
+/// An empty page in the phone's own type: a glyph, a title, a line, and at
+/// most one key. The system's `ContentUnavailableView` sets SF Pro, which
+/// no surface keeps (ADR-0017 §1).
+struct PhoneEmptyState<Action: View>: View {
+    let symbol: String
+    let title: String
+    var text: String? = nil
+    @ViewBuilder var action: Action
+
+    init(symbol: String, title: String, text: String? = nil, @ViewBuilder action: () -> Action) {
+        self.symbol = symbol
+        self.title = title
+        self.text = text
+        self.action = action()
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: symbol)
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(CompanionPalette.ink3)
+                .padding(.bottom, 2)
+            Text(title)
+                .font(CompanionType.font(17, .semibold))
+                .tracking(CompanionType.tracking(17))
+                .foregroundStyle(CompanionPalette.ink)
+            if let text {
+                Text(text)
+                    .font(CompanionType.font(13))
+                    .foregroundStyle(CompanionPalette.ink2)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            action
+                .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, PhoneMetrics.gutter + 8)
+        .padding(.vertical, 40)
+    }
+}
+
+extension PhoneEmptyState where Action == EmptyView {
+    init(symbol: String, title: String, text: String? = nil) {
+        self.init(symbol: symbol, title: title, text: text) { EmptyView() }
     }
 }
 


### PR DESCRIPTION
## Summary

Brings the iPhone dashboard closer to Cursor's iOS register (ADR-0014, ADR-0017) without dropping any state or action.

- **TaskRow**: two-line shape (dot + title, then the `ToolActivity` word in its colour · agent mark · branch), summary under it, compact `5m` times, quiet attention glyph, soft Reply/Jump keys. The whole row is now tappable — the plain-button headline only hit its glyphs before.
- **Composer**: the reply-target card no longer stretches to the full screen (an unbounded colour bar), reads as two lines, and a draft left without a target says it will send as a new task.
- **Offline**: one `PhoneNotice` with Reconnect above the list; rows only add a note when the offline state disables a key they offer; the composer's "not sent" appears only with a draft.
- **New task**: an editor instead of a form — directory and agent chips on the top edge, full path on demand, prompt as the body, name and Cursor options on the bottom edge, one run line with the long version behind a disclosure. Start is disabled offline and the Mac's refusal stays under the editor with the draft (`DashboardStore.dispatch` returns `DispatchFeedback`).
- **Sheets**: New task and Usage use `PhoneSheetHeader` (now with an optional trailing action) instead of the system bar; the task sheet's tinted pill and badge become the row's dot-and-word line; empty states use `PhoneEmptyState` in the packaged face.
- zh-Hans strings for the new copy.

## Verification

- Isolated simulator (iPhone 17 Pro, iOS 26.5) against a hook-seeded isolated `vibebuddyd` and Demo: light / dark / xxxLarge, offline banner and draft, keyboard, reply target with a long title, new task typed / path expanded / offline. Before/after screenshots and the XCUITest driver live in `.scratch/ios-cursor-benchmark-2026-09-13/` (local, gitignored).
- `DashboardFiltersTests`, `DashboardStoreTests`, `AccountQuotaTests`: 22 tests pass.
- Simulator Debug build passes.

## Not yet exercised

- Real-pairing send / approve / answer / disconnect-and-reconnect.
- Cursor dispatch chips (model / mode / worktree): compiled only; the isolated daemon offered no Cursor agent.
- The Mac's refusal line under the editor needs a real `rejected` / `unavailable` reply.
- Chinese UI, dark New task sheet, VoiceStrip and pairing pages were not re-captured.
