### PR TITLE
feat(mcp): observe live sessions by checkout

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/Models.swift
@@ -465,6 +465,8 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
     public let id: String
     public let agent: AgentKind
     public var project: String
+    /// Full local checkout directory, independent of terminal/jump capabilities.
+    public var checkoutPath: String?
     /// Read-only stored conversation; no live task state is known.
     public var historyOnly: Bool? = nil
     public var branch: String?
@@ -561,6 +563,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         id: String,
         agent: AgentKind,
         project: String,
+        checkoutPath: String? = nil,
         branch: String? = nil,
         model: String? = nil,
         status: SessionStatus,
@@ -598,6 +601,7 @@ public struct AgentSession: Codable, Identifiable, Sendable, Equatable {
         self.id = id
         self.agent = agent
         self.project = project
+        self.checkoutPath = checkoutPath
         self.branch = branch
         self.model = model
         self.status = status

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryLiveStatus.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryLiveStatus.swift
@@ -1,0 +1,105 @@
+import Foundation
+import VibeBuddyKit
+
+/// Optional live observation. Never sends a session action or changes local state.
+public enum HistoryLiveStatus {
+    public static var definition: [String: Any] {
+        ["name": "vibebuddy_live_status", "description": "Read live sessions grouped by checkout; an optional collaboration hint, not a lock.",
+         "inputSchema": ["type": "object", "properties": ["project": ["type": "string"], "exclude_session": ["type": "string"]], "additionalProperties": false],
+         "annotations": ["readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false]]
+    }
+
+    public static func call(arguments: [String: Any], environment: [String: String] = ProcessInfo.processInfo.environment,
+                            fetch: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil) async throws -> String {
+        let options = try Options(arguments: arguments, callerID: environment["CODEX_THREAD_ID"])
+        guard environment["VIBEBUDDY_PORT"] == nil || environment["VIBEBUDDY_PORT"].flatMap(Int.init) != nil else { return "live status unknown (invalid daemon port)" }
+        let port = environment["VIBEBUDDY_PORT"].flatMap(Int.init) ?? 9876
+        guard (1...65535).contains(port) else { return "live status unknown (invalid daemon port)" }
+        let token = environment["VIBEBUDDY_TOKEN"] ?? TokenStore.defaultStore().load()
+        guard let token, !token.isEmpty, !token.contains(where: { $0.isNewline }) else {
+            return unknown(port: port)
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 2
+        config.timeoutIntervalForResource = 2
+        config.httpShouldSetCookies = false
+        config.urlCache = nil
+        config.connectionProxyDictionary = [:]
+        let session = URLSession(configuration: config, delegate: NoRedirects(), delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/snapshot")!)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 2
+        request.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response): (Data, URLResponse)
+            if let fetch { (data, response) = try await fetch(request) }
+            else { (data, response) = try await session.data(for: request) }
+            guard let response = response as? HTTPURLResponse, response.statusCode == 200,
+                  data.count <= 8 * 1024 * 1024 else { return unknown(port: port) }
+            let snapshot = try JSONDecoder().decode(Snapshot.self, from: data)
+            return render(snapshot, project: options.project, excludeSession: options.excludeSession)
+                .replacingOccurrences(of: token, with: "[redacted]")
+        } catch { return unknown(port: port) }
+    }
+
+    public static func render(_ snapshot: Snapshot, project: String?, excludeSession: String?) -> String {
+        let current = SessionCurrency.current(snapshot.sessions, now: snapshot.serverTime).filter { $0.historyOnly != true }
+        let grouped = Dictionary(grouping: current.filter { $0.id != excludeSession }, by: checkout)
+        var paths = Set(current.map(checkout)).sorted()
+        if let project {
+            let matching = project.hasPrefix("/") ? [project] : paths.filter { URL(fileURLWithPath: $0).lastPathComponent == project }
+            guard matching.count == 1 else {
+                return (["Live status: project not found or ambiguous. Known checkouts:"] + paths.map { "- " + line($0) } + ["Collaboration hint only; this observation does not reserve a checkout."]).joined(separator: "\n")
+            }
+            paths = matching
+        }
+        paths = paths.filter { !(grouped[$0] ?? []).isEmpty }
+        var lines = ["Live status (collaboration hint only)", "Observed: " + ISO8601DateFormatter().string(from: snapshot.serverTime)]
+        if excludeSession == nil { lines.append("Caller session unknown; pass --exclude-session with your own session id to exclude it.") }
+        if paths.isEmpty { lines.append("No other live sessions found.") }
+        for path in paths {
+            lines.append("\n## " + line(path))
+            let rows = grouped[path, default: []].sorted { $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt > $1.updatedAt }
+            if rows.contains(where: { $0.status == .working }) {
+                lines.append(path.hasPrefix("/") ? "Another agent is working in this checkout." : "An agent is working; checkout directory unknown.")
+            }
+            for row in rows {
+                lines.append("- " + line(row.id) + " | agent: " + row.agent.rawValue + " | " + row.status.rawValue
+                    + " | waitKind: " + (row.waitKind?.rawValue ?? "none")
+                    + " | controlChannel: " + (row.controlChannel?.rawValue ?? "unknown")
+                    + " | last activity: " + ISO8601DateFormatter().string(from: row.updatedAt))
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func checkout(_ session: AgentSession) -> String {
+        if let cwd = session.terminalRef?.cwd, cwd.hasPrefix("/") { return cwd }
+        return session.project.hasPrefix("/") ? session.project : "unknown checkout (" + session.project + ")"
+    }
+    private static func line(_ text: String) -> String { text.components(separatedBy: .controlCharacters).joined(separator: " ") }
+    private static func unknown(port: Int) -> String { "live status unknown (daemon not reachable at 127.0.0.1:\(port))" }
+
+    private struct Options {
+        let project: String?
+        let excludeSession: String?
+        init(arguments: [String: Any], callerID: String?) throws {
+            for (key, value) in arguments {
+                guard ["project", "exclude_session"].contains(key), value is String else {
+                    // Do not echo arbitrary input: it might contain a credential.
+                    throw HistoryToolError.invalidArguments("Live status accepts only string project and exclude_session arguments.")
+                }
+            }
+            project = arguments["project"] as? String
+            let explicit = arguments["exclude_session"] as? String
+            excludeSession = (explicit ?? callerID).flatMap { $0.isEmpty ? nil : $0 }
+        }
+    }
+    private final class NoRedirects: NSObject, URLSessionTaskDelegate {
+        func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse,
+                        newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+            completionHandler(nil)
+        }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryLiveStatus.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryLiveStatus.swift
@@ -48,7 +48,7 @@ public enum HistoryLiveStatus {
         let grouped = Dictionary(grouping: current.filter { $0.id != excludeSession }, by: checkout)
         var paths = Set(current.map(checkout)).sorted()
         if let project {
-            let matching = project.hasPrefix("/") ? [project] : paths.filter { URL(fileURLWithPath: $0).lastPathComponent == project }
+            let matching = project.hasPrefix("/") ? paths.filter { $0 == normalizedPath(project) } : paths.filter { URL(fileURLWithPath: $0).lastPathComponent == project }
             guard matching.count == 1 else {
                 return (["Live status: project not found or ambiguous. Known checkouts:"] + paths.map { "- " + line($0) } + ["Collaboration hint only; this observation does not reserve a checkout."]).joined(separator: "\n")
             }
@@ -67,7 +67,7 @@ public enum HistoryLiveStatus {
             for row in rows {
                 lines.append("- " + line(row.id) + " | agent: " + row.agent.rawValue + " | " + row.status.rawValue
                     + " | waitKind: " + (row.waitKind?.rawValue ?? "none")
-                    + " | controlChannel: " + (row.controlChannel?.rawValue ?? "unknown")
+                    + " | controlChannel: " + (ControlChannel.infer(for: row)?.rawValue ?? "unknown")
                     + " | last activity: " + ISO8601DateFormatter().string(from: row.updatedAt))
             }
         }
@@ -75,9 +75,11 @@ public enum HistoryLiveStatus {
     }
 
     private static func checkout(_ session: AgentSession) -> String {
-        if let cwd = session.terminalRef?.cwd, cwd.hasPrefix("/") { return cwd }
-        return session.project.hasPrefix("/") ? session.project : "unknown checkout (" + session.project + ")"
+        if let cwd = session.checkoutPath, cwd.hasPrefix("/") { return normalizedPath(cwd) }
+        if let cwd = session.terminalRef?.cwd, cwd.hasPrefix("/") { return normalizedPath(cwd) }
+        return session.project.hasPrefix("/") ? normalizedPath(session.project) : "unknown checkout (" + session.project + ")"
     }
+    private static func normalizedPath(_ path: String) -> String { URL(fileURLWithPath: path).standardizedFileURL.path }
     private static func line(_ text: String) -> String { text.components(separatedBy: .controlCharacters).joined(separator: " ") }
     private static func unknown(port: Int) -> String { "live status unknown (daemon not reachable at 127.0.0.1:\(port))" }
 

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -20,7 +20,7 @@ public enum HistoryTools {
             "since": ["type": "string"], "starred": ["type": "boolean"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
         ]), definition("vibebuddy_list_projects", description: "List projects with indexed sessions, newest activity first.", properties: [
             "since": ["type": "string"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
-        ])]
+        ])] + [HistoryLiveStatus.definition]
     }
 
     private static func definition(_ name: String, description: String, properties: [String: Any]) -> [String: Any] {
@@ -34,6 +34,7 @@ public enum HistoryTools {
     }
 
     public static func call(_ name: String, arguments: [String: Any], snapshot: SessionHistorySnapshot, now: Date = Date()) throws -> String {
+        guard name != "vibebuddy_live_status" else { throw HistoryToolError.invalidArguments("Use the live status reader for this tool.") }
         guard let definition = definitions().first(where: { $0["name"] as? String == name }),
               let schema = definition["inputSchema"] as? [String: Any], let properties = schema["properties"] as? [String: Any] else {
             throw HistoryToolError.invalidArguments("Unknown tool: \(name)")
@@ -106,22 +107,22 @@ public enum HistoryTools {
 
 /// Only argv shape is interpreted here; values go unchanged to the tool layer.
 public enum HistoryCLI {
-    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects"]
+    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects", "status": "vibebuddy_live_status"]
     public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
         guard let command = argv.first, let tool = commands[command] else {
-            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N]")
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | status [--project PATH] [--exclude-session ID]")
         }
         var args: [String: Any] = [:]
         var index = 1
         while index < argv.count {
             let flag = argv[index]
             if flag == "--starred" { args["starred"] = true; index += 1; continue }
-            guard ["--project", "--agent", "--since", "--limit"].contains(flag), index + 1 < argv.count else {
+            guard ["--project", "--agent", "--since", "--limit", "--exclude-session"].contains(flag), index + 1 < argv.count else {
                 throw HistoryToolError.invalidArguments("Unknown option or missing value: \(flag)")
             }
             let value = argv[index + 1]
             if flag == "--agent" { args["agents"] = (args["agents"] as? [String] ?? []) + [value] }
-            else { args[String(flag.dropFirst(2))] = value }
+            else { args[String(flag.dropFirst(2)).replacingOccurrences(of: "-", with: "_")] = value }
             index += 2
         }
         return (tool, args)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionReducer.swift
@@ -156,6 +156,7 @@ public struct SessionReducer: Sendable {
             applyChildLifecycle(event)
         }
         if event.kind != .sessionEnd {
+            if let cwd = event.cwd, cwd.hasPrefix("/") { sessions[event.sessionID]?.checkoutPath = cwd }
             if let name = event.sessionName { sessions[event.sessionID]?.name = name }
             // A Desktop thread id is a durable fact about the session, not about
             // this event: carry it onto the session so `/jump` can resolve a
@@ -180,7 +181,10 @@ public struct SessionReducer: Sendable {
     public mutating func applyStatusLine(_ sample: StatusLineSample) -> Bool {
         guard var s = sessions[sample.sessionID] else { return false }
         if let model = sample.model { s.model = model }
-        if let cwd = sample.cwd { s.project = Self.projectName(cwd) }
+        if let cwd = sample.cwd {
+            s.project = Self.projectName(cwd)
+            if cwd.hasPrefix("/") { s.checkoutPath = cwd }
+        }
         if let name = sample.sessionName { s.name = name }
         if let effort = sample.effort { s.effort = effort }
         if let cost = sample.costUSD { s.costUSD = cost }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/Token.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/Token.swift
@@ -24,6 +24,14 @@ public struct TokenStore: Sendable {
         return TokenStore(fileURL: base.appendingPathComponent("vibebuddy/token"))
     }
 
+    /// Read-only clients must never create a token as a side effect of a query.
+    public func load() -> String? {
+        guard let data = try? Data(contentsOf: fileURL),
+              let text = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty else { return nil }
+        return text
+    }
+
     public func loadOrCreate() throws -> String {
         if let data = try? Data(contentsOf: fileURL),
            let existing = String(data: data, encoding: .utf8)?

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -7,6 +7,13 @@ struct VibeBuddyMCP {
         let request: (tool: String, arguments: [String: Any])
         do { request = try HistoryCLI.parse(Array(CommandLine.arguments.dropFirst())) }
         catch { fail(error, code: 2) }
+        if request.tool == "vibebuddy_live_status" {
+            do {
+                let text = try await HistoryLiveStatus.call(arguments: request.arguments)
+                FileHandle.standardOutput.write(Data(HistoryCLI.output(text).utf8))
+                return
+            } catch { fail(error, code: 2) }
+        }
         let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
         let repository = SessionHistoryRepository(cacheDirectory: directory, readOnly: true)
         guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryLiveStatusTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryLiveStatusTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import XCTest
+import VibeBuddyKit
+@testable import VibeBuddyMacCore
+
+final class HistoryLiveStatusTests: XCTestCase {
+    func testGroupingCallerExclusionAndReadOnlyRequest() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        func row(_ id: String, _ cwd: String) -> AgentSession {
+            AgentSession(id: id, agent: .codex, project: "repo", status: .working,
+                         terminalRef: TerminalRef(cwd: cwd), controlChannel: .appserver, statusSince: now, updatedAt: now)
+        }
+        let token = "isolated-test-bearer-do-not-show"
+        let data = try JSONEncoder().encode(Snapshot(sessions: [row("self", "/checkout/a"), row("other", "/checkout/a"), row(token, "/checkout/b")], serverTime: now))
+        let result = try await HistoryLiveStatus.call(arguments: ["exclude_session": "self"], environment: ["VIBEBUDDY_TOKEN": token, "VIBEBUDDY_PORT": "18789"], fetch: { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.absoluteString, "http://127.0.0.1:18789/snapshot")
+            XCTAssertEqual(request.timeoutInterval, 2)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer " + token)
+            return (data, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        })
+        XCTAssertFalse(result.contains("- self |"))
+        XCTAssertTrue(result.contains("## /checkout/a"))
+        XCTAssertTrue(result.contains("## /checkout/b"))
+        XCTAssertTrue(result.contains("Another agent is working in this checkout"))
+        XCTAssertTrue(result.contains("controlChannel: appserver"))
+        XCTAssertFalse(result.contains(token))
+        let alone = HistoryLiveStatus.render(Snapshot(sessions: [row("self", "/checkout/a")], serverTime: now), project: "/checkout/a", excludeSession: "self")
+        XCTAssertTrue(alone.contains("No other live sessions found."))
+        var older = row("old", "/checkout/c")
+        older.status = .done; older.updatedAt = now.addingTimeInterval(-7 * 86400)
+        XCTAssertFalse(HistoryLiveStatus.render(Snapshot(sessions: [older], serverTime: now), project: nil, excludeSession: nil).contains("- old |"))
+        let onlyA = HistoryLiveStatus.render(try JSONDecoder().decode(Snapshot.self, from: data), project: "/checkout/a", excludeSession: "self")
+        XCTAssertTrue(onlyA.contains("- other |")); XCTAssertFalse(onlyA.contains("## /checkout/b"))
+    }
+
+    func testUnknownStatusAndMissingTokenNeverCreateState() async throws {
+        let result = try await HistoryLiveStatus.call(arguments: [:], environment: ["VIBEBUDDY_TOKEN": "synthetic", "VIBEBUDDY_PORT": "1"])
+        XCTAssertEqual(result, "live status unknown (daemon not reachable at 127.0.0.1:1)")
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        XCTAssertNil(TokenStore(fileURL: root.appendingPathComponent("token")).load())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.path))
+        let request = try HistoryCLI.parse(["status", "--project", "/checkout/a", "--exclude-session", "self"])
+        XCTAssertEqual(request.tool, "vibebuddy_live_status")
+        XCTAssertEqual(request.arguments["exclude_session"] as? String, "self")
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryLiveStatusTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryLiveStatusTests.swift
@@ -34,6 +34,39 @@ final class HistoryLiveStatusTests: XCTestCase {
         XCTAssertTrue(onlyA.contains("- other |")); XCTAssertFalse(onlyA.contains("## /checkout/b"))
     }
 
+    func testDesktopCheckoutSurvivesReducerAndSnapshotWithoutTerminalRef() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        var source = CodexAppServerReducer()
+        var reducer = SessionReducer()
+        for (id, cwd) in [("desktop-a", "/clones/a/repo"), ("desktop-b", "/clones/b/repo")] {
+            let thread: [String: Any] = ["id": id, "sessionId": id, "cwd": cwd, "source": "vscode",
+                                        "status": ["type": "active", "activeFlags": []], "turns": []]
+            for event in source.seed(thread: thread, receivedAt: now) { reducer.apply(event) }
+        }
+        let snapshot = try JSONDecoder().decode(Snapshot.self, from: JSONEncoder().encode(
+            Snapshot(sessions: Array(reducer.sessions.values), serverTime: now)))
+        XCTAssertEqual(snapshot.sessions.count, 2)
+        XCTAssertTrue(snapshot.sessions.allSatisfy { $0.terminalRef == nil && $0.desktopThreadID == $0.id })
+        let result = HistoryLiveStatus.render(snapshot, project: nil, excludeSession: nil)
+        XCTAssertTrue(result.contains("## /clones/a/repo"))
+        XCTAssertTrue(result.contains("## /clones/b/repo"))
+        let filtered = HistoryLiveStatus.render(snapshot, project: "/clones/a/repo/", excludeSession: nil)
+        XCTAssertTrue(filtered.contains("- desktop-a |")); XCTAssertFalse(filtered.contains("- desktop-b |"))
+        let typo = HistoryLiveStatus.render(snapshot, project: "/clones/typo/repo", excludeSession: nil)
+        XCTAssertTrue(typo.contains("project not found or ambiguous"))
+        XCTAssertFalse(typo.contains("No other live sessions found."))
+
+        var legacy = try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(snapshot.sessions[0])) as? [String: Any])
+        legacy.removeValue(forKey: "checkoutPath")
+        legacy.removeValue(forKey: "controlChannel")
+        let oldSession = try JSONDecoder().decode(AgentSession.self, from: JSONSerialization.data(withJSONObject: legacy))
+        XCTAssertNil(oldSession.checkoutPath)
+        XCTAssertTrue(HistoryLiveStatus.render(Snapshot(sessions: [oldSession], serverTime: now), project: nil, excludeSession: nil).contains("controlChannel: appserver"))
+        reducer.apply(HookEvent(kind: .sessionMetadataChanged, sessionID: "desktop-a", agent: .codex,
+                               cwd: "https://example.com/repo", timestamp: now))
+        XCTAssertEqual(reducer.sessions["desktop-a"]?.checkoutPath, "/clones/a/repo")
+    }
+
     func testUnknownStatusAndMissingTokenNeverCreateState() async throws {
         let result = try await HistoryLiveStatus.call(arguments: [:], environment: ["VIBEBUDDY_TOKEN": "synthetic", "VIBEBUDDY_PORT": "1"])
         XCTAssertEqual(result, "live status unknown (daemon not reachable at 127.0.0.1:1)")

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -11,7 +11,7 @@ final class HistoryToolsTests: XCTestCase {
 
     func testRegistryAndCLIParity() throws {
         let definitions = HistoryTools.definitions()
-        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_list_sessions", "vibebuddy_list_projects"])
+        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_list_sessions", "vibebuddy_list_projects", "vibebuddy_live_status"])
         XCTAssertEqual(Set(HistoryCLI.commands.values), Set(definitions.compactMap { $0["name"] as? String }))
         for definition in definitions {
             XCTAssertEqual((definition["annotations"] as? [String: Bool])?["readOnlyHint"], true)
@@ -71,7 +71,7 @@ final class HistoryToolsTests: XCTestCase {
         XCTAssertTrue(snapshot.sessions.first?.isFavorite == true)
         XCTAssertTrue(snapshot.sessions.first?.isPinned == true)
         XCTAssertTrue(snapshot.sessions.first?.archivedLocally == true)
-        for tool in HistoryCLI.commands.values { _ = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot) }
+        for tool in HistoryCLI.commands.values where tool != "vibebuddy_live_status" { _ = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot) }
         _ = try await reader.session(id: id)
         _ = try await reader.summary(sessionID: id)
         do { _ = try await reader.refresh(rebuild: true); XCTFail("refresh wrote") } catch {}
@@ -107,7 +107,7 @@ final class HistoryToolsTests: XCTestCase {
         let snapshot = await reader.snapshot()
         XCTAssertEqual(snapshot.sessions.count, 1)
         XCTAssertEqual(snapshot.pendingSourceCount, 1)
-        for tool in HistoryCLI.commands.values {
+        for tool in HistoryCLI.commands.values where tool != "vibebuddy_live_status" {
             let text = try HistoryTools.call(tool, arguments: [:], snapshot: snapshot)
             XCTAssertTrue(text.contains("Partial index: 1 source(s) pending"))
             XCTAssertTrue(text.contains("older or newer"))

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/SessionReducerTests.swift
@@ -266,6 +266,7 @@ struct SessionReducerTests {
         #expect(session?.statusSince == statusSince)
         #expect(session?.activeTool == "Edit")
         #expect(session?.project == "new")
+        #expect(session?.checkoutPath == "/x/new")
         #expect(session?.model == "claude-opus-5")
         #expect(session?.updatedAt == t0.addingTimeInterval(3))
     }


### PR DESCRIPTION
agent-mcp-cli/09

## Summary

Add `vibebuddy-mcp status` and shared `vibebuddy_live_status` observation. Read the authenticated loopback snapshot with a two-second timeout, exclude the caller, and group current sessions by checkout. Unreachable daemons return unknown with exit 0. Queries do not create History or token state.

Preserve full local cwd in optional `AgentSession.checkoutPath`, including Desktop sessions without terminal refs. Normalize and validate absolute checkout filters and infer effective control channels from older snapshots.

Stacked on ticket01 (#169), base `codex/agent-mcp-cli-01-sessions-projects`. MCP dispatcher integration follows when the tool branches are combined. No merge requested.

## Validation

- Final `swift build --package-path VibeBuddyMac --product vibebuddy-mcp -j 2`: passed,22.43s.
- Final `swift test --package-path VibeBuddyMac -j 2`:15 XCTest (3 live-status tests) +1011 Swift Testing /119 suites,0 failures; incremental compile311.98s, Swift Testing6.423s.
- Real isolated vibebuddyd18789: two injected sessions with no terminalRef retain checkoutPath; self excluded and other working session grouped by full checkout. After cleanup unknown/exit0 in0.0612s. Token absent from output; no History directory created.
- Regression drives Codex app-server events through reducer and JSON snapshot for two same-basename checkouts, checks trailing-slash and unmatched filters, and decodes older snapshot fields with inferred channel.
- Independent review passed. Three remote review threads fixed in a221fa21, replied and resolved. `git diff --check` clean.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml` and unsigned macOS `xcodebuild -project VibeBuddyMacApp/VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -derivedDataPath .scratch/build-09 PRODUCT_BUNDLE_IDENTIFIER=com.vibebuddy.e2e.agent-mcp-cli-09 -jobs 2 build`: passed for final a221fa21; see review-xcodebuild.log.

## Not verified here

Final incremental macOS build passed and Package.resolved was restored. MCP wire dispatch awaits ticket05 integration. Production daemon, installed App, user-level client configuration and real devices were not changed. Older daemons lacking full cwd can only report unknown checkout. Evidence: local `.scratch/agent-mcp-cli/acceptance/09/`.
