### PR TITLE
feat(history): read transcripts with stable sequence references

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -2,20 +2,24 @@ import Foundation
 import CoreFoundation
 
 public enum HistoryToolError: Error, LocalizedError {
-    case readOnly, noIndex, invalidArguments(String)
+    case readOnly, noIndex, invalidArguments(String), executionFailed(String)
     public var errorDescription: String? {
         switch self {
         case .readOnly: "History repository is read-only."
         case .noIndex: "No usable index. Open History in the Mac App (index command arrives in a later slice)."
-        case .invalidArguments(let text): text
+        case .invalidArguments(let text), .executionFailed(let text): text
         }
     }
 }
 
-/// The shared read-only tool surface. Formatting and validation have no I/O.
+/// The shared read-only tool surface. Snapshot formatting and validation are pure.
 public enum HistoryTools {
     public static func definitions() -> [[String: Any]] {
-        [definition("vibebuddy_list_sessions", description: "List indexed local sessions, newest activity first.", properties: [
+        [definition("vibebuddy_get_session", description: "Read a transcript by native key or reference; sequence positions are stable for its source revision.", properties: [
+            "key": ["type": "string"], "from_seq": ["type": "integer", "minimum": 1],
+            "max_messages": ["type": "integer", "minimum": 1, "maximum": 200],
+            "tools": ["type": "boolean"], "thinking": ["type": "boolean"]
+        ], required: ["key"]), definition("vibebuddy_list_sessions", description: "List indexed local sessions, newest activity first.", properties: [
             "project": ["type": "string"], "agents": ["type": "array", "items": ["type": "string", "enum": ["claude-code", "codex"]]],
             "since": ["type": "string"], "starred": ["type": "boolean"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
         ]), definition("vibebuddy_list_projects", description: "List projects with indexed sessions, newest activity first.", properties: [
@@ -23,9 +27,9 @@ public enum HistoryTools {
         ])]
     }
 
-    private static func definition(_ name: String, description: String, properties: [String: Any]) -> [String: Any] {
+    private static func definition(_ name: String, description: String, properties: [String: Any], required: [String] = []) -> [String: Any] {
         ["name": name, "description": description,
-         "inputSchema": ["type": "object", "properties": properties, "additionalProperties": false],
+         "inputSchema": ["type": "object", "properties": properties, "required": required, "additionalProperties": false],
          "annotations": ["readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false]]
     }
 
@@ -34,6 +38,7 @@ public enum HistoryTools {
     }
 
     public static func call(_ name: String, arguments: [String: Any], snapshot: SessionHistorySnapshot, now: Date = Date()) throws -> String {
+        guard name != "vibebuddy_get_session" else { throw HistoryToolError.invalidArguments("get_session requires a repository.") }
         guard let definition = definitions().first(where: { $0["name"] as? String == name }),
               let schema = definition["inputSchema"] as? [String: Any], let properties = schema["properties"] as? [String: Any] else {
             throw HistoryToolError.invalidArguments("Unknown tool: \(name)")
@@ -106,22 +111,26 @@ public enum HistoryTools {
 
 /// Only argv shape is interpreted here; values go unchanged to the tool layer.
 public enum HistoryCLI {
-    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects"]
+    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects", "show": "vibebuddy_get_session"]
     public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
         guard let command = argv.first, let tool = commands[command] else {
-            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N]")
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking]")
         }
         var args: [String: Any] = [:]
         var index = 1
+        if command == "show" {
+            guard argv.count > 1, !argv[1].hasPrefix("--") else { throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking]") }
+            args["key"] = argv[1]; index = 2
+        }
         while index < argv.count {
             let flag = argv[index]
-            if flag == "--starred" { args["starred"] = true; index += 1; continue }
-            guard ["--project", "--agent", "--since", "--limit"].contains(flag), index + 1 < argv.count else {
+            if ["--starred", "--tools", "--thinking"].contains(flag) { args[String(flag.dropFirst(2))] = true; index += 1; continue }
+            guard ["--project", "--agent", "--since", "--limit", "--from-seq", "--max-messages"].contains(flag), index + 1 < argv.count else {
                 throw HistoryToolError.invalidArguments("Unknown option or missing value: \(flag)")
             }
             let value = argv[index + 1]
             if flag == "--agent" { args["agents"] = (args["agents"] as? [String] ?? []) + [value] }
-            else { args[String(flag.dropFirst(2))] = value }
+            else { args[String(flag.dropFirst(2)).replacingOccurrences(of: "-", with: "_")] = value }
             index += 2
         }
         return (tool, args)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTranscript.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTranscript.swift
@@ -1,0 +1,101 @@
+import Foundation
+import CoreFoundation
+
+/// Native identity plus an optional, one-based readable message position.
+public struct HistorySessionReference: Sendable {
+    public let agent: SessionHistoryAgent
+    public let nativeID: String
+    public let seq: Int?
+    public var key: String { (agent == .claude ? "claude-code" : "codex") + ":" + nativeID }
+    public init(_ value: String) throws {
+        let prefix = "vibebuddy://session/"
+        let isRef = value.hasPrefix(prefix)
+        let parts = (isRef ? String(value.dropFirst(prefix.count)) : value).split(separator: "#", omittingEmptySubsequences: false)
+        guard parts.count <= (isRef ? 2 : 1), let raw = parts.first,
+              let colon = raw.firstIndex(of: ":") else { throw HistoryToolError.executionFailed("Invalid session key or reference.") }
+        switch raw[..<colon] {
+        case "claude-code": agent = .claude
+        case "codex": agent = .codex
+        default: throw HistoryToolError.executionFailed("Unknown session agent.")
+        }
+        nativeID = String(raw[raw.index(after: colon)...])
+        guard !nativeID.isEmpty, nativeID.unicodeScalars.allSatisfy({ CharacterSet.alphanumerics.contains($0) || "-_".unicodeScalars.contains($0) }) else {
+            throw HistoryToolError.executionFailed("Invalid native session ID.")
+        }
+        if parts.count == 2 {
+            guard let number = Int(parts[1]), number > 0 else { throw HistoryToolError.executionFailed("Invalid reference sequence.") }
+            seq = number
+        } else { seq = nil }
+    }
+    public func ref(seq: Int) -> String { "vibebuddy://session/\(key)#\(seq)" }
+}
+
+public struct HistoryTranscript: Sendable {
+    public let session: SessionHistorySession
+    public let provenance: String
+    /// One-based references index this fixed projection. Meta is absent; standalone
+    /// Thinking retains a position even when default output hides it. Expansion
+    /// flags never renumber a later dialogue or tool row.
+    public let rows: [HistoryMessageRow]
+    private let sequences: [String: Int]
+    public init(session: SessionHistorySession, provenance: String) {
+        self.session = session; self.provenance = provenance
+        rows = SessionHistoryPresentation.rows(session.messages, includingThinking: true)
+        var mapping: [String: Int] = [:]
+        for (index, row) in rows.enumerated() {
+            for id in row.messageIDs { mapping[id] = index + 1 }
+        }
+        sequences = mapping
+    }
+    public func seq(messageID: String) -> Int? { sequences[messageID] }
+}
+
+extension HistoryTools {
+    public static func getSession(arguments: [String: Any], repository: SessionHistoryRepository) async throws -> String {
+        guard Set(arguments.keys).isSubset(of: ["key", "from_seq", "max_messages", "tools", "thinking"]), let key = arguments["key"] as? String else {
+            throw HistoryToolError.invalidArguments("get_session requires key and only its documented arguments.")
+        }
+        let reference = try HistorySessionReference(key)
+        func integer(_ name: String, fallback: Int, maximum: Int) throws -> Int {
+            guard let value = arguments[name] else { return fallback }
+            let result: Int?
+            if let number = value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID(), number.doubleValue.isFinite,
+               number.doubleValue.rounded() == number.doubleValue, number.doubleValue >= 1, number.doubleValue <= Double(maximum) { result = number.intValue }
+            else if let text = value as? String { result = Int(text) }
+            else { result = nil }
+            guard let result, (1...maximum).contains(result) else { throw HistoryToolError.invalidArguments("Invalid argument: \(name)") }
+            return result
+        }
+        func flag(_ name: String) throws -> Bool {
+            guard let value = arguments[name] else { return false }
+            guard let number = value as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() else { throw HistoryToolError.invalidArguments("Invalid argument: \(name)") }
+            return number.boolValue
+        }
+        let from = try integer("from_seq", fallback: reference.seq ?? 1, maximum: Int.max)
+        let limit = try integer("max_messages", fallback: 30, maximum: 200)
+        let tools = try flag("tools"), thinking = try flag("thinking")
+        let transcript = try await repository.readTranscript(key: reference.key)
+        let session = transcript.session
+        let rows = transcript.rows
+        let page = rows.enumerated().filter { $0.offset >= from - 1 && (thinking || !$0.element.text.isEmpty || !$0.element.tools.isEmpty) }.prefix(limit)
+        var lines = ["Source revision: \(session.sourceRevision ?? "unknown") (\(transcript.provenance))", "", "# \(session.title)", "Key: \(reference.key)"]
+        lines += session.warnings.map { "> " + $0 }
+        if !session.isAvailable { lines.append("> Source unavailable; reading retained cached history.") }
+        for (index, row) in page {
+            lines += ["", "## [seq \(index + 1)] \(row.kind == .compactSummary ? "Context compaction" : row.role.rawValue.capitalized)"]
+            if !row.text.isEmpty { lines.append(row.text) }
+            if thinking, !row.thinking.isEmpty { lines += ["", "Thinking:", row.thinking] }
+            for tool in row.tools {
+                lines.append("- Tool: \(tool.name)\(tool.isError ? " (error)" : "") — \(tool.preview)")
+                if tools {
+                    if !tool.input.isEmpty { lines += ["", "Input:", tool.input] }
+                    if let output = tool.output { lines += ["", "Result:", output] }
+                }
+            }
+        }
+        if let last = page.last?.offset, rows.enumerated().contains(where: { $0.offset > last && (thinking || !$0.element.text.isEmpty || !$0.element.tools.isEmpty) }) {
+            lines += ["", "Continue: from_seq=\(last + 2) (\(reference.ref(seq: last + 2)))"]
+        } else { lines += ["", "End of readable transcript."] }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryPresentation.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryPresentation.swift
@@ -33,7 +33,7 @@ public struct HistoryMessageRow: Identifiable, Sendable {
 
 /// A read-only presentation projection. Raw IDs remain addressable by search/export.
 public enum SessionHistoryPresentation {
-    public static func rows(_ messages: [SessionHistoryMessage], revealing target: String? = nil) -> [HistoryMessageRow] {
+    public static func rows(_ messages: [SessionHistoryMessage], revealing target: String? = nil, includingThinking: Bool = false) -> [HistoryMessageRow] {
         var rows: [HistoryMessageRow] = []
         var calls: [String: (Int, Int)] = [:]
         for message in messages {
@@ -77,7 +77,7 @@ public enum SessionHistoryPresentation {
         return rows.filter { row in
             if row.contains(target) { return true }
             if row.kind == .meta { return false }
-            return row.kind == .compactSummary || !row.text.isEmpty || !row.tools.isEmpty
+            return row.kind == .compactSummary || !row.text.isEmpty || !row.tools.isEmpty || (includingThinking && !row.thinking.isEmpty)
         }
     }
 }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -19,6 +19,7 @@ public actor SessionHistoryRepository {
     private var loaded = false
     private var indexDirty = false
     private let readOnly: Bool
+    private var transcriptSlot: (path: String, revision: String, transcript: HistoryTranscript)?
     private var usableIndex = false
     public init(claudeHome: URL? = nil, codexHome: URL? = nil, cacheDirectory: URL? = nil, refreshByteBudget: Int = 256 * 1024 * 1024, readOnly: Bool = false) {
         self.readOnly = readOnly
@@ -151,6 +152,67 @@ public actor SessionHistoryRepository {
         }
         return snapshot()
     }
+    /// Bounded read-only access; never refreshes or publishes a cache.
+    public func readTranscript(key: String) throws -> HistoryTranscript {
+        let reference = try HistorySessionReference(key)
+        ensureLoaded()
+        let matches = entries.values.filter { $0.session.agent == reference.agent && $0.session.nativeSessionID == reference.nativeID }
+        guard matches.count <= 1 else { throw HistoryToolError.executionFailed("Ambiguous session key: multiple source files.") }
+        var metadata = matches.first?.session
+        if metadata == nil {
+            // Locate by native filename only; never parse every conversation to find one ID.
+            var candidates: [URL] = []
+            for (root, agent) in roots where agent == reference.agent {
+                guard let iterator = FileManager.default.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey], options: [.skipsHiddenFiles]) else { continue }
+                for case let file as URL in iterator {
+                    if file.lastPathComponent == "subagents" { iterator.skipDescendants(); continue }
+                    let stem = file.deletingPathExtension().lastPathComponent
+                    guard file.pathExtension == "jsonl", !stem.hasPrefix("agent-"),
+                          stem == reference.nativeID || (agent == .codex && stem.hasSuffix("-" + reference.nativeID)),
+                          file.resolvingSymlinksInPath().path.hasPrefix(root.path + "/"),
+                          let values = try? file.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+                          values.isRegularFile == true, values.isSymbolicLink != true else { continue }
+                    candidates.append(file)
+                }
+            }
+            guard candidates.count == 1 else { throw HistoryToolError.executionFailed(candidates.isEmpty ? "Unknown session key." : "Ambiguous session key: multiple source files.") }
+            let file = candidates[0]
+            metadata = SessionHistorySession(id: "", nativeSessionID: reference.nativeID, agent: reference.agent, projectPath: "", title: "", sourcePath: file.path, updatedAt: .distantPast, messages: [])
+        }
+        guard let metadata else { throw HistoryToolError.executionFailed("Unknown session key.") }
+        let file = URL(fileURLWithPath: metadata.sourcePath)
+        let values = try? file.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+        let modified = values?.contentModificationDate
+        let size = values?.fileSize
+        let current = modified.flatMap { date in size.map { "\(date.timeIntervalSince1970)|\($0)" } }
+        if let current, let slot = transcriptSlot, slot.path == file.path, slot.revision == current { return slot.transcript }
+        let indexed = matches.first.map { "\($0.modified.timeIntervalSince1970)|\($0.size)" }
+        let cacheURL = directory.appendingPathComponent(contentFilename(file.path))
+        if let data = try? Data(contentsOf: cacheURL), var cached = try? JSONDecoder().decode(SessionHistorySession.self, from: data),
+           cached.sourcePath == file.path, cached.agent == reference.agent, cached.nativeSessionID == reference.nativeID {
+            let cacheTime = (try? cacheURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+            let indexTime = (try? directory.appendingPathComponent("index.json").resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+            let legacyPublished = cacheTime.flatMap { cache in indexTime.map { cache <= $0 } } == true
+            let revision = cached.sourceRevision ?? (legacyPublished ? indexed : nil)
+            if let revision, (current == nil || current == revision), indexed == revision {
+                cached.sourceRevision = revision
+                cached.isAvailable = current != nil && FileManager.default.isReadableFile(atPath: file.path)
+                let result = HistoryTranscript(session: cached, provenance: "cache")
+                if let current { transcriptSlot = (file.path, current, result) }
+                return result
+            }
+        }
+        guard let modified, let current else { throw HistoryToolError.executionFailed("Source unavailable and no verifiable transcript cache.") }
+        var session = try SessionHistoryParser.read(url: file, agent: reference.agent, updatedAt: modified)
+        let after = try file.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+        guard after.contentModificationDate == modified, after.fileSize == size else { throw HistoryToolError.executionFailed("Source changed while reading; retry for a consistent revision.") }
+        guard session.nativeSessionID == reference.nativeID else { throw HistoryToolError.executionFailed("Source identity does not match the requested key.") }
+        session.sourceRevision = current
+        let result = HistoryTranscript(session: session, provenance: "source, index stale")
+        transcriptSlot = (file.path, current, result)
+        return result
+    }
+
     /// Snapshots retain metadata only; load the selected transcript off the main actor.
     public func session(id: String) throws -> SessionHistorySession? {
         guard let metadata = snapshot().sessions.first(where: { $0.id == id }) else { return nil }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -152,13 +152,29 @@ public actor SessionHistoryRepository {
         }
         return snapshot()
     }
+    /// Prefer an available source over retained unavailable paths, as snapshot does.
+    /// Multiple eligible files remain ambiguous; callers must not guess an identity.
+    public func resolveIndexedSession(key: String) throws -> SessionHistorySession? {
+        let reference = try HistorySessionReference(key)
+        ensureLoaded()
+        let candidates = entries.values.filter { $0.session.agent == reference.agent && $0.session.nativeSessionID == reference.nativeID }
+        let available = candidates.filter { $0.session.isAvailable }
+        let matches = available.isEmpty ? candidates : available
+        guard matches.count <= 1 else { throw HistoryToolError.executionFailed("Ambiguous session key: multiple source files.") }
+        guard let entry = matches.first else { return nil }
+        var session = entry.session
+        session.sourceRevision = "\(entry.modified.timeIntervalSince1970)|\(entry.size)"
+        session.isFavorite = favorites.contains(session.id)
+        session.isPinned = pins.contains(session.id)
+        session.archivedLocally = archives.contains(session.id)
+        return session
+    }
+
     /// Bounded read-only access; never refreshes or publishes a cache.
     public func readTranscript(key: String) throws -> HistoryTranscript {
         let reference = try HistorySessionReference(key)
-        ensureLoaded()
-        let matches = entries.values.filter { $0.session.agent == reference.agent && $0.session.nativeSessionID == reference.nativeID }
-        guard matches.count <= 1 else { throw HistoryToolError.executionFailed("Ambiguous session key: multiple source files.") }
-        var metadata = matches.first?.session
+        var metadata = try resolveIndexedSession(key: reference.key)
+        let indexed = metadata?.sourceRevision
         if metadata == nil {
             // Locate by native filename only; never parse every conversation to find one ID.
             var candidates: [URL] = []
@@ -186,7 +202,6 @@ public actor SessionHistoryRepository {
         let size = values?.fileSize
         let current = modified.flatMap { date in size.map { "\(date.timeIntervalSince1970)|\($0)" } }
         if let current, let slot = transcriptSlot, slot.path == file.path, slot.revision == current { return slot.transcript }
-        let indexed = matches.first.map { "\($0.modified.timeIntervalSince1970)|\($0.size)" }
         let cacheURL = directory.appendingPathComponent(contentFilename(file.path))
         if let data = try? Data(contentsOf: cacheURL), var cached = try? JSONDecoder().decode(SessionHistorySession.self, from: data),
            cached.sourcePath == file.path, cached.agent == reference.agent, cached.nativeSessionID == reference.nativeID {

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -9,10 +9,14 @@ struct VibeBuddyMCP {
         catch { fail(error, code: 2) }
         let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
         let repository = SessionHistoryRepository(cacheDirectory: directory, readOnly: true)
-        guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
-        let snapshot = await repository.snapshot()
         do {
-            let text = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: snapshot)
+            let text: String
+            if request.tool == "vibebuddy_get_session" {
+                text = try await HistoryTools.getSession(arguments: request.arguments, repository: repository)
+            } else {
+                guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
+                text = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: await repository.snapshot())
+            }
             FileHandle.standardOutput.write(Data(HistoryCLI.output(text).utf8))
         } catch HistoryToolError.invalidArguments(let message) {
             fail(HistoryToolError.invalidArguments(message), code: 2)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -11,15 +11,15 @@ final class HistoryToolsTests: XCTestCase {
 
     func testRegistryAndCLIParity() throws {
         let definitions = HistoryTools.definitions()
-        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_list_sessions", "vibebuddy_list_projects"])
+        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_get_session", "vibebuddy_list_sessions", "vibebuddy_list_projects"])
         XCTAssertEqual(Set(HistoryCLI.commands.values), Set(definitions.compactMap { $0["name"] as? String }))
         for definition in definitions {
             XCTAssertEqual((definition["annotations"] as? [String: Bool])?["readOnlyHint"], true)
             XCTAssertEqual((definition["inputSchema"] as? [String: Any])?["additionalProperties"] as? Bool, false)
         }
         let schemas = definitions.compactMap { $0["inputSchema"] as? [String: Any] }
-        XCTAssertEqual(Set((schemas[0]["properties"] as? [String: Any] ?? [:]).keys), Set(["project", "agents", "since", "starred", "limit"]))
-        XCTAssertEqual(Set((schemas[1]["properties"] as? [String: Any] ?? [:]).keys), Set(["since", "limit"]))
+        XCTAssertEqual(Set((schemas[1]["properties"] as? [String: Any] ?? [:]).keys), Set(["project", "agents", "since", "starred", "limit"]))
+        XCTAssertEqual(Set((schemas[2]["properties"] as? [String: Any] ?? [:]).keys), Set(["since", "limit"]))
         let snapshot = SessionHistorySnapshot(sessions: [session("native-id", project: "/a/repo")])
         let request = try HistoryCLI.parse(["sessions", "--project", "/a/repo", "--limit", "5", "--agent", "codex"])
         XCTAssertEqual(request.arguments["limit"] as? String, "5")
@@ -71,7 +71,7 @@ final class HistoryToolsTests: XCTestCase {
         XCTAssertTrue(snapshot.sessions.first?.isFavorite == true)
         XCTAssertTrue(snapshot.sessions.first?.isPinned == true)
         XCTAssertTrue(snapshot.sessions.first?.archivedLocally == true)
-        for tool in HistoryCLI.commands.values { _ = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot) }
+        for tool in ["vibebuddy_list_sessions", "vibebuddy_list_projects"] { _ = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot) }
         _ = try await reader.session(id: id)
         _ = try await reader.summary(sessionID: id)
         do { _ = try await reader.refresh(rebuild: true); XCTFail("refresh wrote") } catch {}
@@ -107,7 +107,7 @@ final class HistoryToolsTests: XCTestCase {
         let snapshot = await reader.snapshot()
         XCTAssertEqual(snapshot.sessions.count, 1)
         XCTAssertEqual(snapshot.pendingSourceCount, 1)
-        for tool in HistoryCLI.commands.values {
+        for tool in ["vibebuddy_list_sessions", "vibebuddy_list_projects"] {
             let text = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot)
             XCTAssertTrue(text.contains("Partial index: 1 source(s) pending"))
             XCTAssertTrue(text.contains("older or newer"))

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryTranscriptTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryTranscriptTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class HistoryTranscriptTests: XCTestCase {
+    func testProjectionPagingExpansionAndReferenceParity() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("claude/projects/repo/native.jsonl")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let lines = [
+            ##"{"sessionId":"native","type":"user","message":{"role":"user","content":"# AGENTS.md instructions secret-meta"}}"##,
+            #"{"sessionId":"native","type":"user","message":{"role":"user","content":"Hello"}}"#,
+            #"{"sessionId":"native","type":"assistant","message":{"id":"a","role":"assistant","content":[{"type":"thinking","thinking":"reasoning-detail"},{"type":"text","text":"Answer"},{"type":"tool_use","id":"t","name":"Read","input":{"path":"/file","extra":"input-detail"}}]}}"#,
+            #"{"sessionId":"native","type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t","content":"output-detail"}]}}"#,
+            #"{"sessionId":"native","type":"user","message":{"role":"user","content":"Next"}}"#
+        ]
+        try Data(lines.joined(separator: "\n").utf8).write(to: source)
+        let repository = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: root.appendingPathComponent("codex"), cacheDirectory: root.appendingPathComponent("absent"), readOnly: true)
+        let first = try await HistoryTools.getSession(arguments: ["key": "claude-code:native", "max_messages": 1], repository: repository)
+        XCTAssertTrue(first.hasPrefix("Source revision:")); XCTAssertTrue(first.contains("source, index stale"))
+        XCTAssertTrue(first.contains("[seq 1] User")); XCTAssertTrue(first.contains("from_seq=2")); XCTAssertFalse(first.contains("secret-meta"))
+        let request = try HistoryCLI.parse(["show", "vibebuddy://session/claude-code:native#2", "--max-messages", "1"])
+        let page = try await HistoryTools.getSession(arguments: request.arguments, repository: repository)
+        XCTAssertTrue(page.contains("[seq 2] Assistant")); XCTAssertTrue(page.contains("Tool: Read"))
+        XCTAssertFalse(page.contains("output-detail")); XCTAssertFalse(page.contains("reasoning-detail"))
+        let expanded = try await HistoryTools.getSession(arguments: ["key": "claude-code:native", "from_seq": 2, "max_messages": 1, "tools": true, "thinking": true], repository: repository)
+        XCTAssertTrue(expanded.contains("[seq 2] Assistant")); XCTAssertTrue(expanded.contains("output-detail")); XCTAssertTrue(expanded.contains("reasoning-detail"))
+        let transcript = try await repository.readTranscript(key: "claude-code:native")
+        for message in transcript.session.messages where message.role == .tool { XCTAssertEqual(transcript.seq(messageID: message.id), 2) }
+        let beyond = try await HistoryTools.getSession(arguments: ["key": "claude-code:native", "from_seq": 999], repository: repository)
+        XCTAssertTrue(beyond.contains("End of readable transcript")); XCTAssertFalse(beyond.contains("[seq"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("absent").path))
+        XCTAssertThrowsError(try HistorySessionReference("vibebuddy://session/codex:native#0"))
+        do { _ = try await repository.readTranscript(key: "claude-code:missing"); XCTFail("unknown accepted") } catch HistoryToolError.executionFailed { }
+        let duplicate = source.deletingLastPathComponent().appendingPathComponent("other/native.jsonl")
+        try FileManager.default.createDirectory(at: duplicate.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(lines.joined(separator: "\n").utf8).write(to: duplicate)
+        do { _ = try await repository.readTranscript(key: "claude-code:native"); XCTFail("ambiguity accepted") } catch HistoryToolError.executionFailed { }
+    }
+
+    func testLegacyCacheStaleSourceAndRevisionMismatchNeverWrite() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude"), codex = root.appendingPathComponent("codex"), cache = root.appendingPathComponent("cache")
+        let file = codex.appendingPathComponent("sessions/native.jsonl")
+        try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let header = #"{"type":"session_meta","payload":{"id":"native","cwd":"/repo"}}"#
+        let message = #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"old"}]}}"#
+        try Data((header + "\n" + message).utf8).write(to: file)
+        let writer = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        _ = try await writer.refresh()
+        let before = try bytes(cache)
+        let reader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let warm = try await reader.readTranscript(key: "codex:native")
+        XCTAssertEqual(warm.provenance, "cache")
+        try Data((header + "\n" + message + "\n" + message.replacingOccurrences(of: "old", with: "fresh")).utf8).write(to: file)
+        let stale = try await reader.readTranscript(key: "codex:native")
+        XCTAssertEqual(stale.provenance, "source, index stale")
+        XCTAssertNotEqual(stale.session.sourceRevision, warm.session.sourceRevision)
+        XCTAssertTrue(stale.session.messages.contains { $0.text == "fresh" })
+        // A warm page reuses its single slot, even if an unrelated disk cache becomes unreadable.
+        XCTAssertEqual(try bytes(cache), before)
+        let again = try await reader.readTranscript(key: "codex:native")
+        XCTAssertEqual(again.session, stale.session)
+        let content = try XCTUnwrap(FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil).first { $0.lastPathComponent != "index.json" })
+        var full = try JSONDecoder().decode(SessionHistorySession.self, from: Data(contentsOf: content))
+        full.sourceRevision = "mismatched-revision"
+        try JSONEncoder().encode(full).write(to: content)
+        let mismatchedBefore = try bytes(cache)
+        let freshReader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let mismatched = try await freshReader.readTranscript(key: "codex:native")
+        XCTAssertEqual(mismatched.provenance, "source, index stale")
+        XCTAssertEqual(try bytes(cache), mismatchedBefore)
+    }
+    private func bytes(_ directory: URL) throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil).map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryTranscriptTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryTranscriptTests.swift
@@ -73,6 +73,51 @@ final class HistoryTranscriptTests: XCTestCase {
         XCTAssertEqual(mismatched.provenance, "source, index stale")
         XCTAssertEqual(try bytes(cache), mismatchedBefore)
     }
+    func testNativeArchiveMoveSelectsAvailableSourceWithoutWriting() async throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".scratch/history-archive-" + UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude"), codex = root.appendingPathComponent("codex"), cache = root.appendingPathComponent("cache")
+        let file = codex.appendingPathComponent("sessions/native.jsonl")
+        let archived = codex.appendingPathComponent("archived_sessions/native.jsonl")
+        try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: archived.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let source = #"{"type":"session_meta","payload":{"id":"native","cwd":"/repo"}}"# + "\n" +
+            #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Retain this dialogue after archive"}]}}"#
+        try Data(source.utf8).write(to: file)
+        let writer = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        _ = try await writer.refresh()
+        try FileManager.default.moveItem(at: file, to: archived)
+        let refreshed = try await writer.refresh()
+        XCTAssertEqual(refreshed.sessions.count, 1)
+        let canonical = try XCTUnwrap(refreshed.sessions.first)
+        XCTAssertTrue(canonical.isAvailable)
+        XCTAssertEqual(canonical.sourceArchived, true)
+        let before = try bytes(cache)
+        let index = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: cache.appendingPathComponent("index.json"))) as? [String: Any])
+        let entries = try XCTUnwrap(index["entries"] as? [String: [String: Any]])
+        let persisted = entries.values.compactMap { $0["session"] as? [String: Any] }
+        XCTAssertEqual(persisted.count, 2)
+        XCTAssertTrue(persisted.allSatisfy { $0["nativeSessionID"] as? String == "native" })
+        XCTAssertEqual(persisted.filter { $0["isAvailable"] as? Bool == true }.count, 1)
+        let reader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let transcript = try await reader.readTranscript(key: "codex:native")
+        XCTAssertEqual(transcript.session.sourcePath, canonical.sourcePath)
+        let retained = try await writer.readTranscript(key: "codex:native")
+        XCTAssertEqual(retained.session.sourcePath, canonical.sourcePath)
+        let request = try HistoryCLI.parse(["show", "vibebuddy://session/codex:native#1"])
+        let output = try await HistoryTools.getSession(arguments: request.arguments, repository: reader)
+        XCTAssertTrue(output.contains("[seq 1] User"))
+        XCTAssertTrue(output.contains("Retain this dialogue after archive"))
+        XCTAssertEqual(try bytes(cache), before)
+        // Distinct available files remain ambiguous, unlike the retained unavailable path.
+        try Data(source.utf8).write(to: file)
+        _ = try await writer.refresh()
+        let duplicateReader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        do { _ = try await duplicateReader.readTranscript(key: "codex:native"); XCTFail("available duplicates accepted") }
+        catch HistoryToolError.executionFailed { }
+    }
+
     private func bytes(_ directory: URL) throws -> [String: Data] {
         try Dictionary(uniqueKeysWithValues: FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil).map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
     }


### PR DESCRIPTION
agent-mcp-cli/02

## Summary

Adds `vibebuddy-mcp show KEY|REF` and `vibebuddy_get_session` for bounded, read-only transcript access. A matching cached revision is reused; stale caches fall back to reading the source without writing back. Native keys can locate source files even when no index exists. Unknown or ambiguous keys exit 1.

Readable rows have stable, one-based seq references for a source revision. Meta is omitted, tools are compact by default, and `--tools` / `--thinking` expand details without renumbering rows. The repository exposes a single transcript slot and a precomputed messageID-to-seq mapping for search.

Stacked on ticket01 PR #169 (`codex/agent-mcp-cli-01-sessions-projects`, base a5daee28); this PR contains only ticket02. Do not merge as part of automated execution.

## Validation

- `swift build --package-path VibeBuddyMac --product vibebuddy-mcp`: passed.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml` and macOS `xcodebuild ... CODE_SIGNING_ALLOWED=NO`: passed using this ticket's isolated bundle/build directory.
- 14 real-source CLI calls passed: 6 no-index/error cases and 8 cached-read/ref/expansion calls; all 3 isolated History files byte-identical. Cached and source-read bodies match.
- Real isolated Mac App History compared with all 3 Claude and 7 Codex readable rows and their tool groups. App exited after acceptance.
- Independent code review and incremental review passed.
- `swift test --package-path VibeBuddyMac`: 14 XCTest tests (2 new) plus 1011 Swift Testing tests in 119 suites passed, zero failures. A fixture raw-string delimiter was corrected before this successful run.

- Follow-up P1 regression: physical native archive move → refresh retaining both paths → fresh read-only key/ref read. Failed before448480a2; all3 HistoryTranscriptTests pass after fix, with unchanged bytes and multiple-available ambiguity preserved. Shared `resolveIndexedSession(key:)` exposes the selection rule to dependent tools.

## Not verified here

MCP transport and real client connections belong to ticket05. No user-level agent configuration, installed-app replacement, production daemon interaction, device testing, summary generation, deployment or release was performed.
