### PR TITLE
feat(mac): carry Settings' green accent into the dashboard

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/Companion.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Companion.swift
@@ -28,6 +28,9 @@ public enum CompanionPalette {
     /// orange on the brand, not on the product's buttons. Darkened for the
     /// neutral ground so white label text keeps its contrast.
     public static let accent = dynamic(0x3E7A4A, 0x7FC48F)
+    /// Accent as text on a 14 % accent wash over `bg2` (selected sidebar
+    /// titles): light `accent` composites to 3.9:1 there, this to 5.5:1.
+    public static let accentText = dynamic(0x2F6139, 0x7FC48F)
     /// Ground of dark "glance" surfaces: the Mac notch card, the Live Activity.
     public static let glance = dynamic(0x141414, 0x0F0F0F)
 

--- a/VibeBuddyMacApp/Sources/DashboardSidebar.swift
+++ b/VibeBuddyMacApp/Sources/DashboardSidebar.swift
@@ -181,7 +181,7 @@ struct SidebarRow: View {
             HStack(spacing: 8) {
                 Image(systemName: systemName).font(.system(size: 11, weight: .medium))
                     .foregroundStyle(selected ? MacTheme.accent : MacTheme.ink2).frame(width: 14)
-                Text(title).font(MacTheme.font(12, .medium)).foregroundStyle(selected ? MacTheme.accent : MacTheme.ink).lineLimit(1)
+                Text(title).font(MacTheme.font(12, .medium)).foregroundStyle(selected ? MacTheme.accentText : MacTheme.ink).lineLimit(1)
                 Spacer(minLength: 4)
                 if count > 0 {
                     Text("\(count)").font(MacTheme.mono(10, .medium)).foregroundStyle(countTint)
@@ -207,7 +207,7 @@ struct ProjectRow: View {
     var body: some View {
         Button(action: action) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
-                Text(title).font(MacTheme.font(12)).foregroundStyle(selected ? MacTheme.accent : MacTheme.ink2)
+                Text(title).font(MacTheme.font(12)).foregroundStyle(selected ? MacTheme.accentText : MacTheme.ink2)
                     .lineLimit(1).truncationMode(.middle)
                 Spacer(minLength: 4)
                 Text("\(count)").font(MacTheme.mono(10)).foregroundStyle(MacTheme.ink3)

--- a/VibeBuddyMacApp/Sources/DashboardSidebar.swift
+++ b/VibeBuddyMacApp/Sources/DashboardSidebar.swift
@@ -180,8 +180,8 @@ struct SidebarRow: View {
         Button(action: action) {
             HStack(spacing: 8) {
                 Image(systemName: systemName).font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(selected ? MacTheme.ink : MacTheme.ink2).frame(width: 14)
-                Text(title).font(MacTheme.font(12, .medium)).foregroundStyle(MacTheme.ink).lineLimit(1)
+                    .foregroundStyle(selected ? MacTheme.accent : MacTheme.ink2).frame(width: 14)
+                Text(title).font(MacTheme.font(12, .medium)).foregroundStyle(selected ? MacTheme.accent : MacTheme.ink).lineLimit(1)
                 Spacer(minLength: 4)
                 if count > 0 {
                     Text("\(count)").font(MacTheme.mono(10, .medium)).foregroundStyle(countTint)
@@ -207,7 +207,7 @@ struct ProjectRow: View {
     var body: some View {
         Button(action: action) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
-                Text(title).font(MacTheme.font(12)).foregroundStyle(selected ? MacTheme.ink : MacTheme.ink2)
+                Text(title).font(MacTheme.font(12)).foregroundStyle(selected ? MacTheme.accent : MacTheme.ink2)
                     .lineLimit(1).truncationMode(.middle)
                 Spacer(minLength: 4)
                 Text("\(count)").font(MacTheme.mono(10)).foregroundStyle(MacTheme.ink3)
@@ -232,7 +232,8 @@ struct SidebarHeading: View {
     }
 }
 
-/// Hover lifts the row a shade; selection holds it there.
+/// Hover lifts the row a shade of ink; selection is the Settings sidebar's
+/// green wash, so both windows mark "you are here" the same way.
 struct SidebarRowStyle: ButtonStyle {
     var selected: Bool
     @State private var hovering = false
@@ -242,13 +243,14 @@ struct SidebarRowStyle: ButtonStyle {
             .onHover { hovering = $0 }
     }
     private func ground(_ pressed: Bool) -> Color {
-        if selected || pressed { return MacTheme.ink.opacity(0.07) }
+        if selected { return MacTheme.accent.opacity(0.14) }
+        if pressed { return MacTheme.ink.opacity(0.07) }
         return hovering ? MacTheme.ink.opacity(0.04) : .clear
     }
 }
 
-/// The mic as Cursor draws it in the composer: a 20pt disc, filled with ink
-/// while a conversation is live, quiet ground otherwise.
+/// The mic as Cursor draws it in the composer: a 20pt disc, filled with the
+/// accent while a conversation is live, quiet ground otherwise.
 struct MicGlyph: View {
     let phase: VoiceChat.Phase
     let enabled: Bool
@@ -257,7 +259,7 @@ struct MicGlyph: View {
             .font(.system(size: 9, weight: .semibold))
             .foregroundStyle(phase == .idle ? MacTheme.ink2 : MacTheme.bg)
             .frame(width: 20, height: 20)
-            .background(phase == .idle ? MacTheme.bg3 : MacTheme.ink, in: Circle())
+            .background(phase == .idle ? MacTheme.bg3 : MacTheme.accent, in: Circle())
             .overlay(Circle().strokeBorder(MacTheme.line, lineWidth: CompanionType.hairline))
     }
     private var glyph: String {
@@ -271,7 +273,7 @@ struct MicGlyph: View {
     }
 }
 
-/// Cursor's filter chip: outlined at rest, ink-filled when on.
+/// Cursor's filter chip: outlined at rest, accent-filled when on.
 struct FilterChip: View {
     let title: LocalizedStringKey
     let selected: Bool
@@ -281,7 +283,7 @@ struct FilterChip: View {
             Text(title).font(MacTheme.font(10.5, .medium))
                 .foregroundStyle(selected ? MacTheme.bg : MacTheme.ink2)
                 .padding(.horizontal, 9).padding(.vertical, 3)
-                .background(selected ? MacTheme.ink : .clear, in: Capsule())
+                .background(selected ? MacTheme.accent : .clear, in: Capsule())
                 .overlay(Capsule().strokeBorder(selected ? .clear : MacTheme.line, lineWidth: CompanionType.hairline))
                 .contentShape(Capsule())
         }

--- a/VibeBuddyMacApp/Sources/DashboardView.swift
+++ b/VibeBuddyMacApp/Sources/DashboardView.swift
@@ -90,6 +90,8 @@ struct DashboardView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(MacTheme.bg)
+        // Same tint as Settings, so system controls here pick up the buddy's green.
+        .tint(MacTheme.accent)
         .onReceive(DashboardRoute.shared.$requested) { library in
             guard let library else { return }
             libraryScope = library.rawValue
@@ -331,7 +333,7 @@ private struct SummaryRow: View {
         .overlay {
             if isSelected {
                 RoundedRectangle(cornerRadius: MacTheme.cardRadius, style: .continuous)
-                    .strokeBorder(MacTheme.ink.opacity(0.28), lineWidth: CompanionType.hairline)
+                    .strokeBorder(MacTheme.accent.opacity(0.6), lineWidth: CompanionType.hairline)
                     .allowsHitTesting(false)
             }
         }

--- a/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
+++ b/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
@@ -317,7 +317,7 @@ struct HistoryWorkbenchView: View {
             else if !session.warnings.isEmpty { Label("Partial or limited record", systemImage: "info.circle").font(MacTheme.font(10)) }
         }
         .frame(maxWidth: .infinity, alignment: .leading).padding(10)
-        .background(active ? MacTheme.ink.opacity(0.07) : .clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .background(active ? MacTheme.accent.opacity(0.14) : .clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .contentShape(Rectangle())
     }
 

--- a/VibeBuddyMacApp/Sources/MacTheme.swift
+++ b/VibeBuddyMacApp/Sources/MacTheme.swift
@@ -13,6 +13,7 @@ enum MacTheme {
     static let ink2 = CompanionPalette.ink2
     static let ink3 = CompanionPalette.ink3
     static let accent = CompanionPalette.accent
+    static let accentText = CompanionPalette.accentText
     /// Ground of the expanded glance card and the capsule-mode pill. The
     /// collapsed pill in notch mode stays pure black so it merges with the
     /// hardware notch.

--- a/VibeBuddyMacApp/Sources/SettingsView.swift
+++ b/VibeBuddyMacApp/Sources/SettingsView.swift
@@ -221,7 +221,7 @@ private struct SettingsSidebar: View {
                     .foregroundStyle(selected ? MacTheme.accent : MacTheme.ink2)
                 Text(page.title)
                     .font(SettingsChrome.font(13, selected ? .semibold : .medium))
-                    .foregroundStyle(selected ? MacTheme.accent : MacTheme.ink)
+                    .foregroundStyle(selected ? MacTheme.accentText : MacTheme.ink)
                     .lineLimit(1)
                 Spacer(minLength: 0)
             }

--- a/docs/design/mac-companion-redesign.md
+++ b/docs/design/mac-companion-redesign.md
@@ -101,13 +101,16 @@ live and history libraries; only this list scrolls, the rows above stay put.
 At the bottom the account-quota plinth, collapsed by default to one line (the
 provider with the least left, its reset, and any source that cannot be read)
 and expanded to the per-provider rows on click, remembered across launches;
-under it a **Settings** row, where Cursor keeps its gear. Selection and hover
-are an ink wash (7 % / 4 %), never the accent.
+under it a **Settings** row, where Cursor keeps its gear. Selection matches the
+Settings sidebar — accent glyph and title on a 14 % accent wash; hover and press
+stay an ink wash (4 % / 7 %). *(2026-09-13: was an ink wash, never the accent;
+the owner asked the dashboard to carry Settings' green.)*
 
 Content: list column (240–380 pt) + detail column. The list head is the scope
 title, the search pill and a row of filter chips (All / Needs you / Errors /
-Working / Done / Idle; the selected chip is ink-filled). Rows are summary-first
-cards on `bg3`; the selected row sits on `bg2` with a hairline. History uses
+Working / Done / Idle; the selected chip is accent-filled). Rows are summary-first
+cards on `bg3`; the selected row sits on `bg2` with an accent hairline. The
+live mic disc is accent-filled. History uses
 the same head with agent / archive dropdown pills and a `···` menu (Refresh,
 Rebuild index, source notices). Empty panes are `QuietEmptyState`: a 22 pt
 glyph, a body-size title and one line of guidance, centred, no card — never


### PR DESCRIPTION
The dashboard and Settings share the same grounds (`bg` / `bg2`), but Settings marks selection and controls with the buddy's green accent while the dashboard used a neutral ink wash, so the two windows looked mismatched.

## Changes
- Sidebar rows (libraries, projects): selected state is an accent glyph/title on a 14% accent wash, matching the Settings sidebar. Hover and press stay an ink wash.
- Filter chips: selected chip is accent-filled instead of ink-filled.
- Selected task card: accent hairline instead of ink.
- History list: active row uses the accent wash.
- Live mic disc: accent-filled instead of ink.
- Dashboard root takes `.tint(MacTheme.accent)`, same as Settings.
- `docs/design/mac-companion-redesign.md` updated; the former "never the accent" rule is noted as superseded.

## Verification
- `xcodebuild` Debug build of `VibeBuddyMacApp` succeeded.
- Isolated demo instance (`VIBEBUDDY_DEMO=1`, `VIBEBUDDY_DEMO_PAGE=dashboard/live|dashboard/history|settings`), windows captured with `screencapture -l`; the dashboard selection green matches Settings in light mode.
- Not checked: dark mode, History active row with real records (demo has no history), installed app.