### PR TITLE
feat(history): coordinate explicit index refreshes across processes

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryRefreshLock.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryRefreshLock.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Darwin
+
+/// The descriptor stays open for the whole refresh. Never unlink the lock file:
+/// another process may already be waiting on that inode.
+final class HistoryRefreshLock {
+    private let descriptor: Int32
+
+    init(directory: URL) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+                                               attributes: [.posixPermissions: 0o700])
+        descriptor = open(directory.appendingPathComponent(".refresh.lock").path,
+                          O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
+        guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let code = errno
+            close(descriptor)
+            if code == EWOULDBLOCK { throw HistoryToolError.refreshBusy }
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+    }
+
+    deinit { flock(descriptor, LOCK_UN); close(descriptor) }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -2,11 +2,12 @@ import Foundation
 import CoreFoundation
 
 public enum HistoryToolError: Error, LocalizedError {
-    case readOnly, noIndex, invalidArguments(String)
+    case readOnly, noIndex, refreshBusy, invalidArguments(String)
     public var errorDescription: String? {
         switch self {
         case .readOnly: "History repository is read-only."
-        case .noIndex: "No usable index. Open History in the Mac App (index command arrives in a later slice)."
+        case .noIndex: "No usable index. Run vibebuddy-mcp index or open History in the Mac App."
+        case .refreshBusy: "another refresh is running"
         case .invalidArguments(let text): text
         }
     }
@@ -109,7 +110,7 @@ public enum HistoryCLI {
     public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects"]
     public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
         guard let command = argv.first, let tool = commands[command] else {
-            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N]")
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | index [--rebuild]")
         }
         var args: [String: Any] = [:]
         var index = 1

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -39,9 +39,22 @@ public actor SessionHistoryRepository {
         if let data = try? Data(contentsOf: directory.appendingPathComponent("index.json")), let cache = try? JSONDecoder().decode(Cache.self, from: data), [4, 5, 6, 7].contains(cache.version) {
             usableIndex = true
             // Never reuse another configured source home's cached content.
-            let configuredRoots = roots
-            entries = cache.entries.filter { path, _ in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } }
-            pendingPaths = Set((cache.pendingPaths ?? []).filter { path in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } })
+            // A removed leaf cannot resolve symlinks. Keep both spellings of
+            // existing configured roots so /private/var caches survive deletion.
+            let prefixes = roots.flatMap { root, _ -> [String] in
+                var paths = [root.path + "/"]
+                if let physical = realpath(root.path, nil) {
+                    paths.append(String(cString: physical) + "/")
+                    free(physical)
+                }
+                return paths
+            }
+            func belongsToRoots(_ path: String) -> Bool {
+                let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+                return prefixes.contains { path.hasPrefix($0) || resolved.hasPrefix($0) }
+            }
+            entries = cache.entries.filter { belongsToRoots($0.key) }
+            pendingPaths = Set((cache.pendingPaths ?? []).filter(belongsToRoots))
             if cache.version < 7 { pendingPaths.formUnion(entries.keys) }
         }
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import Darwin
 
 /// Local history is a read-only projection, independent of the live Session reducer.
 public actor SessionHistoryRepository {
@@ -12,7 +13,6 @@ public actor SessionHistoryRepository {
     private var favorites = Set<String>()
     private var pins = Set<String>()
     private var archives = Set<String>()
-    private var searchIndex: SessionHistorySearchIndex?
     private var issues: [String] = []
     private var refreshedAt: Date?
     private var pendingPaths = Set<String>()
@@ -65,21 +65,51 @@ public actor SessionHistoryRepository {
     }
     public func refresh(rebuild: Bool = false) throws -> SessionHistorySnapshot {
         guard !readOnly else { throw HistoryToolError.readOnly }
+        let lock: HistoryRefreshLock
+        do { lock = try HistoryRefreshLock(directory: directory) }
+        catch HistoryToolError.refreshBusy {
+            issues = ["another refresh is running; skipped this refresh."]
+            return snapshot()
+        }
+        defer { withExtendedLifetime(lock) {} }
+        return try refreshLocked(rebuild: rebuild)
+    }
+
+    /// Explicit CLI maintenance, never exposed as an MCP tool. A nil result means
+    /// an existing usable index was left alone; contention always throws.
+    public func index(rebuild: Bool = false) throws -> SessionHistorySnapshot? {
+        guard !readOnly else { throw HistoryToolError.readOnly }
+        let lock = try HistoryRefreshLock(directory: directory)
+        defer { withExtendedLifetime(lock) {} }
+        reloadForRefresh()
+        if usableIndex && !rebuild { return nil }
+        return try refreshLocked(rebuild: rebuild, full: true)
+    }
+
+    private func reloadForRefresh() {
+        // Another writer may have advanced a bounded batch since this actor last ran.
+        loaded = false
+        entries = [:]; pendingPaths = []; usableIndex = false
         ensureLoaded()
+    }
+
+    private func refreshLocked(rebuild: Bool, full: Bool = false) throws -> SessionHistorySnapshot {
+        reloadForRefresh()
         let fm = FileManager.default
         issues = []
-        var changed = rebuild
+        var changed = rebuild || !usableIndex
         var cacheFailure: Error?
         var discovered = Set<String>()
         var totalBytes = 0
         var pendingCount = 0
         var excludedChildren = 0
-        if rebuild {
-            searchIndex = nil
-            let indexFile = directory.appendingPathComponent("search.sqlite")
-            if fm.fileExists(atPath: indexFile.path) { try fm.removeItem(at: indexFile) }
-            pendingPaths.formUnion(entries.keys)
-        }
+        // Rebuild into a private database then rename it atomically. Readers with
+        // an open connection finish on the previous complete database; corrupt
+        // derived databases can be replaced without deleting a reader's inode.
+        let staging = rebuild ? directory.appendingPathComponent(".rebuild-" + UUID().uuidString) : nil
+        defer { if let staging { try? fm.removeItem(at: staging) } }
+        let searchIndex = try SessionHistorySearchIndex(directory: staging ?? directory)
+        if rebuild { pendingPaths.formUnion(entries.keys) }
         for (root, agent) in roots {
             guard fm.fileExists(atPath: root.path) else { issues.append("Source directory unavailable: \(root.path)"); continue }
             var enumerationErrors = 0
@@ -99,19 +129,24 @@ public actor SessionHistoryRepository {
                     let size = values.fileSize ?? 0
                     let modified = values.contentModificationDate ?? .distantPast
                     if !pendingPaths.contains(file.path), let cached = entries[file.path], cached.modified == modified, cached.size == size, cached.session.isAvailable { continue }
-                    if totalBytes > 0 && totalBytes + min(size, SessionHistoryParser.byteLimit) > refreshByteBudget {
+                    if !full && totalBytes > 0 && totalBytes + min(size, SessionHistoryParser.byteLimit) > refreshByteBudget {
                         pendingPaths.insert(file.path)
                         pendingCount += 1
                         continue
                     }
                     totalBytes += min(size, SessionHistoryParser.byteLimit)
-                    entries[file.path] = try autoreleasepool {
-                        var session = try SessionHistoryParser.read(url: file, agent: agent, updatedAt: modified)
-                        session.sourceArchived = agent == .codex && root.lastPathComponent == "archived_sessions"
-                        do { try save(session, name: contentFilename(file.path)) } catch { cacheFailure = error; throw error }
-                        session.messages = []
-                        return Entry(modified: modified, size: size, session: session)
+                    var session = try autoreleasepool {
+                        try SessionHistoryParser.read(url: file, agent: agent, updatedAt: modified)
                     }
+                    session.sourceArchived = agent == .codex && root.lastPathComponent == "archived_sessions"
+                    let revision = "\(modified.timeIntervalSince1970)|\(size)"
+                    session.sourceRevision = revision
+                    do {
+                        try save(session, name: contentFilename(file.path))
+                        try searchIndex.replace(session, stamp: "v7|" + revision)
+                    } catch { cacheFailure = error; throw error }
+                    session.messages = []
+                    entries[file.path] = Entry(modified: modified, size: size, session: session)
                     pendingPaths.remove(file.path)
                     changed = true
                 } catch {
@@ -142,12 +177,33 @@ public actor SessionHistoryRepository {
         }
         if excludedChildren > 0 { issues.append("Scope: \(excludedChildren) Claude child-session directories/files excluded from parent history.") }
         if pendingCount > 0 { issues.append("Indexing: \(pendingCount) sources pending; refresh continues the next bounded batch.") }
+        if let cacheFailure { throw cacheFailure }
+        // Migrate old lazy indexes and repair missing FTS rows only while holding
+        // the writer lock. No query ever decodes caches or writes SQLite rows.
+        for entry in entries.values {
+            let stamp = "v7|\(entry.modified.timeIntervalSince1970)|\(entry.size)"
+            if try !searchIndex.isCurrent(path: entry.session.sourcePath, stamp: stamp) {
+                let session = try autoreleasepool { try load(entry.session) }
+                let revision = "\(entry.modified.timeIntervalSince1970)|\(entry.size)"
+                if let cachedRevision = session.sourceRevision, cachedRevision != revision {
+                    issues.append("Not indexed yet: cache revision differs from metadata for \(entry.session.sourcePath).")
+                    continue
+                }
+                try searchIndex.replace(session, stamp: stamp)
+            }
+        }
+        if let staging {
+            guard rename(staging.appendingPathComponent("search.sqlite").path,
+                         directory.appendingPathComponent("search.sqlite").path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
         refreshedAt = Date()
         indexDirty = indexDirty || changed
-        if let cacheFailure { throw cacheFailure }
         if indexDirty {
             try save(Cache(entries: entries, pendingPaths: pendingPaths), name: "index.json")
             indexDirty = false
+            usableIndex = true
         }
         return snapshot()
     }
@@ -162,7 +218,7 @@ public actor SessionHistoryRepository {
         guard full.id == metadata.id, full.sourcePath == metadata.sourcePath else {
             throw CocoaError(.fileReadCorruptFile)
         }
-        full.sourceRevision = metadata.sourceRevision
+        full.sourceRevision = full.sourceRevision ?? metadata.sourceRevision
         full.archivedLocally = metadata.archivedLocally
         full.isPinned = metadata.isPinned
         full.sourceArchived = metadata.sourceArchived
@@ -198,25 +254,13 @@ public actor SessionHistoryRepository {
     public func search(_ query: String, projectPath: String? = nil, favoritesOnly: Bool = false,
                        agent: SessionHistoryAgent? = nil, archived: Bool? = nil,
                        limit: Int = 200) throws -> [SessionHistorySearchResult] {
-        guard !readOnly else { throw HistoryToolError.readOnly }
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty, limit > 0 else { return [] }
         let sessions = snapshot().sessions.filter {
             (projectPath == nil || $0.projectPath == projectPath) && (!favoritesOnly || $0.isFavorite)
                 && (agent == nil || $0.agent == agent) && (archived == nil || $0.isArchived == archived)
         }
-        if searchIndex == nil { searchIndex = try SessionHistorySearchIndex(directory: directory) }
-        guard let searchIndex else { return [] }
-        // Reconcile derived index by source version, including after a restart or cache migration.
-        // Warm queries do not decode transcript caches. A failing cache remains an explicit error.
-        for session in sessions {
-            try Task.checkCancellation()
-            guard let entry = entries[session.sourcePath] else { continue }
-            let stamp = "v7|\(entry.modified.timeIntervalSince1970)|\(entry.size)"
-            if try !searchIndex.isCurrent(path: session.sourcePath, stamp: stamp) {
-                try autoreleasepool { try searchIndex.replace(load(session), stamp: stamp) }
-            }
-        }
+        let searchIndex = try SessionHistorySearchIndex(directory: directory, readOnly: true)
         return try searchIndex.search(needle, sessions: sessions, limit: limit)
     }
     public func summary(sessionID: String) throws -> SessionHistorySummary? {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistorySearchIndex.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistorySearchIndex.swift
@@ -11,18 +11,21 @@ final class SessionHistorySearchIndex {
         var errorDescription: String? { "History search index: \(detail). Rebuild the index to retry." }
     }
 
-    init(directory: URL) throws {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
-                                               attributes: [.posixPermissions: 0o700])
-        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    init(directory: URL, readOnly: Bool = false) throws {
+        if !readOnly {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+                                                   attributes: [.posixPermissions: 0o700])
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        }
         let path = directory.appendingPathComponent("search.sqlite").path
-        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK else {
+        guard sqlite3_open_v2(path, &db, readOnly ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK else {
             let detail = db.map { String(cString: sqlite3_errmsg($0)) } ?? "Cannot open database"
             sqlite3_close(db); db = nil
             throw Failure(detail: detail)
         }
         do {
             sqlite3_busy_timeout(db, 1000)
+            if readOnly { return }
             try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
             try execute("""
                 CREATE TABLE IF NOT EXISTS sources(path TEXT PRIMARY KEY, stamp TEXT NOT NULL);
@@ -72,7 +75,16 @@ final class SessionHistorySearchIndex {
     func search(_ query: String, sessions: [SessionHistorySession], limit: Int) throws -> [SessionHistorySearchResult] {
         let needle = Self.fold(query)
         guard !needle.isEmpty else { return [] }
-        let allowed = Dictionary(uniqueKeysWithValues: sessions.map { ($0.sourcePath, $0) })
+        // Pin isCurrent and the message SELECT to one database snapshot. JSON
+        // publication and SQLite commit may straddle a reader; omit mismatched
+        // revisions instead of attaching new message IDs to old metadata.
+        try execute("BEGIN")
+        defer { try? execute("ROLLBACK") }
+        let current = try sessions.filter {
+            guard let revision = $0.sourceRevision else { return false }
+            return try isCurrent(path: $0.sourcePath, stamp: "v7|" + revision)
+        }
+        let allowed = Dictionary(uniqueKeysWithValues: current.map { ($0.sourcePath, $0) })
         let indexed = needle.unicodeScalars.count >= 3 && !needle.contains("\0")
         let sql = indexed
             ? "SELECT m.path,m.message_id,m.text FROM messages_fts JOIN messages m ON m.id=messages_fts.rowid WHERE messages_fts MATCH ? ORDER BY bm25(messages_fts),m.id"

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -4,10 +4,24 @@ import VibeBuddyMacCore
 @main
 struct VibeBuddyMCP {
     static func main() async {
+        let argv = Array(CommandLine.arguments.dropFirst())
+        let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
+        if argv.first == "index" {
+            guard argv == ["index"] || argv == ["index", "--rebuild"] else {
+                fail(HistoryToolError.invalidArguments("Usage: vibebuddy-mcp index [--rebuild]"), code: 2)
+            }
+            do {
+                let repository = SessionHistoryRepository(cacheDirectory: directory)
+                let snapshot = try await repository.index(rebuild: argv.contains("--rebuild"))
+                let text = snapshot.map { "Indexed \($0.sessions.count) sessions.\n" + $0.issues.joined(separator: "\n") }
+                    ?? "Index already exists. Use --rebuild to refresh all sources."
+                FileHandle.standardOutput.write(Data(HistoryCLI.output(text).utf8))
+                return
+            } catch { fail(error, code: 2) }
+        }
         let request: (tool: String, arguments: [String: Any])
         do { request = try HistoryCLI.parse(Array(CommandLine.arguments.dropFirst())) }
         catch { fail(error, code: 2) }
-        let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
         let repository = SessionHistoryRepository(cacheDirectory: directory, readOnly: true)
         guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
         let snapshot = await repository.snapshot()

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryRefreshCoordinationTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryRefreshCoordinationTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class HistoryRefreshCoordinationTests: XCTestCase {
+    func testLockContentionSkipsAppAndRejectsExplicitIndexThenReleases() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache = root.appendingPathComponent("history")
+        let repository = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"),
+                                                  codexHome: root.appendingPathComponent("codex"), cacheDirectory: cache)
+        var lock: HistoryRefreshLock? = try HistoryRefreshLock(directory: cache)
+        let skipped = try await repository.refresh()
+        XCTAssertTrue(skipped.issues.contains { $0.contains("another refresh is running") })
+        do { _ = try await repository.index(); XCTFail("Index must reject a busy writer") }
+        catch HistoryToolError.refreshBusy { }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cache.appendingPathComponent("index.json").path))
+        withExtendedLifetime(lock) {}
+        lock = nil
+        let created = try await repository.index()
+        XCTAssertNotNil(created)
+        let existing = try await repository.index()
+        XCTAssertNil(existing)
+    }
+
+    func testRefreshPublishesFTSEagerlyAndReloadsOtherWritersWithoutQueryWrites() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude")
+        let codex = root.appendingPathComponent("codex")
+        let cache = root.appendingPathComponent("history")
+        let sources = claude.appendingPathComponent("projects/repo")
+        try FileManager.default.createDirectory(at: sources, withIntermediateDirectories: true)
+        func write(_ id: String, _ message: String) throws {
+            let row: [String: Any] = ["uuid": id, "sessionId": id, "message": ["role": "user", "content": message]]
+            try JSONSerialization.data(withJSONObject: row).write(to: sources.appendingPathComponent(id + ".jsonl"), options: .atomic)
+        }
+        try write("one", "eager 中文 needle")
+        let app = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        _ = try await app.refresh()
+        let oldReader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        _ = await oldReader.snapshot()
+        try write("two", "another needle")
+        let cli = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        _ = try await cli.index(rebuild: true)
+        let refreshed = try await app.refresh()
+        XCTAssertEqual(refreshed.sessions.count, 2)
+        let files = try FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil)
+        let before = try Dictionary(uniqueKeysWithValues: files.map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
+        let reader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let hits = try await reader.search("needle")
+        XCTAssertEqual(hits.count, 2)
+        let chinese = try await reader.search("中文")
+        XCTAssertEqual(chinese.count, 1)
+        let after = try Dictionary(uniqueKeysWithValues: FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil).map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
+        XCTAssertEqual(before, after)
+        try write("one", "changed revision needle")
+        _ = try await cli.index(rebuild: true)
+        let staleHits = try await oldReader.search("needle")
+        XCTAssertTrue(staleHits.isEmpty, "New FTS rows must not be paired with old metadata")
+        // Interrupted publication: a newer content cache outlives the source,
+        // while index.json still names the older revision. Never bless its rows
+        // with the older stamp when rebuilding derived search data.
+        let latest = await cli.snapshot()
+        let first = try XCTUnwrap(latest.sessions.first { $0.nativeSessionID == "one" })
+        let contentFiles = try FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil)
+        let content = try XCTUnwrap(contentFiles.first { file in
+            guard file.lastPathComponent.count == 69,
+                  let data = try? Data(contentsOf: file),
+                  let value = try? JSONDecoder().decode(SessionHistorySession.self, from: data) else { return false }
+            return value.id == first.id
+        })
+        var interrupted = try JSONDecoder().decode(SessionHistorySession.self, from: Data(contentsOf: content))
+        interrupted.sourceRevision = "newer-unpublished-revision"
+        try JSONEncoder().encode(interrupted).write(to: content, options: .atomic)
+        try FileManager.default.removeItem(atPath: first.sourcePath)
+        let repaired = try await cli.index(rebuild: true)
+        XCTAssertTrue(repaired?.issues.contains { $0.contains("cache revision differs") } == true)
+        let safeHits = try await cli.search("changed revision")
+        XCTAssertTrue(safeHits.isEmpty)
+
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -78,7 +78,8 @@ final class HistoryToolsTests: XCTestCase {
         do { try await reader.setFavorite(sessionID: id, isFavorite: false); XCTFail("favorite wrote") } catch {}
         do { try await reader.setPinned(sessionID: id, isPinned: false); XCTFail("pin wrote") } catch {}
         do { try await reader.setArchived(sessionID: id, isArchived: false); XCTFail("archive wrote") } catch {}
-        do { _ = try await reader.search("hello"); XCTFail("search wrote") } catch {}
+        let hits = try await reader.search("hello")
+        XCTAssertEqual(hits.count, 1)
         XCTAssertEqual(try bytes(cache), before)
         let missing = root.appendingPathComponent("missing")
         let empty = SessionHistoryRepository(cacheDirectory: missing, readOnly: true)

--- a/docs/session-history.md
+++ b/docs/session-history.md
@@ -35,8 +35,14 @@ placeholders. There is no syntax-coloring guarantee.
 The app checks sources on opening the library, on Refresh, and every 30 seconds
 while the library is open. Initial indexing advances in bounded batches; pending
 coverage is reported. The local index stores metadata and separate per-source text
-caches under `~/Library/Application Support/VibeBuddy/SessionHistory`. Selected text is loaded for reading; the first query builds missing message indexes
-from cached text. Warm queries reuse those indexes. Conversation timestamps drive
+caches under `~/Library/Application Support/VibeBuddy/SessionHistory`. Selected text is loaded for reading; refresh eagerly builds message indexes.
+Queries open SQLite read-only and omit rows whose source revision differs from
+the loaded metadata. An exclusive `.refresh.lock` coordinates App and CLI refreshes;
+an App refresh skips a busy writer and reports the reason. JSON files publish
+atomically, and SQLite publishes each source in a transaction. Readers see complete
+files and committed matching message revisions, without waiting for the full scan.
+`vibebuddy-mcp index` builds an absent index; `index --rebuild` refreshes all sources.
+The explicit command exits 2 when another refresh holds the lock. Conversation timestamps drive
 list order, with file timestamps as a fallback. Agent-injected setup blocks remain
 searchable but are excluded when deriving titles. Rebuild index re-reads the sources; favorites, pins and library archives are saved
 separately and retained. Missing sources retain their last indexed copy with an


### PR DESCRIPTION
agent-mcp-cli/03

## Summary

Add explicit `vibebuddy-mcp index [--rebuild]` and coordinate it with Mac History refresh through a nonblocking process lock. The App skips a busy refresh with a source notice; CLI contention exits 2. Existing indexes require `--rebuild`.

Refresh eagerly publishes FTS rows; queries open SQLite read-only and match source revisions in one read transaction. Full rebuilds atomically replace a staged database. Preserve missing-source caches across macOS path aliases and reject mismatched cache revisions after interrupted publication.

Stacked on `codex/agent-mcp-cli-01-sessions-projects` (PR #169, base a5daee28). No merge requested.

## Validation

- `swift build --package-path VibeBuddyMac --product vibebuddy-mcp` passed.
- Targeted history regressions: 14 tests passed. Full final `swift test --package-path VibeBuddyMac --skip-build`: 14 XCTest plus 1011 Swift Testing tests in 119 suites passed.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml`; macOS `xcodebuild` with `CODE_SIGNING_ALLOWED=NO` and isolated bundle/derived-data directory passed.
- Separate processes: 30 rebuilds with 200 concurrent listings, 31 complete generations, no mixed snapshots; lock contention exit 2; killed owner releases lock; SQLite integrity ok.
- Real-source-copy isolated App acceptance in both directions: 200 listings per direction, zero errors. CLI completed 40 rebuilds while App History remained usable; App displayed its busy-refresh notice. Source content hashes unchanged.
- Independent review completed; material findings fixed and regression-tested.

## Not verified here

Installed App replacement, physical devices and MCP client setup are outside this ticket.

Cleanup correction: a post-quit accessibility request apparently relaunched the test build; the original PID-only cleanup missed that second process. The coordinator later terminated the exact build and confirmed no matching process remained. Its launch environment and data-path effects were not inspected, so the configured acceptance run does not prove that the relaunched process retained isolation or caused no default-path effects. The concurrency results above remain scoped to the configured test run. No product code changed for this cleanup.
