### PR TITLE
feat(history): add metadata-only Grok Build source

### DIFF
--- a/VibeBuddyKit/Sources/VibeBuddyKit/E2ERunConfiguration.swift
+++ b/VibeBuddyKit/Sources/VibeBuddyKit/E2ERunConfiguration.swift
@@ -25,10 +25,15 @@ public struct E2ERunConfiguration: Sendable {
     }()
 
     /// Pure parsing: creates no directories, touches no secrets and starts no services.
-    /// Absence is allowed only when none of the E2E variables is present.
+    /// Absence is allowed only for ordinary bundles with no E2E variables.
     public init?(environment: [String: String], bundleIdentifier: String?) throws {
         let keys = Set(environment.keys.filter { $0.hasPrefix("VIBEBUDDY_E2E_") })
-        guard !keys.isEmpty else { return nil }
+        guard !keys.isEmpty else {
+            guard bundleIdentifier?.hasPrefix("com.vibebuddy.e2e.") != true else {
+                throw ConfigurationError.invalidEnvironment
+            }
+            return nil
+        }
         let allowed: Set<String> = ["VIBEBUDDY_E2E_ROOT", "VIBEBUDDY_E2E_ID", "VIBEBUDDY_E2E_PORT",
                                     "VIBEBUDDY_E2E_NOTIFICATIONS", "VIBEBUDDY_E2E_AUDIO",
                                     "VIBEBUDDY_E2E_HOST", "VIBEBUDDY_E2E_CODEX_THREAD"]

--- a/VibeBuddyKit/Tests/VibeBuddyKitTests/E2ERunConfigurationTests.swift
+++ b/VibeBuddyKit/Tests/VibeBuddyKitTests/E2ERunConfigurationTests.swift
@@ -13,6 +13,13 @@ struct E2ERunConfigurationTests {
         #expect(try E2ERunConfiguration(environment: ["PATH": "/bin"], bundleIdentifier: "com.vibebuddy.mac") == nil)
     }
 
+    @Test("An E2E app relaunched without its environment refuses production fallback")
+    func isolatedBundleWithoutEnvironment() {
+        #expect(throws: E2ERunConfiguration.ConfigurationError.self) {
+            try E2ERunConfiguration(environment: ["PATH": "/bin"], bundleIdentifier: "com.vibebuddy.e2e.probe-1")
+        }
+    }
+
     @Test("Valid run confines names, paths and flags to the explicit namespace")
     func validRun() throws {
         let config = try #require(try E2ERunConfiguration(environment: environment, bundleIdentifier: "com.vibebuddy.e2e.probe-1"))

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokHistorySource.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/GrokHistorySource.swift
@@ -1,0 +1,127 @@
+import CryptoKit
+import Foundation
+
+/// Grok 1.0.30's official inventory only. Never reads updates.jsonl or exports
+/// conversations: the three-session TUI fidelity gate was not completed.
+public enum GrokHistorySource {
+    public static let coverage = "Grok Build: official list and titles only; no transcript or full-text search. List dates have day precision."
+    static let noTranscript = "该来源无全文 (Grok Build: list and title only; no transcript)."
+    static let sandboxProfile = "(version 1)(allow default)(deny file-write*)(deny process-fork)"
+    struct Inventory {
+        var sessions: [SessionHistorySession] = []
+        var issues: [String] = []
+    }
+
+    /// Directory names locate workspaces only; all record metadata comes from
+    /// `sessions list`. The local directory verifies which cwd owns each row,
+    /// since the CLI may also list siblings and remote-only sessions.
+    static func scan(home: URL) -> Inventory {
+        let root = home.appendingPathComponent("sessions").resolvingSymlinksInPath()
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: root.path) else { return Inventory() }
+        guard let executable = executable(), fm.isExecutableFile(atPath: "/usr/bin/sandbox-exec") else {
+            return Inventory(issues: ["Grok history unavailable: official CLI or read-only process sandbox unavailable."])
+        }
+        guard let directories = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey], options: [.skipsHiddenFiles]) else {
+            return Inventory(issues: ["Grok history unavailable: workspace directory cannot be enumerated."])
+        }
+        var result = Inventory()
+        let deadline = Date().addingTimeInterval(15)
+        for directory in directories.sorted(by: { $0.path < $1.path }) {
+            guard let properties = try? directory.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                  properties.isDirectory == true, properties.isSymbolicLink != true else { continue }
+            guard let cwd = directory.lastPathComponent.removingPercentEncoding,
+                  cwd.hasPrefix("/"), !cwd.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains),
+                  fm.fileExists(atPath: cwd) else {
+                result.issues.append("Grok history: a workspace path is unavailable; its inventory was not refreshed.")
+                continue
+            }
+            let timeout = min(3, deadline.timeIntervalSinceNow)
+            guard timeout > 0.2 else {
+                result.issues.append("Grok history: workspace inventory time limit reached; coverage is partial.")
+                break
+            }
+            do {
+                var environment = ProcessInfo.processInfo.environment
+                environment["GROK_HOME"] = home.path
+                let output = try POSIXCommandSupervisor().run(
+                    executableURL: URL(fileURLWithPath: "/usr/bin/sandbox-exec"),
+                    arguments: ["-p", sandboxProfile, executable.path, "--cwd", cwd, "sessions", "list", "-n", "200"],
+                    environment: environment, timeout: timeout, outputLimit: min(SessionHistoryParser.byteLimit, 1024 * 1024))
+                guard output.exitedSuccessfully, let text = String(data: output.standardOutput, encoding: .utf8) else {
+                    result.issues.append("Grok history: protected official list failed; no unprotected retry was attempted.")
+                    continue
+                }
+                // CLI diagnostics can contain authentication details. Never expose them.
+                if !output.standardError.isEmpty { result.issues.append("Grok history: official list reported diagnostics; inventory may be partial.") }
+                var parsed = parse(text, cwd: cwd, directory: directory)
+                var unmatched = false
+                parsed.sessions.removeAll { session in
+                    let values = try? URL(fileURLWithPath: session.sourcePath).resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+                    if values?.isDirectory == true, values?.isSymbolicLink != true { return false }
+                    unmatched = true
+                    return true
+                }
+                if unmatched { parsed.issues.append("Grok history: list row has no matching local workspace directory; project was not guessed.") }
+                result.sessions += parsed.sessions
+                result.issues += parsed.issues
+            } catch {
+                result.issues.append("Grok history: protected official list failed or exceeded its time/output limit.")
+            }
+        }
+        return result
+    }
+
+    /// Fixed text format verified against grok 1.0.30. Reject an entire malformed
+    /// row; never infer a session ID, date, source, or project from its title.
+    static func parse(_ text: String, cwd: String, directory: URL) -> Inventory {
+        var result = Inventory()
+        let pattern = #"^([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})\s+(\d{4}-\d{2}-\d{2})\s+(\d{4}-\d{2}-\d{2})\s+(local|remote)\s+(.+)$"#
+        let regex = try! NSRegularExpression(pattern: pattern)
+        let date = DateFormatter()
+        date.locale = Locale(identifier: "en_US_POSIX"); date.calendar = Calendar(identifier: .gregorian)
+        date.dateFormat = "yyyy-MM-dd"; date.isLenient = false
+        var seen = Set<String>()
+        var count = 0
+        for (index, raw) in text.components(separatedBy: .newlines).enumerated() {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line == "(no label)" || line.hasPrefix("Label: ") || line == "No sessions found." { continue }
+            if line.split(whereSeparator: \.isWhitespace).joined(separator: " ") == "SESSION ID CREATED UPDATED SOURCE SUMMARY" { continue }
+            guard !line.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains),
+                  let match = regex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)),
+                  let idRange = Range(match.range(at: 1), in: line),
+                  let createdRange = Range(match.range(at: 2), in: line),
+                  let updatedRange = Range(match.range(at: 3), in: line),
+                  let sourceRange = Range(match.range(at: 4), in: line),
+                  let titleRange = Range(match.range(at: 5), in: line),
+                  let created = date.date(from: String(line[createdRange])), date.string(from: created) == line[createdRange],
+                  let updated = date.date(from: String(line[updatedRange])), date.string(from: updated) == line[updatedRange] else {
+                result.issues.append("Grok history: unrecognized official list row \(index + 1) omitted.")
+                continue
+            }
+            count += 1
+            guard line[sourceRange] == "local" else { continue }
+            let id = String(line[idRange]).lowercased()
+            guard seen.insert(id).inserted else {
+                result.issues.append("Grok history: duplicate native ID omitted.")
+                result.sessions.removeAll { $0.nativeSessionID == id }
+                continue
+            }
+            let path = directory.appendingPathComponent(id).path
+            var session = SessionHistorySession(id: "grokBuild:" + id, nativeSessionID: id, agent: .grokBuild,
+                projectPath: cwd, title: String(line[titleRange].prefix(120)), sourcePath: path, updatedAt: updated,
+                messages: [], warnings: [coverage], source: "official-list")
+            session.sourceRevision = "list-row:" + SHA256.hash(data: Data((path + "\n" + line).utf8)).map { String(format: "%02x", $0) }.joined()
+            result.sessions.append(session)
+        }
+        if count >= 200 { result.issues.append("Grok history: official list reached its 200-row limit; coverage may be partial.") }
+        return result
+    }
+
+    private static func executable() -> URL? {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let paths = [home.appendingPathComponent(".local/bin/grok").path, home.appendingPathComponent(".grok/bin/grok").path,
+                     "/opt/homebrew/bin/grok", "/usr/local/bin/grok"]
+        return paths.first(where: FileManager.default.isExecutableFile(atPath:)).map { URL(fileURLWithPath: $0) }
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryResumePolicy.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryResumePolicy.swift
@@ -7,7 +7,7 @@ public enum HistoryResumePolicy {
         guard history.projectPath.hasPrefix("/"), !history.nativeSessionID.isEmpty else { return nil }
         let matches = sessions.filter {
             guard $0.id == history.nativeSessionID,
-                  $0.agent == (history.agent == .claude ? .claudeCode : .codex) else { return false }
+                  $0.agent == agentKind(history.agent) else { return false }
             if let cwd = $0.terminalRef?.cwd { return cwd == history.projectPath }
             // Daemon/desktop observations have a verified thread identity but
             // need not have a terminal. Keep using the live action capability;
@@ -20,14 +20,23 @@ public enum HistoryResumePolicy {
     /// Copying never invokes an agent. Only explicit CLI provenance can supply
     /// a Codex terminal command; Desktop and child sessions keep their own route.
     public static func command(for history: SessionHistorySession, directoryExists: Bool) -> String? {
-        guard (history.agent == .claude || (history.agent == .codex && history.source == "cli")),
+        guard (history.agent == .claude || history.agent == .grokBuild || (history.agent == .codex && history.source == "cli")),
               history.sourceArchived != true, history.isAvailable, directoryExists,
               UUID(uuidString: history.nativeSessionID) != nil,
               history.projectPath.hasPrefix("/"),
               !history.projectPath.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) })
         else { return nil }
-        let command = history.agent == .claude ? "claude --resume" : "codex resume"
+        let command: String
+        switch history.agent {
+        case .claude: command = "claude --resume"
+        case .codex: command = "codex resume"
+        case .grokBuild: command = "grok --resume"
+        }
         return "cd -- \(quote(history.projectPath)) && \(command) \(quote(history.nativeSessionID))"
+    }
+
+    private static func agentKind(_ agent: SessionHistoryAgent) -> AgentKind {
+        switch agent { case .claude: .claudeCode; case .codex: .codex; case .grokBuild: .grok }
     }
 
     private static func quote(_ value: String) -> String {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistorySearch.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistorySearch.swift
@@ -22,6 +22,9 @@ extension HistoryTools {
         if let notice = scope.notice { return notice + "\n\n" + scope.freshness }
         let page = try await repository.search(query, sessionIDs: Set(scope.sessions.map(\.id)), limit: scope.limit)
         var lines = ["# Search results", "", "Coverage: indexed readable dialogue and tool text; Meta and Thinking omitted. Use show REF --tools to expand tool details."]
+        if scope.sessions.contains(where: { !$0.agent.supportsTranscript }) || (arguments["agents"] as? [String])?.contains("grok-build") == true {
+            lines += ["", GrokHistorySource.coverage]
+        }
         if page.hits.isEmpty { lines += ["", "No matches found."] }
         for hit in page.hits {
             lines += ["", "## \(oneLine(hit.session.title))", "Key: \(key(hit.session)) | Project: \(oneLine(hit.session.projectPath))",

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -21,13 +21,13 @@ public enum HistoryTools {
             "max_messages": ["type": "integer", "minimum": 1, "maximum": 200],
             "tools": ["type": "boolean"], "thinking": ["type": "boolean"]
         ], required: ["key"]), definition("vibebuddy_list_sessions", description: "List indexed local sessions, newest activity first.", properties: [
-            "project": ["type": "string"], "agents": ["type": "array", "items": ["type": "string", "enum": ["claude-code", "codex"]]],
+            "project": ["type": "string"], "agents": ["type": "array", "items": ["type": "string", "enum": SessionHistoryAgent.allCases.map(\.keyName)]],
             "since": ["type": "string"], "starred": ["type": "boolean"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
         ]), definition("vibebuddy_list_projects", description: "List projects with indexed sessions, newest activity first.", properties: [
             "since": ["type": "string"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
         ]), definition("vibebuddy_search", description: "Search indexed readable message text literally, with session references and unindexed source coverage.", properties: [
             "query": ["type": "string", "minLength": 1], "project": ["type": "string"],
-            "agents": ["type": "array", "items": ["type": "string", "enum": ["claude-code", "codex"]]],
+            "agents": ["type": "array", "items": ["type": "string", "enum": SessionHistoryAgent.allCases.map(\.keyName)]],
             "since": ["type": "string"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
         ], required: ["query"])]
     }
@@ -39,7 +39,7 @@ public enum HistoryTools {
     }
 
     public static func key(_ session: SessionHistorySession) -> String {
-        (session.agent == .claude ? "claude-code" : "codex") + ":" + session.nativeSessionID
+        session.agent.keyName + ":" + session.nativeSessionID
     }
 
     struct Selection {
@@ -69,7 +69,7 @@ public enum HistoryTools {
                 } else if let string = value as? String, let number = Int(string) { valid = (1...200).contains(number) }
                 else { valid = false }
             case "starred": valid = (value as? NSNumber).map { CFGetTypeID($0) == CFBooleanGetTypeID() } ?? false
-            case "agents": valid = (value as? [String]).map { $0.allSatisfy { ["claude-code", "codex"].contains($0) } } ?? false
+            case "agents": valid = (value as? [String]).map { $0.allSatisfy { SessionHistoryAgent.allCases.map(\.keyName).contains($0) } } ?? false
             default: valid = value is String
             }
             guard valid else { throw HistoryToolError.invalidArguments("Invalid argument: \(key)") }
@@ -90,7 +90,7 @@ public enum HistoryTools {
             sessions = sessions.filter { $0.projectPath == matches[0] }
         }
         if let agents = arguments["agents"] as? [String], !agents.isEmpty {
-            sessions = sessions.filter { agents.contains($0.agent == .claude ? "claude-code" : "codex") }
+            sessions = sessions.filter { agents.contains($0.agent.keyName) }
         }
         if let starred = arguments["starred"] as? Bool { sessions = sessions.filter { $0.isFavorite == starred } }
         return Selection(sessions: sessions, limit: limit, freshness: freshness)
@@ -110,10 +110,11 @@ public enum HistoryTools {
             }
             return (["| Project | Updated | Sessions |", "| --- | --- | ---: |"] + (rows.isEmpty ? ["No projects found."] : rows) + ["", freshness]).joined(separator: "\n")
         }
+        let coverage = sessions.contains { !$0.agent.supportsTranscript } ? ["", GrokHistorySource.coverage] : []
         let rows = sessions.prefix(limit).map { s in
-            "| \(cell(key(s))) | \(s.agent.displayName) | \(stamp(s.updatedAt)) | \(cell(s.projectPath)) | \(cell(s.title)) | \(s.messageCount) |"
+            "| \(cell(key(s))) | \(s.agent.displayName) | \(stamp(s.updatedAt)) | \(cell(s.projectPath)) | \(cell(s.title)) | \(s.agent.supportsTranscript ? String(s.messageCount) : "unavailable") |"
         }
-        return (["| Key | Agent | Updated | Project | Title | Messages |", "| --- | --- | --- | --- | --- | ---: |"] + (rows.isEmpty ? ["No sessions found."] : rows) + ["", freshness]).joined(separator: "\n")
+        return (["| Key | Agent | Updated | Project | Title | Messages |", "| --- | --- | --- | --- | --- | ---: |"] + (rows.isEmpty ? ["No sessions found."] : rows) + coverage + ["", freshness]).joined(separator: "\n")
     }
 
     private static func stamp(_ date: Date) -> String { ISO8601DateFormatter().string(from: date) }

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTranscript.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTranscript.swift
@@ -6,7 +6,7 @@ public struct HistorySessionReference: Sendable {
     public let agent: SessionHistoryAgent
     public let nativeID: String
     public let seq: Int?
-    public var key: String { (agent == .claude ? "claude-code" : "codex") + ":" + nativeID }
+    public var key: String { agent.keyName + ":" + nativeID }
     public init(_ value: String) throws {
         let prefix = "vibebuddy://session/"
         let isRef = value.hasPrefix(prefix)
@@ -16,6 +16,7 @@ public struct HistorySessionReference: Sendable {
         switch raw[..<colon] {
         case "claude-code": agent = .claude
         case "codex": agent = .codex
+        case "grok-build": agent = .grokBuild
         default: throw HistoryToolError.executionFailed("Unknown session agent.")
         }
         nativeID = String(raw[raw.index(after: colon)...])
@@ -76,6 +77,10 @@ extension HistoryTools {
         let tools = try flag("tools"), thinking = try flag("thinking")
         let transcript = try await repository.readTranscript(key: reference.key)
         let session = transcript.session
+        if !session.agent.supportsTranscript {
+            return ["# " + session.title, "Key: " + reference.key, "", GrokHistorySource.noTranscript,
+                    GrokHistorySource.coverage, "Source revision: " + (session.sourceRevision ?? "unknown") + " (official list row only)"].joined(separator: "\n")
+        }
         let rows = transcript.rows
         let page = rows.enumerated().filter { $0.offset >= from - 1 && (thinking || !$0.element.text.isEmpty || !$0.element.tools.isEmpty) }.prefix(limit)
         var lines = ["Source revision: \(session.sourceRevision ?? "unknown") (\(transcript.provenance))", "", "# \(session.title)", "Key: \(reference.key)"]

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryModels.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryModels.swift
@@ -1,8 +1,14 @@
 import Foundation
 
 public enum SessionHistoryAgent: String, Codable, Sendable, CaseIterable {
-    case claude, codex
-    public var displayName: String { self == .claude ? "Claude Code" : "Codex" }
+    case claude, codex, grokBuild
+    public var displayName: String {
+        switch self { case .claude: "Claude Code"; case .codex: "Codex"; case .grokBuild: "Grok Build" }
+    }
+    public var keyName: String {
+        switch self { case .claude: "claude-code"; case .codex: "codex"; case .grokBuild: "grok-build" }
+    }
+    public var supportsTranscript: Bool { self != .grokBuild }
 }
 public enum SessionHistoryRole: String, Codable, Sendable { case user, assistant, tool, system }
 public enum SessionHistoryMessageKind: String, Codable, Sendable { case text, meta, thinking, compactSummary }
@@ -64,6 +70,9 @@ public struct SessionHistorySearchResult: Identifiable, Sendable {
     public var messageID: String
     public var excerpt: String
     public var id: String { sessionID + "|" + messageID }
+    public init(sessionID: String, messageID: String, excerpt: String) {
+        self.sessionID = sessionID; self.messageID = messageID; self.excerpt = excerpt
+    }
 }
 public enum SessionHistoryExport {
     public static func markdown(session: SessionHistorySession) -> String {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryParser.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryParser.swift
@@ -13,6 +13,7 @@ enum SessionHistoryParser {
     }
     static let byteLimit = 32 * 1024 * 1024
     static func read(url: URL, agent: SessionHistoryAgent, updatedAt: Date) throws -> SessionHistorySession {
+        guard agent.supportsTranscript else { throw HistoryToolError.executionFailed(GrokHistorySource.noTranscript) }
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         let data = try handle.read(upToCount: byteLimit + 1) ?? Data()

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -61,7 +61,7 @@ public actor SessionHistoryRepository {
                 belongsToRoots(path) || (entry.session.agent == .grokBuild && grokPrefix.map { path.hasPrefix($0) } == true)
             }
             pendingPaths = Set((cache.pendingPaths ?? []).filter(belongsToRoots))
-            if cache.version < 7 { pendingPaths.formUnion(entries.keys) }
+            if cache.version < 7 { pendingPaths.formUnion(entries.filter { $0.value.session.agent.supportsTranscript }.keys) }
         }
     }
     public func hasUsableIndex() -> Bool { ensureLoaded(); return usableIndex }
@@ -128,7 +128,7 @@ public actor SessionHistoryRepository {
         let staging = rebuild ? directory.appendingPathComponent(".rebuild-" + UUID().uuidString) : nil
         defer { if let staging { try? fm.removeItem(at: staging) } }
         let searchIndex = try SessionHistorySearchIndex(directory: staging ?? directory)
-        if rebuild { pendingPaths.formUnion(entries.keys) }
+        if rebuild { pendingPaths.formUnion(entries.filter { $0.value.session.agent.supportsTranscript }.keys) }
         for (root, agent) in roots {
             guard fm.fileExists(atPath: root.path) else { issues.append("Source directory unavailable: \(root.path)"); continue }
             var enumerationErrors = 0
@@ -196,6 +196,7 @@ public actor SessionHistoryRepository {
             if !inventory.sessions.isEmpty { issues.append(GrokHistorySource.coverage) }
             for session in inventory.sessions {
                 discovered.insert(session.sourcePath)
+                pendingPaths.remove(session.sourcePath)
                 if entries[session.sourcePath]?.session != session {
                     entries[session.sourcePath] = Entry(modified: session.updatedAt, size: 0, session: session)
                     changed = true

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -8,6 +8,7 @@ public actor SessionHistoryRepository {
     private struct Cache: Codable { var version: Int = 7; var entries: [String: Entry]; var pendingPaths: Set<String>? = nil }
     private let roots: [(URL, SessionHistoryAgent)]
     private let directory: URL
+    private let grokHome: URL?
     private let refreshByteBudget: Int
     private var entries: [String: Entry] = [:]
     private var favorites = Set<String>()
@@ -21,8 +22,9 @@ public actor SessionHistoryRepository {
     private let readOnly: Bool
     private var transcriptSlot: (path: String, revision: String, transcript: HistoryTranscript)?
     private var usableIndex = false
-    public init(claudeHome: URL? = nil, codexHome: URL? = nil, cacheDirectory: URL? = nil, refreshByteBudget: Int = 256 * 1024 * 1024, readOnly: Bool = false) {
+    public init(claudeHome: URL? = nil, codexHome: URL? = nil, grokHome: URL? = nil, cacheDirectory: URL? = nil, refreshByteBudget: Int = 256 * 1024 * 1024, readOnly: Bool = false) {
         self.readOnly = readOnly
+        self.grokHome = grokHome?.resolvingSymlinksInPath()
         self.refreshByteBudget = max(1, refreshByteBudget)
         let home = FileManager.default.homeDirectoryForCurrentUser
         let env = ProcessInfo.processInfo.environment
@@ -54,7 +56,10 @@ public actor SessionHistoryRepository {
                 let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
                 return prefixes.contains { path.hasPrefix($0) || resolved.hasPrefix($0) }
             }
-            entries = cache.entries.filter { belongsToRoots($0.key) }
+            let grokPrefix = grokHome?.appendingPathComponent("sessions").resolvingSymlinksInPath().path.appending("/")
+            entries = cache.entries.filter { path, entry in
+                belongsToRoots(path) || (entry.session.agent == .grokBuild && grokPrefix.map { path.hasPrefix($0) } == true)
+            }
             pendingPaths = Set((cache.pendingPaths ?? []).filter(belongsToRoots))
             if cache.version < 7 { pendingPaths.formUnion(entries.keys) }
         }
@@ -66,7 +71,7 @@ public actor SessionHistoryRepository {
         var byID: [String: SessionHistorySession] = [:]
         for entry in entries.values {
             var session = entry.session; session.isFavorite = favorites.contains(session.id); session.isPinned = pins.contains(session.id); session.archivedLocally = archives.contains(session.id)
-            session.sourceRevision = "\(entry.modified.timeIntervalSince1970)|\(entry.size)"
+            if session.agent.supportsTranscript { session.sourceRevision = "\(entry.modified.timeIntervalSince1970)|\(entry.size)" }
             if let existing = byID[session.id] {
                 if existing.isAvailable != session.isAvailable {
                     if existing.isAvailable { continue }
@@ -185,6 +190,18 @@ public actor SessionHistoryRepository {
                 if !removed.isEmpty { pendingPaths.subtract(removed); changed = true }
             }
         }
+        if let grokHome {
+            let inventory = GrokHistorySource.scan(home: grokHome)
+            issues += inventory.issues
+            if !inventory.sessions.isEmpty { issues.append(GrokHistorySource.coverage) }
+            for session in inventory.sessions {
+                discovered.insert(session.sourcePath)
+                if entries[session.sourcePath]?.session != session {
+                    entries[session.sourcePath] = Entry(modified: session.updatedAt, size: 0, session: session)
+                    changed = true
+                }
+            }
+        }
         for path in entries.keys where !discovered.contains(path) {
             // Retain a cached transcript for provenance/favorites, but never claim its source is available.
             if entries[path]?.session.isAvailable == true { entries[path]?.session.isAvailable = false; changed = true }
@@ -194,7 +211,7 @@ public actor SessionHistoryRepository {
         if let cacheFailure { throw cacheFailure }
         // Migrate old lazy indexes and repair missing FTS rows only while holding
         // the writer lock. No query ever decodes caches or writes SQLite rows.
-        for entry in entries.values {
+        for entry in entries.values where entry.session.agent.supportsTranscript {
             let stamp = "v7|\(entry.modified.timeIntervalSince1970)|\(entry.size)"
             if try !searchIndex.isCurrent(path: entry.session.sourcePath, stamp: stamp) {
                 let session = try autoreleasepool { try load(entry.session) }
@@ -228,6 +245,10 @@ public actor SessionHistoryRepository {
         let matches = entries.values.filter { $0.session.agent == reference.agent && $0.session.nativeSessionID == reference.nativeID }
         guard matches.count <= 1 else { throw HistoryToolError.executionFailed("Ambiguous session key: multiple source files.") }
         var metadata = matches.first?.session
+        if reference.agent == .grokBuild {
+            guard let metadata else { throw HistoryToolError.executionFailed("Unknown session key.") }
+            return HistoryTranscript(session: metadata, provenance: "official list metadata, no transcript")
+        }
         if metadata == nil {
             // Locate by native filename only; never parse every conversation to find one ID.
             var candidates: [URL] = []
@@ -298,6 +319,7 @@ public actor SessionHistoryRepository {
         return try load(metadata)
     }
     private func load(_ metadata: SessionHistorySession) throws -> SessionHistorySession {
+        if !metadata.agent.supportsTranscript { return metadata }
         let data = try Data(contentsOf: directory.appendingPathComponent(contentFilename(metadata.sourcePath)))
         var full = try JSONDecoder().decode(SessionHistorySession.self, from: data)
         guard full.id == metadata.id, full.sourcePath == metadata.sourcePath else {
@@ -342,9 +364,10 @@ public actor SessionHistoryRepository {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty, limit > 0 else { return [] }
         let sessions = snapshot().sessions.filter {
-            (projectPath == nil || $0.projectPath == projectPath) && (!favoritesOnly || $0.isFavorite)
+            $0.agent.supportsTranscript && (projectPath == nil || $0.projectPath == projectPath) && (!favoritesOnly || $0.isFavorite)
                 && (agent == nil || $0.agent == agent) && (archived == nil || $0.isArchived == archived)
         }
+        guard !sessions.isEmpty else { return [] }
         let searchIndex = try SessionHistorySearchIndex(directory: directory, readOnly: true)
         return try searchIndex.search(needle, sessions: sessions, limit: limit)
     }
@@ -352,7 +375,7 @@ public actor SessionHistoryRepository {
     /// hits whose cached dialogue projection and source revision can be verified.
     /// No source discovery, transcript reparsing or store writes happen here.
     public func search(_ query: String, sessionIDs: Set<String>, limit: Int = 200) throws -> HistorySearchPage {
-        let sessions = snapshot().sessions.filter { sessionIDs.contains($0.id) }
+        let sessions = snapshot().sessions.filter { $0.agent.supportsTranscript && sessionIDs.contains($0.id) }
         guard !sessions.isEmpty else { return HistorySearchPage(hits: [], notIndexed: [], unavailable: []) }
         guard FileManager.default.fileExists(atPath: directory.appendingPathComponent("search.sqlite").path) else {
             return HistorySearchPage(hits: [], notIndexed: sessions, unavailable: [])

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -11,7 +11,7 @@ struct VibeBuddyMCP {
                 fail(HistoryToolError.invalidArguments("Usage: vibebuddy-mcp index [--rebuild]"), code: 2)
             }
             do {
-                let repository = SessionHistoryRepository(cacheDirectory: directory)
+                let repository = SessionHistoryRepository(grokHome: GrokHome.url, cacheDirectory: directory)
                 let snapshot = try await repository.index(rebuild: argv.contains("--rebuild"))
                 let text = snapshot.map { "Indexed \($0.sessions.count) sessions.\n" + $0.issues.joined(separator: "\n") }
                     ?? "Index already exists. Use --rebuild to refresh all sources."
@@ -22,7 +22,7 @@ struct VibeBuddyMCP {
         let request: (tool: String, arguments: [String: Any])
         do { request = try HistoryCLI.parse(Array(CommandLine.arguments.dropFirst())) }
         catch { fail(error, code: 2) }
-        let repository = SessionHistoryRepository(cacheDirectory: directory, readOnly: true)
+        let repository = SessionHistoryRepository(grokHome: GrokHome.url, cacheDirectory: directory, readOnly: true)
         do {
             let text: String
             if request.tool == "vibebuddy_get_session" {

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokHistorySourceTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokHistorySourceTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class GrokHistorySourceTests: XCTestCase {
+    private let id = "00000000-0000-4000-8000-000000000007"
+    private let sample = """
+
+    (no label)
+    SESSION ID                            CREATED     UPDATED     SOURCE      SUMMARY
+    00000000-0000-4000-8000-000000000007  2026-09-08  2026-09-09  local  Plan 中文 reading workflow
+    00000000-0000-4000-8000-000000000008  2026-09-08  2026-09-09  remote  Remote conversation
+    """
+
+    func testOfficialListIsMetadataOnlyAndRejectsMalformedRows() {
+        let parsed = GrokHistorySource.parse(sample + "\nmalformed row", cwd: "/project", directory: URL(fileURLWithPath: "/grok/sessions/%2Fproject"))
+        XCTAssertEqual(parsed.sessions.count, 1)
+        XCTAssertEqual(parsed.issues.count, 1)
+        let session = parsed.sessions[0]
+        XCTAssertEqual(session.nativeSessionID, id)
+        XCTAssertEqual(session.projectPath, "/project")
+        XCTAssertEqual(session.title, "Plan 中文 reading workflow")
+        XCTAssertEqual(session.messages, [])
+        XCTAssertEqual(session.messageCount, 0)
+        XCTAssertTrue(session.warnings.contains(GrokHistorySource.coverage))
+        XCTAssertTrue(session.sourceRevision?.hasPrefix("list-row:") == true)
+        let changed = GrokHistorySource.parse(sample.replacingOccurrences(of: "Plan 中文", with: "Changed 中文"), cwd: "/project", directory: URL(fileURLWithPath: "/grok/sessions/%2Fproject"))
+        XCTAssertNotEqual(changed.sessions[0].sourceRevision, session.sourceRevision, "List row revisions include title changes on the same day.")
+    }
+
+    func testDuplicateIdentityAndInvalidDatesAreOmitted() {
+        let duplicate = sample + "\n" + sample
+        XCTAssertTrue(GrokHistorySource.parse(duplicate, cwd: "/project", directory: URL(fileURLWithPath: "/grok")).sessions.isEmpty)
+        let invalid = sample.replacingOccurrences(of: "2026-09-09", with: "2026-02-30")
+        XCTAssertTrue(GrokHistorySource.parse(invalid, cwd: "/project", directory: URL(fileURLWithPath: "/grok")).sessions.isEmpty)
+    }
+
+    func testReadOnlyMetadataWorksWithoutTranscriptCacheOrFTS() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("grok-history-" + UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let grok = root.appendingPathComponent("grok")
+        let cache = root.appendingPathComponent("cache")
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+        let record = GrokHistorySource.parse(sample, cwd: "/project", directory: grok.appendingPathComponent("sessions/%2Fproject")).sessions[0]
+        let session = try JSONSerialization.jsonObject(with: JSONEncoder().encode(record))
+        let data = try JSONSerialization.data(withJSONObject: ["version": 7, "entries": [record.sourcePath: ["modified": record.updatedAt.timeIntervalSinceReferenceDate, "size": 0, "session": session]]])
+        let index = cache.appendingPathComponent("index.json")
+        try data.write(to: index)
+        let repository = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: root.appendingPathComponent("codex"), grokHome: grok, cacheDirectory: cache, readOnly: true)
+        let snapshot = await repository.snapshot()
+        XCTAssertEqual(snapshot.sessions.count, 1)
+        XCTAssertEqual(snapshot.sessions[0].sourceRevision, record.sourceRevision)
+        let list = try HistoryTools.call("vibebuddy_list_sessions", arguments: ["agents": ["grok-build"]], snapshot: snapshot)
+        XCTAssertTrue(list.contains("grok-build:" + id)); XCTAssertTrue(list.contains(GrokHistorySource.coverage))
+        let shown = try await HistoryTools.getSession(arguments: ["key": "vibebuddy://session/grok-build:" + id + "#1"], repository: repository)
+        XCTAssertTrue(shown.contains("该来源无全文")); XCTAssertFalse(shown.contains("[seq"))
+        let search = try await HistoryTools.search(arguments: ["query": "reading", "agents": ["grok-build"]], repository: repository)
+        XCTAssertTrue(search.contains(GrokHistorySource.coverage)); XCTAssertTrue(search.contains("No matches found"))
+        XCTAssertFalse(search.contains("not indexed yet")); XCTAssertFalse(search.contains("ref:"))
+        let selected = try await repository.session(id: record.id)
+        XCTAssertEqual(selected?.messages, [])
+        XCTAssertEqual(try Data(contentsOf: index), data)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: cache.path), ["index.json"])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: grok.path), "Queries must not create a Grok home or run the source command.")
+    }
+
+    func testResumeCopiesGrokCommandAndParserCannotReadItsStream() throws {
+        let session = GrokHistorySource.parse(sample, cwd: "/project's folder", directory: URL(fileURLWithPath: "/grok")).sessions[0]
+        XCTAssertEqual(HistoryResumePolicy.command(for: session, directoryExists: true), "cd -- '/project'\"'\"'s folder' && grok --resume '" + id + "'")
+        XCTAssertNil(HistoryResumePolicy.command(for: session, directoryExists: false))
+        XCTAssertEqual(try HistorySessionReference("grok-build:" + id).key, "grok-build:" + id)
+        XCTAssertThrowsError(try SessionHistoryParser.read(url: URL(fileURLWithPath: "/not-read/updates.jsonl"), agent: .grokBuild, updatedAt: Date())) { error in
+            XCTAssertEqual(error.localizedDescription, GrokHistorySource.noTranscript)
+        }
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokHistorySourceTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/GrokHistorySourceTests.swift
@@ -73,4 +73,31 @@ final class GrokHistorySourceTests: XCTestCase {
             XCTAssertEqual(error.localizedDescription, GrokHistorySource.noTranscript)
         }
     }
+
+    func testMetadataOnlyRebuildNeverBecomesPendingFullText() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("grok-rebuild-" + UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let grok = root.appendingPathComponent("absent-grok")
+        let cache = root.appendingPathComponent("cache")
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+        let record = GrokHistorySource.parse(sample, cwd: "/project", directory: grok.appendingPathComponent("sessions/%2Fproject")).sessions[0]
+        let session = try JSONSerialization.jsonObject(with: JSONEncoder().encode(record))
+        // Version 6 also exercises migration into the eager message index. The
+        // Grok source root is absent, so neither refresh can run a real CLI.
+        let data = try JSONSerialization.data(withJSONObject: ["version": 6, "entries": [record.sourcePath: ["modified": record.updatedAt.timeIntervalSinceReferenceDate, "size": 0, "session": session]]])
+        try data.write(to: cache.appendingPathComponent("index.json"))
+        let repository = SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: root.appendingPathComponent("codex"), grokHome: grok, cacheDirectory: cache)
+        let initial = await repository.snapshot()
+        XCTAssertEqual(initial.sessions.count, 1)
+        XCTAssertEqual(initial.pendingSourceCount, 0)
+        let first = try await repository.index(rebuild: true)
+        XCTAssertEqual(first?.pendingSourceCount, 0)
+        let second = try await repository.refresh(rebuild: true)
+        XCTAssertEqual(second.sessions.count, 1)
+        XCTAssertEqual(second.pendingSourceCount, 0)
+        let reloaded = SessionHistoryRepository(grokHome: grok, cacheDirectory: cache, readOnly: true)
+        let persisted = await reloaded.snapshot()
+        XCTAssertEqual(persisted.pendingSourceCount, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: grok.path))
+    }
 }

--- a/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
+++ b/VibeBuddyMacApp/Sources/HistoryWorkbenchView.swift
@@ -24,21 +24,26 @@ final class HistoryLibraryModel: ObservableObject {
     private var readGeneration = 0
     private let repository: SessionHistoryRepository
     private var searchGeneration = 0
+    let isDemo: Bool
 
     init() {
         let environment = ProcessInfo.processInfo.environment
+        isDemo = environment["VIBEBUDDY_E2E_ROOT"] == nil && environment["VIBEBUDDY_DEMO"] == "1"
         if let root = environment["VIBEBUDDY_E2E_ROOT"] {
             let url = URL(fileURLWithPath: root)
             repository = SessionHistoryRepository(
                 claudeHome: url.appendingPathComponent("agents/claude"),
                 codexHome: url.appendingPathComponent("agents/codex"),
+                grokHome: url.appendingPathComponent("agents/grok"),
                 cacheDirectory: url.appendingPathComponent("history"))
         } else {
-            repository = SessionHistoryRepository()
+            repository = SessionHistoryRepository(grokHome: isDemo ? nil : GrokHome.url, readOnly: isDemo)
         }
+        if isDemo { snapshot = SessionHistorySnapshot(sessions: MacDemoData.historySessions(), refreshedAt: Date()) }
     }
 
     func refresh(rebuild: Bool = false) async {
+        guard !isDemo else { return }
         guard !loading else { return }
         loading = true
         defer { loading = false }
@@ -49,6 +54,18 @@ final class HistoryLibraryModel: ObservableObject {
     }
 
     func search(_ query: String, project: String?, favorites: Bool, agent: SessionHistoryAgent?, archived: Bool?) async {
+        if isDemo {
+            let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            results = needle.isEmpty ? [] : Array(snapshot.sessions.filter {
+                (project == nil || $0.projectPath == project) && (!favorites || $0.isFavorite)
+                    && (agent == nil || $0.agent == agent) && (archived == nil || $0.isArchived == archived)
+            }.flatMap { session in
+                session.messages.filter { $0.kind != .meta && $0.kind != .thinking && $0.text.localizedCaseInsensitiveContains(needle) }
+                    .map { SessionHistorySearchResult(sessionID: session.id, messageID: $0.id, excerpt: String($0.text.prefix(240))) }
+            }.prefix(200))
+            searching = false; searchError = nil
+            return
+        }
         searchGeneration += 1
         let generation = searchGeneration
         searching = true
@@ -78,6 +95,7 @@ final class HistoryLibraryModel: ObservableObject {
         readingError = nil
         summaryTask?.cancel(); summaryTask = nil; summarizing = false; summary = nil; summaryError = nil
         guard let id else { transcript = nil; reading = false; return }
+        if isDemo { transcript = snapshot.sessions.first { $0.id == id }; reading = false; return }
         if transcript?.id != id { transcript = nil }
         reading = true
         do {
@@ -97,7 +115,7 @@ final class HistoryLibraryModel: ObservableObject {
     }
 
     func generateSummary() {
-        guard !summarizing, let selected = transcript else { return }
+        guard !isDemo, !summarizing, let selected = transcript, selected.agent.supportsTranscript else { return }
         let generation = readGeneration
         let config = CompletionSummaryConfiguration.load()
         let style = HistorySummaryStyle.load()
@@ -126,12 +144,14 @@ final class HistoryLibraryModel: ObservableObject {
     func cancelSummary() { summaryTask?.cancel() }
 
     func togglePinned(_ session: SessionHistorySession) async {
+        if isDemo { updateDemo(session.id) { $0.isPinned = $0.isPinned != true }; return }
         do {
             try await repository.setPinned(sessionID: session.id, isPinned: session.isPinned != true)
             snapshot = await repository.snapshot()
         } catch { self.error = error.localizedDescription }
     }
     func toggleArchive(_ session: SessionHistorySession) async {
+        if isDemo { updateDemo(session.id) { $0.archivedLocally = $0.archivedLocally != true }; return }
         do {
             try await repository.setArchived(sessionID: session.id, isArchived: session.archivedLocally != true)
             snapshot = await repository.snapshot()
@@ -139,11 +159,18 @@ final class HistoryLibraryModel: ObservableObject {
     }
 
     func toggleFavorite(_ session: SessionHistorySession) async {
+        if isDemo { updateDemo(session.id) { $0.isFavorite.toggle() }; return }
         do {
             try await repository.setFavorite(sessionID: session.id, isFavorite: !session.isFavorite)
             snapshot = await repository.snapshot()
             if transcript?.id == session.id { transcript?.isFavorite = !session.isFavorite }
         } catch { self.error = error.localizedDescription }
+    }
+
+    private func updateDemo(_ id: String, change: (inout SessionHistorySession) -> Void) {
+        guard let index = snapshot.sessions.firstIndex(where: { $0.id == id }) else { return }
+        change(&snapshot.sessions[index])
+        if transcript?.id == id { transcript = snapshot.sessions[index] }
     }
 }
 
@@ -228,6 +255,9 @@ struct HistoryWorkbenchView: View {
                 // The dashboard's one query; the sidebar's Search row and ⌘F
                 // land here while a history library is showing.
                 SearchPill(query: $query, focused: searchFocused)
+                if agent == .grokBuild || (isSearching && sessions.contains { !$0.agent.supportsTranscript }) {
+                    Text(GrokHistorySource.coverage).font(MacTheme.font(10)).foregroundStyle(MacTheme.ink2)
+                }
                 HStack(spacing: 6) {
                     MenuPill(title: agent?.displayName ?? String(localized: "All agents")) {
                         Button("All agents") { agent = nil }
@@ -348,10 +378,15 @@ struct HistoryWorkbenchView: View {
                         Text(error).foregroundStyle(MacTheme.ink2)
                         Button("Retry") { Task { await history.read(metadata.id) } }
                     }.frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if !session.agent.supportsTranscript {
+                    QuietEmptyState(title: "Full transcript unavailable", message: "This source provides a session list and titles only.", systemName: "text.book.closed")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     VStack(spacing: 0) {
-                        HistorySummaryView(history: history, session: session)
-                        Divider()
+                        if !history.isDemo {
+                            HistorySummaryView(history: history, session: session)
+                            Divider()
+                        }
                         HistoryMessageReader(session: session, targetMessage: targetMessage)
                     }
                 }
@@ -383,7 +418,7 @@ struct HistoryWorkbenchView: View {
             Task { await history.toggleArchive(session) }
         }.help("Organizes this library only; the original agent and current tasks are unchanged.")
         Button("Export Markdown…") { export(session) }
-            .disabled(history.reading || history.transcript?.id != session.id || history.readingError != nil)
+            .disabled(!session.agent.supportsTranscript || history.reading || history.transcript?.id != session.id || history.readingError != nil)
         Button("Show source") { NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: session.sourcePath)]) }
             .disabled(!session.isAvailable)
     }

--- a/VibeBuddyMacApp/Sources/MacDemoData.swift
+++ b/VibeBuddyMacApp/Sources/MacDemoData.swift
@@ -6,6 +6,14 @@ import VibeBuddyMacCore
 /// A demo instance seeds these and skips the server/polling entirely, so it never
 /// binds the port, pushes to a phone, or touches real session data (privacy-safe).
 enum MacDemoData {
+    static func historySessions(now: Date = Date()) -> [SessionHistorySession] {
+        let id = "00000000-0000-4000-8000-000000000007"
+        return [SessionHistorySession(id: "grokBuild:" + id, nativeSessionID: id, agent: .grokBuild,
+            projectPath: "/demo/glaux-book", title: "Demo: plan the reading workflow",
+            sourcePath: "/demo/grok-history/" + id, updatedAt: now, messages: [],
+            warnings: [GrokHistorySource.coverage], isAvailable: false, source: "official-list")]
+    }
+
     /// Sample account readings for the quota plinth and the Usage tab. One
     /// provider burns faster than its window's clock (Claude's Opus week), one
     /// is quiet, one is signed out, one carries credits and one carries spend —

--- a/VibeBuddyMacApp/Sources/MenuBarModel.swift
+++ b/VibeBuddyMacApp/Sources/MenuBarModel.swift
@@ -228,7 +228,10 @@ final class MenuBarModel: ObservableObject {
             attentionURL: AttentionOverrides.defaultURL(),
             missedURL: (E2ERunConfiguration.current == nil ? ProcessInfo.processInfo.environment["VIBEBUDDY_MISSED_PATH"] : nil).map {
                 URL(fileURLWithPath: $0)
-            } ?? MissedLedgerLocation.defaultURL()
+            } ?? MissedLedgerLocation.defaultURL(),
+            grokHome: E2ERunConfiguration.current?.file("agents").appendingPathComponent("grok"),
+            copilotDatabase: E2ERunConfiguration.current?.file("agents").appendingPathComponent("copilot/session-store.db"),
+            cursorDatabase: E2ERunConfiguration.current?.file("agents").appendingPathComponent("cursor/state.vscdb")
         )
         // File-based store (owner-only): no Keychain ACL, so an ad-hoc rebuild
         // never re-prompts. Shared with vibebuddyd's default store.

--- a/docs/adr/0019-agent-mcp-cli-history-and-handoff.md
+++ b/docs/adr/0019-agent-mcp-cli-history-and-handoff.md
@@ -67,8 +67,9 @@ export sessions: `grok sessions list` / `grok sessions search <query>` (search
 covers summaries and first prompts only) and `grok export <session-id> [OUTPUT]`
 (Markdown, stdout by default). Those are the documented interface; the
 `~/.grok/sessions/**/updates.jsonl` layout that live observation reads
-(`GrokSessionReader`) is not, and the CLI options suggest the commands talk to
-Grok's own leader process, which the tickets must verify.
+(`GrokSessionReader`) is not. Ticket 07 verified official list and three local
+exports without a leader while denying file writes and child-process creation.
+That proves command availability under those protections, not transcript fidelity.
 
 ## Decision
 
@@ -108,12 +109,19 @@ can be named without guessing.
 Grok Build, each reporting its own coverage.** Claude and Codex are the existing
 roots. Cursor adds the agent transcript that Cursor's hook documentation names
 as `transcript_path`, already located and parsed by `CursorTranscripts`; it has
-no tool results, and says so. Grok Build is enumerated with `grok sessions list`
-and read with `grok export <id>`, the exported Markdown parsed into the same
-message shape and indexed for full text by vibebuddy, since Grok's own search
-covers only summaries and first prompts. The `updates.jsonl` layout is not the
-first choice for history and is used only if the official commands prove
-unusable, recorded in the ticket. No source claims the same fidelity as another;
+no tool results, and says so. **Grok Build is list/title-only in the first version.**
+Ticket 07 obtained three official exports, but its protected TUI comparison did
+not complete. The owner-defined downgrade therefore applies: enumerate local
+rows with `grok sessions list`, publish no Grok messages or FTS rows, and return
+"该来源无全文" from `show`. Grok's own search covers summaries and first prompts
+only; its protected invocation failed in preflight and is not used here.
+Official list dates have day precision and cannot stand in for transcript
+revisions. Workspace directory metadata verifies the cwd of a local list row;
+remote-only and unmatched sibling rows are excluded without guessing a project.
+The process sandbox forbids file writes and child-process creation; time/output
+limits bound the inventory, and queries never invoke it. `updates.jsonl` is not
+a history source in this ticket; any future alternative needs separate scope
+and authorization. No source claims the same fidelity as another;
 the per-source capability table lives in `docs/session-history.md`. Excluded:
 Cursor IDE chats (encrypted), Cursor cloud agents (ADR-0018), Copilot history
 rows, Grok Bot.
@@ -181,8 +189,9 @@ Acceptance is same-machine relay.
   the owner: it adds a write path to a read-only binary, and "CLI only" does
   not make it human-only.
 - **Reverse-engineered `updates.jsonl` as the Grok history source.** An official
-  enumerate-and-export interface exists; the undocumented layout is a fallback,
-  not the choice.
+  enumerate-and-export interface exists. The first version applies its explicit
+  list/title downgrade when the fidelity gate is not proved; reverse engineering
+  is excluded from ticket 07.
 - **Filling `Source session` from the newest session.** Wrong whenever two
   agents work in one project, which is the case the feature exists for.
 - **A daemon-side lock on "who is working in this checkout".** The three states

--- a/docs/session-history.md
+++ b/docs/session-history.md
@@ -5,6 +5,40 @@ The Dashboard has three library scopes: **Current tasks**, **History**, and
 reads local Claude Code and Codex conversation files independently; selecting or
 searching an archive never inserts it into the live snapshot.
 
+Grok Build also appears as **list and title metadata only**, from its official
+`grok sessions list` command. The first-version transcript acceptance gate was
+not completed; `show 'grok-build:<id>'` reports that this source has no transcript.
+No Grok messages or titles enter the full-text index. Search explicitly states
+this coverage limit instead of treating the source as an index that needs repair.
+
+| Source | History list | Transcript / full-text search | Limits |
+| --- | --- | --- | --- |
+| Claude Code | Local conversation metadata | Readable conversation records | Source warnings report omitted or bounded records |
+| Codex | Local and archived conversation metadata | Readable conversation records | Source warnings report omitted or bounded records |
+| Grok Build | Official local session IDs, dates and titles | Unavailable in the first version | List dates have day precision; remote-only rows are excluded |
+
+Grok workspace directory names under `$GROK_HOME/sessions` (default `~/.grok`)
+locate candidate working directories; the importer does not read `updates.jsonl`.
+Each local row must match a directory in that workspace, since official list
+output may include sibling worktrees or remote sessions without their absolute
+working directories. Unmatched or malformed rows are omitted with a coverage
+notice. Missing working directories and command time/output limits also produce
+partial-coverage notices; existing metadata is retained as unavailable.
+
+Only the App's locked refresh or explicit `vibebuddy-mcp index --rebuild` runs
+the inventory command. Queries read cached metadata and never launch Grok.
+The command runs through the macOS process sandbox with file writes and child
+process creation denied, a three-second per-workspace timeout, a 15-second scan
+budget and a 1 MiB combined output limit. If that protection is unavailable or
+the command fails, no unprotected retry occurs and no leader is started.
+List-row revisions fingerprint metadata; they are not transcript revisions and
+cannot detect unchanged titles after dialogue changes on the same day.
+
+**Copy resume command** can prepare `grok --resume <id>` for an available local
+row with a valid native UUID and working directory. Copying does not run it.
+The History agent filter includes Grok Build; Demo uses an in-memory Grok metadata
+sample and does not scan user history, generate summaries or contact providers.
+
 Open History to index `~/.claude/projects`, `~/.codex/sessions`, and
 `~/.codex/archived_sessions`. `CLAUDE_CONFIG_DIR` and `CODEX_HOME` replace the
 respective home directory. Project groups use the original full working directory;


### PR DESCRIPTION
agent-mcp-cli/07

## Summary

Add local Grok Build history through the installed official `grok sessions list` command. The source is intentionally limited to list metadata and titles: three official exports succeeded, but the required TUI transcript comparison was not established. `show` reports that full text is unavailable, and search does not claim Grok full-text coverage.

The adapter bounds subprocess time/output, denies source writes and process forks, validates local identities and workspace paths, and records malformed or unavailable sources without guessing. Long workspace folders use only bounded standalone summary identity/cwd metadata to locate their working directory. Executable lookup reuses the shared configured-home/standard-path resolver, including the retained ~/.local/bin fallback for Finder launches. Grok records enter the shared Mac History list/filter and Demo data, support copying a safely quoted resume command, and never enter transcript cache, FTS, or pending full-text work. Update the capability table and ADR source decision. The shared E2E corrections from ticket 06 pass isolated source locations into the App live store and reject an E2E bundle without its configuration before initialization, preserving production defaults.

Stacked on ticket 04 (`codex/agent-mcp-cli-04-search`, `ac3412f69564ab500cd0aa5788a25c011ac9982b`); preserves its available-source resolver correction.

## Validation

- `swift build --package-path VibeBuddyMac --product vibebuddy-mcp -j 2`: passed, 211.74 seconds.
- `swift test --package-path VibeBuddyMac -j 2`: 27 XCTest and 1,011 Swift Testing tests passed at `321c869e`; includes five Grok source/regression cases using fixed samples without invoking the real CLI. The subsequent E2E-only App constructor correction leaves the tested Swift core unchanged.
- Actual compiled CLI against three isolated native metadata copies: eight commands passed, including two rebuilds; three sessions, zero pending sources, and zero rows in all three full-text tables. Three store files were byte-identical after the six read queries, and three source files were byte-identical after all eight commands.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml` and `xcodebuild -project VibeBuddyMacApp/VibeBuddyMacApp.xcodeproj -scheme VibeBuddyMacApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -derivedDataPath .scratch/build-07 PRODUCT_BUNDLE_IDENTIFIER=com.vibebuddy.e2e.agent-mcp-cli-07 -jobs 2 build`: passed at `80397a0c`, exit 0. Bundle identity verified.
- Final `71920816`: `swift test --package-path VibeBuddyKit --filter E2ERunConfigurationTests -j 2` passed 4 tests; the same isolated Xcode command passed incrementally, exit 0.
- Native UI acceptance on the final guarded App: all three real metadata records matched CLI, Grok filter showed three, reading explicitly reported no full transcript, export was disabled and Generate controls were absent. Copy resume confirmed copying without starting a task. Search showed zero matches with the source limitation visible. Source hashes stayed unchanged; pending and full-text tables stayed empty. The owned App process exited and its isolated port closed.
- Independent standards/spec review passed after fixing metadata-only legacy/rebuild pending work; both shared E2E corrections were independently reviewed. Diff whitespace and commit leakguard checks passed.
- Review follow-up `e36ea660`: 8 focused Grok source tests passed (0.627 seconds), CLI build passed (13.88 seconds), and eight actual isolated CLI commands passed with `PATH=/usr/bin:/bin`; metadata counts and unchanged source/store hashes remained valid. Both new P2 review threads were fixed, independently reviewed, replied to and resolved.
- Private local evidence: `.scratch/agent-mcp-cli/acceptance/07/README.md`; no source transcript or private session data is included in this PR.

## Not verified here

- App UI evidence was captured at `71920816`; the later source-discovery fixes were verified with focused tests and actual CLI acceptance, without an unrelated UI/full-suite rerun.

- The Grok full-transcript gate did not pass; the documented list/title-only fallback is the delivered scope. No full-text parser or FTS ingestion is included.
- No installation, deployment, release, real-device operation, production daemon access, user-level configuration change, or Grok leader lifecycle operation. Merge remains owner-controlled.
