### PR TITLE
feat(history): add read-only search with stable references

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryRefreshLock.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryRefreshLock.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Darwin
+
+/// The descriptor stays open for the whole refresh. Never unlink the lock file:
+/// another process may already be waiting on that inode.
+final class HistoryRefreshLock {
+    private let descriptor: Int32
+
+    init(directory: URL) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+                                               attributes: [.posixPermissions: 0o700])
+        descriptor = open(directory.appendingPathComponent(".refresh.lock").path,
+                          O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
+        guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let code = errno
+            close(descriptor)
+            if code == EWOULDBLOCK { throw HistoryToolError.refreshBusy }
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+    }
+
+    deinit { flock(descriptor, LOCK_UN); close(descriptor) }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistorySearch.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistorySearch.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public struct HistorySearchHit: Sendable {
+    public var session: SessionHistorySession
+    public var seq: Int
+    public var excerpt: String
+    public var reference: String { "vibebuddy://session/\(HistoryTools.key(session))#\(seq)" }
+}
+
+public struct HistorySearchPage: Sendable {
+    public var hits: [HistorySearchHit]
+    public var notIndexed: [SessionHistorySession]
+    public var unavailable: [SessionHistorySession]
+}
+
+extension HistoryTools {
+    public static func search(arguments: [String: Any], repository: SessionHistoryRepository, now: Date = Date()) async throws -> String {
+        let scope = try selection("vibebuddy_search", arguments: arguments, snapshot: await repository.snapshot(), now: now)
+        guard let query = arguments["query"] as? String, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw HistoryToolError.invalidArguments("query must contain non-whitespace text.")
+        }
+        if let notice = scope.notice { return notice + "\n\n" + scope.freshness }
+        let page = try await repository.search(query, sessionIDs: Set(scope.sessions.map(\.id)), limit: scope.limit)
+        var lines = ["# Search results", "", "Coverage: indexed readable dialogue and tool text; Meta and Thinking omitted. Use show REF --tools to expand tool details."]
+        if page.hits.isEmpty { lines += ["", "No matches found."] }
+        for hit in page.hits {
+            lines += ["", "## \(oneLine(hit.session.title))", "Key: \(key(hit.session)) | Project: \(oneLine(hit.session.projectPath))",
+                      "Source revision: \(hit.session.sourceRevision ?? "unknown")", "", "> " + oneLine(hit.excerpt), "ref: \(hit.reference)"]
+        }
+        if !page.notIndexed.isEmpty {
+            lines += ["", "Not indexed yet (missing rows or source revision changed); run vibebuddy-mcp index --rebuild:"]
+            lines += page.notIndexed.sorted { key($0) < key($1) }.map { "- \(key($0)): not indexed yet — \(oneLine($0.sourcePath))" }
+        }
+        if !page.unavailable.isEmpty {
+            lines += ["", "References unavailable: cached transcript or unique source identity could not be verified. Use show KEY or rebuild the index."]
+            lines += page.unavailable.sorted { key($0) < key($1) }.map { "- " + key($0) }
+        }
+        lines += ["", scope.freshness]
+        return lines.joined(separator: "\n")
+    }
+
+    // The FTS layer returns literal source excerpts, never highlighted HTML or
+    // marker-delimited text. Flatten line breaks without stripping source code.
+    private static func oneLine(_ value: String) -> String {
+        value.components(separatedBy: .controlCharacters).joined(separator: " ")
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -25,7 +25,11 @@ public enum HistoryTools {
             "since": ["type": "string"], "starred": ["type": "boolean"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
         ]), definition("vibebuddy_list_projects", description: "List projects with indexed sessions, newest activity first.", properties: [
             "since": ["type": "string"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
-        ])]
+        ]), definition("vibebuddy_search", description: "Search indexed readable message text literally, with session references and unindexed source coverage.", properties: [
+            "query": ["type": "string", "minLength": 1], "project": ["type": "string"],
+            "agents": ["type": "array", "items": ["type": "string", "enum": ["claude-code", "codex"]]],
+            "since": ["type": "string"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
+        ], required: ["query"])]
     }
 
     private static func definition(_ name: String, description: String, properties: [String: Any], required: [String] = []) -> [String: Any] {
@@ -38,11 +42,22 @@ public enum HistoryTools {
         (session.agent == .claude ? "claude-code" : "codex") + ":" + session.nativeSessionID
     }
 
-    public static func call(_ name: String, arguments: [String: Any], snapshot: SessionHistorySnapshot, now: Date = Date()) throws -> String {
-        guard name != "vibebuddy_get_session" else { throw HistoryToolError.invalidArguments("get_session requires a repository.") }
+    struct Selection {
+        var sessions: [SessionHistorySession]
+        var limit: Int
+        var freshness: String
+        var notice: String? = nil
+    }
+
+    /// One scope/validation path for listings and indexed search. Resolve project
+    /// against the complete metadata set before applying time/agent filters.
+    static func selection(_ name: String, arguments: [String: Any], snapshot: SessionHistorySnapshot, now: Date) throws -> Selection {
         guard let definition = definitions().first(where: { $0["name"] as? String == name }),
               let schema = definition["inputSchema"] as? [String: Any], let properties = schema["properties"] as? [String: Any] else {
             throw HistoryToolError.invalidArguments("Unknown tool: \(name)")
+        }
+        for required in schema["required"] as? [String] ?? [] where arguments[required] == nil {
+            throw HistoryToolError.invalidArguments("Missing argument: \(required)")
         }
         for (key, value) in arguments {
             guard properties[key] != nil else { throw HistoryToolError.invalidArguments("Unknown argument: \(key)") }
@@ -65,18 +80,12 @@ public enum HistoryTools {
         let partial = snapshot.pendingSourceCount > 0 ? " Partial index: \(snapshot.pendingSourceCount) source(s) pending; omitted activity may be older or newer." : ""
         let freshness = "Index covers activity up to \(all.first.map { stamp($0.updatedAt) } ?? "unknown (empty index)"). Cached metadata only; newer activity may not be indexed." + partial
         var sessions = all.filter { since == nil || $0.updatedAt >= since! }
-        if name == "vibebuddy_list_projects" {
-            var seen = Set<String>()
-            let rows = sessions.filter { seen.insert($0.projectPath).inserted }.prefix(limit).map { session in
-                "| \(cell(session.projectPath)) | \(stamp(session.updatedAt)) | \(sessions.filter { $0.projectPath == session.projectPath }.count) |"
-            }
-            return (["| Project | Updated | Sessions |", "| --- | --- | ---: |"] + (rows.isEmpty ? ["No projects found."] : rows) + ["", freshness]).joined(separator: "\n")
-        }
         if let project = arguments["project"] as? String {
             let known = Set(all.map(\.projectPath)).sorted()
             let matches = project.hasPrefix("/") ? known.filter { $0 == project } : known.filter { URL(fileURLWithPath: $0).lastPathComponent == project }
             guard matches.count == 1 else {
-                return (["Project not found or ambiguous. Known projects:"] + known.map { "- " + cell($0) } + ["", freshness]).joined(separator: "\n")
+                return Selection(sessions: [], limit: limit, freshness: freshness,
+                                 notice: (["Project not found or ambiguous. Known projects:"] + known.map { "- " + cell($0) }).joined(separator: "\n"))
             }
             sessions = sessions.filter { $0.projectPath == matches[0] }
         }
@@ -84,6 +93,23 @@ public enum HistoryTools {
             sessions = sessions.filter { agents.contains($0.agent == .claude ? "claude-code" : "codex") }
         }
         if let starred = arguments["starred"] as? Bool { sessions = sessions.filter { $0.isFavorite == starred } }
+        return Selection(sessions: sessions, limit: limit, freshness: freshness)
+    }
+
+    public static func call(_ name: String, arguments: [String: Any], snapshot: SessionHistorySnapshot, now: Date = Date()) throws -> String {
+        guard !["vibebuddy_get_session", "vibebuddy_search"].contains(name) else {
+            throw HistoryToolError.invalidArguments("\(name) requires a repository.")
+        }
+        let scope = try selection(name, arguments: arguments, snapshot: snapshot, now: now)
+        let sessions = scope.sessions, limit = scope.limit, freshness = scope.freshness
+        if let notice = scope.notice { return notice + "\n\n" + freshness }
+        if name == "vibebuddy_list_projects" {
+            var seen = Set<String>()
+            let rows = sessions.filter { seen.insert($0.projectPath).inserted }.prefix(limit).map { session in
+                "| \(cell(session.projectPath)) | \(stamp(session.updatedAt)) | \(sessions.filter { $0.projectPath == session.projectPath }.count) |"
+            }
+            return (["| Project | Updated | Sessions |", "| --- | --- | ---: |"] + (rows.isEmpty ? ["No projects found."] : rows) + ["", freshness]).joined(separator: "\n")
+        }
         let rows = sessions.prefix(limit).map { s in
             "| \(cell(key(s))) | \(s.agent.displayName) | \(stamp(s.updatedAt)) | \(cell(s.projectPath)) | \(cell(s.title)) | \(s.messageCount) |"
         }
@@ -112,16 +138,16 @@ public enum HistoryTools {
 
 /// Only argv shape is interpreted here; values go unchanged to the tool layer.
 public enum HistoryCLI {
-    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects", "show": "vibebuddy_get_session"]
+    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects", "show": "vibebuddy_get_session", "search": "vibebuddy_search"]
     public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
         guard let command = argv.first, let tool = commands[command] else {
-            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking] | index [--rebuild]")
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking] | search QUERY [--project PATH] [--agent AGENT] [--since DATE] [--limit N] | index [--rebuild]")
         }
         var args: [String: Any] = [:]
         var index = 1
-        if command == "show" {
-            guard argv.count > 1, !argv[1].hasPrefix("--") else { throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking]") }
-            args["key"] = argv[1]; index = 2
+        if command == "show" || command == "search" {
+            guard argv.count > 1, command == "search" || !argv[1].hasPrefix("--") else { throw HistoryToolError.invalidArguments("\(command) requires a positional \(command == "show" ? "key or reference" : "query").") }
+            args[command == "show" ? "key" : "query"] = argv[1]; index = 2
         }
         while index < argv.count {
             let flag = argv[index]

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -2,11 +2,12 @@ import Foundation
 import CoreFoundation
 
 public enum HistoryToolError: Error, LocalizedError {
-    case readOnly, noIndex, invalidArguments(String)
+    case readOnly, noIndex, refreshBusy, invalidArguments(String)
     public var errorDescription: String? {
         switch self {
         case .readOnly: "History repository is read-only."
-        case .noIndex: "No usable index. Open History in the Mac App (index command arrives in a later slice)."
+        case .noIndex: "No usable index. Run vibebuddy-mcp index or open History in the Mac App."
+        case .refreshBusy: "another refresh is running"
         case .invalidArguments(let text): text
         }
     }
@@ -109,7 +110,7 @@ public enum HistoryCLI {
     public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects"]
     public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
         guard let command = argv.first, let tool = commands[command] else {
-            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N]")
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | index [--rebuild]")
         }
         var args: [String: Any] = [:]
         var index = 1

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -392,7 +392,8 @@ public actor SessionHistoryRepository {
             if sequences[metadata.id] == nil {
                 // Decode only candidates, retaining their small ID mapping instead
                 // of keeping every full transcript in memory for the whole search.
-                guard entries.values.filter({ $0.session.agent == metadata.agent && $0.session.nativeSessionID == metadata.nativeSessionID }).count == 1,
+                guard let canonical = try? resolveIndexedSession(key: HistoryTools.key(metadata)),
+                      canonical.sourcePath == metadata.sourcePath, canonical.sourceRevision == metadata.sourceRevision,
                       let full = verifiedCache(metadata, indexedRevision: metadata.sourceRevision), full.id == metadata.id,
                       (try? HistorySessionReference(HistoryTools.key(metadata))) != nil else {
                     unavailable.insert(metadata.id)

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -256,20 +256,12 @@ public actor SessionHistoryRepository {
         let current = modified.flatMap { date in size.map { "\(date.timeIntervalSince1970)|\($0)" } }
         if let current, let slot = transcriptSlot, slot.path == file.path, slot.revision == current { return slot.transcript }
         let indexed = matches.first.map { "\($0.modified.timeIntervalSince1970)|\($0.size)" }
-        let cacheURL = directory.appendingPathComponent(contentFilename(file.path))
-        if let data = try? Data(contentsOf: cacheURL), var cached = try? JSONDecoder().decode(SessionHistorySession.self, from: data),
-           cached.sourcePath == file.path, cached.agent == reference.agent, cached.nativeSessionID == reference.nativeID {
-            let cacheTime = (try? cacheURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
-            let indexTime = (try? directory.appendingPathComponent("index.json").resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
-            let legacyPublished = cacheTime.flatMap { cache in indexTime.map { cache <= $0 } } == true
-            let revision = cached.sourceRevision ?? (legacyPublished ? indexed : nil)
-            if let revision, (current == nil || current == revision), indexed == revision {
-                cached.sourceRevision = revision
-                cached.isAvailable = current != nil && FileManager.default.isReadableFile(atPath: file.path)
-                let result = HistoryTranscript(session: cached, provenance: "cache")
-                if let current { transcriptSlot = (file.path, current, result) }
-                return result
-            }
+        if var cached = verifiedCache(metadata, indexedRevision: indexed),
+           current == nil || current == cached.sourceRevision {
+            cached.isAvailable = current != nil && FileManager.default.isReadableFile(atPath: file.path)
+            let result = HistoryTranscript(session: cached, provenance: "cache")
+            if let current { transcriptSlot = (file.path, current, result) }
+            return result
         }
         guard let modified, let current else { throw HistoryToolError.executionFailed("Source unavailable and no verifiable transcript cache.") }
         var session = try SessionHistoryParser.read(url: file, agent: reference.agent, updatedAt: modified)
@@ -280,6 +272,24 @@ public actor SessionHistoryRepository {
         let result = HistoryTranscript(session: session, provenance: "source, index stale")
         transcriptSlot = (file.path, current, result)
         return result
+    }
+
+    /// Legacy caches have no embedded revision. They are usable only when
+    /// published no later than index.json; otherwise a refresh may have replaced
+    /// the cache while metadata/FTS still describe the previous generation.
+    private func verifiedCache(_ metadata: SessionHistorySession, indexedRevision: String?) -> SessionHistorySession? {
+        let cacheURL = directory.appendingPathComponent(contentFilename(metadata.sourcePath))
+        guard let data = try? Data(contentsOf: cacheURL),
+              var cached = try? JSONDecoder().decode(SessionHistorySession.self, from: data),
+              cached.sourcePath == metadata.sourcePath, cached.agent == metadata.agent,
+              cached.nativeSessionID == metadata.nativeSessionID else { return nil }
+        let cacheTime = (try? cacheURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        let indexTime = (try? directory.appendingPathComponent("index.json").resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        let legacyPublished = cacheTime.flatMap { cache in indexTime.map { cache <= $0 } } == true
+        guard let revision = cached.sourceRevision ?? (legacyPublished ? indexedRevision : nil),
+              revision == indexedRevision else { return nil }
+        cached.sourceRevision = revision
+        return cached
     }
 
     /// Snapshots retain metadata only; load the selected transcript off the main actor.
@@ -338,6 +348,56 @@ public actor SessionHistoryRepository {
         let searchIndex = try SessionHistorySearchIndex(directory: directory, readOnly: true)
         return try searchIndex.search(needle, sessions: sessions, limit: limit)
     }
+    /// Reference-bearing search shares the App's raw FTS path, but accepts only
+    /// hits whose cached dialogue projection and source revision can be verified.
+    /// No source discovery, transcript reparsing or store writes happen here.
+    public func search(_ query: String, sessionIDs: Set<String>, limit: Int = 200) throws -> HistorySearchPage {
+        let sessions = snapshot().sessions.filter { sessionIDs.contains($0.id) }
+        guard !sessions.isEmpty else { return HistorySearchPage(hits: [], notIndexed: [], unavailable: []) }
+        guard FileManager.default.fileExists(atPath: directory.appendingPathComponent("search.sqlite").path) else {
+            return HistorySearchPage(hits: [], notIndexed: sessions, unavailable: [])
+        }
+        var notIndexed: [SessionHistorySession] = []
+        let current = sessions.filter { session in
+            let values = try? URL(fileURLWithPath: session.sourcePath).resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            if let modified = values?.contentModificationDate, let size = values?.fileSize,
+               session.sourceRevision != "\(modified.timeIntervalSince1970)|\(size)" {
+                notIndexed.append(session)
+                return false
+            }
+            return true // An unavailable source may still have a verifiable retained cache.
+        }
+        let byID = Dictionary(uniqueKeysWithValues: current.map { ($0.id, $0) })
+        var sequences: [String: [String: Int]] = [:]
+        var unavailable = Set<String>()
+        var hits: [HistorySearchHit] = []
+        let searchIndex = try SessionHistorySearchIndex(directory: directory, readOnly: true)
+        let page = try searchIndex.page(query, sessions: current, limit: limit) { hit in
+            guard let metadata = byID[hit.sessionID], !unavailable.contains(metadata.id) else { return false }
+            if sequences[metadata.id] == nil {
+                // Decode only candidates, retaining their small ID mapping instead
+                // of keeping every full transcript in memory for the whole search.
+                guard entries.values.filter({ $0.session.agent == metadata.agent && $0.session.nativeSessionID == metadata.nativeSessionID }).count == 1,
+                      let full = verifiedCache(metadata, indexedRevision: metadata.sourceRevision), full.id == metadata.id,
+                      (try? HistorySessionReference(HistoryTools.key(metadata))) != nil else {
+                    unavailable.insert(metadata.id)
+                    return false
+                }
+                let transcript = HistoryTranscript(session: full, provenance: "cache")
+                var mapping: [String: Int] = [:]
+                for message in full.messages where message.kind != .meta && message.kind != .thinking {
+                    if let seq = transcript.seq(messageID: message.id) { mapping[message.id] = seq }
+                }
+                sequences[metadata.id] = mapping
+            }
+            guard let seq = sequences[metadata.id]?[hit.messageID] else { return false }
+            hits.append(HistorySearchHit(session: metadata, seq: seq, excerpt: hit.excerpt))
+            return true
+        }
+        notIndexed += page.notIndexed
+        return HistorySearchPage(hits: hits, notIndexed: notIndexed, unavailable: current.filter { unavailable.contains($0.id) })
+    }
+
     public func summary(sessionID: String) throws -> SessionHistorySummary? {
         let file = directory.appendingPathComponent("summary-" + contentFilename(sessionID))
         guard FileManager.default.fileExists(atPath: file.path) else { return nil }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -39,9 +39,22 @@ public actor SessionHistoryRepository {
         if let data = try? Data(contentsOf: directory.appendingPathComponent("index.json")), let cache = try? JSONDecoder().decode(Cache.self, from: data), [4, 5, 6, 7].contains(cache.version) {
             usableIndex = true
             // Never reuse another configured source home's cached content.
-            let configuredRoots = roots
-            entries = cache.entries.filter { path, _ in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } }
-            pendingPaths = Set((cache.pendingPaths ?? []).filter { path in configuredRoots.contains { URL(fileURLWithPath: path).resolvingSymlinksInPath().path.hasPrefix($0.0.path + "/") } })
+            // A removed leaf cannot resolve symlinks. Keep both spellings of
+            // existing configured roots so /private/var caches survive deletion.
+            let prefixes = roots.flatMap { root, _ -> [String] in
+                var paths = [root.path + "/"]
+                if let physical = realpath(root.path, nil) {
+                    paths.append(String(cString: physical) + "/")
+                    free(physical)
+                }
+                return paths
+            }
+            func belongsToRoots(_ path: String) -> Bool {
+                let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+                return prefixes.contains { path.hasPrefix($0) || resolved.hasPrefix($0) }
+            }
+            entries = cache.entries.filter { belongsToRoots($0.key) }
+            pendingPaths = Set((cache.pendingPaths ?? []).filter(belongsToRoots))
             if cache.version < 7 { pendingPaths.formUnion(entries.keys) }
         }
     }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import Darwin
 
 /// Local history is a read-only projection, independent of the live Session reducer.
 public actor SessionHistoryRepository {
@@ -12,7 +13,6 @@ public actor SessionHistoryRepository {
     private var favorites = Set<String>()
     private var pins = Set<String>()
     private var archives = Set<String>()
-    private var searchIndex: SessionHistorySearchIndex?
     private var issues: [String] = []
     private var refreshedAt: Date?
     private var pendingPaths = Set<String>()
@@ -65,21 +65,51 @@ public actor SessionHistoryRepository {
     }
     public func refresh(rebuild: Bool = false) throws -> SessionHistorySnapshot {
         guard !readOnly else { throw HistoryToolError.readOnly }
+        let lock: HistoryRefreshLock
+        do { lock = try HistoryRefreshLock(directory: directory) }
+        catch HistoryToolError.refreshBusy {
+            issues = ["another refresh is running; skipped this refresh."]
+            return snapshot()
+        }
+        defer { withExtendedLifetime(lock) {} }
+        return try refreshLocked(rebuild: rebuild)
+    }
+
+    /// Explicit CLI maintenance, never exposed as an MCP tool. A nil result means
+    /// an existing usable index was left alone; contention always throws.
+    public func index(rebuild: Bool = false) throws -> SessionHistorySnapshot? {
+        guard !readOnly else { throw HistoryToolError.readOnly }
+        let lock = try HistoryRefreshLock(directory: directory)
+        defer { withExtendedLifetime(lock) {} }
+        reloadForRefresh()
+        if usableIndex && !rebuild { return nil }
+        return try refreshLocked(rebuild: rebuild, full: true)
+    }
+
+    private func reloadForRefresh() {
+        // Another writer may have advanced a bounded batch since this actor last ran.
+        loaded = false
+        entries = [:]; pendingPaths = []; usableIndex = false
         ensureLoaded()
+    }
+
+    private func refreshLocked(rebuild: Bool, full: Bool = false) throws -> SessionHistorySnapshot {
+        reloadForRefresh()
         let fm = FileManager.default
         issues = []
-        var changed = rebuild
+        var changed = rebuild || !usableIndex
         var cacheFailure: Error?
         var discovered = Set<String>()
         var totalBytes = 0
         var pendingCount = 0
         var excludedChildren = 0
-        if rebuild {
-            searchIndex = nil
-            let indexFile = directory.appendingPathComponent("search.sqlite")
-            if fm.fileExists(atPath: indexFile.path) { try fm.removeItem(at: indexFile) }
-            pendingPaths.formUnion(entries.keys)
-        }
+        // Rebuild into a private database then rename it atomically. Readers with
+        // an open connection finish on the previous complete database; corrupt
+        // derived databases can be replaced without deleting a reader's inode.
+        let staging = rebuild ? directory.appendingPathComponent(".rebuild-" + UUID().uuidString) : nil
+        defer { if let staging { try? fm.removeItem(at: staging) } }
+        let searchIndex = try SessionHistorySearchIndex(directory: staging ?? directory)
+        if rebuild { pendingPaths.formUnion(entries.keys) }
         for (root, agent) in roots {
             guard fm.fileExists(atPath: root.path) else { issues.append("Source directory unavailable: \(root.path)"); continue }
             var enumerationErrors = 0
@@ -99,19 +129,24 @@ public actor SessionHistoryRepository {
                     let size = values.fileSize ?? 0
                     let modified = values.contentModificationDate ?? .distantPast
                     if !pendingPaths.contains(file.path), let cached = entries[file.path], cached.modified == modified, cached.size == size, cached.session.isAvailable { continue }
-                    if totalBytes > 0 && totalBytes + min(size, SessionHistoryParser.byteLimit) > refreshByteBudget {
+                    if !full && totalBytes > 0 && totalBytes + min(size, SessionHistoryParser.byteLimit) > refreshByteBudget {
                         pendingPaths.insert(file.path)
                         pendingCount += 1
                         continue
                     }
                     totalBytes += min(size, SessionHistoryParser.byteLimit)
-                    entries[file.path] = try autoreleasepool {
-                        var session = try SessionHistoryParser.read(url: file, agent: agent, updatedAt: modified)
-                        session.sourceArchived = agent == .codex && root.lastPathComponent == "archived_sessions"
-                        do { try save(session, name: contentFilename(file.path)) } catch { cacheFailure = error; throw error }
-                        session.messages = []
-                        return Entry(modified: modified, size: size, session: session)
+                    var session = try autoreleasepool {
+                        try SessionHistoryParser.read(url: file, agent: agent, updatedAt: modified)
                     }
+                    session.sourceArchived = agent == .codex && root.lastPathComponent == "archived_sessions"
+                    let revision = "\(modified.timeIntervalSince1970)|\(size)"
+                    session.sourceRevision = revision
+                    do {
+                        try save(session, name: contentFilename(file.path))
+                        try searchIndex.replace(session, stamp: "v7|" + revision)
+                    } catch { cacheFailure = error; throw error }
+                    session.messages = []
+                    entries[file.path] = Entry(modified: modified, size: size, session: session)
                     pendingPaths.remove(file.path)
                     changed = true
                 } catch {
@@ -142,12 +177,33 @@ public actor SessionHistoryRepository {
         }
         if excludedChildren > 0 { issues.append("Scope: \(excludedChildren) Claude child-session directories/files excluded from parent history.") }
         if pendingCount > 0 { issues.append("Indexing: \(pendingCount) sources pending; refresh continues the next bounded batch.") }
+        if let cacheFailure { throw cacheFailure }
+        // Migrate old lazy indexes and repair missing FTS rows only while holding
+        // the writer lock. No query ever decodes caches or writes SQLite rows.
+        for entry in entries.values {
+            let stamp = "v7|\(entry.modified.timeIntervalSince1970)|\(entry.size)"
+            if try !searchIndex.isCurrent(path: entry.session.sourcePath, stamp: stamp) {
+                let session = try autoreleasepool { try load(entry.session) }
+                let revision = "\(entry.modified.timeIntervalSince1970)|\(entry.size)"
+                if let cachedRevision = session.sourceRevision, cachedRevision != revision {
+                    issues.append("Not indexed yet: cache revision differs from metadata for \(entry.session.sourcePath).")
+                    continue
+                }
+                try searchIndex.replace(session, stamp: stamp)
+            }
+        }
+        if let staging {
+            guard rename(staging.appendingPathComponent("search.sqlite").path,
+                         directory.appendingPathComponent("search.sqlite").path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
         refreshedAt = Date()
         indexDirty = indexDirty || changed
-        if let cacheFailure { throw cacheFailure }
         if indexDirty {
             try save(Cache(entries: entries, pendingPaths: pendingPaths), name: "index.json")
             indexDirty = false
+            usableIndex = true
         }
         return snapshot()
     }
@@ -162,7 +218,7 @@ public actor SessionHistoryRepository {
         guard full.id == metadata.id, full.sourcePath == metadata.sourcePath else {
             throw CocoaError(.fileReadCorruptFile)
         }
-        full.sourceRevision = metadata.sourceRevision
+        full.sourceRevision = full.sourceRevision ?? metadata.sourceRevision
         full.archivedLocally = metadata.archivedLocally
         full.isPinned = metadata.isPinned
         full.sourceArchived = metadata.sourceArchived
@@ -198,25 +254,13 @@ public actor SessionHistoryRepository {
     public func search(_ query: String, projectPath: String? = nil, favoritesOnly: Bool = false,
                        agent: SessionHistoryAgent? = nil, archived: Bool? = nil,
                        limit: Int = 200) throws -> [SessionHistorySearchResult] {
-        guard !readOnly else { throw HistoryToolError.readOnly }
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty, limit > 0 else { return [] }
         let sessions = snapshot().sessions.filter {
             (projectPath == nil || $0.projectPath == projectPath) && (!favoritesOnly || $0.isFavorite)
                 && (agent == nil || $0.agent == agent) && (archived == nil || $0.isArchived == archived)
         }
-        if searchIndex == nil { searchIndex = try SessionHistorySearchIndex(directory: directory) }
-        guard let searchIndex else { return [] }
-        // Reconcile derived index by source version, including after a restart or cache migration.
-        // Warm queries do not decode transcript caches. A failing cache remains an explicit error.
-        for session in sessions {
-            try Task.checkCancellation()
-            guard let entry = entries[session.sourcePath] else { continue }
-            let stamp = "v7|\(entry.modified.timeIntervalSince1970)|\(entry.size)"
-            if try !searchIndex.isCurrent(path: session.sourcePath, stamp: stamp) {
-                try autoreleasepool { try searchIndex.replace(load(session), stamp: stamp) }
-            }
-        }
+        let searchIndex = try SessionHistorySearchIndex(directory: directory, readOnly: true)
         return try searchIndex.search(needle, sessions: sessions, limit: limit)
     }
     public func summary(sessionID: String) throws -> SessionHistorySummary? {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistorySearchIndex.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistorySearchIndex.swift
@@ -72,9 +72,21 @@ final class SessionHistorySearchIndex {
 
     /// Literal substring semantics, including punctuation, quotes, CJK and short queries.
     /// Trigram narrows candidates for >=3 scalars; instr handles shorter text exactly.
+    struct Page {
+        var results: [SessionHistorySearchResult]
+        var notIndexed: [SessionHistorySession]
+    }
+
     func search(_ query: String, sessions: [SessionHistorySession], limit: Int) throws -> [SessionHistorySearchResult] {
+        try page(query, sessions: sessions, limit: limit).results
+    }
+
+    /// The acceptance predicate runs before the limit so hidden/unaddressable
+    /// raw records cannot crowd readable hits off the page.
+    func page(_ query: String, sessions: [SessionHistorySession], limit: Int,
+              accepting: (SessionHistorySearchResult) -> Bool = { _ in true }) throws -> Page {
         let needle = Self.fold(query)
-        guard !needle.isEmpty else { return [] }
+        guard !needle.isEmpty, limit > 0 else { return Page(results: [], notIndexed: []) }
         // Pin isCurrent and the message SELECT to one database snapshot. JSON
         // publication and SQLite commit may straddle a reader; omit mismatched
         // revisions instead of attaching new message IDs to old metadata.
@@ -85,6 +97,7 @@ final class SessionHistorySearchIndex {
             return try isCurrent(path: $0.sourcePath, stamp: "v7|" + revision)
         }
         let allowed = Dictionary(uniqueKeysWithValues: current.map { ($0.sourcePath, $0) })
+        let missing = sessions.filter { allowed[$0.sourcePath] == nil }
         let indexed = needle.unicodeScalars.count >= 3 && !needle.contains("\0")
         let sql = indexed
             ? "SELECT m.path,m.message_id,m.text FROM messages_fts JOIN messages m ON m.id=messages_fts.rowid WHERE messages_fts MATCH ? ORDER BY bm25(messages_fts),m.id"
@@ -103,10 +116,12 @@ final class SessionHistorySearchIndex {
             guard let match = body.range(of: query, options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX")) else { continue }
             let start = body.index(match.lowerBound, offsetBy: -70, limitedBy: body.startIndex) ?? body.startIndex
             let end = body.index(match.upperBound, offsetBy: 130, limitedBy: body.endIndex) ?? body.endIndex
-            results.append(SessionHistorySearchResult(sessionID: session.id, messageID: text(statement, 1), excerpt: String(body[start..<end])))
+            let result = SessionHistorySearchResult(sessionID: session.id, messageID: text(statement, 1), excerpt: String(body[start..<end]))
+            guard accepting(result) else { continue }
+            results.append(result)
             if results.count >= limit { break }
         }
-        return results
+        return Page(results: results, notIndexed: missing)
     }
 
     private static func fold(_ text: String) -> String {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistorySearchIndex.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistorySearchIndex.swift
@@ -11,18 +11,21 @@ final class SessionHistorySearchIndex {
         var errorDescription: String? { "History search index: \(detail). Rebuild the index to retry." }
     }
 
-    init(directory: URL) throws {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
-                                               attributes: [.posixPermissions: 0o700])
-        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    init(directory: URL, readOnly: Bool = false) throws {
+        if !readOnly {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+                                                   attributes: [.posixPermissions: 0o700])
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        }
         let path = directory.appendingPathComponent("search.sqlite").path
-        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK else {
+        guard sqlite3_open_v2(path, &db, readOnly ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK else {
             let detail = db.map { String(cString: sqlite3_errmsg($0)) } ?? "Cannot open database"
             sqlite3_close(db); db = nil
             throw Failure(detail: detail)
         }
         do {
             sqlite3_busy_timeout(db, 1000)
+            if readOnly { return }
             try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
             try execute("""
                 CREATE TABLE IF NOT EXISTS sources(path TEXT PRIMARY KEY, stamp TEXT NOT NULL);
@@ -72,7 +75,16 @@ final class SessionHistorySearchIndex {
     func search(_ query: String, sessions: [SessionHistorySession], limit: Int) throws -> [SessionHistorySearchResult] {
         let needle = Self.fold(query)
         guard !needle.isEmpty else { return [] }
-        let allowed = Dictionary(uniqueKeysWithValues: sessions.map { ($0.sourcePath, $0) })
+        // Pin isCurrent and the message SELECT to one database snapshot. JSON
+        // publication and SQLite commit may straddle a reader; omit mismatched
+        // revisions instead of attaching new message IDs to old metadata.
+        try execute("BEGIN")
+        defer { try? execute("ROLLBACK") }
+        let current = try sessions.filter {
+            guard let revision = $0.sourceRevision else { return false }
+            return try isCurrent(path: $0.sourcePath, stamp: "v7|" + revision)
+        }
+        let allowed = Dictionary(uniqueKeysWithValues: current.map { ($0.sourcePath, $0) })
         let indexed = needle.unicodeScalars.count >= 3 && !needle.contains("\0")
         let sql = indexed
             ? "SELECT m.path,m.message_id,m.text FROM messages_fts JOIN messages m ON m.id=messages_fts.rowid WHERE messages_fts MATCH ? ORDER BY bm25(messages_fts),m.id"

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -4,10 +4,24 @@ import VibeBuddyMacCore
 @main
 struct VibeBuddyMCP {
     static func main() async {
+        let argv = Array(CommandLine.arguments.dropFirst())
+        let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
+        if argv.first == "index" {
+            guard argv == ["index"] || argv == ["index", "--rebuild"] else {
+                fail(HistoryToolError.invalidArguments("Usage: vibebuddy-mcp index [--rebuild]"), code: 2)
+            }
+            do {
+                let repository = SessionHistoryRepository(cacheDirectory: directory)
+                let snapshot = try await repository.index(rebuild: argv.contains("--rebuild"))
+                let text = snapshot.map { "Indexed \($0.sessions.count) sessions.\n" + $0.issues.joined(separator: "\n") }
+                    ?? "Index already exists. Use --rebuild to refresh all sources."
+                FileHandle.standardOutput.write(Data(HistoryCLI.output(text).utf8))
+                return
+            } catch { fail(error, code: 2) }
+        }
         let request: (tool: String, arguments: [String: Any])
         do { request = try HistoryCLI.parse(Array(CommandLine.arguments.dropFirst())) }
         catch { fail(error, code: 2) }
-        let directory = ProcessInfo.processInfo.environment["VIBEBUDDY_HISTORY_DIRECTORY"].map { URL(fileURLWithPath: $0) }
         let repository = SessionHistoryRepository(cacheDirectory: directory, readOnly: true)
         guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
         let snapshot = await repository.snapshot()

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -29,7 +29,11 @@ struct VibeBuddyMCP {
                 text = try await HistoryTools.getSession(arguments: request.arguments, repository: repository)
             } else {
                 guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
-                text = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: await repository.snapshot())
+                if request.tool == "vibebuddy_search" {
+                    text = try await HistoryTools.search(arguments: request.arguments, repository: repository)
+                } else {
+                    text = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: await repository.snapshot())
+                }
             }
             FileHandle.standardOutput.write(Data(HistoryCLI.output(text).utf8))
         } catch HistoryToolError.invalidArguments(let message) {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryRefreshCoordinationTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryRefreshCoordinationTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class HistoryRefreshCoordinationTests: XCTestCase {
+    func testLockContentionSkipsAppAndRejectsExplicitIndexThenReleases() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache = root.appendingPathComponent("history")
+        let repository = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"),
+                                                  codexHome: root.appendingPathComponent("codex"), cacheDirectory: cache)
+        var lock: HistoryRefreshLock? = try HistoryRefreshLock(directory: cache)
+        let skipped = try await repository.refresh()
+        XCTAssertTrue(skipped.issues.contains { $0.contains("another refresh is running") })
+        do { _ = try await repository.index(); XCTFail("Index must reject a busy writer") }
+        catch HistoryToolError.refreshBusy { }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cache.appendingPathComponent("index.json").path))
+        withExtendedLifetime(lock) {}
+        lock = nil
+        let created = try await repository.index()
+        XCTAssertNotNil(created)
+        let existing = try await repository.index()
+        XCTAssertNil(existing)
+    }
+
+    func testRefreshPublishesFTSEagerlyAndReloadsOtherWritersWithoutQueryWrites() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let claude = root.appendingPathComponent("claude")
+        let codex = root.appendingPathComponent("codex")
+        let cache = root.appendingPathComponent("history")
+        let sources = claude.appendingPathComponent("projects/repo")
+        try FileManager.default.createDirectory(at: sources, withIntermediateDirectories: true)
+        func write(_ id: String, _ message: String) throws {
+            let row: [String: Any] = ["uuid": id, "sessionId": id, "message": ["role": "user", "content": message]]
+            try JSONSerialization.data(withJSONObject: row).write(to: sources.appendingPathComponent(id + ".jsonl"), options: .atomic)
+        }
+        try write("one", "eager 中文 needle")
+        let app = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        _ = try await app.refresh()
+        let oldReader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        _ = await oldReader.snapshot()
+        try write("two", "another needle")
+        let cli = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache)
+        _ = try await cli.index(rebuild: true)
+        let refreshed = try await app.refresh()
+        XCTAssertEqual(refreshed.sessions.count, 2)
+        let files = try FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil)
+        let before = try Dictionary(uniqueKeysWithValues: files.map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
+        let reader = SessionHistoryRepository(claudeHome: claude, codexHome: codex, cacheDirectory: cache, readOnly: true)
+        let hits = try await reader.search("needle")
+        XCTAssertEqual(hits.count, 2)
+        let chinese = try await reader.search("中文")
+        XCTAssertEqual(chinese.count, 1)
+        let after = try Dictionary(uniqueKeysWithValues: FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil).map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
+        XCTAssertEqual(before, after)
+        try write("one", "changed revision needle")
+        _ = try await cli.index(rebuild: true)
+        let staleHits = try await oldReader.search("needle")
+        XCTAssertTrue(staleHits.isEmpty, "New FTS rows must not be paired with old metadata")
+        // Interrupted publication: a newer content cache outlives the source,
+        // while index.json still names the older revision. Never bless its rows
+        // with the older stamp when rebuilding derived search data.
+        let latest = await cli.snapshot()
+        let first = try XCTUnwrap(latest.sessions.first { $0.nativeSessionID == "one" })
+        let contentFiles = try FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil)
+        let content = try XCTUnwrap(contentFiles.first { file in
+            guard file.lastPathComponent.count == 69,
+                  let data = try? Data(contentsOf: file),
+                  let value = try? JSONDecoder().decode(SessionHistorySession.self, from: data) else { return false }
+            return value.id == first.id
+        })
+        var interrupted = try JSONDecoder().decode(SessionHistorySession.self, from: Data(contentsOf: content))
+        interrupted.sourceRevision = "newer-unpublished-revision"
+        try JSONEncoder().encode(interrupted).write(to: content, options: .atomic)
+        try FileManager.default.removeItem(atPath: first.sourcePath)
+        let repaired = try await cli.index(rebuild: true)
+        XCTAssertTrue(repaired?.issues.contains { $0.contains("cache revision differs") } == true)
+        let safeHits = try await cli.search("changed revision")
+        XCTAssertTrue(safeHits.isEmpty)
+
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistorySearchTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistorySearchTests.swift
@@ -122,6 +122,39 @@ final class HistorySearchTests: XCTestCase {
         XCTAssertEqual(try fixture.bytes(), before)
     }
 
+    func testArchivedMoveSearchReferenceUsesSameCanonicalSourceAsShow() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let writer = fixture.repository()
+        _ = try await writer.refresh()
+        let original = fixture.root.appendingPathComponent("codex/sessions/older.jsonl")
+        let archived = fixture.root.appendingPathComponent("codex/archived_sessions/older.jsonl")
+        try FileManager.default.createDirectory(at: archived.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.moveItem(at: original, to: archived)
+        _ = try await writer.refresh()
+        let before = try fixture.bytes()
+        let reader = fixture.repository(readOnly: true)
+        let text = try await HistoryTools.search(arguments: ["query": "中文结果", "agents": ["codex"]], repository: reader)
+        XCTAssertEqual(reference(text), "vibebuddy://session/codex:older#1")
+        let shown = try await HistoryTools.getSession(arguments: ["key": reference(text), "max_messages": 1], repository: reader)
+        XCTAssertTrue(shown.contains("## [seq 1] User"))
+        XCTAssertTrue(shown.contains("中文结果"))
+        XCTAssertEqual(try fixture.bytes(), before)
+
+        // Two genuinely available files with the same native identity must still
+        // refuse a reference; only the retained unavailable old path is ignored.
+        try FileManager.default.copyItem(at: archived, to: original)
+        _ = try await writer.refresh()
+        let ambiguousBefore = try fixture.bytes()
+        let ambiguousReader = fixture.repository(readOnly: true)
+        let ambiguous = try await HistoryTools.search(arguments: ["query": "中文结果", "agents": ["codex"]], repository: ambiguousReader)
+        XCTAssertTrue(ambiguous.contains("References unavailable:"))
+        XCTAssertFalse(ambiguous.contains("ref: "))
+        do { _ = try await ambiguousReader.readTranscript(key: "codex:older"); XCTFail("ambiguous source accepted") }
+        catch HistoryToolError.executionFailed { }
+        XCTAssertEqual(try fixture.bytes(), ambiguousBefore)
+    }
+
     private func reference(_ text: String) -> String {
         text.components(separatedBy: "\n").first { $0.hasPrefix("ref: ") }.map { String($0.dropFirst(5)) } ?? "missing"
     }

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistorySearchTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistorySearchTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class HistorySearchTests: XCTestCase {
+    func testReadableHitsScopeLimitAndRawToolReferenceRoundTripNeverWrite() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let writer = fixture.repository()
+        _ = try await writer.refresh()
+        let before = try fixture.bytes()
+        let reader = fixture.repository(readOnly: true)
+        let request = try HistoryCLI.parse(["search", "中文", "--project", "repo", "--agent", "claude-code", "--limit", "1"])
+        XCTAssertEqual(request.tool, "vibebuddy_search")
+        let text = try await HistoryTools.search(arguments: request.arguments, repository: reader)
+        let direct = try await HistoryTools.search(arguments: ["query": "中文", "project": "/work/repo", "agents": ["claude-code"], "limit": 1], repository: reader)
+        XCTAssertEqual(HistoryCLI.output(text), direct + "\n")
+        XCTAssertTrue(text.contains("ref: vibebuddy://session/claude-code:native#1"))
+        XCTAssertEqual(text.components(separatedBy: "ref: ").count - 1, 1)
+        XCTAssertFalse(text.contains("injected-only"))
+        let page = try await HistoryTools.getSession(arguments: ["key": reference(text), "max_messages": 1], repository: reader)
+        XCTAssertTrue(page.contains("## [seq 1] User"))
+        XCTAssertTrue(page.contains("中文结果"))
+
+        let code = try await HistoryTools.search(arguments: ["query": "worker.run(", "project": "/work/repo"], repository: reader)
+        let transcript = try await reader.readTranscript(key: "claude-code:native")
+        let raw = try XCTUnwrap(transcript.session.messages.first { $0.isToolOutput == true })
+        let seq = try XCTUnwrap(transcript.seq(messageID: raw.id))
+        XCTAssertEqual(reference(code), "vibebuddy://session/claude-code:native#\(seq)")
+        let expanded = try await HistoryTools.getSession(arguments: ["key": reference(code), "max_messages": 1, "tools": true], repository: reader)
+        XCTAssertTrue(expanded.contains("## [seq \(seq)] Assistant"))
+        XCTAssertTrue(expanded.contains("worker.run("))
+
+        let scoped = try await HistoryTools.search(arguments: ["query": "中文结果", "agents": ["codex"], "limit": 1], repository: reader)
+        XCTAssertTrue(scoped.contains("ref: vibebuddy://session/codex:older#1"))
+        let recent = try await HistoryTools.search(arguments: ["query": "中文结果", "agents": ["codex"], "since": "2026-09-01"], repository: reader)
+        XCTAssertTrue(recent.contains("No matches found."))
+        let missingProject = try await HistoryTools.search(arguments: ["query": "中文结果", "project": "unknown"], repository: reader)
+        XCTAssertTrue(missingProject.contains("Known projects:"))
+        XCTAssertEqual(text.components(separatedBy: "\n").last, direct.components(separatedBy: "\n").last)
+        let empty = try await HistoryTools.search(arguments: ["query": "no-match-sentinel"], repository: reader)
+        XCTAssertTrue(empty.contains("No matches found."))
+        XCTAssertEqual(try fixture.bytes(), before)
+    }
+
+    func testReadOnlyOpenMissingRowsAndMissingDatabaseAreExplicitAndDoNotCreateFiles() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let writer = fixture.repository()
+        let snapshot = try await writer.refresh()
+        let native = try XCTUnwrap(snapshot.sessions.first { $0.agent == .claude })
+        let fullValue = try await writer.session(id: native.id)
+        let full = try XCTUnwrap(fullValue)
+        do {
+            let writable = try SessionHistorySearchIndex(directory: fixture.cache)
+            try writable.replace(full, stamp: "old-revision")
+        }
+        let before = try fixture.bytes()
+        do {
+            let readonly = try SessionHistorySearchIndex(directory: fixture.cache, readOnly: true)
+            XCTAssertThrowsError(try readonly.replace(full, stamp: "must-not-write"))
+        }
+        let reader = fixture.repository(readOnly: true)
+        let text = try await HistoryTools.search(arguments: ["query": "中文结果", "project": "/work/repo"], repository: reader)
+        XCTAssertTrue(text.contains("claude-code:native: not indexed yet"))
+        XCTAssertFalse(text.contains("ref: "))
+        XCTAssertEqual(try fixture.bytes(), before)
+
+        try FileManager.default.removeItem(at: fixture.cache.appendingPathComponent("search.sqlite"))
+        let withoutDB = try fixture.bytes()
+        let missing = try await HistoryTools.search(arguments: ["query": "中文结果"], repository: reader)
+        XCTAssertTrue(missing.contains("claude-code:native: not indexed yet"))
+        XCTAssertTrue(missing.contains("codex:older: not indexed yet"))
+        XCTAssertEqual(try fixture.bytes(), withoutDB)
+        let absent = fixture.root.appendingPathComponent("absent")
+        XCTAssertThrowsError(try SessionHistorySearchIndex(directory: absent, readOnly: true))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: absent.path))
+    }
+
+    func testChangedSourceCannotProduceReferenceToWrongRevision() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        _ = try await fixture.repository().refresh()
+        let original = try Data(contentsOf: fixture.claudeSource)
+        try (original + Data("\n".utf8)).write(to: fixture.claudeSource)
+        let before = try fixture.bytes()
+        let reader = fixture.repository(readOnly: true)
+        let text = try await HistoryTools.search(arguments: ["query": "中文结果", "project": "/work/repo"], repository: reader)
+        XCTAssertTrue(text.contains("not indexed yet"))
+        XCTAssertFalse(text.contains("ref: "))
+        for invalid: [String: Any] in [[:], ["query": "  "], ["query": 3], ["query": "中文", "limit": true], ["query": "中文", "starred": true]] {
+            do { _ = try await HistoryTools.search(arguments: invalid, repository: reader); XCTFail("invalid arguments accepted") }
+            catch HistoryToolError.invalidArguments { }
+        }
+        XCTAssertEqual(try fixture.bytes(), before)
+    }
+
+    func testUnstampedCachePublishedAfterMetadataCannotInventReference() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        _ = try await fixture.repository().refresh()
+        let cacheFile = try XCTUnwrap(FileManager.default.contentsOfDirectory(at: fixture.cache, includingPropertiesForKeys: nil).first { file in
+            guard file.pathExtension == "json", file.lastPathComponent != "index.json",
+                  let session = try? JSONDecoder().decode(SessionHistorySession.self, from: Data(contentsOf: file)) else { return false }
+            return session.agent == .claude
+        })
+        var session = try JSONDecoder().decode(SessionHistorySession.self, from: Data(contentsOf: cacheFile))
+        session.sourceRevision = nil
+        session.messages.reverse()
+        try JSONEncoder().encode(session).write(to: cacheFile)
+        let indexFile = fixture.cache.appendingPathComponent("index.json")
+        let indexTime = try XCTUnwrap(indexFile.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+        try FileManager.default.setAttributes([.modificationDate: indexTime.addingTimeInterval(10)], ofItemAtPath: cacheFile.path)
+        let before = try fixture.bytes()
+        let reader = fixture.repository(readOnly: true)
+        let text = try await HistoryTools.search(arguments: ["query": "中文结果", "project": "/work/repo"], repository: reader)
+        XCTAssertTrue(text.contains("References unavailable:"))
+        XCTAssertFalse(text.contains("ref: "))
+        let shown = try await HistoryTools.getSession(arguments: ["key": "claude-code:native"], repository: reader)
+        XCTAssertTrue(shown.contains("source, index stale"))
+        XCTAssertTrue(shown.contains("## [seq 1] User"))
+        XCTAssertEqual(try fixture.bytes(), before)
+    }
+
+    private func reference(_ text: String) -> String {
+        text.components(separatedBy: "\n").first { $0.hasPrefix("ref: ") }.map { String($0.dropFirst(5)) } ?? "missing"
+    }
+
+    private struct Fixture {
+        let root: URL
+        var cache: URL { root.appendingPathComponent("history") }
+        var claudeSource: URL { root.appendingPathComponent("claude/projects/repo/native.jsonl") }
+        init() throws {
+            root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let codexSource = root.appendingPathComponent("codex/sessions/older.jsonl")
+            for file in [claudeSource, codexSource] {
+                try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+            }
+            let claude = [
+                ##"{"sessionId":"native","cwd":"/work/repo","timestamp":"2026-09-10T10:00:00Z","type":"user","message":{"role":"user","content":"# AGENTS.md instructions 中文结果 injected-only"}}"##,
+                #"{"sessionId":"native","type":"user","message":{"role":"user","content":"中文结果"}}"#,
+                #"{"sessionId":"native","type":"assistant","message":{"id":"a","role":"assistant","content":[{"type":"text","text":"Checking code"},{"type":"tool_use","id":"tool","name":"Bash","input":{"command":"cat result"}}]}}"#,
+                #"{"sessionId":"native","type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool","content":"worker.run(argument) 完成"}]}}"#
+            ]
+            let codex = [
+                #"{"timestamp":"2026-08-01T10:00:00Z","type":"session_meta","payload":{"id":"older","cwd":"/work/other"}}"#,
+                #"{"timestamp":"2026-08-01T10:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"中文结果"}]}}"#
+            ]
+            try Data(claude.joined(separator: "\n").utf8).write(to: claudeSource)
+            try Data(codex.joined(separator: "\n").utf8).write(to: codexSource)
+        }
+        func repository(readOnly: Bool = false) -> SessionHistoryRepository {
+            SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: root.appendingPathComponent("codex"), cacheDirectory: cache, readOnly: readOnly)
+        }
+        func bytes() throws -> [String: Data] {
+            try Dictionary(uniqueKeysWithValues: FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil).map { ($0.lastPathComponent, try Data(contentsOf: $0)) })
+        }
+        func remove() { try? FileManager.default.removeItem(at: root) }
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -11,7 +11,7 @@ final class HistoryToolsTests: XCTestCase {
 
     func testRegistryAndCLIParity() throws {
         let definitions = HistoryTools.definitions()
-        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_get_session", "vibebuddy_list_sessions", "vibebuddy_list_projects"])
+        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_get_session", "vibebuddy_list_sessions", "vibebuddy_list_projects", "vibebuddy_search"])
         XCTAssertEqual(Set(HistoryCLI.commands.values), Set(definitions.compactMap { $0["name"] as? String }))
         for definition in definitions {
             XCTAssertEqual((definition["annotations"] as? [String: Bool])?["readOnlyHint"], true)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -78,7 +78,8 @@ final class HistoryToolsTests: XCTestCase {
         do { try await reader.setFavorite(sessionID: id, isFavorite: false); XCTFail("favorite wrote") } catch {}
         do { try await reader.setPinned(sessionID: id, isPinned: false); XCTFail("pin wrote") } catch {}
         do { try await reader.setArchived(sessionID: id, isArchived: false); XCTFail("archive wrote") } catch {}
-        do { _ = try await reader.search("hello"); XCTFail("search wrote") } catch {}
+        let hits = try await reader.search("hello")
+        XCTAssertEqual(hits.count, 1)
         XCTAssertEqual(try bytes(cache), before)
         let missing = root.appendingPathComponent("missing")
         let empty = SessionHistoryRepository(cacheDirectory: missing, readOnly: true)

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryTranscriptTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryTranscriptTests.swift
@@ -63,7 +63,7 @@ final class HistoryTranscriptTests: XCTestCase {
         XCTAssertEqual(try bytes(cache), before)
         let again = try await reader.readTranscript(key: "codex:native")
         XCTAssertEqual(again.session, stale.session)
-        let content = try XCTUnwrap(FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil).first { $0.lastPathComponent != "index.json" })
+        let content = try XCTUnwrap(FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil).first { $0.pathExtension == "json" && $0.lastPathComponent != "index.json" })
         var full = try JSONDecoder().decode(SessionHistorySession.self, from: Data(contentsOf: content))
         full.sourceRevision = "mismatched-revision"
         try JSONEncoder().encode(full).write(to: content)

--- a/docs/session-history.md
+++ b/docs/session-history.md
@@ -35,8 +35,14 @@ placeholders. There is no syntax-coloring guarantee.
 The app checks sources on opening the library, on Refresh, and every 30 seconds
 while the library is open. Initial indexing advances in bounded batches; pending
 coverage is reported. The local index stores metadata and separate per-source text
-caches under `~/Library/Application Support/VibeBuddy/SessionHistory`. Selected text is loaded for reading; the first query builds missing message indexes
-from cached text. Warm queries reuse those indexes. Conversation timestamps drive
+caches under `~/Library/Application Support/VibeBuddy/SessionHistory`. Selected text is loaded for reading; refresh eagerly builds message indexes.
+Queries open SQLite read-only and omit rows whose source revision differs from
+the loaded metadata. An exclusive `.refresh.lock` coordinates App and CLI refreshes;
+an App refresh skips a busy writer and reports the reason. JSON files publish
+atomically, and SQLite publishes each source in a transaction. Readers see complete
+files and committed matching message revisions, without waiting for the full scan.
+`vibebuddy-mcp index` builds an absent index; `index --rebuild` refreshes all sources.
+The explicit command exits 2 when another refresh holds the lock. Conversation timestamps drive
 list order, with file timestamps as a fallback. Agent-injected setup blocks remain
 searchable but are excluded when deriving titles. Rebuild index re-reads the sources; favorites, pins and library archives are saved
 separately and retained. Missing sources retain their last indexed copy with an


### PR DESCRIPTION
agent-mcp-cli/04

## Summary

Add `vibebuddy_search` to the tool layer and `vibebuddy-mcp search QUERY` to the CLI. Literal Chinese and code searches use the existing project/agent/time/limit rules, plain snippets and freshness line. Every readable hit carries its source revision and a stable `vibebuddy://session/<key>#<seq>` reference; tool-result IDs map to their grouped dialogue row. Meta and Thinking do not consume the result limit.

Search opens FTS read-only and reports missing/outdated index rows or unverifiable cached references. It shares cache verification and canonical source selection with `show`, so archive moves retain valid refs while genuinely duplicated available sources remain ambiguous. The App's existing search API is preserved.

Stacked on `codex/agent-mcp-cli-02-show-transcript`, including its `448480a2` archive fix. Also merges ticket03's index coordination through `7d3356b7` (dependency merges `f3d8044b` and `a7f865a6`). Final source commit: `ac3412f6`.

## Validation

- `swift build --package-path VibeBuddyMac --product vibebuddy-mcp -j 2`: passed.
- Focused search/tools/transcript tests: 12 XCTest passed, including cache publication, missing rows/database, scope-before-limit, raw tool refs, archive moves and real ambiguity rejection.
- Full suite: 22 XCTest and 1011 Swift Testing tests in 119 suites passed. An intermediate full run had one timing failure in unchanged `CodexRolloutMonitorTests.eventDrivenDebouncedAppend` (refresh count 2 vs 1); its isolated retry and the single complete retry passed. All logs were retained, and no monitor code/test changed.
- Nine actual CLI calls over copied local Claude/Codex sources passed. Chinese and code refs opened matching `show` context at the same sequence/revision. All seven store files and source copies remained byte-identical.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml` and macOS `xcodebuild ... CODE_SIGNING_ALLOWED=NO -jobs 2 build`: passed in this ticket's isolated derived-data directory.
- Independent implementation review and both incremental fix reviews passed. Worktree `Package.resolved` restored; branch clean and pushed.

## Not verified here

MCP client transport is ticket05. This ticket used the real CLI and built the isolated macOS App; it did not replace the installed App, access the production daemon or real devices, change user-level client configuration, deploy, synchronize machines or merge.
