### PR TITLE
feat(history): add read-only sessions and projects CLI

### DIFF
--- a/VibeBuddyMac/Package.swift
+++ b/VibeBuddyMac/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     products: [
         .library(name: "VibeBuddyMacCore", targets: ["VibeBuddyMacCore"]),
+        .executable(name: "vibebuddy-mcp", targets: ["vibebuddy-mcp"]),
         .executable(name: "vibebuddyd", targets: ["vibebuddyd"]),
     ],
     dependencies: [
@@ -28,6 +29,7 @@ let package = Package(
                 .product(name: "SweetCookieKit", package: "SweetCookieKit"),
             ]
         ),
+        .executableTarget(name: "vibebuddy-mcp", dependencies: ["VibeBuddyMacCore"]),
         .executableTarget(
             name: "vibebuddyd",
             dependencies: ["VibeBuddyMacCore"]

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -56,7 +56,8 @@ public enum HistoryTools {
         let limit = (arguments["limit"] as? NSNumber)?.intValue ?? (arguments["limit"] as? String).flatMap(Int.init) ?? 20
         let since = try (arguments["since"] as? String).map { try date($0, now: now) }
         let all = snapshot.sessions.sorted { $0.updatedAt == $1.updatedAt ? key($0) < key($1) : $0.updatedAt > $1.updatedAt }
-        let freshness = "Index covers activity up to \(all.first.map { stamp($0.updatedAt) } ?? "unknown (empty index)"). Cached metadata only; newer activity may not be indexed."
+        let partial = snapshot.pendingSourceCount > 0 ? " Partial index: \(snapshot.pendingSourceCount) source(s) pending; omitted activity may be older or newer." : ""
+        let freshness = "Index covers activity up to \(all.first.map { stamp($0.updatedAt) } ?? "unknown (empty index)"). Cached metadata only; newer activity may not be indexed." + partial
         var sessions = all.filter { since == nil || $0.updatedAt >= since! }
         if name == "vibebuddy_list_projects" {
             var seen = Set<String>()

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -1,0 +1,129 @@
+import Foundation
+import CoreFoundation
+
+public enum HistoryToolError: Error, LocalizedError {
+    case readOnly, noIndex, invalidArguments(String)
+    public var errorDescription: String? {
+        switch self {
+        case .readOnly: "History repository is read-only."
+        case .noIndex: "No usable index. Open History in the Mac App (index command arrives in a later slice)."
+        case .invalidArguments(let text): text
+        }
+    }
+}
+
+/// The shared read-only tool surface. Formatting and validation have no I/O.
+public enum HistoryTools {
+    public static func definitions() -> [[String: Any]] {
+        [definition("vibebuddy_list_sessions", description: "List indexed local sessions, newest activity first.", properties: [
+            "project": ["type": "string"], "agents": ["type": "array", "items": ["type": "string", "enum": ["claude-code", "codex"]]],
+            "since": ["type": "string"], "starred": ["type": "boolean"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
+        ]), definition("vibebuddy_list_projects", description: "List projects with indexed sessions, newest activity first.", properties: [
+            "since": ["type": "string"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
+        ])]
+    }
+
+    private static func definition(_ name: String, description: String, properties: [String: Any]) -> [String: Any] {
+        ["name": name, "description": description,
+         "inputSchema": ["type": "object", "properties": properties, "additionalProperties": false],
+         "annotations": ["readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false]]
+    }
+
+    public static func key(_ session: SessionHistorySession) -> String {
+        (session.agent == .claude ? "claude-code" : "codex") + ":" + session.nativeSessionID
+    }
+
+    public static func call(_ name: String, arguments: [String: Any], snapshot: SessionHistorySnapshot, now: Date = Date()) throws -> String {
+        guard let definition = definitions().first(where: { $0["name"] as? String == name }),
+              let schema = definition["inputSchema"] as? [String: Any], let properties = schema["properties"] as? [String: Any] else {
+            throw HistoryToolError.invalidArguments("Unknown tool: \(name)")
+        }
+        for (key, value) in arguments {
+            guard properties[key] != nil else { throw HistoryToolError.invalidArguments("Unknown argument: \(key)") }
+            let valid: Bool
+            switch key {
+            case "limit":
+                if let number = value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID() {
+                    valid = number.doubleValue.rounded() == number.doubleValue && (1...200).contains(number.doubleValue)
+                } else if let string = value as? String, let number = Int(string) { valid = (1...200).contains(number) }
+                else { valid = false }
+            case "starred": valid = (value as? NSNumber).map { CFGetTypeID($0) == CFBooleanGetTypeID() } ?? false
+            case "agents": valid = (value as? [String]).map { $0.allSatisfy { ["claude-code", "codex"].contains($0) } } ?? false
+            default: valid = value is String
+            }
+            guard valid else { throw HistoryToolError.invalidArguments("Invalid argument: \(key)") }
+        }
+        let limit = (arguments["limit"] as? NSNumber)?.intValue ?? (arguments["limit"] as? String).flatMap(Int.init) ?? 20
+        let since = try (arguments["since"] as? String).map { try date($0, now: now) }
+        let all = snapshot.sessions.sorted { $0.updatedAt == $1.updatedAt ? key($0) < key($1) : $0.updatedAt > $1.updatedAt }
+        let freshness = "Index covers activity up to \(all.first.map { stamp($0.updatedAt) } ?? "unknown (empty index)"). Cached metadata only; newer activity may not be indexed."
+        var sessions = all.filter { since == nil || $0.updatedAt >= since! }
+        if name == "vibebuddy_list_projects" {
+            var seen = Set<String>()
+            let rows = sessions.filter { seen.insert($0.projectPath).inserted }.prefix(limit).map { session in
+                "| \(cell(session.projectPath)) | \(stamp(session.updatedAt)) | \(sessions.filter { $0.projectPath == session.projectPath }.count) |"
+            }
+            return (["| Project | Updated | Sessions |", "| --- | --- | ---: |"] + (rows.isEmpty ? ["No projects found."] : rows) + ["", freshness]).joined(separator: "\n")
+        }
+        if let project = arguments["project"] as? String {
+            let known = Set(all.map(\.projectPath)).sorted()
+            let matches = project.hasPrefix("/") ? known.filter { $0 == project } : known.filter { URL(fileURLWithPath: $0).lastPathComponent == project }
+            guard matches.count == 1 else {
+                return (["Project not found or ambiguous. Known projects:"] + known.map { "- " + cell($0) } + ["", freshness]).joined(separator: "\n")
+            }
+            sessions = sessions.filter { $0.projectPath == matches[0] }
+        }
+        if let agents = arguments["agents"] as? [String], !agents.isEmpty {
+            sessions = sessions.filter { agents.contains($0.agent == .claude ? "claude-code" : "codex") }
+        }
+        if let starred = arguments["starred"] as? Bool { sessions = sessions.filter { $0.isFavorite == starred } }
+        let rows = sessions.prefix(limit).map { s in
+            "| \(cell(key(s))) | \(s.agent.displayName) | \(stamp(s.updatedAt)) | \(cell(s.projectPath)) | \(cell(s.title)) | \(s.messageCount) |"
+        }
+        return (["| Key | Agent | Updated | Project | Title | Messages |", "| --- | --- | --- | --- | --- | ---: |"] + (rows.isEmpty ? ["No sessions found."] : rows) + ["", freshness]).joined(separator: "\n")
+    }
+
+    private static func stamp(_ date: Date) -> String { ISO8601DateFormatter().string(from: date) }
+    private static func cell(_ text: String) -> String {
+        text.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "|", with: "\\|")
+            .components(separatedBy: .controlCharacters).joined(separator: " ")
+    }
+    private static func date(_ text: String, now: Date) throws -> Date {
+        if let unit = text.last, unit == "d" || unit == "h", let count = Double(text.dropLast()), count.isFinite, count >= 0 {
+            let seconds = count * (unit == "d" ? 86400 : 3600)
+            if seconds.isFinite { return now.addingTimeInterval(-seconds) }
+        }
+        let iso = ISO8601DateFormatter()
+        if let result = iso.date(from: text) { return result }
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let result = iso.date(from: text) { return result }
+        iso.formatOptions = [.withFullDate]
+        if let result = iso.date(from: text), iso.string(from: result) == text { return result }
+        throw HistoryToolError.invalidArguments("Invalid since: use 7d, 24h, or an ISO date.")
+    }
+}
+
+/// Only argv shape is interpreted here; values go unchanged to the tool layer.
+public enum HistoryCLI {
+    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects"]
+    public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
+        guard let command = argv.first, let tool = commands[command] else {
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N]")
+        }
+        var args: [String: Any] = [:]
+        var index = 1
+        while index < argv.count {
+            let flag = argv[index]
+            if flag == "--starred" { args["starred"] = true; index += 1; continue }
+            guard ["--project", "--agent", "--since", "--limit"].contains(flag), index + 1 < argv.count else {
+                throw HistoryToolError.invalidArguments("Unknown option or missing value: \(flag)")
+            }
+            let value = argv[index + 1]
+            if flag == "--agent" { args["agents"] = (args["agents"] as? [String] ?? []) + [value] }
+            else { args[String(flag.dropFirst(2))] = value }
+            index += 2
+        }
+        return (tool, args)
+    }
+    public static func output(_ text: String) -> String { text.trimmingCharacters(in: .newlines) + "\n" }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryModels.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryModels.swift
@@ -54,8 +54,9 @@ public struct SessionHistorySnapshot: Sendable {
     public var sessions: [SessionHistorySession]
     public var issues: [String]
     public var refreshedAt: Date?
-    public init(sessions: [SessionHistorySession] = [], issues: [String] = [], refreshedAt: Date? = nil) {
-        self.sessions = sessions; self.issues = issues; self.refreshedAt = refreshedAt
+    public var pendingSourceCount: Int
+    public init(sessions: [SessionHistorySession] = [], issues: [String] = [], refreshedAt: Date? = nil, pendingSourceCount: Int = 0) {
+        self.sessions = sessions; self.issues = issues; self.refreshedAt = refreshedAt; self.pendingSourceCount = pendingSourceCount
     }
 }
 public struct SessionHistorySearchResult: Identifiable, Sendable {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -18,7 +18,10 @@ public actor SessionHistoryRepository {
     private var pendingPaths = Set<String>()
     private var loaded = false
     private var indexDirty = false
-    public init(claudeHome: URL? = nil, codexHome: URL? = nil, cacheDirectory: URL? = nil, refreshByteBudget: Int = 256 * 1024 * 1024) {
+    private let readOnly: Bool
+    private var usableIndex = false
+    public init(claudeHome: URL? = nil, codexHome: URL? = nil, cacheDirectory: URL? = nil, refreshByteBudget: Int = 256 * 1024 * 1024, readOnly: Bool = false) {
+        self.readOnly = readOnly
         self.refreshByteBudget = max(1, refreshByteBudget)
         let home = FileManager.default.homeDirectoryForCurrentUser
         let env = ProcessInfo.processInfo.environment
@@ -34,6 +37,7 @@ public actor SessionHistoryRepository {
         if let data = try? Data(contentsOf: directory.appendingPathComponent("pins.json")), let decoded = try? JSONDecoder().decode(Set<String>.self, from: data) { pins = decoded }
         if let data = try? Data(contentsOf: directory.appendingPathComponent("favorites.json")), let decoded = try? JSONDecoder().decode(Set<String>.self, from: data) { favorites = decoded }
         if let data = try? Data(contentsOf: directory.appendingPathComponent("index.json")), let cache = try? JSONDecoder().decode(Cache.self, from: data), [4, 5, 6, 7].contains(cache.version) {
+            usableIndex = true
             // Never reuse another configured source home's cached content.
             let configuredRoots = roots
             entries = cache.entries.filter { path, _ in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } }
@@ -41,6 +45,8 @@ public actor SessionHistoryRepository {
             if cache.version < 7 { pendingPaths.formUnion(entries.keys) }
         }
     }
+    public func hasUsableIndex() -> Bool { ensureLoaded(); return usableIndex }
+
     public func snapshot() -> SessionHistorySnapshot {
         ensureLoaded()
         var byID: [String: SessionHistorySession] = [:]
@@ -58,6 +64,7 @@ public actor SessionHistoryRepository {
         return SessionHistorySnapshot(sessions: byID.values.sorted { if ($0.isPinned == true) != ($1.isPinned == true) { return $0.isPinned == true }; return $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt > $1.updatedAt }, issues: issues, refreshedAt: refreshedAt)
     }
     public func refresh(rebuild: Bool = false) throws -> SessionHistorySnapshot {
+        guard !readOnly else { throw HistoryToolError.readOnly }
         ensureLoaded()
         let fm = FileManager.default
         issues = []
@@ -174,6 +181,7 @@ public actor SessionHistoryRepository {
     public func search(_ query: String, projectPath: String? = nil, favoritesOnly: Bool = false,
                        agent: SessionHistoryAgent? = nil, archived: Bool? = nil,
                        limit: Int = 200) throws -> [SessionHistorySearchResult] {
+        guard !readOnly else { throw HistoryToolError.readOnly }
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty, limit > 0 else { return [] }
         let sessions = snapshot().sessions.filter {
@@ -205,6 +213,7 @@ public actor SessionHistoryRepository {
         try save(summary, name: "summary-" + contentFilename(summary.sessionID))
     }
     private func save<T: Encodable>(_ value: T, name: String) throws {
+        guard !readOnly else { throw HistoryToolError.readOnly }
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
         try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
         let file = directory.appendingPathComponent(name)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -41,7 +41,7 @@ public actor SessionHistoryRepository {
             // Never reuse another configured source home's cached content.
             let configuredRoots = roots
             entries = cache.entries.filter { path, _ in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } }
-            pendingPaths = Set((cache.pendingPaths ?? []).filter { entries[$0] != nil })
+            pendingPaths = Set((cache.pendingPaths ?? []).filter { path in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } })
             if cache.version < 7 { pendingPaths.formUnion(entries.keys) }
         }
     }
@@ -61,7 +61,7 @@ public actor SessionHistoryRepository {
             }
             byID[session.id] = session
         }
-        return SessionHistorySnapshot(sessions: byID.values.sorted { if ($0.isPinned == true) != ($1.isPinned == true) { return $0.isPinned == true }; return $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt > $1.updatedAt }, issues: issues, refreshedAt: refreshedAt)
+        return SessionHistorySnapshot(sessions: byID.values.sorted { if ($0.isPinned == true) != ($1.isPinned == true) { return $0.isPinned == true }; return $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt > $1.updatedAt }, issues: issues, refreshedAt: refreshedAt, pendingSourceCount: pendingPaths.count)
     }
     public func refresh(rebuild: Bool = false) throws -> SessionHistorySnapshot {
         guard !readOnly else { throw HistoryToolError.readOnly }
@@ -83,6 +83,7 @@ public actor SessionHistoryRepository {
         for (root, agent) in roots {
             guard fm.fileExists(atPath: root.path) else { issues.append("Source directory unavailable: \(root.path)"); continue }
             var enumerationErrors = 0
+            var seenPaths = Set<String>()
             guard let iterator = fm.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey, .contentModificationDateKey], options: [.skipsHiddenFiles], errorHandler: { _, _ in enumerationErrors += 1; return true }) else {
                 issues.append("Unable to enumerate source: \(root.path)"); continue
             }
@@ -90,6 +91,7 @@ public actor SessionHistoryRepository {
                 if agent == .claude, file.lastPathComponent == "subagents" { iterator.skipDescendants(); excludedChildren += 1; continue }
                 guard file.pathExtension == "jsonl" else { continue }
                 if agent == .claude, file.lastPathComponent.hasPrefix("agent-") { excludedChildren += 1; continue }
+                seenPaths.insert(file.path)
                 do {
                     let values = try file.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey, .contentModificationDateKey])
                     guard values.isRegularFile == true, values.isSymbolicLink != true else { continue }
@@ -118,6 +120,21 @@ public actor SessionHistoryRepository {
                 }
             }
             if enumerationErrors > 0 { issues.append("Partial coverage: \(enumerationErrors) inaccessible paths in \(root.path).") }
+            else {
+                // A complete enumeration can retire deferred sources that disappeared.
+                // Unavailable/partial roots retain them so omissions stay visible.
+                var prefixes = [root.path + "/"]
+                // Foundation may shorten /private/var while enumeration returns its
+                // physical spelling. Resolve the existing root, not a deleted leaf.
+                if let physical = realpath(root.path, nil) {
+                    prefixes.append(String(cString: physical) + "/")
+                    free(physical)
+                }
+                let removed = pendingPaths.filter { path in
+                    prefixes.contains { path.hasPrefix($0) } && !seenPaths.contains(path)
+                }
+                if !removed.isEmpty { pendingPaths.subtract(removed); changed = true }
+            }
         }
         for path in entries.keys where !discovered.contains(path) {
             // Retain a cached transcript for provenance/favorites, but never claim its source is available.

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -1,0 +1,25 @@
+import Foundation
+import VibeBuddyMacCore
+
+@main
+struct VibeBuddyMCP {
+    static func main() async {
+        let request: (tool: String, arguments: [String: Any])
+        do { request = try HistoryCLI.parse(Array(CommandLine.arguments.dropFirst())) }
+        catch { fail(error, code: 2) }
+        let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
+        let repository = SessionHistoryRepository(cacheDirectory: directory, readOnly: true)
+        guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
+        let snapshot = await repository.snapshot()
+        do {
+            let text = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: snapshot)
+            FileHandle.standardOutput.write(Data(HistoryCLI.output(text).utf8))
+        } catch HistoryToolError.invalidArguments(let message) {
+            fail(HistoryToolError.invalidArguments(message), code: 2)
+        } catch { fail(error, code: 1) }
+    }
+    private static func fail(_ error: Error, code: Int32) -> Never {
+        FileHandle.standardError.write(Data("vibebuddy-mcp: \(error.localizedDescription)\n".utf8))
+        exit(code)
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -87,6 +87,42 @@ final class HistoryToolsTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: missing.path))
     }
 
+
+    func testPersistedPendingSourceWithoutEntryIsReportedByBothLists() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let codex = root.appendingPathComponent("codex")
+        let cache = root.appendingPathComponent("cache")
+        let sources = codex.appendingPathComponent("sessions")
+        try FileManager.default.createDirectory(at: sources, withIntermediateDirectories: true)
+        for id in ["one", "two"] {
+            let data = try JSONSerialization.data(withJSONObject: ["type": "session_meta", "payload": ["id": id, "cwd": "/repo", "source": "cli"]])
+            try data.write(to: sources.appendingPathComponent(id + ".jsonl"))
+        }
+        let writer = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: codex, cacheDirectory: cache, refreshByteBudget: 1)
+        let initial = try await writer.refresh()
+        XCTAssertEqual(initial.pendingSourceCount, 1)
+        let before = try bytes(cache)
+        let reader = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let snapshot = await reader.snapshot()
+        XCTAssertEqual(snapshot.sessions.count, 1)
+        XCTAssertEqual(snapshot.pendingSourceCount, 1)
+        for tool in HistoryCLI.commands.values {
+            let text = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot)
+            XCTAssertTrue(text.contains("Partial index: 1 source(s) pending"))
+            XCTAssertTrue(text.contains("older or newer"))
+        }
+        XCTAssertEqual(try bytes(cache), before)
+        let stored = try JSONSerialization.jsonObject(with: Data(contentsOf: cache.appendingPathComponent("index.json"))) as! [String: Any]
+        let pending = try XCTUnwrap((stored["pendingPaths"] as? [String])?.first)
+        try FileManager.default.removeItem(atPath: pending)
+        let afterRemoval = try await writer.refresh()
+        XCTAssertEqual(afterRemoval.pendingSourceCount, 0, "root=\(codex.path) resolved=\(codex.resolvingSymlinksInPath().path) pending=\(pending)")
+        let reopened = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let final = await reopened.snapshot()
+        XCTAssertEqual(final.pendingSourceCount, 0)
+    }
+
     private func bytes(_ root: URL) throws -> [String: Data] {
         let urls = FileManager.default.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey])!
         var result: [String: Data] = [:]

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class HistoryToolsTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private func session(_ id: String, project: String, age: TimeInterval = 0) -> SessionHistorySession {
+        SessionHistorySession(id: id, nativeSessionID: id, agent: .codex, projectPath: project,
+                              title: "中文 | title\nnext", sourcePath: "/source/\(id)", updatedAt: now.addingTimeInterval(-age), messages: [])
+    }
+
+    func testRegistryAndCLIParity() throws {
+        let definitions = HistoryTools.definitions()
+        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_list_sessions", "vibebuddy_list_projects"])
+        XCTAssertEqual(Set(HistoryCLI.commands.values), Set(definitions.compactMap { $0["name"] as? String }))
+        for definition in definitions {
+            XCTAssertEqual((definition["annotations"] as? [String: Bool])?["readOnlyHint"], true)
+            XCTAssertEqual((definition["inputSchema"] as? [String: Any])?["additionalProperties"] as? Bool, false)
+        }
+        let schemas = definitions.compactMap { $0["inputSchema"] as? [String: Any] }
+        XCTAssertEqual(Set((schemas[0]["properties"] as? [String: Any] ?? [:]).keys), Set(["project", "agents", "since", "starred", "limit"]))
+        XCTAssertEqual(Set((schemas[1]["properties"] as? [String: Any] ?? [:]).keys), Set(["since", "limit"]))
+        let snapshot = SessionHistorySnapshot(sessions: [session("native-id", project: "/a/repo")])
+        let request = try HistoryCLI.parse(["sessions", "--project", "/a/repo", "--limit", "5", "--agent", "codex"])
+        XCTAssertEqual(request.arguments["limit"] as? String, "5")
+        let direct = try HistoryTools.call(request.tool, arguments: ["project": "/a/repo", "limit": 5, "agents": ["codex"]], snapshot: snapshot, now: now)
+        let cli = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: snapshot, now: now)
+        XCTAssertEqual(Data(HistoryCLI.output(cli).utf8), Data((direct + "\n").utf8))
+        XCTAssertTrue(cli.contains("codex:native-id"))
+        XCTAssertTrue(cli.contains("中文 \\| title next"))
+    }
+
+    func testFiltersAmbiguityAndFreshness() throws {
+        var favorite = session("old", project: "/a/repo", age: 8 * 86400)
+        favorite.isFavorite = true; favorite.isPinned = true
+        let snapshot = SessionHistorySnapshot(sessions: [favorite, session("new", project: "/b/repo")])
+        let tool = "vibebuddy_list_sessions"
+        XCTAssertTrue(try HistoryTools.call(tool, arguments: ["project": "repo"], snapshot: snapshot).contains("ambiguous"))
+        let exact = try HistoryTools.call(tool, arguments: ["project": "/a/repo"], snapshot: snapshot)
+        XCTAssertTrue(exact.contains("codex:old")); XCTAssertFalse(exact.contains("codex:new"))
+        let recent = try HistoryTools.call(tool, arguments: ["since": "7d"], snapshot: snapshot, now: now)
+        XCTAssertTrue(recent.contains("codex:new")); XCTAssertFalse(recent.contains("codex:old"))
+        XCTAssertTrue(try HistoryTools.call(tool, arguments: ["starred": true], snapshot: snapshot).contains("codex:old"))
+        XCTAssertTrue(try HistoryTools.call(tool, arguments: ["limit": 1], snapshot: snapshot).contains("codex:new"))
+        let invalidArguments: [[String: Any]] = [["limit": 0], ["limit": true], ["limit": 1.5], ["starred": 1], ["since": "yesterday"], ["agents": ["cursor"]], ["dispatch": true]]
+        for invalid in invalidArguments {
+            XCTAssertThrowsError(try HistoryTools.call(tool, arguments: invalid, snapshot: snapshot))
+        }
+        for since in ["24h", "2026-09-13", "2026-09-13T10:00:00Z"] {
+            XCTAssertNoThrow(try HistoryTools.call(tool, arguments: ["since": since], snapshot: snapshot, now: now))
+        }
+    }
+
+    func testReadOnlyStoreRemainsByteIdenticalAndRejectsWrites() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude"), codex = root.appendingPathComponent("codex"), cache = root.appendingPathComponent("cache")
+        let file = codex.appendingPathComponent("sessions/test.jsonl")
+        try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data((#"{"type":"session_meta","payload":{"id":"native","cwd":"/repo","source":"cli"}}"# + "\n" + #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}"#).utf8).write(to: file)
+        let writer = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        let original = try await writer.refresh()
+        let id = try XCTUnwrap(original.sessions.first?.id)
+        try await writer.setFavorite(sessionID: id, isFavorite: true)
+        try await writer.setPinned(sessionID: id, isPinned: true)
+        try await writer.setArchived(sessionID: id, isArchived: true)
+        let before = try bytes(cache)
+        let reader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let usable = await reader.hasUsableIndex(); XCTAssertTrue(usable)
+        let snapshot = await reader.snapshot()
+        XCTAssertTrue(snapshot.sessions.first?.isFavorite == true)
+        XCTAssertTrue(snapshot.sessions.first?.isPinned == true)
+        XCTAssertTrue(snapshot.sessions.first?.archivedLocally == true)
+        for tool in HistoryCLI.commands.values { _ = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot) }
+        _ = try await reader.session(id: id)
+        _ = try await reader.summary(sessionID: id)
+        do { _ = try await reader.refresh(rebuild: true); XCTFail("refresh wrote") } catch {}
+        do { try await reader.setFavorite(sessionID: id, isFavorite: false); XCTFail("favorite wrote") } catch {}
+        do { try await reader.setPinned(sessionID: id, isPinned: false); XCTFail("pin wrote") } catch {}
+        do { try await reader.setArchived(sessionID: id, isArchived: false); XCTFail("archive wrote") } catch {}
+        do { _ = try await reader.search("hello"); XCTFail("search wrote") } catch {}
+        XCTAssertEqual(try bytes(cache), before)
+        let missing = root.appendingPathComponent("missing")
+        let empty = SessionHistoryRepository(cacheDirectory: missing, readOnly: true)
+        let exists = await empty.hasUsableIndex(); XCTAssertFalse(exists)
+        _ = await empty.snapshot()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: missing.path))
+    }
+
+    private func bytes(_ root: URL) throws -> [String: Data] {
+        let urls = FileManager.default.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey])!
+        var result: [String: Data] = [:]
+        for case let url as URL in urls where try url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true {
+            result[url.path] = try Data(contentsOf: url)
+        }
+        return result
+    }
+}

--- a/docs/adr/0019-agent-mcp-cli-history-and-handoff.md
+++ b/docs/adr/0019-agent-mcp-cli-history-and-handoff.md
@@ -1,0 +1,205 @@
+# ADR-0019: Agents read local session history and live status through one read-only `vibebuddy-mcp` binary; relay between agents is a handoff note that names its source session
+
+- Status: accepted in direction, first version scoped by the owner on 2026-09-13; implementation authorized by the owner on 2026-09-13 (tickets in `.scratch/agent-mcp-cli/`)
+- Date: 2026-09-13
+- Supersedes / amends: nothing. Sits beside ADR-0009 (daemon routes need the
+  bearer token), ADR-0011 (Codex through the app-server daemon), ADR-0016 and
+  ADR-0018 (Cursor sources). Turns the "MCP/CLI access" line in
+  `docs/session-history.md` from future work into a decision.
+
+## Context
+
+vibebuddy already owns the data this decision exposes. `SessionHistoryRepository`
+indexes Claude Code and Codex conversations under
+`~/Library/Application Support/VibeBuddy/SessionHistory`; `SessionHistorySearchIndex`
+is an FTS5 trigram index over readable message text; the Mac dashboard's History
+scope reads, searches, exports and summarises those conversations. Only the Mac
+app loads the repository, and nothing outside the app can ask it anything.
+
+**What that data layer is not:** a service another process can safely open.
+Three facts, checked against the source on 2026-09-13, bound the work:
+
+- Full-text reading does not parse the agent's file. `session(id:)` decodes the
+  per-source cache `SessionHistory/<sha256 of path>.json` that the last refresh
+  wrote, so a reader that never refreshes reads whatever the app last cached.
+- `SessionHistorySearchIndex` opens `search.sqlite` with
+  `SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE` and lazily builds message rows on
+  the first query. There is no read-only path.
+- Consistency is a Swift actor, which holds inside one process only. `index.json`,
+  the content caches and `search.sqlite` are written without any cross-process
+  lock, so a second writer (or a reader during a write) is undefined behaviour
+  today.
+
+So this is not "one more exit layer over an existing index". The reading and
+index code has to be made safe for a second process before any tool is worth
+exposing, and the tickets are ordered that way.
+
+Agents cannot see any of this history. A Codex session that picks up a task
+Claude Code left has no way to find that conversation. The practice today is a
+hand-written handoff file inside a ticket
+(`.scratch/watch-complication/issues/01-handoff.md` and siblings). Those files
+carry the outgoing agent's intent, which is exactly what a summary written
+later by another model cannot recover, but they never name the conversation
+they came from.
+
+[Wake](https://github.com/iAmCorey/Wake) (read 2026-09-13: `docs/mcp.md`,
+`docs/cli.md`, `crates/wake-core/src/mcp/tools.rs`, `cli.rs`,
+`skills/wake/SKILL.md`) is the interface to copy: four read-only tools
+(`search`, `list_sessions`, `get_session`, `list_projects`) that answer in
+Markdown; every hit carries a `wake://session/<key>#<seq>` reference and
+`get_session` pages by `from_seq`; `project` takes the agent's working
+directory; the CLI is argv-to-JSON over the same tool layer and a test asserts
+the two surfaces print identical bytes; exit `0` includes "no matches" and `2`
+means no usable index; every listing ends with an index-freshness line; the
+server never scans; `setup` prints per-client config; a bundled skill makes
+agents reach for it unprompted. Its code is Rust and is not reused.
+
+The `handoff` skill in [mattpocock/skills](https://github.com/mattpocock/skills)
+(already linked at `.agents/skills/handoff`) supplies the writing discipline for
+the relay half: reference specs, tickets, ADRs and diffs by path instead of
+copying them; redact secrets; name the suggested skills; write for the stated
+next task; downgrade anything the session assumed but never verified. Its
+storage choice (the OS temp directory) is the part its own documentation lists
+as the most reported friction, and it is not adopted.
+
+Grok Build has, since this Mac's `grok 1.0.30`, an official way to enumerate and
+export sessions: `grok sessions list` / `grok sessions search <query>` (search
+covers summaries and first prompts only) and `grok export <session-id> [OUTPUT]`
+(Markdown, stdout by default). Those are the documented interface; the
+`~/.grok/sessions/**/updates.jsonl` layout that live observation reads
+(`GrokSessionReader`) is not, and the CLI options suggest the commands talk to
+Grok's own leader process, which the tickets must verify.
+
+## Decision
+
+**One binary, `vibebuddy-mcp`.** A new executable target in
+`VibeBuddyMac/Package.swift` on `VibeBuddyMacCore`, shipped inside the Mac app
+bundle at `Contents/MacOS/vibebuddy-mcp`. With no arguments it serves MCP over
+stdio; with a subcommand it is the CLI over the same tool layer, so the two
+surfaces cannot drift. No alias or symlink in the first version. Whether the
+MCP framing uses an SDK or is hand-written is an implementation choice made in
+ticket 05, not here.
+
+**Six read-only tools.** The first four keep Wake's names and parameters minus
+the prefix so prompts and habits transfer; the last two are vibebuddy's own.
+
+| Tool | Reads |
+| --- | --- |
+| `vibebuddy_list_sessions` | most recently updated sessions; `project` (path or unique name), `agents`, `since`, `starred`, `limit` |
+| `vibebuddy_search` | FTS over readable message text; each snippet carries `vibebuddy://session/<key>#<seq>` |
+| `vibebuddy_get_session` | one transcript as compact Markdown with `[seq N]` markers, tool calls folded to a line, Meta and Thinking omitted unless asked; paged by `from_seq` |
+| `vibebuddy_list_projects` | projects with indexed sessions, most recent first |
+| `vibebuddy_get_summary` | the persisted conversation summary for a key with its style, provider, model, date, **coverage**, and whether the source changed since it was written; never generates one |
+| `vibebuddy_live_status` | the daemon's current sessions for a project: three states, `waitKind`, control channel, agent, checkout directory, last activity |
+
+Every answer states what it covers. A listing ends with the index-freshness
+line; `get_session` opens with the source revision it read; `get_summary`
+prints the summary's coverage statement and marks a summary whose source
+revision moved as stale rather than hiding it.
+
+**Keys and references.** A session key is `<agent>:<nativeSessionID>` with
+agent one of `claude-code`, `codex`, `cursor`, `grok-build`. A reference is
+`vibebuddy://session/<key>#<seq>` where `seq` is the message's position in the
+readable dialogue for a given source revision. Keys carry the native id the
+agents themselves report in hooks, transcripts and status lines, so a session
+can be named without guessing.
+
+**Sources in the first version: Claude Code, Codex, Cursor local transcripts,
+Grok Build, each reporting its own coverage.** Claude and Codex are the existing
+roots. Cursor adds the agent transcript that Cursor's hook documentation names
+as `transcript_path`, already located and parsed by `CursorTranscripts`; it has
+no tool results, and says so. Grok Build is enumerated with `grok sessions list`
+and read with `grok export <id>`, the exported Markdown parsed into the same
+message shape and indexed for full text by vibebuddy, since Grok's own search
+covers only summaries and first prompts. The `updates.jsonl` layout is not the
+first choice for history and is used only if the official commands prove
+unusable, recorded in the ticket. No source claims the same fidelity as another;
+the per-source capability table lives in `docs/session-history.md`. Excluded:
+Cursor IDE chats (encrypted), Cursor cloud agents (ADR-0018), Copilot history
+rows, Grok Bot.
+
+**The index is shared and written by two parties under explicit coordination.**
+The store stays at `SessionHistory/`. The Mac app refreshes it as today;
+`vibebuddy-mcp index` refreshes it explicitly. Nothing else writes, and a
+query never rebuilds or refreshes implicitly. Ticket 03 adds cross-process
+write coordination (an exclusive lock around a refresh, atomic publication of
+`index.json` and the content caches, a read-only open path for `search.sqlite`)
+and defines what a reader sees during a refresh. Listing and reading need only
+the atomically written JSON files and can ship first; search waits for that
+ticket, because today the first query builds index rows. Headless `vibebuddyd`
+does not gain the index.
+
+**`live_status` is in the first version as an optional enhancement.** It is the
+only tool that talks to the daemon and it only does `GET /snapshot`. When the
+daemon is unreachable it answers "live status unknown", and every history tool
+keeps working. It excludes the caller's own session when the caller can name it,
+reports the checkout directory of each session, and its answer is a
+collaboration hint: another agent being busy in the same checkout is something
+to tell the user, not a rule that forces a worktree switch. The install token
+is read from `TokenStore` to authenticate that request and appears in no
+output, log or error text.
+
+**Read-only is the contract.** No tool approves, denies, answers, steers, stops,
+dispatches, stars, archives or deletes. Those stay on the phone and Mac routes
+under ADR-0009. A test asserts that an existing store is byte-identical after
+any tool call. "The CLI is for humans" is not an argument this ADR makes:
+agents run shell commands too, so the CLI carries exactly the same read-only
+tool set and nothing else.
+
+**Relay is a handoff note that names its source session.** The `handoff`
+discipline is adopted as a project skill with these fixed contents: goal,
+decisions already made, authorization scope, current changes, verification
+evidence, next steps; existing material referenced by path; unverified
+judgements marked as such. Notes are saved under
+`.scratch/<feature>/handoffs/` and referenced from the ticket; existing handoff
+files are not migrated. The note opens with `Source session: <key>` holding the
+**actual** session id of the writing session, taken from the agent's own
+runtime (its hook envelope, status line, transcript path or session file); when
+the writer cannot determine it, the line says `unknown`. "The most recent
+session in this project" is never used to fill it, because parallel agents
+would cross wires. The reader reads the handoff first, then `get_summary` and
+`get_session` only for what the note does not settle; a summary is never
+allowed to override a newer handoff. No background-launch or dispatch mechanism
+is added for relay; starting the next agent stays a human action through the
+existing entry points.
+
+**Out of the first version:** cross-machine mirroring, the Mac App Store
+edition (`docs/agents/mac-app-store.md`), Copilot history, any write path.
+Acceptance is same-machine relay.
+
+## Alternatives rejected
+
+- **Treating this as an exit layer only.** The store is single-process today;
+  exposing it without coordination would corrupt the index the Mac app relies on.
+- **History over the daemon's HTTP routes.** LAN-reachable surface for data the
+  phone does not need, requires the app running, and every target agent already
+  speaks MCP over stdio.
+- **Pointing agents at Wake's `wake.db`.** Different schema and lifecycle, not
+  ours to keep working, and the user would need Wake running.
+- **Write tools over MCP or CLI.** A model could approve its own tool call.
+- **A relay-specific dispatch path.** Considered on 2026-09-13 and removed by
+  the owner: it adds a write path to a read-only binary, and "CLI only" does
+  not make it human-only.
+- **Reverse-engineered `updates.jsonl` as the Grok history source.** An official
+  enumerate-and-export interface exists; the undocumented layout is a fallback,
+  not the choice.
+- **Filling `Source session` from the newest session.** Wrong whenever two
+  agents work in one project, which is the case the feature exists for.
+- **A daemon-side lock on "who is working in this checkout".** The three states
+  are observation, not scheduling; a missed hook would become a blocked agent.
+- **Handoff notes in the OS temp directory.** They vanish between sessions and
+  harnesses; project rules already place durable non-Git artifacts in `.scratch/`.
+
+## Consequences
+
+- Work order: (1) history reading and index consistency, including the two new
+  sources; (2) the binary, tools and CLI; (3) packaging, skill, docs, glossary;
+  (4) a real Claude Code to Codex relay on one machine as acceptance.
+- `SessionHistoryAgent` grows `cursor` and `grokBuild`; the Mac History scope
+  shows those conversations, a visible product change listed in acceptance.
+- `CONTEXT.md` gains **Session key**, **History reference**, **Live status
+  (tool)**, **Handoff note**. `docs/session-history.md` drops the future-work
+  sentence and gains a per-source capability table and a Connect section.
+- Tests: tool definitions stable; CLI and MCP print identical bytes; exit
+  codes; store unchanged by any read; concurrent refresh and read do not
+  corrupt or crash; key parsing accepts a full reference.


### PR DESCRIPTION
agent-mcp-cli/01

## Summary

Add the first vertical slice of `vibebuddy-mcp`: `sessions` and `projects` read the existing History index through a shared, pure tool layer. Results include native session keys, project/agent/date/favorite filters, deterministic recent-activity ordering, and index coverage. Absolute project paths match exactly; ambiguous names return known projects.

Read-only repository instances reject refresh, persisted changes, and the existing lazy-writing search path. CLI argument errors and missing indexes exit 2 with stderr diagnostics; successful output ends with one newline. `VIBEBUDDY_HISTORY_DIRECTORY` selects an isolated store for a process without changing user configuration. Include ADR-0019, copied from the owner's untracked workspace decision, with the current implementation authorization recorded. No dependency added. Stdio MCP remains ticket 05.

## Validation

- `swift build --package-path VibeBuddyMac --product vibebuddy-mcp` — passed (314.49s, fresh build).
- `swift test --package-path VibeBuddyMac` — 11 XCTest tests (3 new) + 1011 Swift Testing tests in 119 suites passed, 0 failures.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml` — passed.
- `xcodebuild -project VibeBuddyMacApp/VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -derivedDataPath .scratch/build-01 PRODUCT_BUNDLE_IDENTIFIER=com.vibebuddy.e2e.agent-mcp-cli-01 build` — BUILD SUCCEEDED.
- Isolated Mac App History on port 18781: 4 copied real source files produced 3 unique sessions; CLI matched the App's titles, agents, times and ordering. Duplicate Codex native ID was deduplicated. Isolated App exited afterward.
- 13 real binary process checks passed (4 no-index/syntax checks + 9 indexed-store checks); 5 store files remained byte-identical. Unit fixture also verifies user-file reads, rejected mutations and absent-directory preservation.
- Independent review found an exit-code mismatch; corrected and re-reviewed. `git diff --check` passed; `VibeBuddyMac/Package.resolved` restored after builds.
- Local evidence: `.scratch/agent-mcp-cli/acceptance/01/` in the primary checkout (not committed).

- Review follow-up `a5daee28`: persisted pending-source coverage now appears in both listings; disappeared deferred sources are retired only after complete enumeration. The full suite above was run at the initial checkpoint; after this fix, all 4 `HistoryToolsTests`, CLI build and incremental macOS Xcode build passed. The P2 review thread was answered and resolved.

## Not verified here

The default production History index is absent on this machine; acceptance used real source copies indexed by the isolated App. No installed app, default daemon, user client configuration, device, deployment or release was changed.

Browser security policy blocked opening the local PLAN.html URL and prohibited workarounds. Board JSON/state validation passed; the owner still needs to open the board and confirm rendering. MCP/client connection, search, transcript, summary and live status are later tickets. Merge remains owner-controlled.
