### PR TITLE
feat(history): expose saved summaries with coverage and staleness

### DIFF
--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistorySummaryTool.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistorySummaryTool.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A saved reading aid, checked against source attributes at query time.
+public struct HistorySummaryRead: Sendable {
+    public let summary: SessionHistorySummary
+    public let currentSourceRevision: String?
+    public let isStale: Bool
+}
+
+extension HistoryTools {
+    public static func getSummary(arguments: [String: Any], repository: SessionHistoryRepository) async throws -> String {
+        guard Set(arguments.keys) == ["key"], let key = arguments["key"] as? String else {
+            throw HistoryToolError.invalidArguments("get_summary requires only a string key.")
+        }
+        let reference = try HistorySessionReference(key)
+        guard let result = try await repository.readSummary(key: reference.key) else {
+            return "No saved summary for \(reference.key). Open this session in Mac App History and choose Generate summary."
+        }
+        let summary = result.summary
+        var lines = ["stale: \(result.isStale); Coverage: \(summary.coverage)", "",
+            "Key: \(reference.key)",
+            "Style: \(summary.style.rawValue) (\(summary.style.title))",
+            "Provider: \(summary.provider)", "Model: \(summary.model)",
+            "Generated: \(ISO8601DateFormatter().string(from: summary.generatedAt))",
+            "Summary source revision: \(summary.sourceRevision ?? "unknown")",
+            "Current source revision: \(result.currentSourceRevision ?? "unknown")"]
+        if result.currentSourceRevision == nil {
+            lines.append("> Source unavailable; freshness cannot be verified. The saved summary is retained.")
+        } else if summary.sourceRevision == nil {
+            lines.append("> Saved source revision unknown; freshness cannot be verified.")
+        } else if result.isStale {
+            lines.append("> Source changed since this summary was saved. The saved summary is retained.")
+        }
+        lines += ["", summary.text]
+        return lines.joined(separator: "\n")
+    }
+}

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/HistoryTools.swift
@@ -19,6 +19,8 @@ public enum HistoryTools {
             "key": ["type": "string"], "from_seq": ["type": "integer", "minimum": 1],
             "max_messages": ["type": "integer", "minimum": 1, "maximum": 200],
             "tools": ["type": "boolean"], "thinking": ["type": "boolean"]
+        ], required: ["key"]), definition("vibebuddy_get_summary", description: "Read an existing conversation summary with its saved coverage and current source staleness; never generates a summary.", properties: [
+            "key": ["type": "string"]
         ], required: ["key"]), definition("vibebuddy_list_sessions", description: "List indexed local sessions, newest activity first.", properties: [
             "project": ["type": "string"], "agents": ["type": "array", "items": ["type": "string", "enum": ["claude-code", "codex"]]],
             "since": ["type": "string"], "starred": ["type": "boolean"], "limit": ["type": "integer", "minimum": 1, "maximum": 200]
@@ -38,7 +40,7 @@ public enum HistoryTools {
     }
 
     public static func call(_ name: String, arguments: [String: Any], snapshot: SessionHistorySnapshot, now: Date = Date()) throws -> String {
-        guard name != "vibebuddy_get_session" else { throw HistoryToolError.invalidArguments("get_session requires a repository.") }
+        guard !["vibebuddy_get_session", "vibebuddy_get_summary"].contains(name) else { throw HistoryToolError.invalidArguments("\(name) requires a repository.") }
         guard let definition = definitions().first(where: { $0["name"] as? String == name }),
               let schema = definition["inputSchema"] as? [String: Any], let properties = schema["properties"] as? [String: Any] else {
             throw HistoryToolError.invalidArguments("Unknown tool: \(name)")
@@ -111,15 +113,15 @@ public enum HistoryTools {
 
 /// Only argv shape is interpreted here; values go unchanged to the tool layer.
 public enum HistoryCLI {
-    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects", "show": "vibebuddy_get_session"]
+    public static let commands = ["sessions": "vibebuddy_list_sessions", "projects": "vibebuddy_list_projects", "show": "vibebuddy_get_session", "summary": "vibebuddy_get_summary"]
     public static func parse(_ argv: [String]) throws -> (tool: String, arguments: [String: Any]) {
         guard let command = argv.first, let tool = commands[command] else {
-            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking]")
+            throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp sessions [--project PATH] [--agent AGENT] [--since DATE] [--starred] [--limit N] | projects [--since DATE] [--limit N] | show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking] | summary KEY")
         }
         var args: [String: Any] = [:]
         var index = 1
-        if command == "show" {
-            guard argv.count > 1, !argv[1].hasPrefix("--") else { throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp show KEY|REF [--from-seq N] [--max-messages N] [--tools] [--thinking]") }
+        if command == "show" || command == "summary" {
+            guard argv.count > 1, !argv[1].hasPrefix("--") else { throw HistoryToolError.invalidArguments("Usage: vibebuddy-mcp \(command) KEY|REF") }
             args["key"] = argv[1]; index = 2
         }
         while index < argv.count {

--- a/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
+++ b/VibeBuddyMac/Sources/VibeBuddyMacCore/SessionHistoryRepository.swift
@@ -152,9 +152,8 @@ public actor SessionHistoryRepository {
         }
         return snapshot()
     }
-    /// Bounded read-only access; never refreshes or publishes a cache.
-    public func readTranscript(key: String) throws -> HistoryTranscript {
-        let reference = try HistorySessionReference(key)
+    /// Resolve one native identity before reading either transcript or saved summary.
+    private func locateSession(_ reference: HistorySessionReference) throws -> (session: SessionHistorySession, indexedRevision: String?) {
         ensureLoaded()
         let matches = entries.values.filter { $0.session.agent == reference.agent && $0.session.nativeSessionID == reference.nativeID }
         guard matches.count <= 1 else { throw HistoryToolError.executionFailed("Ambiguous session key: multiple source files.") }
@@ -177,16 +176,22 @@ public actor SessionHistoryRepository {
             }
             guard candidates.count == 1 else { throw HistoryToolError.executionFailed(candidates.isEmpty ? "Unknown session key." : "Ambiguous session key: multiple source files.") }
             let file = candidates[0]
-            metadata = SessionHistorySession(id: "", nativeSessionID: reference.nativeID, agent: reference.agent, projectPath: "", title: "", sourcePath: file.path, updatedAt: .distantPast, messages: [])
+            metadata = SessionHistorySession(id: "\(reference.agent.rawValue):\(reference.nativeID)", nativeSessionID: reference.nativeID, agent: reference.agent, projectPath: "", title: "", sourcePath: file.path, updatedAt: .distantPast, messages: [])
         }
         guard let metadata else { throw HistoryToolError.executionFailed("Unknown session key.") }
+        return (metadata, matches.first.map { "\($0.modified.timeIntervalSince1970)|\($0.size)" })
+    }
+
+    /// Bounded read-only access; never refreshes or publishes a cache.
+    public func readTranscript(key: String) throws -> HistoryTranscript {
+        let reference = try HistorySessionReference(key)
+        let (metadata, indexed) = try locateSession(reference)
         let file = URL(fileURLWithPath: metadata.sourcePath)
         let values = try? file.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
         let modified = values?.contentModificationDate
         let size = values?.fileSize
         let current = modified.flatMap { date in size.map { "\(date.timeIntervalSince1970)|\($0)" } }
         if let current, let slot = transcriptSlot, slot.path == file.path, slot.revision == current { return slot.transcript }
-        let indexed = matches.first.map { "\($0.modified.timeIntervalSince1970)|\($0.size)" }
         let cacheURL = directory.appendingPathComponent(contentFilename(file.path))
         if let data = try? Data(contentsOf: cacheURL), var cached = try? JSONDecoder().decode(SessionHistorySession.self, from: data),
            cached.sourcePath == file.path, cached.agent == reference.agent, cached.nativeSessionID == reference.nativeID {
@@ -281,6 +286,21 @@ public actor SessionHistoryRepository {
         }
         return try searchIndex.search(needle, sessions: sessions, limit: limit)
     }
+    /// Reads only the persisted summary and source attributes; never parses or generates content.
+    public func readSummary(key: String) throws -> HistorySummaryRead? {
+        let reference = try HistorySessionReference(key)
+        let (metadata, _) = try locateSession(reference)
+        guard let saved = try summary(sessionID: metadata.id) else { return nil }
+        let file = URL(fileURLWithPath: metadata.sourcePath)
+        let values = try? file.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey, .contentModificationDateKey])
+        let current: String?
+        if values?.isRegularFile == true, let modified = values?.contentModificationDate, let size = values?.fileSize {
+            current = "\(modified.timeIntervalSince1970)|\(size)"
+        } else { current = nil }
+        return HistorySummaryRead(summary: saved, currentSourceRevision: current,
+            isStale: current == nil || saved.sourceRevision == nil || saved.sourceRevision != current || saved.sourcePath != file.path)
+    }
+
     public func summary(sessionID: String) throws -> SessionHistorySummary? {
         let file = directory.appendingPathComponent("summary-" + contentFilename(sessionID))
         guard FileManager.default.fileExists(atPath: file.path) else { return nil }

--- a/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
+++ b/VibeBuddyMac/Sources/vibebuddy-mcp/main.swift
@@ -13,6 +13,8 @@ struct VibeBuddyMCP {
             let text: String
             if request.tool == "vibebuddy_get_session" {
                 text = try await HistoryTools.getSession(arguments: request.arguments, repository: repository)
+            } else if request.tool == "vibebuddy_get_summary" {
+                text = try await HistoryTools.getSummary(arguments: request.arguments, repository: repository)
             } else {
                 guard await repository.hasUsableIndex() else { fail(HistoryToolError.noIndex, code: 2) }
                 text = try HistoryTools.call(request.tool, arguments: request.arguments, snapshot: await repository.snapshot())

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistorySummaryToolTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistorySummaryToolTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import XCTest
+@testable import VibeBuddyMacCore
+
+final class HistorySummaryToolTests: XCTestCase {
+    func testSavedMissingAndStaleSummaryRemainReadOnly() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let writer = fixture.repository()
+        let snapshot = try await writer.refresh()
+        let session = try XCTUnwrap(snapshot.sessions.first)
+        let reader = fixture.repository(readOnly: true)
+        let beforeMissing = try fixture.storeBytes()
+        let missing = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: reader)
+        XCTAssertTrue(missing.contains("No saved summary")); XCTAssertTrue(missing.contains("Mac App History"))
+        XCTAssertEqual(try fixture.storeBytes(), beforeMissing)
+
+        let summary = fixture.summary(session)
+        try await writer.saveSummary(summary)
+        let before = try fixture.storeBytes()
+        let direct = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: reader)
+        XCTAssertTrue(direct.hasPrefix("stale: false; Coverage: 1 of 2 readable records; partial/excerpted source"))
+        XCTAssertTrue(direct.contains("Style: briefing (Action briefing)"))
+        XCTAssertTrue(direct.contains("Provider: test-provider\nModel: test-model\nGenerated: 2026-09-13T00:00:00Z"))
+        XCTAssertTrue(direct.hasSuffix(summary.text))
+        let request = try HistoryCLI.parse(["summary", "vibebuddy://session/codex:native#2"])
+        XCTAssertEqual(request.tool, "vibebuddy_get_summary")
+        let cli = try await HistoryTools.getSummary(arguments: request.arguments, repository: reader)
+        XCTAssertEqual(Data(HistoryCLI.output(cli).utf8), Data((direct + "\n").utf8))
+        // A long-lived reader must stat the source again even though its index is unchanged.
+        let source = try Data(contentsOf: fixture.source)
+        try (source + Data("\n".utf8)).write(to: fixture.source)
+        let stale = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: reader)
+        XCTAssertTrue(stale.hasPrefix("stale: true; Coverage: " + summary.coverage))
+        XCTAssertTrue(stale.contains("Source changed")); XCTAssertTrue(stale.hasSuffix(summary.text))
+        // Reading the summary must survive a missing transcript/cache and retain the body.
+        try FileManager.default.removeItem(at: fixture.source)
+        let unavailable = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: reader)
+        XCTAssertTrue(unavailable.hasPrefix("stale: true;"))
+        XCTAssertTrue(unavailable.contains("Source unavailable")); XCTAssertTrue(unavailable.hasSuffix(summary.text))
+        XCTAssertEqual(try fixture.storeBytes(), before)
+    }
+
+    func testKeyFailuresAndUnknownRevisionAreExplicit() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let writer = fixture.repository()
+        let snapshot = try await writer.refresh()
+        let session = try XCTUnwrap(snapshot.sessions.first)
+        var summary = fixture.summary(session)
+        summary.sourceRevision = nil
+        try await writer.saveSummary(summary)
+        let reader = fixture.repository(readOnly: true)
+        let before = try fixture.storeBytes()
+        let legacy = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: reader)
+        XCTAssertTrue(legacy.hasPrefix("stale: true;")); XCTAssertTrue(legacy.contains("Saved source revision unknown"))
+        for (key, message) in [("broken", "Invalid session key or reference."),
+                               ("codex:missing", "Unknown session key."),
+                               ("other-agent:native", "Unknown session agent.")] {
+            do { _ = try await HistoryTools.getSummary(arguments: ["key": key], repository: reader); XCTFail("Accepted \(key)") }
+            catch HistoryToolError.executionFailed(let text) { XCTAssertEqual(text, message) }
+        }
+        let invalidArguments: [[String: Any]] = [[:], ["key": 1], ["key": "codex:native", "generate": true]]
+        for args in invalidArguments {
+            do { _ = try await HistoryTools.getSummary(arguments: args, repository: reader); XCTFail("Accepted invalid arguments") }
+            catch HistoryToolError.invalidArguments { }
+        }
+        XCTAssertEqual(try fixture.storeBytes(), before)
+        let duplicate = fixture.source.deletingLastPathComponent().appendingPathComponent("other/native.jsonl")
+        try FileManager.default.createDirectory(at: duplicate.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contentsOf: fixture.source).write(to: duplicate)
+        _ = try await writer.refresh()
+        let ambiguous = fixture.repository(readOnly: true)
+        let ambiguousBefore = try fixture.storeBytes()
+        do { _ = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: ambiguous); XCTFail("Accepted ambiguous identity") }
+        catch HistoryToolError.executionFailed(let text) { XCTAssertEqual(text, "Ambiguous session key: multiple source files.") }
+        XCTAssertEqual(try fixture.storeBytes(), ambiguousBefore)
+    }
+
+    func testSummaryWithoutIndexUsesNativeIdentityAndCreatesNothing() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let writer = fixture.repository()
+        let snapshot = try await writer.refresh()
+        let session = try XCTUnwrap(snapshot.sessions.first)
+        try await writer.saveSummary(fixture.summary(session))
+        for url in try FileManager.default.contentsOfDirectory(at: fixture.cache, includingPropertiesForKeys: nil)
+            where !url.lastPathComponent.hasPrefix("summary-") { try FileManager.default.removeItem(at: url) }
+        let before = try fixture.storeBytes()
+        let result = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: fixture.repository(readOnly: true))
+        XCTAssertTrue(result.hasPrefix("stale: false;"))
+        XCTAssertEqual(try fixture.storeBytes(), before)
+        let absent = fixture.root.appendingPathComponent("absent")
+        let empty = SessionHistoryRepository(claudeHome: fixture.root.appendingPathComponent("claude"),
+            codexHome: fixture.root.appendingPathComponent("codex"), cacheDirectory: absent, readOnly: true)
+        let missing = try await HistoryTools.getSummary(arguments: ["key": "codex:native"], repository: empty)
+        XCTAssertTrue(missing.contains("No saved summary"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: absent.path))
+    }
+
+    private struct Fixture {
+        let root: URL
+        var source: URL { root.appendingPathComponent("codex/sessions/native.jsonl") }
+        var cache: URL { root.appendingPathComponent("cache") }
+        init() throws {
+            root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let header = #"{"type":"session_meta","payload":{"id":"native","cwd":"/repo"}}"#
+            let message = #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}"#
+            try Data((header + "\n" + message).utf8).write(to: source)
+        }
+        func repository(readOnly: Bool = false) -> SessionHistoryRepository {
+            SessionHistoryRepository(claudeHome: root.appendingPathComponent("claude"), codexHome: root.appendingPathComponent("codex"), cacheDirectory: cache, readOnly: readOnly)
+        }
+        func summary(_ session: SessionHistorySession) -> SessionHistorySummary {
+            SessionHistorySummary(sessionID: session.id, sourcePath: session.sourcePath, sourceRevision: session.sourceRevision,
+                text: "## Saved result\nExisting body", provider: "test-provider", model: "test-model",
+                generatedAt: ISO8601DateFormatter().date(from: "2026-09-13T00:00:00Z")!,
+                coverage: "1 of 2 readable records; partial/excerpted source", style: .briefing)
+        }
+        func storeBytes() throws -> [String: Data] {
+            try Dictionary(uniqueKeysWithValues: FileManager.default.contentsOfDirectory(at: cache, includingPropertiesForKeys: nil).map {
+                ($0.lastPathComponent, try Data(contentsOf: $0))
+            })
+        }
+        func remove() { try? FileManager.default.removeItem(at: root) }
+    }
+}

--- a/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
+++ b/VibeBuddyMac/Tests/VibeBuddyMacCoreTests/HistoryToolsTests.swift
@@ -11,15 +11,15 @@ final class HistoryToolsTests: XCTestCase {
 
     func testRegistryAndCLIParity() throws {
         let definitions = HistoryTools.definitions()
-        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_get_session", "vibebuddy_list_sessions", "vibebuddy_list_projects"])
+        XCTAssertEqual(definitions.compactMap { $0["name"] as? String }, ["vibebuddy_get_session", "vibebuddy_get_summary", "vibebuddy_list_sessions", "vibebuddy_list_projects"])
         XCTAssertEqual(Set(HistoryCLI.commands.values), Set(definitions.compactMap { $0["name"] as? String }))
         for definition in definitions {
             XCTAssertEqual((definition["annotations"] as? [String: Bool])?["readOnlyHint"], true)
             XCTAssertEqual((definition["inputSchema"] as? [String: Any])?["additionalProperties"] as? Bool, false)
         }
         let schemas = definitions.compactMap { $0["inputSchema"] as? [String: Any] }
-        XCTAssertEqual(Set((schemas[1]["properties"] as? [String: Any] ?? [:]).keys), Set(["project", "agents", "since", "starred", "limit"]))
-        XCTAssertEqual(Set((schemas[2]["properties"] as? [String: Any] ?? [:]).keys), Set(["since", "limit"]))
+        XCTAssertEqual(Set((schemas[2]["properties"] as? [String: Any] ?? [:]).keys), Set(["project", "agents", "since", "starred", "limit"]))
+        XCTAssertEqual(Set((schemas[3]["properties"] as? [String: Any] ?? [:]).keys), Set(["since", "limit"]))
         let snapshot = SessionHistorySnapshot(sessions: [session("native-id", project: "/a/repo")])
         let request = try HistoryCLI.parse(["sessions", "--project", "/a/repo", "--limit", "5", "--agent", "codex"])
         XCTAssertEqual(request.arguments["limit"] as? String, "5")


### PR DESCRIPTION
agent-mcp-cli/08

## Summary

Adds `vibebuddy_get_summary` and `vibebuddy-mcp summary KEY` to read an existing conversation summary. Output starts with saved coverage and current source staleness, then includes saved style, provider, model, generation date, revisions and the unchanged body. Missing summaries succeed with a Mac App Generate hint; malformed, unknown and ambiguous keys fail precisely. Queries never generate summaries or write the store.

Stacked on ticket02 branch `codex/agent-mcp-cli-02-show-transcript` at `448480a2` (PR #171), including its fix for retained unavailable sources after Codex archive moves. Transcript and summary share that canonical resolution and preserve source lookup without an index. Merge remains owner-controlled.

## Validation

- `swift build --package-path VibeBuddyMac --product vibebuddy-mcp -j 2`: passed on final code.
- `VIBEBUDDY_HISTORY_SUMMARY_E2E=0 swift test --package-path VibeBuddyMac -j 2`: 17 XCTest and 1011 Swift Testing tests in 119 suites passed at the summary implementation checkpoint. After merging the dependency fix, `swift test --package-path VibeBuddyMac -j 2 --filter 'History(SummaryTool|Transcript|Tools)Tests'` passed all 10 selected tests, including the strengthened archive-move case.
- `xcodegen generate --spec VibeBuddyMacApp/project.yml` and macOS `xcodebuild` with `CODE_SIGNING_ALLOWED=NO`, `-jobs 2`, and an isolated derived-data directory/bundle ID: passed, including the final incremental build.
- 11 final real-source CLI cases plus two App-store fresh/stale CLI calls passed. The 11-case run verified unchanged input/store hashes for each query; all original evidence files also remained unchanged after App acceptance.
- Final isolated App: CUA AX showed the saved summary body and metadata; controlled mutation of only the copied source changed fresh to stale while retaining body and coverage. Rendered AX body matches persisted Markdown after presentation-only normalization; CLI body matches its bytes. App process and isolated listener were stopped.
- Independent Standards/Spec review and dependency-merge review passed. `git diff --check` passed; generated Package.resolved changes restored.

## Not verified here

Live MCP transport integration remains on ticket05's separate branch and needs the summary dispatch case. No user-level client setup, installed-app replacement, deployment/release, device or cross-machine acceptance. A final CUA screenshot contained a control absent from the exact-App AX tree and built source, so it is excluded as exact-App identity evidence; native acceptance uses the preserved AX responses and controlled source mutation. No new summary was generated.
