### PR TITLE
feat(history): serve read-only tools over stdio MCP

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryMCPServer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryMCPServer.swift
@@ -1,0 +1,83 @@
+import Foundation
+import CoreFoundation
+
+/// A single stdio connection. Only read-only tools are advertised; application
+/// execution is delegated unchanged to the same executor the CLI uses.
+@MainActor
+public final class HistoryMCPServer {
+    public static let protocolVersions = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
+    private let executor: HistoryToolExecutor
+    private var initialized = false
+
+    public init(executor: HistoryToolExecutor) { self.executor = executor }
+
+    /// One newline-delimited frame in; one JSON frame out (without its delimiter).
+    /// Notifications never produce a response, including unknown notifications.
+    public func response(to data: Data) async throws -> Data? {
+        let object: Any
+        do { object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) }
+        catch { return try encodeError(id: NSNull(), code: -32700, message: "Parse error") }
+        guard let request = object as? [String: Any], request["jsonrpc"] as? String == "2.0",
+              let method = request["method"] as? String else {
+            return try encodeError(id: NSNull(), code: -32600, message: "Invalid request")
+        }
+        guard let id = request["id"] else { return nil }
+        guard Self.validID(id) else { return try encodeError(id: NSNull(), code: -32600, message: "Invalid request id") }
+        do {
+            guard request["params"] == nil || request["params"] is [String: Any] else {
+                throw HistoryToolError.invalidArguments("params must be an object")
+            }
+            let params = request["params"] as? [String: Any] ?? [:]
+            let result: [String: Any]
+            switch method {
+            case "initialize":
+                guard !initialized, let version = params["protocolVersion"] as? String,
+                      params["capabilities"] is [String: Any],
+                      let client = params["clientInfo"] as? [String: Any],
+                      client["name"] is String, client["version"] is String else {
+                    throw HistoryToolError.invalidArguments("initialize requires protocolVersion, capabilities and clientInfo; initialize once per connection")
+                }
+                initialized = true
+                result = ["protocolVersion": Self.protocolVersions.contains(version) ? version : Self.protocolVersions[0],
+                          "capabilities": ["tools": ["listChanged": false]],
+                          "serverInfo": ["name": "vibebuddy", "version": "1.0.0"]]
+            case "ping": result = [:]
+            case "tools/list":
+                guard initialized else { throw HistoryToolError.invalidArguments("Initialize the connection first") }
+                guard params["cursor"] == nil else { throw HistoryToolError.invalidArguments("This tool list is not paginated") }
+                result = ["tools": HistoryTools.definitions()]
+            case "tools/call":
+                guard initialized else { throw HistoryToolError.invalidArguments("Initialize the connection first") }
+                guard let name = params["name"] as? String,
+                      params["arguments"] == nil || params["arguments"] is [String: Any] else {
+                    throw HistoryToolError.invalidArguments("tools/call requires a name and an arguments object")
+                }
+                let arguments = params["arguments"] as? [String: Any] ?? [:]
+                do {
+                    let text = try await executor.execute(name, arguments: arguments)
+                    result = Self.toolResult(text, isError: false)
+                } catch HistoryToolError.invalidArguments(let message) {
+                    throw HistoryToolError.invalidArguments(message)
+                } catch {
+                    result = Self.toolResult(error.localizedDescription, isError: true)
+                }
+            default: return try encodeError(id: id, code: -32601, message: "Method not found")
+            }
+            return try JSONSerialization.data(withJSONObject: ["jsonrpc": "2.0", "id": id, "result": result], options: [.sortedKeys])
+        } catch HistoryToolError.invalidArguments(let message) {
+            return try encodeError(id: id, code: -32602, message: message)
+        }
+    }
+
+    private static func toolResult(_ text: String, isError: Bool) -> [String: Any] {
+        ["content": [["type": "text", "text": text]], "isError": isError]
+    }
+    private static func validID(_ value: Any) -> Bool {
+        if value is String { return true }
+        guard let number = value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID() else { return false }
+        return number.doubleValue.isFinite && number.doubleValue.rounded() == number.doubleValue
+    }
+    private func encodeError(id: Any, code: Int, message: String) throws -> Data {
+        try JSONSerialization.data(withJSONObject: ["jsonrpc": "2.0", "id": id, "error": ["code": code, "message": message]], options: [.sortedKeys])
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryToolExecutor.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryToolExecutor.swift
@@ -1,0 +1,85 @@
+import Foundation
+import CoreFoundation
+
+/// Both CLI and MCP route through this entry; new tools add business routing here,
+/// never in the protocol adapter. The caller supplies a read-only repository.
+public struct HistoryToolExecutor: Sendable {
+    public let repository: SessionHistoryRepository
+    public init(repository: SessionHistoryRepository) { self.repository = repository }
+
+    public static func requiresIndex(_ name: String) -> Bool {
+        ["vibebuddy_list_sessions", "vibebuddy_list_projects"].contains(name)
+    }
+
+    public func execute(_ name: String, arguments: [String: Any], isolation: isolated (any Actor)? = #isolation) async throws -> String {
+        try HistoryTools.validateArguments(name, arguments: arguments)
+        if Self.requiresIndex(name) {
+            try await repository.reloadReadOnlyMetadata()
+            guard await repository.hasUsableIndex() else { throw HistoryToolError.noIndex }
+            let snapshot = await repository.snapshot()
+            do { return try HistoryTools.call(name, arguments: arguments, snapshot: snapshot) }
+            catch HistoryToolError.invalidArguments(let message) {
+                // Shape already passed the schema. Date syntax and other domain
+                // failures are tool results that the model can act on.
+                throw HistoryToolError.invalidValue(message)
+            }
+        }
+        throw HistoryToolError.executionFailed("Tool execution is unavailable: \(name)")
+    }
+}
+
+extension HistoryTools {
+    /// CLI flags reach the tool layer unchanged. Only this shared layer interprets
+    /// their scalar representation; JSON `call` and MCP skip this normalization.
+    public static func normalizeCLIArguments(_ name: String, arguments: [String: Any]) throws -> [String: Any] {
+        let schema = try inputSchema(name)
+        let properties = schema["properties"] as? [String: [String: Any]] ?? [:]
+        var result = arguments
+        for (key, value) in arguments where properties[key]?["type"] as? String == "integer" {
+            if let text = value as? String, let integer = Int(text) { result[key] = integer }
+        }
+        return result
+    }
+
+    /// Validate the schema subset used by our definitions. Unknown schema types
+    /// fail closed so adding a tool cannot silently weaken input validation.
+    public static func validateArguments(_ name: String, arguments: [String: Any]) throws {
+        let schema = try inputSchema(name)
+        let properties = schema["properties"] as? [String: [String: Any]] ?? [:]
+        for key in schema["required"] as? [String] ?? [] where arguments[key] == nil {
+            throw HistoryToolError.invalidArguments("Missing argument: \(key)")
+        }
+        for (key, value) in arguments {
+            guard let property = properties[key] else { throw HistoryToolError.invalidArguments("Unknown argument: \(key)") }
+            guard matches(value, schema: property) else { throw HistoryToolError.invalidArguments("Invalid argument: \(key)") }
+        }
+    }
+
+    private static func inputSchema(_ name: String) throws -> [String: Any] {
+        guard let definition = definitions().first(where: { $0["name"] as? String == name }),
+              let schema = definition["inputSchema"] as? [String: Any] else {
+            throw HistoryToolError.invalidArguments("Unknown tool: \(name)")
+        }
+        return schema
+    }
+
+    private static func matches(_ value: Any, schema: [String: Any]) -> Bool {
+        switch schema["type"] as? String {
+        case "string":
+            guard let text = value as? String else { return false }
+            return (schema["enum"] as? [String]).map { $0.contains(text) } ?? true
+        case "boolean":
+            return (value as? NSNumber).map { CFGetTypeID($0) == CFBooleanGetTypeID() } ?? false
+        case "integer":
+            guard let number = value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID(),
+                  number.doubleValue.isFinite, number.doubleValue.rounded() == number.doubleValue else { return false }
+            if let minimum = schema["minimum"] as? NSNumber, number.doubleValue < minimum.doubleValue { return false }
+            if let maximum = schema["maximum"] as? NSNumber, number.doubleValue > maximum.doubleValue { return false }
+            return true
+        case "array":
+            guard let items = value as? [Any], let itemSchema = schema["items"] as? [String: Any] else { return false }
+            return items.allSatisfy { matches($0, schema: itemSchema) }
+        default: return false
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -2,12 +2,12 @@ import Foundation
 import CoreFoundation
 
 public enum HistoryToolError: Error, LocalizedError {
-    case readOnly, noIndex, invalidArguments(String)
+    case readOnly, noIndex, invalidArguments(String), invalidValue(String), executionFailed(String)
     public var errorDescription: String? {
         switch self {
         case .readOnly: "History repository is read-only."
-        case .noIndex: "No usable index. Open History in the Mac App (index command arrives in a later slice)."
-        case .invalidArguments(let text): text
+        case .noIndex: "No usable index. Run vibebuddy-mcp index or open History in the Mac App."
+        case .invalidArguments(let text), .invalidValue(let text), .executionFailed(let text): text
         }
     }
 }
@@ -108,8 +108,15 @@ public enum HistoryTools {
 public enum HistoryCLI {
     public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects"]
     public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
+        if argv.first == "call" {
+            guard argv.count == 3, let data = argv[2].data(using: .utf8),
+                  let arguments = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+                throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp call <tool> '<JSON object>'")
+            }
+            return (argv[1], arguments)
+        }
         guard let command = argv.first, let tool = commands[command] else {
-            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N]")
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | call <tool> '<JSON object>'; no arguments starts stdio MCP")
         }
         var args: [String: Any] = [:]
         var index = 1

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -45,6 +45,20 @@ public actor SessionHistoryRepository {
             if cache.version < 7 { pendingPaths.formUnion(entries.keys) }
         }
     }
+    /// Long-lived MCP readers see the next atomically published metadata files.
+    /// This deliberately leaves transcript caches alone and never invokes refresh.
+    public func reloadReadOnlyMetadata() throws {
+        guard readOnly else { throw HistoryToolError.executionFailed("Metadata reload requires a read-only repository.") }
+        loaded = false
+        usableIndex = false
+        entries.removeAll()
+        favorites.removeAll()
+        pins.removeAll()
+        archives.removeAll()
+        pendingPaths.removeAll()
+        ensureLoaded()
+    }
+
     public func hasUsableIndex() -> Bool { ensureLoaded(); return usableIndex }
 
     public func snapshot() -> SessionHistorySnapshot {

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -1,23 +1,78 @@
 import Foundation
+import Darwin
 import VibeBuddyMacCore
 
 @main
 struct VibeBuddyMCP {
+    @MainActor
     static func main() async {
-        let request: (tool: String, arguments: [String: Any])
-        do { request = try HistoryCLI.parse(Array(CommandLine.arguments.dropFirst())) }
-        catch { fail(error, code: 2) }
+        signal(SIGPIPE, SIG_IGN)
+        let argv = Array(CommandLine.arguments.dropFirst())
         let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
         let repository = SessionHistoryRepository(cacheDirectory: directory, readOnly: true)
-        guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
-        let snapshot = await repository.snapshot()
+        let executor = HistoryToolExecutor(repository: repository)
+        if argv.isEmpty {
+            // When every registered tool needs the index, fail startup helpfully.
+            // Adding source-only/show or live tools allows them to start without it;
+            // each indexed call still checks its own prerequisite in the executor.
+            let names = HistoryTools.definitions().compactMap { $0["name"] as? String }
+            if names.allSatisfy(HistoryToolExecutor.requiresIndex), !(await repository.hasUsableIndex()) {
+                fail(HistoryToolError.noIndex, code: 2)
+            }
+            do { try await serve(HistoryMCPServer(executor: executor)) }
+            catch { fail(error, code: 1) }
+            return
+        }
+        let request: (tool: String, arguments: [String: Any])
+        do { request = try HistoryCLI.parse(argv) }
+        catch { fail(error, code: 2) }
         do {
-            let text = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: snapshot)
-            FileHandle.standardOutput.write(Data(HistoryCLI.output(text).utf8))
+            let arguments = argv.first == "call" ? request.arguments : try HistoryTools.normalizeCLIArguments(request.tool, arguments: request.arguments)
+            let text = try await executor.execute(request.tool, arguments: arguments)
+            try FileHandle.standardOutput.write(contentsOf: Data(HistoryCLI.output(text).utf8))
+        } catch HistoryToolError.noIndex { fail(HistoryToolError.noIndex, code: 2) }
+        catch HistoryToolError.invalidValue(let message) {
+            fail(HistoryToolError.invalidValue(message), code: argv.first == "call" ? 1 : 2)
         } catch HistoryToolError.invalidArguments(let message) {
-            fail(HistoryToolError.invalidArguments(message), code: 2)
+            fail(HistoryToolError.invalidArguments(message), code: argv.first == "call" ? 1 : 2)
         } catch { fail(error, code: 1) }
     }
+
+    /// Bounded newline framing. read(2) returns available bytes rather than
+    /// waiting to fill a buffer, so interactive clients receive replies promptly.
+    @MainActor
+    private static func serve(_ server: HistoryMCPServer) async throws {
+        let frameLimit = 1024 * 1024
+        var pending = Data()
+        var scannedBytes = 0
+        var chunk = [UInt8](repeating: 0, count: 8192)
+        while true {
+            let count = Darwin.read(STDIN_FILENO, &chunk, chunk.count)
+            if count < 0 {
+                if errno == EINTR { continue }
+                throw HistoryToolError.executionFailed("Unable to read MCP stdin")
+            }
+            if count == 0 {
+                if !pending.isEmpty { throw HistoryToolError.executionFailed("MCP stdin ended before a newline delimiter") }
+                return
+            }
+            pending.append(contentsOf: chunk.prefix(count))
+            while let newline = pending.dropFirst(scannedBytes).firstIndex(of: 10) {
+                guard pending.distance(from: pending.startIndex, to: newline) <= frameLimit else {
+                    throw HistoryToolError.executionFailed("MCP request exceeds the 1 MiB frame limit")
+                }
+                let frame = Data(pending[..<newline])
+                pending.removeSubrange(...newline)
+                scannedBytes = 0
+                if let response = try await server.response(to: frame) {
+                    try FileHandle.standardOutput.write(contentsOf: response + Data([10]))
+                }
+            }
+            scannedBytes = pending.count
+            guard pending.count <= frameLimit else { throw HistoryToolError.executionFailed("MCP request exceeds the 1 MiB frame limit") }
+        }
+    }
+
     private static func fail(_ error: Error, code: Int32) -> Never {
         FileHandle.standardError.write(Data("vibebuddy-mcp: \(error.localizedDescription)\n".utf8))
         exit(code)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/Fixtures/history-mcp-tools.json
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/Fixtures/history-mcp-tools.json
@@ -1,0 +1,66 @@
+[
+  {
+    "name": "vibebuddy_list_sessions",
+    "description": "List indexed local sessions, newest activity first.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "string"
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "claude-code",
+              "codex"
+            ]
+          }
+        },
+        "since": {
+          "type": "string"
+        },
+        "starred": {
+          "type": "boolean"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200
+        }
+      },
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  {
+    "name": "vibebuddy_list_projects",
+    "description": "List projects with indexed sessions, newest activity first.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "since": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200
+        }
+      },
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  }
+]

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryMCPTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryMCPTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+@MainActor
+final class HistoryMCPTests: XCTestCase {
+    private func fixture() async throws -> (URL, SessionHistoryRepository) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let claude = root.appendingPathComponent("claude"), codex = root.appendingPathComponent("codex")
+        let source = codex.appendingPathComponent("sessions/one.jsonl")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data((#"{"type":"session_meta","payload":{"id":"native","cwd":"/repo","source":"cli"}}"# + "\n" + #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"中文 context"}]}}"#).utf8).write(to: source)
+        let directory = root.appendingPathComponent("history")
+        let writer = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: directory)
+        _ = try await writer.refresh()
+        return (root, SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: directory, readOnly: true))
+    }
+    private func request(_ server: HistoryMCPServer, _ method: String, _ params: [String: Any] = [:]) async throws -> [String: Any] {
+        let data = try JSONSerialization.data(withJSONObject: ["jsonrpc": "2.0", "id": "request", "method": method, "params": params])
+        let response = try await server.response(to: data)
+        return try JSONSerialization.jsonObject(with: XCTUnwrap(response)) as! [String: Any]
+    }
+    private func initialize(_ server: HistoryMCPServer, version: String = "2025-11-25") async throws -> [String: Any] {
+        try await request(server, "initialize", ["protocolVersion": version, "capabilities": [:], "clientInfo": ["name": "test", "version": "1"]])
+    }
+    private func text(_ response: [String: Any]) throws -> String {
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        return try XCTUnwrap((result["content"] as? [[String: Any]])?.first?["text"] as? String)
+    }
+
+    func testLifecycleRegistrySnapshotAndNotifications() async throws {
+        let (root, repository) = try await fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let server = HistoryMCPServer(executor: HistoryToolExecutor(repository: repository))
+        let early = try await request(server, "tools/list")
+        XCTAssertEqual((early["error"] as? [String: Any])?["code"] as? Int, -32602)
+        let initialized = try await initialize(server, version: "future-version")
+        XCTAssertEqual((initialized["result"] as? [String: Any])?["protocolVersion"] as? String, "2025-11-25")
+        let notification = try await server.response(to: Data(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.utf8))
+        XCTAssertNil(notification)
+        let listed = try await request(server, "tools/list")
+        let tools = try XCTUnwrap((listed["result"] as? [String: Any])?["tools"] as? [[String: Any]])
+        let expected = Bundle.module.url(forResource: "history-mcp-tools", withExtension: "json", subdirectory: "Fixtures")!
+        let actualData = try JSONSerialization.data(withJSONObject: tools, options: [.sortedKeys])
+        let expectedData = try JSONSerialization.data(withJSONObject: JSONSerialization.jsonObject(with: Data(contentsOf: expected)), options: [.sortedKeys])
+        XCTAssertEqual(actualData, expectedData)
+        let names = tools.compactMap { $0["name"] as? String }
+        XCTAssertEqual(Set(names), Set(HistoryCLI.commands.values))
+        XCTAssertEqual(names.count, HistoryCLI.commands.count)
+        let unknown = try await request(server, "write/anything")
+        XCTAssertEqual((unknown["error"] as? [String: Any])?["code"] as? Int, -32601)
+    }
+
+    func testSharedExecutionParityErrorsEmptyResultsAndUnchangedStore() async throws {
+        let (root, repository) = try await fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = root.appendingPathComponent("history")
+        func bytes() throws -> [String: Data] {
+            try Dictionary(uniqueKeysWithValues: FileManager.default.contentsOfDirectory(at: store, includingPropertiesForKeys: nil).map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
+        }
+        let before = try bytes()
+        let executor = HistoryToolExecutor(repository: repository)
+        let server = HistoryMCPServer(executor: executor)
+        _ = try await initialize(server)
+        for (command, name) in HistoryCLI.commands {
+            let parsed = try HistoryCLI.parse([command, "--limit", "5"])
+            XCTAssertEqual(parsed.arguments["limit"] as? String, "5")
+            let arguments = try HistoryTools.normalizeCLIArguments(name, arguments: parsed.arguments)
+            let cli = try await executor.execute(name, arguments: arguments)
+            let response = try await request(server, "tools/call", ["name": name, "arguments": ["limit": 5]])
+            XCTAssertEqual(Data(HistoryCLI.output(cli).utf8), Data((try text(response) + "\n").utf8))
+            let call = try HistoryCLI.parse(["call", name, #"{"limit":5}"#])
+            let called = try await executor.execute(call.tool, arguments: call.arguments)
+            XCTAssertEqual(called, cli)
+        }
+        let malformed = try await request(server, "tools/call", ["name": "vibebuddy_list_sessions", "arguments": ["limit": "5"]])
+        XCTAssertEqual((malformed["error"] as? [String: Any])?["code"] as? Int, -32602)
+        let failed = try await request(server, "tools/call", ["name": "vibebuddy_list_sessions", "arguments": ["since": "yesterday"]])
+        XCTAssertNil(failed["error"])
+        XCTAssertEqual((failed["result"] as? [String: Any])?["isError"] as? Bool, true)
+        XCTAssertTrue(try text(failed).contains("Invalid since"))
+        let empty = try await request(server, "tools/call", ["name": "vibebuddy_list_sessions", "arguments": ["since": "2999-01-01"]])
+        XCTAssertEqual((empty["result"] as? [String: Any])?["isError"] as? Bool, false)
+        XCTAssertTrue(try text(empty).contains("No sessions found"))
+        XCTAssertEqual(try bytes(), before)
+    }
+
+    func testLongLivedConnectionSeesPublishedMetadata() async throws {
+        let (root, repository) = try await fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let server = HistoryMCPServer(executor: HistoryToolExecutor(repository: repository))
+        _ = try await initialize(server)
+        let params: [String: Any] = ["name": "vibebuddy_list_sessions", "arguments": ["starred": true]]
+        let first = try await request(server, "tools/call", params)
+        XCTAssertTrue(try text(first).contains("No sessions found"))
+        let writer = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: root.appendingPathComponent("codex"), cacheDirectory: root.appendingPathComponent("history"))
+        let snapshot = await writer.snapshot()
+        let id = try XCTUnwrap(snapshot.sessions.first?.id)
+        try await writer.setFavorite(sessionID: id, isFavorite: true)
+        let second = try await request(server, "tools/call", params)
+        XCTAssertTrue(try text(second).contains("codex:native"))
+        let source = root.appendingPathComponent("codex/sessions/two.jsonl")
+        try Data(#"{"type":"session_meta","payload":{"id":"second","cwd":"/repo","source":"cli"}}"#.utf8).write(to: source)
+        _ = try await writer.refresh()
+        let third = try await request(server, "tools/call", ["name": "vibebuddy_list_sessions"])
+        XCTAssertTrue(try text(third).contains("codex:second"))
+    }
+
+    func testMalformedJSONAndShapeAreProtocolErrors() async throws {
+        let (root, repository) = try await fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let server = HistoryMCPServer(executor: HistoryToolExecutor(repository: repository))
+        let response = try await server.response(to: Data("{".utf8))
+        let invalid = try JSONSerialization.jsonObject(with: XCTUnwrap(response)) as! [String: Any]
+        XCTAssertEqual((invalid["error"] as? [String: Any])?["code"] as? Int, -32700)
+        _ = try await initialize(server)
+        let shape = try await request(server, "tools/call", ["name": "vibebuddy_list_sessions", "arguments": []])
+        XCTAssertEqual((shape["error"] as? [String: Any])?["code"] as? Int, -32602)
+        XCTAssertThrowsError(try HistoryCLI.parse(["call", "vibebuddy_list_sessions", "[]"]))
+        for arguments: [String: Any] in [["limit": true], ["starred": 1], ["limit": 1.5], ["unexpected": "x"]] {
+            XCTAssertThrowsError(try HistoryTools.validateArguments("vibebuddy_list_sessions", arguments: arguments))
+        }
+    }
+}


### PR DESCRIPTION
agent-mcp-cli/05

## Summary

Running `vibebuddy-mcp` without arguments now serves read-only MCP tools over stdio. CLI commands and `call <tool> '<json>'` share an asynchronous execution entry, schema validation and output text. Long-lived connections reload published read-only metadata so subsequent calls see index and favorite updates. The transport handles initialization, tool discovery/calls, ping, protocol errors, EOF and bounded newline frames.

Stacked on `codex/agent-mcp-cli-02-show-transcript` (PR #171), which includes ticket01. Ticket02 is now an explicit dependency so its real `get_session` implementation shares the CLI/MCP executor and validates key/reference behavior end to end. Source-only transcript reads remain available without an index; list tools report the working Open History recovery path. No write operations are introduced.

## Validation

- `swift build --package-path VibeBuddyMac --product vibebuddy-mcp -j 2`: passed.
- Initial standalone05 full suite: 16 XCTest tests and 1011 Swift Testing tests in 119 suites passed, zero failures. Current transcript-integration regression: `swift test --package-path VibeBuddyMac -j 2 --filter 'History(MCP|Tools|Transcript)Tests'` passed 12 XCTest tests, zero failures.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml`: passed.
- `xcodebuild -project VibeBuddyMacApp/VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -derivedDataPath .scratch/build-05 PRODUCT_BUNDLE_IDENTIFIER=com.vibebuddy.e2e.agent-mcp-cli-05 -jobs 2 build`: BUILD SUCCEEDED. The final transcript-integration incremental build also passed with BUILD SUCCEEDED (exit 0); no App was installed or launched.

- 13 real binary process checks and 7 real-source transcript integration checks passed, including CLI/MCP key/ref byte parity, malformed/absent key errors, source-only reads without an index, exit codes, EOF and oversized input.
- 5 copied store files and 4 real-source transcript copies remained byte-identical.
- Real Claude Code sessions verified list_sessions and, after integration, discovered all three tools and called get_session with a real reference; both tool results matched CLI bytes exactly apart from the trailing newline. Hooks were disabled, user config writes and production port access were denied by a local sandbox, and the temporary command-local MCP configuration was removed.
- Independent review found stale metadata in a long-lived reader; fixed and re-reviewed.

## Not verified here

Packaging and additional client setup belong to later tickets; no installation or user-level MCP registration was performed. Literal bad-key wire behavior is now verified with the real get_session implementation.
